### PR TITLE
don't use static routing with econotag platform

### DIFF
--- a/examples/er-rest-example/Makefile
+++ b/examples/er-rest-example/Makefile
@@ -7,8 +7,10 @@ CFLAGS += -DPROJECT_CONF_H=\"project-conf.h\"
 # for static routing, if enabled
 ifneq ($(TARGET), minimal-net)
 ifneq ($(TARGET), native)
+ifneq ($(TARGET), econotag)
 ifneq ($(findstring avr,$(TARGET)), avr)
 PROJECT_SOURCEFILES += static-routing.c
+endif
 endif
 endif
 endif


### PR DESCRIPTION
econotag doesn't need static routing --- added benefit is that this avoids the need for node-id as well.
