### PR TITLE
Remove travis email notifications

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+notifications:
+  email: false
 language: c #NOTE: this will set CC=gcc which might cause trouble
 before_script:
   - "sudo apt-get -qq update"


### PR DESCRIPTION
Added a notifications: clause to the .travis.yml file turn off email notifications, which are otherwise enabled by default.
