### PR TITLE
Add support for encryption and decryption calls

### DIFF
--- a/core/net/mac/contikimac.c
+++ b/core/net/mac/contikimac.c
@@ -626,6 +626,12 @@ send_packet(mac_callback_t mac_callback, void *mac_callback_ptr, struct rdc_buf_
 
   packetbuf_compact();
 
+#ifdef NETSTACK_ENCRYPT
+  NETSTACK_ENCRYPT();
+#endif /* NETSTACK_ENCRYPT */
+
+  transmit_len = packetbuf_totlen();
+
   NETSTACK_RADIO.prepare(packetbuf_hdrptr(), transmit_len);
 
   /* Remove the MAC-layer header since it will be recreated next time around. */
@@ -915,7 +921,11 @@ input_packet(void)
   }
 
   /*  printf("cycle_start 0x%02x 0x%02x\n", cycle_start, cycle_start % CYCLE_TIME);*/
-  
+
+#ifdef NETSTACK_DECRYPT
+  NETSTACK_DECRYPT();
+#endif /* NETSTACK_DECRYPT */
+
   if(packetbuf_totlen() > 0 && NETSTACK_FRAMER.parse() >= 0) {
 
 #if WITH_CONTIKIMAC_HEADER

--- a/core/net/mac/nullrdc.c
+++ b/core/net/mac/nullrdc.c
@@ -114,6 +114,10 @@ send_packet(mac_callback_t sent, void *ptr)
     ret = MAC_TX_ERR_FATAL;
   } else {
 
+#ifdef NETSTACK_ENCRYPT
+    NETSTACK_ENCRYPT();
+#endif /* NETSTACK_ENCRYPT */
+
 #if NULLRDC_802154_AUTOACK
     int is_broadcast;
     uint8_t dsn;
@@ -213,6 +217,10 @@ send_list(mac_callback_t sent, void *ptr, struct rdc_buf_list *buf_list)
 static void
 packet_input(void)
 {
+#ifdef NETSTACK_DECRYPT
+    NETSTACK_DECRYPT();
+#endif /* NETSTACK_DECRYPT */
+
 #if NULLRDC_802154_AUTOACK
   if(packetbuf_datalen() == ACK_LEN) {
     /* Ignore ack packets */

--- a/core/net/netstack.c
+++ b/core/net/netstack.c
@@ -46,5 +46,9 @@ netstack_init(void)
   NETSTACK_RDC.init();
   NETSTACK_MAC.init();
   NETSTACK_NETWORK.init();
+
+#ifdef NETSTACK_ENCRYPTION_INIT
+  NETSTACK_ENCRYPTION_INIT();
+#endif /* NETSTACK_ENCRYPTION_INIT */
 }
 /*---------------------------------------------------------------------------*/


### PR DESCRIPTION
This small pull request adds support for calling encryption and decryption functions in the netstack, if such functions are defined. Encryption and decryption shouldn't be done below the RDC layer, as it would incur delays that could disrupt the behavior of timing-sensitive RDC layers. It can't be done at the MAC or network layers either, as it is the RDC layer that gives radio packets their link-layer frames.
