### PR TITLE
Bug fix: corrected the macro RPL_LOLLIPOP_INCREMENT

### DIFF
--- a/core/net/rpl/rpl-private.h
+++ b/core/net/rpl/rpl-private.h
@@ -211,10 +211,14 @@
 #define RPL_LOLLIPOP_CIRCULAR_REGION     127
 #define RPL_LOLLIPOP_SEQUENCE_WINDOWS    16
 #define RPL_LOLLIPOP_INIT                (RPL_LOLLIPOP_MAX_VALUE - RPL_LOLLIPOP_SEQUENCE_WINDOWS + 1)
-#define RPL_LOLLIPOP_INCREMENT(counter)					\
-  ((counter) > RPL_LOLLIPOP_CIRCULAR_REGION ?				\
-   ++(counter) & RPL_LOLLIPOP_MAX_VALUE :				\
-   ++(counter) & RPL_LOLLIPOP_CIRCULAR_REGION)
+#define RPL_LOLLIPOP_INCREMENT(counter)                                 \
+  do {                                                                  \
+    if((counter) > RPL_LOLLIPOP_CIRCULAR_REGION) {                      \
+      (counter) = ((counter) + 1) & RPL_LOLLIPOP_MAX_VALUE;             \
+    } else {                                                            \
+      (counter) = ((counter) + 1) & RPL_LOLLIPOP_CIRCULAR_REGION;       \
+    }                                                                   \
+  } while(0)
 
 #define RPL_LOLLIPOP_IS_INIT(counter)		\
   ((counter) > RPL_LOLLIPOP_CIRCULAR_REGION)


### PR DESCRIPTION
Changed the macro RPL_LOLLIPOP_INCREMENT to update the counter instead of returning the new value since this is how the macro is used today.
