### PR TITLE
Improve handling of CDC ACM line state

### DIFF
--- a/cpu/cc2538/usb/usb-serial.c
+++ b/cpu/cc2538/usb/usb-serial.c
@@ -201,21 +201,9 @@ do_work(void)
   if(events & USB_CDC_ACM_LINE_STATE) {
     uint8_t line_state = usb_cdc_acm_get_line_state();
     PRINTF("CDC-ACM event 0x%04x, Line State = %u\n", events, line_state);
-    if(line_state == 0) {
-      /* CDC-ACM line went down. Stop streaming */
-      enabled = 0;
-    } else if(line_state == (USB_CDC_ACM_DTE | USB_CDC_ACM_RTS)) {
+    if(line_state & USB_CDC_ACM_DTE) {
       enabled = 1;
     } else {
-      /*
-       * During tests on Ubuntu and OS X, line_state never stays == 2
-       * (USB_CDC_ACM_RTS) for too long. We always see this value when the
-       * line is in the process of going up or coming down. If it is going
-       * up, value 3 will enable us shortly. Otherwise, we may as well
-       * disable already.
-       *
-       * All other values: disable
-       */
       enabled = 0;
     }
   }

--- a/platform/cc2530dk/dev/usb-serial.c
+++ b/platform/cc2530dk/dev/usb-serial.c
@@ -170,6 +170,16 @@ do_work(void)
     enabled = 0;
   }
 
+  events = usb_cdc_acm_get_events();
+  if(events & USB_CDC_ACM_LINE_STATE) {
+    uint8_t line_state = usb_cdc_acm_get_line_state();
+    if(line_state & USB_CDC_ACM_DTE) {
+      enabled = 1;
+    } else {
+      enabled = 0;
+    }
+  }
+
   if(!enabled) {
     return;
   }
@@ -254,6 +264,7 @@ PROCESS_THREAD(usb_serial_process, ev, data)
   usb_setup();
   usb_cdc_acm_setup();
   usb_set_global_event_process(&usb_serial_process);
+  usb_cdc_acm_set_event_process(&usb_serial_process);
   usb_set_ep_event_process(EPIN, &usb_serial_process);
   usb_set_ep_event_process(EPOUT, &usb_serial_process);
 


### PR DESCRIPTION
- For the CC2538, simplify handling of USB_CDC_ACM_LINE_STATE
  events. Ignore the Carrier Control (RTS) bit when receiving
  a SET_CONTROL_LINE _STATE request, we are a full duplex device.
- Improve behaviour of the CC2531 USB stick when there is no
  process on the host to read IN data. Basically, we adopt the
  CC2538 approach and we only send data when a DTE is present

Closes #196
