### PR TITLE
Replace twitter app with generic http-post-auth

### DIFF
--- a/apps/http-post-auth/Makefile.http-post-auth
+++ b/apps/http-post-auth/Makefile.http-post-auth
@@ -1,0 +1,2 @@
+http-post-auth_src = http-post-auth.c
+http-post-auth_dsc =

--- a/apps/http-post-auth/http-post-auth.h
+++ b/apps/http-post-auth/http-post-auth.h
@@ -30,9 +30,13 @@
  *
  */
 
-#ifndef __TWITTER_H__
-#define __TWITTER_H__
+#ifndef __HTTP_POST_AUTH_H__
+#define __HTTP_POST_AUTH_H__
 
-int twitter_post(const uint8_t *username_password, const char *message);
+#include "contiki-net.h"
 
-#endif /* __TWITTER_H__ */
+PROCESS_NAME(http_post_auth_process);
+
+int http_post_auth(const uint8_t *username_password, const char *message);
+
+#endif /* __HTTP_POST_AUTH_H__ */

--- a/apps/twitter/Makefile.twitter
+++ b/apps/twitter/Makefile.twitter
@@ -1,2 +1,0 @@
-twitter_src = twitter.c
-twitter_dsc =


### PR DESCRIPTION
Twitter removed http basic auth from the api in august 2010, but this
underlying code is a good example of doing http basic auth in contiki.

The app has been renamed, and some fixes applied to make it build
cleanly.

This fixes issue #207

I have not included an example in this pull, as there was no example before, but I have one locally if people think it should be added.

Here's a trace of it hitting my webserver:
==> /var/log/nginx/access.log <==
172.18.0.2 - karl [04/May/2013:12:13:21 +0000] "POST /statuses/update.json HTTP/1.1" 404 536 "-" "Contiki 2.x" "-"

==> /var/log/nginx/error.log <==
2013/05/04 12:13:24 [error] 803#0: *21 open() "/home/www/site/statuses/update.json" failed (2: No such file or directory), client: 172.18.0.2, server: _, request: "POST /statuses/update.json HTTP/1.1", host: "api.example.org"
