### PR TITLE
Updates AVR settings

### DIFF
--- a/cpu/avr/settings.c
+++ b/cpu/avr/settings.c
@@ -1,26 +1,105 @@
+/*! @file settings.c
+**  Settings Manager
+**  @author Robert Quattlebaum <darco@deepdarc.com>
+**
+**  Format based on OLPC manufacturing data, as described here:
+**  <http://wiki.laptop.org/go/Manufacturing_data>
+**
+**  @par Features
+**
+**      - Robust data format which requires no initialization.
+**      - Supports multiple values with the same key.
+**      - Data can be appended without erasing EEPROM.
+**      - Max size of settings data can be easily increased in the future,
+**        as long as it doesn't overlap with application data.
+**
+**  @par Data Format
+**
+**  Since the beginning of EEPROM often contains application-specific
+**  information, the best place to store settings is at the end of
+**  EEPROM. Because we are starting at the end of EEPROM, it makes sense
+**  to grow the list of key-value pairs downward, toward the start of
+**  EEPROM.
+**
+**  Each key-value pair is stored in memory in the following format:
+** <table>
+**  <thead>
+**   <td>Order</td>
+**   <td>Size<small> (in bytes)</small></td>
+**   <td>Name</td>
+**   <td>Description</td>
+**  </thead>
+**  <tr>
+**   <td>0</td>
+**   <td>2</td>
+**   <td>key</td>
+**   <td></td>
+**  </tr>
+**  <tr>
+**   <td>-2</td>
+**   <td>1</td>
+**   <td>size_check</td>
+**   <td>One's-complement of next byte</td>
+**  </tr>
+**  <tr>
+**   <td>-3</td>
+**   <td>1 or 2</td>
+**   <td>size</td>
+**   <td>The size of the value, in bytes.</td>
+**  </tr>
+**  <tr>
+**   <td>-4 or -5</td>
+**   <td>variable</td>
+**   <td>value</td>
+**  </tr>
+** </table>
+**
+**  The end of the key-value pairs is denoted by the first invalid entry.
+**  An invalid entry has any of the following attributes:
+**      - The size_check byte doesn't match the one's compliment
+**        of the size byte (or size_low byte).
+**      - The key has a value of 0x0000.
+**
+**  Note that we actually aren't starting at the very end of EEPROM, instead
+**  we are starting 4 bytes from the end of EEPROM. This allows for things like
+**  AVRDUDE's erase counter, and possibly bootloader flags.
+**
+*/
 
 #include <stdbool.h>
-//#include <sys/param.h>
-#define MIN(a,b) ((a) < (b) ? (a) : (b))
 #include <avr/io.h>
 #include "settings.h"
+
+#include "contiki.h"
 #include "dev/eeprom.h"
+
 #include <stdio.h>
+
+#if __AVR__
 #include <avr/pgmspace.h>
 #include <avr/eeprom.h>
 #include <avr/wdt.h>
-#include "contiki.h"
+#endif
+
+#ifndef MIN
+#define MIN(a,b) ({ __typeof__ (a) _a = (a); __typeof__ (b) _b = (b); _a < _b ? _a : _b; })
+#endif
 
 #ifndef SETTINGS_TOP_ADDR
-#define SETTINGS_TOP_ADDR	(E2END-4)	//!< Defaults to end of EEPROM, minus 4 bytes for avrdude erase count
+//! Defaults to end of EEPROM, minus 4 bytes for avrdude erase count
+#define SETTINGS_TOP_ADDR	(settings_iter_t)(E2END-4)
 #endif
 
 #ifndef SETTINGS_MAX_SIZE
 #define SETTINGS_MAX_SIZE	(1024)	//!< Defaults to 1KB
 #endif
 
