### PR TITLE
core/net: Added support for "bridge mode".

### DIFF
--- a/core/net/mac/contikimac.c
+++ b/core/net/mac/contikimac.c
@@ -549,7 +549,10 @@ send_packet(mac_callback_t mac_callback, void *mac_callback_ptr, struct rdc_buf_
     return MAC_TX_ERR_FATAL;
   }
 
+#if !NETSTACK_CONF_BRIDGE_MODE
+  /* If NETSTACK_CONF_BRIDGE_MODE is set, assume PACKETBUF_ADDR_SENDER is already set. */
   packetbuf_set_addr(PACKETBUF_ADDR_SENDER, &rimeaddr_node_addr);
+#endif
   if(rimeaddr_cmp(packetbuf_addr(PACKETBUF_ADDR_RECEIVER), &rimeaddr_null)) {
     is_broadcast = 1;
     PRINTDEBUG("contikimac: send broadcast\n");

--- a/core/net/mac/cxmac.c
+++ b/core/net/mac/cxmac.c
@@ -429,7 +429,10 @@ send_packet(void)
 
 
   /* Create the X-MAC header for the data packet. */
+#if !NETSTACK_CONF_BRIDGE_MODE
+  /* If NETSTACK_CONF_BRIDGE_MODE is set, assume PACKETBUF_ADDR_SENDER is already set. */
   packetbuf_set_addr(PACKETBUF_ADDR_SENDER, &rimeaddr_node_addr);
+#endif
   if(rimeaddr_cmp(packetbuf_addr(PACKETBUF_ADDR_RECEIVER), &rimeaddr_null)) {
     is_broadcast = 1;
     PRINTDEBUG("cxmac: send broadcast\n");

--- a/core/net/mac/sicslowmac.c
+++ b/core/net/mac/sicslowmac.c
@@ -146,7 +146,11 @@ send_packet(mac_callback_t sent, void *ptr)
    * Set up the source address using only the long address mode for
    * phase 1.
    */
+#if NETSTACK_CONF_BRIDGE_MODE
+  rimeaddr_copy((rimeaddr_t *)&params.src_addr,packetbuf_addr(PACKETBUF_ADDR_SENDER));
+#else
   rimeaddr_copy((rimeaddr_t *)&params.src_addr, &rimeaddr_node_addr);
+#endif
 
   params.payload = packetbuf_dataptr();
   params.payload_len = packetbuf_datalen();
@@ -203,12 +207,14 @@ input_packet(void)
       }
       if(!is_broadcast_addr(frame.fcf.dest_addr_mode, frame.dest_addr)) {
         packetbuf_set_addr(PACKETBUF_ADDR_RECEIVER, (rimeaddr_t *)&frame.dest_addr);
+#if !NETSTACK_CONF_BRIDGE_MODE
         if(!rimeaddr_cmp(packetbuf_addr(PACKETBUF_ADDR_RECEIVER),
                          &rimeaddr_node_addr)) {
           /* Not for this node */
           PRINTF("6MAC: not for us\n");
           return;
         }
+#endif
       }
     }
     packetbuf_set_addr(PACKETBUF_ADDR_SENDER, (rimeaddr_t *)&frame.src_addr);

--- a/core/net/sicslowpan.c
+++ b/core/net/sicslowpan.c
@@ -1329,6 +1329,11 @@ send_packet(rimeaddr_t *dest)
    */
   packetbuf_set_addr(PACKETBUF_ADDR_RECEIVER, dest);
 
+#if NETSTACK_CONF_BRIDGE_MODE
+  /* This needs to be explicitly set here for bridge mode to work */
+  packetbuf_set_addr(PACKETBUF_ADDR_SENDER,(void*)&uip_lladdr);
+#endif
+
   /* Force acknowledge from sender (test hardware autoacks) */
 #if SICSLOWPAN_CONF_ACK_ALL
     packetbuf_set_attr(PACKETBUF_ATTR_RELIABLE, 1);


### PR DESCRIPTION
"Bridge mode" allows devices to more easily send 802.15.4 packets as if they were a different device. It also turns off any packet filtering that may be implemented at layer 2. It works by allowing `PACKETBUF_ADDR_SENDER` to be set earlier in the stack.

This is useful for implementing 6LoWPAN-ethernet bridges.

Enabled via setting `NETSTACK_CONF_BRIDGE_MODE` to 1. Disabled by default.
