### PR TITLE
sys/clock: Autosleep: added `clock_sleep_with_max_duration()` and example AVR implementation.

### DIFF
--- a/core/sys/clock.h
+++ b/core/sys/clock.h
@@ -117,6 +117,16 @@ CCIF unsigned long clock_seconds(void);
 void clock_set_seconds(unsigned long sec);
 
 /**
+ * Sleep the CPU for no more than the given number of ticks.
+ * If an interrupt occurs, the function will return once the
+ * interrupt has been handled. Useful for automatically
+ * sleeping the microcontroller to save power while remaining
+ * responsive to events.
+ * \param t   The maximum number of ticks to sleep
+ */
+void clock_sleep_with_max_duration(clock_time_t t);
+
+/**
  * Wait for a given number of ticks.
  * \param t   How many ticks.
  *

--- a/cpu/avr/dev/clock.c
+++ b/cpu/avr/dev/clock.c
@@ -176,6 +176,35 @@ clock_wait(clock_time_t t)
 }
 /*---------------------------------------------------------------------------*/
 /**
+ * Sleep the CPU for no more than the given number of ticks.
+ * If an interrupt occurs, the function will return once the
+ * interrupt has been handled. Useful for automatically
+ * sleeping the microcontroller to save power while remaining
+ * responsive to events.
+ * \param t   The maximum number of ticks to sleep
+ */
+void
+clock_sleep_with_max_duration(clock_time_t t) {
+  /* This needs to be breakable by any interrupt, but stop before
+   * the expiration of the given duration. This is doable, but not
+   * trivial, so I will have to implement this later. */
+
+  /* In other words, this method needs to set up one of the
+   * hardware timers to generate an interrupt at around
+   * the time given by 't' and then go to sleep. Once we
+   * wake up (from either our timer interrupt or some other
+   * interrupt), we clean up and return. */
+
+  /* Note that if you don't have an implementation for this method
+   * which will properly return once an interrupt has been handled,
+   * then you must always return immediately. Waiting until the max
+   * duration would make the microcontroller very sluggish and
+   * practically unusable. */
+
+  /* TODO: Writeme! */
+}
+/*---------------------------------------------------------------------------*/
+/**
  * Delay the CPU for up to 65535*(4000000/F_CPU) microseconds.
  * Copied from _delay_loop_2 in AVR library delay_basic.h, 4 clocks per loop.
  * For accurate short delays, inline _delay_loop_2 in the caller, use a constant
@@ -421,6 +450,7 @@ ISR(BADISR_vect) {
 //static volatile uint8_t x;while (1) x++;
 }
 #endif
+
 #ifdef HANG_ON_UNKNOWN_INTERRUPT
 /* Hang on any unsupported interrupt */
 /* Useful for diagnosing unknown interrupts that reset the mcu.

--- a/platform/avr-raven/contiki-raven-main.c
+++ b/platform/avr-raven/contiki-raven-main.c
@@ -432,8 +432,21 @@ main(void)
   initialize();
 
   while(1) {
-    process_run();
     watchdog_periodic();
+
+    if(process_run()==0) {
+      clock_time_t sleep_period = etimer_next_expiration_time() - clock_time();
+
+      //PRINTF("Going to sleep for %lu clock ticks...\n",(unsigned long)sleep_period);
+
+      watchdog_stop();
+
+      clock_sleep_with_max_duration(sleep_period);
+
+      watchdog_start();
+
+      //PRINTF("...Woke from sleep\n");
+    }
 
 #if 0
 /* Various entry points for debugging in the AVR Studio simulator.

--- a/platform/avr-ravenusb/contiki-raven-main.c
+++ b/platform/avr-ravenusb/contiki-raven-main.c
@@ -600,9 +600,21 @@ main(void)
 #endif
 
   while(1) {
-    process_run();
-
     watchdog_periodic();
+
+    if(process_run()==0) {
+      clock_time_t sleep_period = etimer_next_expiration_time() - clock_time();
+
+      //PRINTD("Going to sleep for %lu clock ticks...\n",(unsigned long)sleep_period);
+
+      watchdog_stop();
+
+      clock_sleep_with_max_duration(sleep_period);
+
+      watchdog_start();
+
+      //PRINTD("...Woke from sleep\n");
+    }
 
 /* Print rssi of all received packets, useful for range testing */
 #ifdef RF230_MIN_RX_POWER


### PR DESCRIPTION
Contiki support for "automatic" sleep (autosleep) can be easily
implemented with the addition of the CPU-specific function
`clock_sleep_with_max_duration()`. This function must be implemented
in such a way that any interrupts that occur will cause it to exit
immediately after the interrupt is handled. This is normally
implemented by setting a timer to generate an interrupt at the
requested expiration and then putting the microcontroller into
one of its built-in sleep modes. In the main run loop, you then
call then method when you have nothing to do, passing as an
argument the point in time at which you know you will have something
to do. If you are familiar with asynchronous socket IO design
patterns, then you can think of `click_sleep_with_max_duration()`
as a more simple verison of `select()` or `poll()`---except that
the interrupts pretty much handle themselves.

This pattern allows the system to sleep implicitly when it has
nothing to do, while still being responsive to timed events. For the
most part, after you implement it you can forget about it.

The key is, of course, having a reasonable implementation of
`clock_sleep_with_max_duration()` for the platform you are
interested in. I've included some example code for the avr-raven
and avr-ravenusb platforms to show how to use this function
in your main loops, but I don't yet have a reasonable implementation
of this function yet for the AVR CPU---it is just a stub.

This technique is not limited to AVR microcontrollers. Any
microcontroller which implements a sleep mode which can be awoken from
interrupts is a prime candidate for autosleep.
