### PR TITLE
Fixes bug a node not using RPL joins a network which does

### DIFF
--- a/core/net/uip6.c
+++ b/core/net/uip6.c
@@ -52,7 +52,7 @@
  * statement. While it would be possible to break the uip_process()
  * function into many smaller functions, this would increase the code
  * size because of the overhead of parameter passing and the fact that
- * the optimier would not be as efficient.
+ * the optimizer would not be as efficient.
  *
  * The principle is that we have a small buffer, called the uip_buf,
  * in which the device driver puts an incoming packet. The TCP/IP
@@ -63,7 +63,7 @@
  * a byte stream if needed. The application will not be fed with data
  * that is out of sequence.
  *
- * If the application whishes to send data to the peer, it should put
+ * If the application wishes to send data to the peer, it should put
  * its data into the uip_buf. The uip_appdata pointer points to the
  * first available byte. The TCP/IP stack will calculate the
  * checksums, and fill in the necessary header fields and finally send
@@ -852,16 +852,24 @@ ext_hdr_options_process(void)
         PRINTF("Processing PADN option\n");
         uip_ext_opt_offset += UIP_EXT_HDR_OPT_PADN_BUF->opt_len + 2;
         break;
-#if UIP_CONF_IPV6_RPL
       case UIP_EXT_HDR_OPT_RPL:
+		/* Fixes situation when a node that is not using RPL
+		 * joins a network which does. The received packages will include the
+		 * RPL header and processed by the "default" case of the switch
+		 * (0x63 & 0xC0 = 0x40). Hence, the packet is discarded as the header
+		 * is considered invalid.
+		 * Using this fix, the header is ignored, and the next header (if
+		 * present) is processed.
+		 */
+#if UIP_CONF_IPV6_RPL
         PRINTF("Processing RPL option\n");
         if(rpl_verify_header(uip_ext_opt_offset)) {
           PRINTF("RPL Option Error: Dropping Packet\n");
           return 1;
         }
-        uip_ext_opt_offset += (UIP_EXT_HDR_OPT_RPL_BUF->opt_len) + 2;
-        return 0;
 #endif /* UIP_CONF_IPV6_RPL */
+        uip_ext_opt_offset += (UIP_EXT_HDR_OPT_BUF->len) + 2;
+        return 0;
       default:
         /*
          * check the two highest order bits of the option


### PR DESCRIPTION
The main problem is that the RPL header is send by the other nodes and processed by the non-rpl node, declared invalid and the packet dropped.

tadoº GmbH (www.tado.com)
