### PR TITLE
Corrects some leftover uncapitalized printfs

### DIFF
--- a/core/net/mac/contikimac.c
+++ b/core/net/mac/contikimac.c
@@ -215,7 +215,6 @@ static volatile uint8_t contikimac_keep_radio_on = 0;
 static volatile unsigned char we_are_sending = 0;
 static volatile unsigned char radio_is_on = 0;
 
-#undef DEBUG
 #define DEBUG 0
 #if DEBUG
 #include <stdio.h>

--- a/core/net/rime/collect.c
+++ b/core/net/rime/collect.c
@@ -193,7 +193,6 @@ struct {
 
 /* Debug definition: draw routing tree in Cooja. */
 #define DRAW_TREE 0
-#undef DEBUG
 #define DEBUG 0
 #if DEBUG
 #include <stdio.h>

--- a/core/net/uiplib.c
+++ b/core/net/uiplib.c
@@ -37,7 +37,6 @@
 #include "net/uiplib.h"
 #include <string.h>
 
-#undef DEBUG
 #define DEBUG DEBUG_NONE
 #include "net/uip-debug.h"
 


### PR DESCRIPTION
This may cause systems which do not implement printf to crash. The module has already defined PRINTF macro which is later on not used.

tadoº GmbH (www.tado.com)