-//#pragma mark -
-//#pragma mark Private Functions
+/** This macro will protect the following code from interrupts.*/
+#define AVR_ENTER_CRITICAL_REGION( ) {uint8_t volatile saved_sreg = SREG; cli( )
+
+/** This macro must always be used in conjunction with AVR_ENTER_CRITICAL_REGION
+    so that interrupts are enabled again.*/
+#define AVR_LEAVE_CRITICAL_REGION( ) SREG = saved_sreg;}
 
 typedef struct {
 	uint8_t size_extra;
@@ -29,18 +108,38 @@ typedef struct {
 	settings_key_t key;
 } item_header_t;
 
-inline static bool
-settings_is_item_valid_(eeprom_addr_t item_addr) {
+#pragma mark - Public Travesal Functions
+
+settings_iter_t
+settings_iter_begin() {
+	return settings_iter_is_valid(SETTINGS_TOP_ADDR)?SETTINGS_TOP_ADDR:0;
+}
+
+settings_iter_t
+settings_iter_next(settings_iter_t ret) {
+    if(ret) {
+        // A settings iterator always points to the first byte
+        // after the actual key-value pair in memory. This means that
+        // the address of our value in EEPROM just happens
+        // to be the address of our next iterator.
+        ret = settings_iter_get_value_addr(ret);
+        return settings_iter_is_valid(ret)?ret:0;
+    }
+    return SETTINGS_INVALID_ITER;
+}
+
+bool
+settings_iter_is_valid(settings_iter_t iter) {
 	item_header_t header = {};
 
-	if(item_addr==EEPROM_NULL)
+	if(iter==EEPROM_NULL)
 		return false;
 
-//	if((SETTINGS_TOP_ADDR-item_addr)>=SETTINGS_MAX_SIZE-3)
-//		return false;
+	if((SETTINGS_TOP_ADDR-iter)>=SETTINGS_MAX_SIZE-3)
+		return false;
 	
 	eeprom_read(
-		item_addr+1-sizeof(header),
+		iter-sizeof(header),
 		(unsigned char*)&header,
 		sizeof(header)
 	);
@@ -53,12 +152,12 @@ settings_is_item_valid_(eeprom_addr_t item_addr) {
 	return true;
 }
 
-inline static settings_key_t
-settings_get_key_(eeprom_addr_t item_addr) {
+settings_key_t
+settings_iter_get_key(settings_iter_t iter) {
 	item_header_t header;
 	
 	eeprom_read(
-		item_addr+1-sizeof(header),
+		iter-sizeof(header),
 		(unsigned char*)&header,
 		sizeof(header)
 	);
@@ -69,13 +168,13 @@ settings_get_key_(eeprom_addr_t item_addr) {
 	return header.key;
 }
 
-inline static size_t
-settings_get_value_length_(eeprom_addr_t item_addr) {
+settings_length_t
+settings_iter_get_value_length(settings_iter_t iter) {
 	item_header_t header;
-	size_t ret = 0;
+	settings_length_t ret = 0;
 	
 	eeprom_read(
-		item_addr+1-sizeof(header),
+		iter-sizeof(header),
 		(unsigned char*)&header,
 		sizeof(header)
 	);
@@ -93,32 +192,64 @@ bail:
 	return ret;
 }
 
-inline static eeprom_addr_t
-settings_get_value_addr_(eeprom_addr_t item_addr) {
-	size_t len = settings_get_value_length_(item_addr);
+eeprom_addr_t
+settings_iter_get_value_addr(settings_iter_t iter) {
+	settings_length_t len = settings_iter_get_value_length(iter);
 	
-	if(len>128)
-		return item_addr+1-sizeof(item_header_t)-len;
-
-	return item_addr+1-sizeof(item_header_t)+1-len;
+	return iter-sizeof(item_header_t)-len + (len>128);
 }
 
-inline static eeprom_addr_t
-settings_next_item_(eeprom_addr_t item_addr) {
-	return settings_get_value_addr_(item_addr)-1;
+settings_length_t
+settings_iter_get_value_bytes(settings_iter_t iter, void* bytes, settings_length_t max_length) {
+    max_length = MIN(max_length,settings_iter_get_value_length(iter));
+
+    eeprom_read(
+        settings_iter_get_value_addr(iter),
+        bytes,
+        max_length
+    );
+
+    return max_length;
 }
 
+settings_status_t
+settings_iter_delete(settings_iter_t iter) {
+    settings_status_t ret = SETTINGS_STATUS_FAILURE;
+    settings_iter_t next = settings_iter_next(iter);
 
-//#pragma mark -
-//#pragma mark Public Functions
+    if(!next) {
+        // Special case: we are the last item. we can get away with
+        // just wiping out our own header.
+        item_header_t header;
+
+        memset(&header,0xFF,sizeof(header));
+
+        eeprom_write(
+            iter-sizeof(header),
+            (unsigned char*)&header,
+            sizeof(header)
+        );
+
+        ret = SETTINGS_STATUS_OK;
+    }
+
+	// This case requires the settings store to be shifted.
+    // Currently unimplemented.
+	// TODO: Writeme!
+    ret = SETTINGS_STATUS_UNIMPLEMENTED;
+
+	return ret;
+}
+
+#pragma mark - Public Functions
 
 bool
 settings_check(settings_key_t key,uint8_t index) {
 	bool ret = false;
-	eeprom_addr_t current_item = SETTINGS_TOP_ADDR;
+	settings_iter_t iter;
 
-	for(current_item=SETTINGS_TOP_ADDR;settings_is_item_valid_(current_item);current_item=settings_next_item_(current_item)) {
-		if(settings_get_key_(current_item)==key) {
+	for(iter=settings_iter_begin();iter;iter=settings_iter_next(iter)) {
+		if(settings_iter_get_key(iter)==key) {
 			if(!index) {
 				ret = true;
 				break;
@@ -133,20 +264,15 @@ settings_check(settings_key_t key,uint8_t index) {
 }
 
 settings_status_t
-settings_get(settings_key_t key,uint8_t index,unsigned char* value,size_t* value_size) {
+settings_get(settings_key_t key,uint8_t index,unsigned char* value,settings_length_t* value_size) {
 	settings_status_t ret = SETTINGS_STATUS_NOT_FOUND;
-	eeprom_addr_t current_item = SETTINGS_TOP_ADDR;
+	settings_iter_t iter;
 	
-	for(current_item=SETTINGS_TOP_ADDR;settings_is_item_valid_(current_item);current_item=settings_next_item_(current_item)) {
-		if(settings_get_key_(current_item)==key) {
+	for(iter=settings_iter_begin();iter;iter=settings_iter_next(iter)) {
+		if(settings_iter_get_key(iter)==key) {
 			if(!index) {
 				// We found it!
-				*value_size = MIN(*value_size,settings_get_value_length_(current_item));
-				eeprom_read(
-					settings_get_value_addr_(current_item),
-					value,
-					*value_size
-				);
+                *value_size = settings_iter_get_value_bytes(iter,(void*)value,*value_size);
 				ret = SETTINGS_STATUS_OK;
 				break;
 			} else {
@@ -160,16 +286,16 @@ settings_get(settings_key_t key,uint8_t index,unsigned char* value,size_t* value
 }
 
 settings_status_t
-settings_add(settings_key_t key,const unsigned char* value,size_t value_size) {
+settings_add(settings_key_t key,const unsigned char* value,settings_length_t value_size) {
 	settings_status_t ret = SETTINGS_STATUS_FAILURE;
-	eeprom_addr_t current_item = SETTINGS_TOP_ADDR;
+	settings_iter_t iter;
 	item_header_t header;
 	
-	// Find end of list
-	for(current_item=SETTINGS_TOP_ADDR;settings_is_item_valid_(current_item);current_item=settings_next_item_(current_item));
-	
-	if(current_item==EEPROM_NULL)
-		goto bail;
+	// Find the last item.
+	for(iter=settings_iter_begin();settings_iter_next(iter);iter=settings_iter_next(iter)) { }
+
+	// Value address of item is the same as the iterator for next item.
+	iter = settings_iter_get_value_addr(iter);
 
 	// TODO: size check!
 
@@ -198,23 +324,35 @@ settings_add(settings_key_t key,const unsigned char* value,size_t value_size) {
 
 	// Write the header first
 	eeprom_write(
-		current_item+1-sizeof(header),
+		iter-sizeof(header),
 		(unsigned char*)&header,
 		sizeof(header)
 	);
 	
 	// Sanity check, remove once confident
-	if(settings_get_value_length_(current_item)!=value_size) {
+	if(settings_iter_get_value_length(iter)!=value_size) {
 		goto bail;
 	}
-	
+
 	// Now write the data
 	eeprom_write(
-		settings_get_value_addr_(current_item),
+		settings_iter_get_value_addr(iter),
 		(unsigned char*)value,
 		value_size
 	);
-	
+
+    // This should be the last item. If this is not the case,
+    // then we need to clear out the phantom setting.
+    if((iter = settings_iter_next(iter))) {
+        memset(&header,0xFF,sizeof(header));
+
+        eeprom_write(
+            iter-sizeof(header),
+            (unsigned char*)&header,
+            sizeof(header)
+        );
+    }
+
 	ret = SETTINGS_STATUS_OK;
 	
 bail:
@@ -222,29 +360,30 @@ bail:
 }
 
 settings_status_t
-settings_set(settings_key_t key,const unsigned char* value,size_t value_size) {
+settings_set(settings_key_t key,const unsigned char* value,settings_length_t value_size) {
 	settings_status_t ret = SETTINGS_STATUS_FAILURE;
-	eeprom_addr_t current_item = SETTINGS_TOP_ADDR;
+	settings_iter_t iter;
 
-	for(current_item=SETTINGS_TOP_ADDR;settings_is_item_valid_(current_item);current_item=settings_next_item_(current_item)) {
-		if(settings_get_key_(current_item)==key) {
+	for(iter=settings_iter_begin();iter;iter=settings_iter_next(iter)) {
+		if(settings_iter_get_key(iter)==key) {
 			break;
 		}
 	}
 
-	if((current_item==EEPROM_NULL) || !settings_is_item_valid_(current_item)) {
+	if((iter==EEPROM_NULL) || !settings_iter_is_valid(iter)) {
 		ret = settings_add(key,value,value_size);
 		goto bail;
 	}
 	
-	if(value_size!=settings_get_value_length_(current_item)) {
+	if(value_size!=settings_iter_get_value_length(iter)) {
 		// Requires the settings store to be shifted. Currently unimplemented.
+		ret = SETTINGS_STATUS_UNIMPLEMENTED;
 		goto bail;
 	}
 	
 	// Now write the data
 	eeprom_write(
-		settings_get_value_addr_(current_item),
+		settings_iter_get_value_addr(iter),
 		(unsigned char*)value,
 		value_size
 	);
@@ -257,19 +396,73 @@ bail:
 
 settings_status_t
 settings_delete(settings_key_t key,uint8_t index) {
-	// Requires the settings store to be shifted. Currently unimplemented.
-	// TODO: Writeme!
-	return SETTINGS_STATUS_UNIMPLEMENTED;
+	settings_status_t ret = SETTINGS_STATUS_NOT_FOUND;
+	settings_iter_t iter;
+
+	for(iter=settings_iter_begin();iter;iter=settings_iter_next(iter)) {
+		if(settings_iter_get_key(iter)==key) {
+			if(!index) {
+				// We found it!
+                ret = settings_iter_delete(iter);
+				break;
+			} else {
+				// Nope, keep looking
+				index--;
+			}
+		}
+	}
+
+    return ret;
 }
 
 
 void
 settings_wipe(void) {
-	size_t i = SETTINGS_TOP_ADDR-SETTINGS_MAX_SIZE;
+#if __AVR__
+	settings_length_t i = SETTINGS_TOP_ADDR-SETTINGS_MAX_SIZE;
+	AVR_ENTER_CRITICAL_REGION();
 	for(;i<=SETTINGS_TOP_ADDR;i++) {
 		eeprom_write_byte((uint8_t*)i,0xFF);
 		wdt_reset();
 	}
+	AVR_LEAVE_CRITICAL_REGION();
+#endif
 }
 
+void
+settings_debug_dump(FILE* file) {
+	settings_iter_t iter;
+    fputs("{\n",file);
+	for(iter=settings_iter_begin();iter;iter=settings_iter_next(iter)) {
+        {
+            union {
+                settings_key_t key;
+                char bytes[0];
+            } u;
+            u.key = settings_iter_get_key(iter);
 
+            fputs("\t\"",file);
+            fputc(u.bytes[0],file);
+            fputc(u.bytes[1],file);
+            fputs("\" = <",file);
+        }
+        {
+            settings_length_t len = settings_iter_get_value_length(iter);
+            eeprom_addr_t addr = settings_iter_get_value_addr(iter);
+            unsigned char byte;
+            for(;len;len--,addr++) {
+                eeprom_read(
+                    addr,
+                    &byte,
+                    1
+                );
+                // TODO: Figure out a way to do this without fprintf.
+                fprintf(file,"%02X",byte);
+                if(len!=1)
+                    fputc(' ',file);
+            }
+        }
+        fputs(">;\n",file);
+    }
+    fputs("}\n",file);
+}

--- a/cpu/avr/settings.h
+++ b/cpu/avr/settings.h
@@ -3,18 +3,11 @@
 
 #include <inttypes.h>
 #include <stdlib.h>
+#include <stdio.h>
 #include <stdbool.h>
+#include "dev/eeprom.h"
 
-typedef uint16_t settings_key_t;
-
-#define SETTINGS_KEY_EUI64			'E'*256+'8'	//!< Value always 8 bytes long
-#define SETTINGS_KEY_EUI48			'E'*256+'6'	//!< Value always 8 bytes long
-#define SETTINGS_KEY_CHANNEL		'C'*256+'H'	//!< Value always 1 byte long
-#define SETTINGS_KEY_TXPOWER		'T'*256+'P'	//!< Value always 1 byte long
-#define SETTINGS_KEY_PAN_ID			'P'*256+'N'	//!< Value always 2 bytes long
-#define SETTINGS_KEY_PAN_ADDR		'P'*256+'A'	//!< Value always 2 bytes long
-#define SETTINGS_KEY_AES128KEY		'S'*256+'K'	//!< Value always 16 bytes long
-#define SETTINGS_KEY_AES128ENABLED	'S'*256+'E'	//!< Value always 16 bytes long
+#pragma mark - Types
 
 typedef enum {
 	SETTINGS_STATUS_OK=0,
@@ -25,28 +18,101 @@ typedef enum {
 	SETTINGS_STATUS_FAILURE,
 } settings_status_t;
 
+typedef eeprom_addr_t settings_iter_t;
+
+typedef uint16_t settings_key_t;
+
+typedef uint16_t settings_length_t;
+
+#pragma mark - Settings Keys
+
+// Two-character constant
+#define TCC(a,b)	((a)+(b)*256)
+
+#define SETTINGS_KEY_EUI64			TCC('E','8')	//!< Value always 8 bytes long
+#define SETTINGS_KEY_EUI48			TCC('E','6')	//!< Value always 8 bytes long
+#define SETTINGS_KEY_CHANNEL		TCC('C','H')	//!< Value always 1 byte long
+#define SETTINGS_KEY_TXPOWER		TCC('T','P')	//!< Value always 1 byte long
+#define SETTINGS_KEY_PAN_ID			TCC('P','N')	//!< Value always 2 bytes long
+#define SETTINGS_KEY_PAN_ADDR		TCC('P','A')	//!< Value always 2 bytes long
+#define SETTINGS_KEY_AES128KEY		TCC('S','K')	//!< Value always 16 bytes long
+#define SETTINGS_KEY_AES128ENABLED	TCC('S','E')	//!< Value always 16 bytes long
+#define SETTINGS_KEY_HOSTNAME		TCC('H','N')	//!< Variable Length
+#define SETTINGS_KEY_DOMAINNAME		TCC('D','N')	//!< Variable Length
+
+#pragma mark - Experimental Settings Keys
+
+#define SETTINGS_KEY_RDC_INDEX		TCC('R','D')	//!< Always 1 byte long
+
+#pragma mark - Constants
+
 // Use this when you want to retrieve the last item
 #define SETTINGS_LAST_INDEX		(0xFF)
 
-#define SETTINGS_INVALID_KEY	(0x00)
+#define SETTINGS_INVALID_KEY	(0xFFFF)
+
+#define SETTINGS_INVALID_ITER	(EEPROM_NULL)
 
 #define SETTINGS_MAX_VALUE_SIZE	(0x3FFF)	// 16383 bytes
 
-extern settings_status_t settings_get(settings_key_t key,uint8_t index,unsigned char* value,size_t* value_size);
-extern settings_status_t settings_add(settings_key_t key,const unsigned char* value,size_t value_size);
+#pragma mark - Settings accessors
+
+extern settings_status_t settings_get(settings_key_t key,uint8_t index,unsigned char* value,settings_length_t* value_size);
+extern settings_status_t settings_add(settings_key_t key,const unsigned char* value,settings_length_t value_size);
 extern bool settings_check(settings_key_t key,uint8_t index);
 extern void settings_wipe(void);
 
-extern settings_status_t settings_set(settings_key_t key,const unsigned char* value,size_t value_size);
+extern settings_status_t settings_set(settings_key_t key,const unsigned char* value,settings_length_t value_size);
 extern settings_status_t settings_delete(settings_key_t key,uint8_t index);
 
-//#pragma mark -
-//#pragma mark Inline convenience functions
+extern void settings_debug_dump(FILE* file);
+
+#pragma mark - Settings traversal functions
+
+/*!	Will return extern SETTINGS_INVALID_ITER if at the end of settings list */
+extern settings_iter_t settings_iter_begin();
+
+/*!	Will return extern SETTINGS_INVALID_ITER if at the end of settings list */
+extern settings_iter_t settings_iter_next(settings_iter_t iter);
+
+extern bool settings_iter_is_valid(settings_iter_t iter);
+
+extern settings_key_t settings_iter_get_key(settings_iter_t iter);
+
+extern settings_length_t settings_iter_get_value_length(settings_iter_t iter);
+
+extern eeprom_addr_t settings_iter_get_value_addr(settings_iter_t iter);
+
+extern settings_length_t settings_iter_get_value_bytes(settings_iter_t item, void* bytes, settings_length_t max_length);
+
+extern settings_status_t settings_iter_delete(settings_iter_t item);
+
+#pragma mark - Inline convenience functions
+
+static inline const char*
+settings_get_cstr(settings_key_t key,uint8_t index,char* c_str,settings_length_t c_str_size) {
+	c_str_size--;
+	if(settings_get(key,index,(unsigned char*)c_str,&c_str_size)==SETTINGS_STATUS_OK) {
+		// Zero terminate.
+		c_str[c_str_size] = 0;
+	} else {
+		c_str = NULL;
+	}
+	return c_str;
+}
+
+static inline bool
+settings_get_bool_with_default(settings_key_t key,uint8_t index, bool default_value) {
+	uint8_t ret = default_value;
+	settings_length_t sizeof_uint8 = sizeof(uint8_t);
+	settings_get(key,index,(unsigned char*)&ret,&sizeof_uint8);
+	return (bool)ret;
+}
 
 static inline uint8_t
 settings_get_uint8(settings_key_t key,uint8_t index) {
 	uint8_t ret = 0;
-	size_t sizeof_uint8 = sizeof(uint8_t);
+	settings_length_t sizeof_uint8 = sizeof(uint8_t);
 	settings_get(key,index,(unsigned char*)&ret,&sizeof_uint8);
 	return ret;
 }
@@ -64,7 +130,7 @@ settings_set_uint8(settings_key_t key,uint8_t value) {
 static inline uint16_t
 settings_get_uint16(settings_key_t key,uint8_t index) {
 	uint16_t ret = 0;
-	size_t sizeof_uint16 = sizeof(uint16_t);
+	settings_length_t sizeof_uint16 = sizeof(uint16_t);
 	settings_get(key,index,(unsigned char*)&ret,&sizeof_uint16);
 	return ret;
 }
@@ -82,7 +148,7 @@ settings_set_uint16(settings_key_t key,uint16_t value) {
 static inline uint32_t
 settings_get_uint32(settings_key_t key,uint8_t index) {
 	uint32_t ret = 0;
-	size_t sizeof_uint32 = sizeof(uint32_t);
+	settings_length_t sizeof_uint32 = sizeof(uint32_t);
 	settings_get(key,index,(unsigned char*)&ret,&sizeof_uint32);
 	return ret;
 }
@@ -100,7 +166,7 @@ settings_set_uint32(settings_key_t key,uint32_t value) {
 static inline uint64_t
 settings_get_uint64(settings_key_t key,uint8_t index) {
 	uint64_t ret = 0;
-	size_t sizeof_uint64 = sizeof(uint64_t);
+	settings_length_t sizeof_uint64 = sizeof(uint64_t);
 	settings_get(key,index,(unsigned char*)&ret,&sizeof_uint64);
 	return ret;
 }


### PR DESCRIPTION
~~I've updated the avr/settings mechanism to work with any platform that has implemented the Contiki EEPROM API. I've also added a fake EEPROM implementation to the native target, for testing purposes.~~

I've pulled out the native-target EEPROM changes for now and backed out the general case for `settings.c` for now, until I get it building properly.
