### PR TITLE
Bugfix z1 i2cmaster

### DIFF
--- a/platform/z1/dev/i2cmaster.c
+++ b/platform/z1/dev/i2cmaster.c
@@ -214,7 +214,6 @@ ISR(USCIAB1TX, i2c_tx_interrupt)
 {
   // TX Part
   if (UC1IFG & UCB1TXIFG) {        // TX int. condition
-    PRINTFDEBUG("!!! TX int\n");
     if (tx_byte_ctr == 0) {
       UCB1CTL1 |= UCTXSTP;	   // I2C stop condition
       UC1IFG &= ~UCB1TXIFG;	   // Clear USCI_B1 TX int flag


### PR DESCRIPTION
Discovered a bug in the z1 i2cmaster.c. When there was more than 1 byte read from the slave there were another 2 extra bytes being read, this because of an i2c stop command that was issued too late to the msp430.

With most i2c slaves this wouldn't be a problem, but when you have a slave that automaticaly advances the adress pointer with every read from the master (like the hmc5843) you would skip and loose 2 registers.

Fix was to change the ISR to give the i2c stop command while the last byte is being read.
