### PR TITLE
Removed uiplib_ip6addrconv() from IPv4 builds.

### DIFF
--- a/core/net/uiplib.c
+++ b/core/net/uiplib.c
@@ -41,6 +41,7 @@
 #include "net/uip-debug.h"
 
 /*-----------------------------------------------------------------------------------*/
+#if UIP_CONF_IPV6
 int
 uiplib_ip6addrconv(const char *addrstr, uip_ip6addr_t *ipaddr)
 {
@@ -102,6 +103,7 @@ uiplib_ip6addrconv(const char *addrstr, uip_ip6addr_t *ipaddr)
 
   return 1;
 }
+#endif /* UIP_CONF_IPV6 */
 /*-----------------------------------------------------------------------------------*/
 /* Parse a IPv4-address from a string. Returns the number of characters read 
  * for the address. */
@@ -138,15 +140,4 @@ uiplib_ip4addrconv(const char *addrstr, uip_ip4addr_t *ipaddr)
   }
   return charsread-1;
 }
-/*-----------------------------------------------------------------------------------*/
-int
-uiplib_ipaddrconv(const char *addrstr, uip_ipaddr_t *ipaddr)
-{
-#if UIP_CONF_IPV6
-  return uiplib_ip6addrconv(addrstr, ipaddr);
-#else /* UIP_CONF_IPV6 */
-  return uiplib_ip4addrconv(addrstr, ipaddr);
-#endif /* UIP_CONF_IPV6 */
-}
-
 /*-----------------------------------------------------------------------------------*/

--- a/core/net/uiplib.h
+++ b/core/net/uiplib.h
@@ -66,7 +66,11 @@
  * \retval 0 If the IP address could not be parsed.
  * \retval Non-zero If the IP address was parsed. 
  */
-CCIF int uiplib_ipaddrconv(const char *addrstr, uip_ipaddr_t *addr);
+#if UIP_CONF_IPV6
+#define uiplib_ipaddrconv uiplib_ip6addrconv
+#else /* UIP_CONF_IPV6 */
+#define uiplib_ipaddrconv uiplib_ip4addrconv
+#endif /* UIP_CONF_IPV6 */
 
 CCIF int uiplib_ip4addrconv(const char *addrstr, uip_ip4addr_t *addr);
 CCIF int uiplib_ip6addrconv(const char *addrstr, uip_ip6addr_t *addr);


### PR DESCRIPTION
While it may very well be beneficial to have explict uiplib_ip4addrconv() and uiplib_ip6addrconv() available for IPv6 builds I'm having a hard time to see the point in uiplib_ip6addrconv() for IPv4 builds.

Unrelated to the above the dispatching of uiplib_ipaddrconv() to either uiplib_ip4addrconv() or uiplib_ip6addrconv() can be accomplished by the C preprocessor only thus avoiding the size/speed overhead of an additional callframe.
