### PR TITLE
We can now turn off example-provided putchars

### DIFF
--- a/examples/ipv6/rpl-border-router/slip-bridge.c
+++ b/examples/ipv6/rpl-border-router/slip-bridge.c
@@ -118,6 +118,7 @@ output(void)
 }
 
 /*---------------------------------------------------------------------------*/
+#if !SLIP_BRIDGE_CONF_NO_PUTCHAR
 #undef putchar
 int
 putchar(int c)
@@ -145,6 +146,7 @@ putchar(int c)
   }
   return c;
 }
+#endif
 /*---------------------------------------------------------------------------*/
 const struct uip_fallback_interface rpl_interface = {
   init, output

--- a/examples/ipv6/slip-radio/slip-radio.c
+++ b/examples/ipv6/slip-radio/slip-radio.c
@@ -169,6 +169,7 @@ init(void)
   packet_pos = 0;
 }
 /*---------------------------------------------------------------------------*/
+#if !SLIP_RADIO_CONF_NO_PUTCHAR
 #undef putchar
 int
 putchar(int c)
@@ -196,6 +197,7 @@ putchar(int c)
   }
   return c;
 }
+#endif
 /*---------------------------------------------------------------------------*/
 PROCESS(slip_radio_process, "Slip radio process");
 AUTOSTART_PROCESSES(&slip_radio_process);


### PR DESCRIPTION
The two examples using SLIP (rpl-border-router and slip-radio) make the assumption that SLIP and debugging output will always be over the same peripheral and provide their own implementation of putchar to handle SLIP/putchar multiplexing.

This assumption may have been true during Contiki's earlier days. However, new hardware keeps coming out with on-chip USB controllers and this assumption is now becoming increasingly questionable. For example, one may wish to send debugging over UART and SLIP over USB, in which case those putchar implementations only get in the way.

This little patch wraps the two putchars in #if guards, allowing the platform maintainer to provide a platform-specific way to handle things, if so desired.

This is implemented in the least disruptive way possible; the examples will behave in exactly the same fashion as they did before the patch, unless a platform's contiki-conf.h explicitly tells us to do otherwise.
