### PR TITLE
Fix a mismatch between declaration and definition

### DIFF
--- a/apps/slip-cmd/cmd.c
+++ b/apps/slip-cmd/cmd.c
@@ -45,7 +45,7 @@
 
 void CMD_OUTPUT(const uint8_t *data, int data_len);
 
-extern cmd_handler_t cmd_handlers[];
+extern const cmd_handler_t cmd_handlers[];
 
 /*---------------------------------------------------------------------------*/
 void


### PR DESCRIPTION
The `CMD_HANDLERS` macro defines `cmd_handlers` as `const`

```
#define CMD_HANDLERS(...) \
const cmd_handler_t cmd_handlers[] = {__VA_ARGS__, NULL}
```

whereas the `extern` declaration in `cmd.c` does not use `const`.

```
extern cmd_handler_t cmd_handlers[];
```

SDCC really dislikes this situation and silently treats the two `cmd_handlers` as residing in different memory spaces: one is in `CONST` and the other in `XDATA`.
