### PR TITLE
Sky flash optimization

### DIFF
--- a/platform/sky/Makefile.common
+++ b/platform/sky/Makefile.common
@@ -34,7 +34,6 @@ LDFLAGS += $(LDFLAGSNO) -Felf -yn
 endif # IAR
 
 NUMPAR=20
-IHEXFILE=tmpimage.ihex
 
 # Check if we are running under Windows
 ifeq ($(HOST_OS),Windows)
@@ -118,20 +117,17 @@ sky-motes:
 
 ifdef MOTE
 %.upload: %.ihex
-	cp $< $(IHEXFILE)
-	$(MAKE) sky-u.$(subst /,_,$(word $(MOTE), $(MOTES)))
+	$(MAKE) IHEXFILE=$< sky-u.$(subst /,_,$(word $(MOTE), $(MOTES)))
 else # MOTE
 %.upload: %.ihex
-	cp $< $(IHEXFILE)
-	$(MAKE) sky-reset sky-upload
+	$(MAKE) IHEXFILE=$< sky-reset sky-upload
 endif # MOTE
 
 upload-ihex:
 ifdef FILE
 	@echo Uploading $(FILE)
-	cp $(FILE) $(IHEXFILE)
 ifdef MOTE
-	$(MAKE) sky-u.$(subst /,_,$(word $(MOTE), $(MOTES)))
+	$(MAKE) IHEXFILE=$(FILE) sky-u.$(subst /,_,$(word $(MOTE), $(MOTES)))
 else # MOTE
 	$(MAKE) sky-reset sky-upload
 endif # MOTE


### PR DESCRIPTION
These to patches improve the way sky motes can be falshed:
7213d36 allows: "make bla.upload MOTEIDS="XBR1AYN3 MFUD5O6Z" Thus there is no need to know which /dev/ttySx they were assigned. This is especially nice when reconnecting nodes.
79aa5db gets rid of the constant tmpimage.ihex. Thus it is possible to flash to different firmware files from the same directory.
