### PR TITLE
Use the .csc speedlimit parameter in headless cooja (-nogui) instead of forcing max speed

### DIFF
--- a/tools/cooja/java/se/sics/cooja/GUI.java
+++ b/tools/cooja/java/se/sics/cooja/GUI.java
@@ -3246,7 +3246,6 @@ public class GUI extends Observable {
           System.exit(1);
         }
       }
-      sim.setSpeedLimit(null);
       sim.startSimulation();
       
     } else if (args.length > 0 && args[0].startsWith("-applet")) {


### PR DESCRIPTION
In headless mode, GUI.java overrides what is previously read from the .csc and forces the simulation to run at max speed by calling <pre>sim.setSpeedLimit(null);</pre> before <pre>sim.startSimulation();</pre>

Although I understand the rationale behind this, there are cases where we need the headless mode to run at 100% speed and not full speed. For instance, I'm using headless COOJA to automate 6lbr regression tests, where running at real-time is important because the simulated motes need to run at the same pace as the router and the rest of the scripts.
