### PR TITLE
Fix false positive travis build problems

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,10 +25,11 @@ script:
   - "make -C regression-tests/??-$BUILD_TYPE RUNALL=true summary"
 
 after_script:
-  ## Print a basic summary in unix style
+  ## Print a basic summary 
   - "echo 'Summary:'; cat regression-tests/??-$BUILD_TYPE/summary"
+  - "FAILS=`grep -c -i 'fail' regression-tests/??-$BUILD_TYPE/summary`"
   ## This will detect whether the build should pass or fail
-  - "test `grep -c -i 'fail' regression-tests/??-$BUILD_TYPE/summary` -eq 0"
+  - "test $FAILS -eq 0; exit $?"
 
 
 env:


### PR DESCRIPTION
We found that the travis builds sometimes would indicate a false positive: that travis said that the build succeeded, when it in fact had failed.

This was caused by an exit value in the script not doing what it was supposed to do. This pull request seems to fix the problem.

To be honest, I'm not sure why this problem manifested itself, and the fix is somewhat of a kludge. But it seems to work.
