### PR TITLE
Extra slash in path in makefile

### DIFF
--- a/cpu/arm/stm32f103/Makefile.stm32f103
+++ b/cpu/arm/stm32f103/Makefile.stm32f103
@@ -6,7 +6,7 @@ SUBTARGET = CB
 
 ### Code common for all ARM CPUs
 
-CONTIKI_CPU_ARM=$(CONTIKI)/cpu/arm/
+CONTIKI_CPU_ARM=$(CONTIKI)/cpu/arm
 CONTIKI_CPU_ARM_COMMON=$(CONTIKI_CPU_ARM)/common
 
 ### Define the CPU directory


### PR DESCRIPTION
Hi!

Noticed that there existed an  extra slash in Makefile.stm32f103. This caused problems when including 
files since it would point to an none existing directory

Example of output before change:
-I../../cpu/arm//stm32f103

Example of output after change:
-I../../cpu/arm/stm32f103
