### PR TITLE
Bug fix: add_timer() does not set owning process

### DIFF
--- a/core/sys/etimer.c
+++ b/core/sys/etimer.c
@@ -158,7 +158,7 @@ add_timer(struct etimer *timer)
     for(t = timerlist; t != NULL; t = t->next) {
       if(t == timer) {
 	/* Timer already on list, bail out. */
-         timer->p = PROCESS_CURRENT();
+        timer->p = PROCESS_CURRENT();
 	update_time();
 	return;
       }


### PR DESCRIPTION
Documentation states: "When the event timer expires, the event PROCESS_EVENT_TIMER will be posted to the process that called the etimer_set() function." (from doc of etimer_set()).

This is not true, if an unexpired etimer is being etimer_set by another process than the current owning process.

Fix is simple: in add_timer() directly after the comment "/\* Timer already on list, bail out. */" the line

```
timer->p = PROCESS_CURRENT();
```

has to be added.

I hope this fix will not break anything existing.

Background: in our application there is a protothread which does some action (of course).  In the end the protothread is waiting either for an event or a timeout, implemented by an etimer.  The etimer is a static variable of the protothread, the internals of the protothread are protected by a semaphore.

The protothread itself is called by several processes via PROCESS_PT_SPAWN().

If the protothread exits via its usual path (without timeout), the etimer still belongs (until expiration) to the calling first process.

Then the second process is calling the protothread and sets the etimer - unfortunately for the first process.  If the actual completion event is not sent (due to some failure), the etimer timeout is sent to the wrong process and the protothread is stuck - and the calling second process.

Other case: the first process is exiting after returning from the protothread (unexpired etimer).  Then the etimer (still owned by the first process) is removed from the etimer list.  Again no event to the second process.

Second comment in the original issue:

Just to make it a little bit clearer and hopefully get it fixed officially: even the example in http://contiki.sourceforge.net/docs/2.6/a01671.html#gaa355c55e3ff7aa0999f2ae770298b7bb (PROCESS_CONTEXT_BEGIN()) does not work if the etimer is not expired.
