### PR TITLE
Add missing brace in sky Makefile

### DIFF
--- a/platform/sky/Makefile.common
+++ b/platform/sky/Makefile.common
@@ -97,7 +97,7 @@ else
     ifdef MOTEIDS
   	  MOTES = $(foreach MOTEID, $(MOTEIDS), $(shell $(MOTELIST)  2>&- | grep $(MOTEID) | \
           cut -f 4 -d \  | \
-          perl -ne 'print $$1 . " " if(m-(/dev/[\w+\.\-]+)-);') 
+          perl -ne 'print $$1 . " " if(m-(/dev/[\w+\.\-]+)-);')) 
     else
       MOTES = $(shell $(MOTELIST) 2>&- | grep USB | \
          cut -f 4 -d \  | \


### PR DESCRIPTION
Looks like my patch 7213d36 lost a brace on its way from my local repo to the pull-request. Sorry for that.
