### PR TITLE
Force sicslowpan to use uip-debug rather than an own system

### DIFF
--- a/core/net/sicslowpan.c
+++ b/core/net/sicslowpan.c
@@ -72,7 +72,6 @@
 
 #include <stdio.h>
 
-#undef DEBUG
 #define DEBUG DEBUG_NONE
 #include "net/uip-debug.h"
 #if DEBUG


### PR DESCRIPTION
Most of the macros are already implemented. There's no need to implement them again.

tadoº GmbH (www.tado.com)
