### PR TITLE
Use memcpy, memcmp functions for the rime cmp and cpy

### DIFF
--- a/core/net/rime/rimeaddr.c
+++ b/core/net/rime/rimeaddr.c
@@ -65,7 +65,7 @@ rimeaddr_copy(rimeaddr_t *dest, const rimeaddr_t *src)
 int
 rimeaddr_cmp(const rimeaddr_t *addr1, const rimeaddr_t *addr2)
 {
-	return (memcmp( addr1, addr2, RIMEADDR_SIZE) == 0);
+	return (memcmp(addr1, addr2, RIMEADDR_SIZE) == 0);
 }
 /*---------------------------------------------------------------------------*/
 void


### PR DESCRIPTION
memcpy and memcmp are used all over contiki. Why not use them here as well. This saves few bytes.

tadoº GmbH (www.tado.com)
