### PR TITLE
Make gcc default LD, and allow override with LD_OVERRIDE

### DIFF
--- a/cpu/native/Makefile.native
+++ b/cpu/native/Makefile.native
@@ -4,7 +4,11 @@ CONTIKI_SOURCEFILES += mtarch.c rtimer-arch.c elfloader-stub.c watchdog.c
 
 ### Compiler definitions
 CC       ?= gcc
-LD       ?= gcc
+ifdef LD_OVERRIDE
+  LD     = $(LD_OVERRIDE)
+else
+  LD     = gcc
+endif
 AS       ?= as
 NM       ?= nm
 OBJCOPY  ?= objcopy


### PR DESCRIPTION
This fixes the build problem on the native platform that was introduced with the last pull request.
