### PR TITLE
cpu/avr: Make sure that GCC removes all unused symbols.

### DIFF
--- a/cpu/avr/Makefile.avr
+++ b/cpu/avr/Makefile.avr
@@ -106,6 +106,15 @@ endif
 LDFLAGS  += -mmcu=$(MCU) -Wl,-Map=contiki-$(TARGET).map \
            -Wl,--section-start=.bootloader=$(BOOTLOADER_START)
 
+SMALL ?= 1
+
+### These flags help significantly reduce the code size
+ifeq ($(SMALL),1)
+CFLAGS += -ffunction-sections
+CFLAGS += -fdata-sections
+LDFLAGS += -Wl,--gc-sections
+endif # SMALL
+
 ### Setup directory search path for source files
 
 CONTIKI_TARGET_DIRS_CONCAT = ${addprefix $(CONTIKI)/platform/$(TARGET)/, \


### PR DESCRIPTION
This patch makes sure that GCC removes all unused symbols for AVR CPUs.

This magic comes from the `--gc-sections` linker flag, which turns on garbage collection for unused input sections. The compiler flags `-ffunction-sections` and `-fdata-sections` make sure that each function and each static data definition have their own section. The result is that GCC can prune away all unused symbols, reducing the size of the resulting executable.
