### PR TITLE
remove -g (request for comments)

### DIFF
--- a/cpu/msp430/Makefile.msp430
+++ b/cpu/msp430/Makefile.msp430
@@ -143,7 +143,7 @@ ifndef CC_MCU
 endif
 
 ifndef CFLAGSNO
-CFLAGSNO = -Wall -mmcu=$(CC_MCU) -g $(CFLAGSWERROR)
+CFLAGSNO = -Wall -mmcu=$(CC_MCU) $(CFLAGSWERROR)
 endif
 CFLAGS  += -Os -fno-strict-aliasing
 LDFLAGS += -mmcu=$(CC_MCU) -Wl,-Map=contiki-$(TARGET).map


### PR DESCRIPTION
see http://comments.gmane.org/gmane.os.contiki.devel/13869

If I don't do this I get the following error when building rpl-collect (or any rpl thing...) with make TARGET=sky

msp430-gcc -mmcu=msp430f1611 -Wl,-Map=contiki-sky.map -Wl,--gc-sections,--undefined=_reset_vector__,--undefined=InterruptVectors,--undefined=_copy_data_init__,--undefined=_clear_bss_init__,--undefined=_end_of_init__  udp-sender.co obj_sky/collect-common.o obj_sky/contiki-sky-main.o contiki-sky.a  -o udp-sender.sky
contiki-sky.a(cc2420.o):(.debug_loc+0x247): relocation truncated to fit: R_MSP430_16_BYTE against `no symbol'
/usr/lib/gcc/msp430/4.6.3/../../../../msp430/lib/mmpy-16/libc.a(rand.o):(.debug_info+0xd3): relocation truncated to fit: R_MSP430_16_BYTE against`no symbol'
collect2: ld returned 1 exit status
make: **\* [udp-sender.sky] Error 1
rm udp-sender.co obj_sky/collect-common.o obj_sky/contiki-sky-main.o

What's the proper fix here?
