### PR TITLE
Limit partially size of uip/tcpip stack when not using TCP at all

### DIFF
--- a/core/net/tcpip.c
+++ b/core/net/tcpip.c
@@ -166,6 +166,7 @@ start_periodic_tcp_timer(void)
 static void
 check_for_tcp_syn(void)
 {
+#if UIP_TCP || UIP_CONF_IP_FORWARD
   /* This is a hack that is needed to start the periodic TCP timer if
      an incoming packet contains a SYN: since uIP does not inform the
      application if a SYN arrives, we have no other way of starting
@@ -176,6 +177,7 @@ check_for_tcp_syn(void)
      (UIP_TCP_BUF->flags & TCP_SYN) == TCP_SYN) {
     start_periodic_tcp_timer();
   }
+#endif /* UIP_TCP || UIP_CONF_IP_FORWARD */
 }
 /*---------------------------------------------------------------------------*/
 static void

--- a/core/net/uip.c
+++ b/core/net/uip.c
@@ -690,7 +690,7 @@ uip_process(uint8_t flag)
 	uip_flags = UIP_POLL;
 	UIP_APPCALL();
 	goto appsend;
-#if UIP_ACTIVE_OPEN
+#if UIP_ACTIVE_OPEN && UIP_TCP
     } else if((uip_connr->tcpstateflags & UIP_TS_MASK) == UIP_SYN_SENT) {
       /* In the SYN_SENT state, we retransmit out SYN. */
       BUF->flags = 0;
@@ -719,6 +719,7 @@ uip_process(uint8_t flag)
     uip_len = 0;
     uip_slen = 0;
 
+#if UIP_TCP
     /* Check if the connection is in a state in which we simply wait
        for the connection to time out. If so, we increase the
        connection's timer and remove the connection if it times
@@ -804,6 +805,7 @@ uip_process(uint8_t flag)
 	goto appsend;
       }
     }
+#endif
     goto drop;
   }
 #if UIP_UDP
@@ -951,11 +953,13 @@ uip_process(uint8_t flag)
   }
 #endif /* UIP_CONF_IPV6 */
 
+#if UIP_TCP
   if(BUF->proto == UIP_PROTO_TCP) { /* Check for TCP packet. If so,
 				       proceed with TCP input
 				       processing. */
     goto tcp_input;
   }
+#endif
 
 #if UIP_UDP
   if(BUF->proto == UIP_PROTO_UDP) {
@@ -1213,6 +1217,7 @@ uip_process(uint8_t flag)
 #endif /* UIP_UDP */
   
   /* TCP input processing. */
+#if UIP_TCP
  tcp_input:
   UIP_STAT(++uip_stat.tcp.recv);
 
@@ -1901,6 +1906,7 @@ uip_process(uint8_t flag)
   /* Calculate TCP checksum. */
   BUF->tcpchksum = 0;
   BUF->tcpchksum = ~(uip_tcpchksum());
+#endif
 
  ip_send_nolen:
 #if UIP_CONF_IPV6


### PR DESCRIPTION
This has proved to slightly lower the size of the tcp/ip stack when just using UDP. At the same time has been long tested and works fine with both TCP+UDP systems and UDP-only systems.

tadoº GmbH (www.tado.com)
