### PR TITLE
Fix er 3 and 7 buids in latest erbuim (subscribers counter has changed type)

### DIFF
--- a/apps/er-coap-03/er-coap-03-observing.c
+++ b/apps/er-coap-03/er-coap-03-observing.c
@@ -122,7 +122,7 @@ coap_remove_observer_by_token(uip_ipaddr_t *addr, uint16_t port, uint8_t *token,
 }
 /*-----------------------------------------------------------------------------------*/
 void
-coap_notify_observers(resource_t *resource, uint16_t obs_counter, void *notification)
+coap_notify_observers(resource_t *resource, int32_t obs_counter, void *notification)
 {
   coap_packet_t *const coap_res = (coap_packet_t *) notification;
   coap_observer_t* obs = NULL;

--- a/apps/er-coap-03/er-coap-03-observing.h
+++ b/apps/er-coap-03/er-coap-03-observing.h
@@ -69,7 +69,7 @@ coap_observer_t *coap_add_observer(uip_ipaddr_t *addr, uint16_t port, const uint
 void coap_remove_observer(coap_observer_t *o);
 int coap_remove_observer_by_client(uip_ipaddr_t *addr, uint16_t port);
 int coap_remove_observer_by_token(uip_ipaddr_t *addr, uint16_t port, uint8_t *token, size_t token_len);
-void coap_notify_observers(resource_t *resource, uint16_t obs_counter, void *notification);
+void coap_notify_observers(resource_t *resource, int32_t obs_counter, void *notification);
 
 void coap_observe_handler(resource_t *resource, void *request, void *response);
 

--- a/apps/er-coap-07/er-coap-07-observing.c
+++ b/apps/er-coap-07/er-coap-07-observing.c
@@ -167,7 +167,7 @@ coap_remove_observer_by_mid(uip_ipaddr_t *addr, uint16_t port, uint16_t mid)
 }
 /*-----------------------------------------------------------------------------------*/
 void
-coap_notify_observers(resource_t *resource, uint16_t obs_counter, void *notification)
+coap_notify_observers(resource_t *resource, int32_t obs_counter, void *notification)
 {
   coap_packet_t *const coap_res = (coap_packet_t *) notification;
   coap_observer_t* obs = NULL;

--- a/apps/er-coap-07/er-coap-07-observing.h
+++ b/apps/er-coap-07/er-coap-07-observing.h
@@ -75,7 +75,7 @@ int coap_remove_observer_by_token(uip_ipaddr_t *addr, uint16_t port, uint8_t *to
 int coap_remove_observer_by_url(uip_ipaddr_t *addr, uint16_t port, const char *url);
 int coap_remove_observer_by_mid(uip_ipaddr_t *addr, uint16_t port, uint16_t mid);
 
-void coap_notify_observers(resource_t *resource, uint16_t obs_counter, void *notification);
+void coap_notify_observers(resource_t *resource, int32_t obs_counter, void *notification);
 
 void coap_observe_handler(resource_t *resource, void *request, void *response);
 


### PR DESCRIPTION
er-13 has changed the type of notify_subscribers counter to int32_t from uint16_t which breaks builds of WITH_COAP=3 or 7.

This patch changes the 03 and 07 engine to int32_t.

An alternate fix would be to switch out the type in erbuim.h based on
WITH_COAP.

Or, maybe better, would be to drop old COAP versions.

@mkovatsc thoughts?
