### PR TITLE
Load Makefile.target for slip-radio

### DIFF
--- a/examples/ipv6/slip-radio/Makefile
+++ b/examples/ipv6/slip-radio/Makefile
@@ -2,6 +2,10 @@ CONTIKI_PROJECT=slip-radio
 all: $(CONTIKI_PROJECT)
 APPS = slip-cmd
 
+ifeq ($(TARGET),)
+  -include Makefile.target
+endif
+
 CONTIKI=../../..
 
 WITH_UIP6=1


### PR DESCRIPTION
This loads Makefile.target into Makefile so we can check for TARGET==sky
when building this. Compilation for sky fails without it.

Signed-off-by: Johannes Gilger heipei@hackvalue.de
