### PR TITLE
Fixed year in LICENSE file to make it more generic

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -7,7 +7,7 @@ The copyright for different parts of the code is held by different
 people and organizations, but the code is licensed under the same type
 of license. The license text is:
 
- * Copyright (c) 2012, (Name of copyright holder)
+ * Copyright (c) (Year), (Name of copyright holder)
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
The LICENSE file has a hard-coded year "(2012)". This patch replaces this with the generic text "(Year)".
