### PR TITLE
Added missing include of contiki-conf.h in rpl-conf.h

### DIFF
--- a/core/net/rpl/rpl-conf.h
+++ b/core/net/rpl/rpl-conf.h
@@ -38,6 +38,8 @@
 #ifndef RPL_CONF_H
 #define RPL_CONF_H
 
+#include "contiki-conf.h"
+
 /* Set to 1 to enable RPL statistics */
 #ifndef RPL_CONF_STATS
 #define RPL_CONF_STATS 0


### PR DESCRIPTION
rpl-conf.h being a config file, it should include contiki-conf.h in order not to ignore other project- and platform-specific config files
