### PR TITLE
Add mesh_ready() to mesh

### DIFF
--- a/core/net/rime/mesh.c
+++ b/core/net/rime/mesh.c
@@ -201,4 +201,11 @@ mesh_send(struct mesh_conn *c, const rimeaddr_t *to)
   return 1;
 }
 /*---------------------------------------------------------------------------*/
+int
+mesh_ready(struct mesh_conn *c)
+{
+  return (c->queued_data == NULL);
+}
+
+
 /** @} */

--- a/core/net/rime/mesh.h
+++ b/core/net/rime/mesh.h
@@ -133,6 +133,14 @@ void mesh_close(struct mesh_conn *c);
  */
 int mesh_send(struct mesh_conn *c, const rimeaddr_t *dest);
 
+/**
+ * \brief      Test if mesh is ready to send a packet (or packet is queued)
+ * \param c    The mesh connection on which is to be tested
+ * \retval 0   Packet queued
+ * \retval !0  Ready
+ */
+int mesh_ready(struct mesh_conn *c);
+
 #endif /* __MESH_H__ */
 /** @} */
 /** @} */


### PR DESCRIPTION
mesh_ready checkes whether a packet is queued. This allows to avoid packet loss at application level.
