### PR TITLE
disable pad keeper when using ADC pin; otherwise you'll see a 20k input

### DIFF
--- a/cpu/mc1322x/lib/adc.c
+++ b/cpu/mc1322x/lib/adc.c
@@ -76,6 +76,7 @@ void adc_service(void) {
             ADC->SEQ_1bits.CH##x = 1; \
             GPIO->FUNC_SEL.ADC##x = 1; \
 	    GPIO->PAD_DIR.ADC##x = 0; \
+	    GPIO->PAD_KEEP.ADC##x = 0; \
             GPIO->PAD_PU_EN.ADC##x = 0; \
 }} while (0)
 


### PR DESCRIPTION
impedance.
