### PR TITLE
[ci] Travis needs 32-bit compatibility libraries

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ before_script:
   - "sudo apt-get -qq install gcc-msp430 || true"
   - "sudo apt-get -qq install gcc-avr avr-libc || true"
   - "sudo apt-get -qq install srecord || true"
+  - "sudo apt-get -qq install libc6:i386 libgcc1:i386 gcc-4.6-base:i386 libstdc++5:i386 libstdc++6:i386 || true"
   ## Install toolchain for mc1233x in care-free way
   - "[ $BUILD_TYPE = compile ] && curl -s \
        https://sourcery.mentor.com/public/gnu_toolchain/arm-none-eabi/arm-2008q3-66-arm-none-eabi-i686-pc-linux-gnu.tar.bz2 \


### PR DESCRIPTION
This fixes the issue with 32-bit CodeSourcery toolchain on Travis, although there still some odd failures in Cooja builds.
