### PR TITLE
Only build symbols for Sky if they are needed.

### DIFF
--- a/platform/sky/Makefile.common
+++ b/platform/sky/Makefile.common
@@ -24,7 +24,9 @@ CONTIKI_TARGET_SOURCEFILES += $(ARCH) $(UIPDRIVERS)
 MCU=msp430f1611
 include $(CONTIKI)/cpu/msp430/Makefile.msp430
 
+ifdef CORE
 contiki-$(TARGET).a: ${addprefix $(OBJECTDIR)/,symbols.o}
+endif
 #	$(AR) rcf $@ $^
 
 


### PR DESCRIPTION
Currently the symbols are always built, even if thy are not needed.
