### PR TITLE
Make driver names optional (names enabled by default)

### DIFF
--- a/core/net/mac/contikimac.c
+++ b/core/net/mac/contikimac.c
@@ -1065,7 +1065,7 @@ duty_cycle(void)
 }
 /*---------------------------------------------------------------------------*/
 const struct rdc_driver contikimac_driver = {
-#ifndef RDC_CONF_NO_DRIVER_NAMES
+#if RDC_DRIVER_NAMES
   "ContikiMAC",
 #endif
   init,

--- a/core/net/mac/csma.c
+++ b/core/net/mac/csma.c
@@ -396,7 +396,7 @@ init(void)
 }
 /*---------------------------------------------------------------------------*/
 const struct mac_driver csma_driver = {
-#ifndef MAC_CONF_NO_DRIVER_NAMES
+#if MAC_DRIVER_NAMES
   "CSMA",
 #endif
   init,

--- a/core/net/mac/cxmac.c
+++ b/core/net/mac/cxmac.c
@@ -925,7 +925,7 @@ channel_check_interval(void)
 /*---------------------------------------------------------------------------*/
 const struct rdc_driver cxmac_driver =
   {
-#ifndef RDC_CONF_NO_DRIVER_NAMES
+#if RDC_DRIVER_NAMES
     "CX-MAC",
 #endif
     cxmac_init,

--- a/core/net/mac/lpp.c
+++ b/core/net/mac/lpp.c
@@ -1042,7 +1042,7 @@ init(void)
 }
 /*---------------------------------------------------------------------------*/
 const struct rdc_driver lpp_driver = {
-#ifndef RDC_CONF_NO_DRIVER_NAMES
+#if RDC_DRIVER_NAMES
   "LPP",
 #endif
   init,

--- a/core/net/mac/mac.h
+++ b/core/net/mac/mac.h
@@ -43,6 +43,11 @@
 #include "contiki-conf.h"
 #include "dev/radio.h"
 
+#ifdef MAC_CONF_DRIVER_NAMES
+#define MAC_DRIVER_NAMES MAC_CONF_DRIVER_NAMES
+#else
+#define MAC_DRIVER_NAMES 1
+#endif
 
 typedef void (* mac_callback_t)(void *ptr, int status, int transmissions);
 
@@ -52,7 +57,7 @@ void mac_call_sent_callback(mac_callback_t sent, void *ptr, int status, int num_
  * The structure of a MAC protocol driver in Contiki.
  */
 struct mac_driver {
-#ifndef MAC_CONF_NO_DRIVER_NAMES
+#if MAC_DRIVER_NAMES
   char *name;
 #endif
 

--- a/core/net/mac/nullmac.c
+++ b/core/net/mac/nullmac.c
@@ -78,7 +78,7 @@ init(void)
 }
 /*---------------------------------------------------------------------------*/
 const struct mac_driver nullmac_driver = {
-#ifndef MAC_CONF_NO_DRIVER_NAMES
+#if MAC_DRIVER_NAMES
   "nullmac",
 #endif
   init,

--- a/core/net/mac/nullrdc-noframer.c
+++ b/core/net/mac/nullrdc-noframer.c
@@ -100,7 +100,7 @@ init(void)
 }
 /*---------------------------------------------------------------------------*/
 const struct rdc_driver nullrdc_noframer_driver = {
-#ifndef RDC_CONF_NO_DRIVER_NAMES
+#if RDC_DRIVER_NAMES
   "nullrdc-noframer",
 #endif
   init,

--- a/core/net/mac/nullrdc.c
+++ b/core/net/mac/nullrdc.c
@@ -337,7 +337,7 @@ init(void)
 }
 /*---------------------------------------------------------------------------*/
 const struct rdc_driver nullrdc_driver = {
-#ifndef RDC_CONF_NO_DRIVER_NAMES
+#if RDC_DRIVER_NAMES
   "nullrdc",
 #endif
   init,

--- a/core/net/mac/rdc.h
+++ b/core/net/mac/rdc.h
@@ -44,6 +44,12 @@
 #include "contiki-conf.h"
 #include "net/mac/mac.h"
 
+#ifdef RDC_CONF_DRIVER_NAMES
+#define RDC_DRIVER_NAMES RDC_CONF_DRIVER_NAMES
+#else
+#define RDC_DRIVER_NAMES 1
+#endif
+
 /* List of packets to be sent by RDC layer */
 struct rdc_buf_list {
   struct rdc_buf_list *next;
@@ -55,7 +61,7 @@ struct rdc_buf_list {
  * The structure of a RDC (radio duty cycling) driver in Contiki.
  */
 struct rdc_driver {
-#ifndef RDC_CONF_NO_DRIVER_NAMES
+#if RDC_DRIVER_NAMES
   char *name;
 #endif
 

--- a/core/net/mac/sicslowmac.c
+++ b/core/net/mac/sicslowmac.c
@@ -260,7 +260,7 @@ channel_check_interval(void)
 }
 /*---------------------------------------------------------------------------*/
 const struct rdc_driver sicslowmac_driver = {
-#ifndef RDC_CONF_NO_DRIVER_NAMES
+#if RDC_DRIVER_NAMES
   "sicslowmac",
 #endif
   init,

--- a/core/net/mac/xmac.c
+++ b/core/net/mac/xmac.c
@@ -1019,7 +1019,7 @@ channel_check_interval(void)
 /*---------------------------------------------------------------------------*/
 const struct rdc_driver xmac_driver =
   {
-#ifndef RDC_CONF_NO_DRIVER_NAMES
+#if RDC_DRIVER_NAMES
     "X-MAC",
 #endif
     init,

--- a/core/net/netstack.h
+++ b/core/net/netstack.h
@@ -96,6 +96,12 @@
 #endif /* NETSTACK_CONF_FRAMER */
 #endif /* NETSTACK_FRAMER */
 
+#ifdef NETSTACK_CONF_DRIVER_NAMES
+#define NETSTACK_DRIVER_NAMES NETSTACK_CONF_DRIVER_NAMES
+#else
+#define NETSTACK_DRIVER_NAMES 1
+#endif
+
 #include "net/mac/mac.h"
 #include "net/mac/rdc.h"
 #include "net/mac/framer.h"
@@ -105,7 +111,7 @@
  * The structure of a network driver in Contiki.
  */
 struct network_driver {
-#ifndef NETSTACK_CONF_NO_DRIVER_NAMES
+#if NETSTACK_DRIVER_NAMES
   char *name;
 #endif
 

--- a/core/net/rime/rime-udp.c
+++ b/core/net/rime/rime-udp.c
@@ -164,7 +164,7 @@ init(void)
 }
 /*---------------------------------------------------------------------------*/
 const struct mac_driver rime_udp_driver = {
-#ifndef MAC_CONF_NO_DRIVER_NAMES
+#if MAC_DRIVER_NAMES
   "rime-udp",
 #endif
   init,

--- a/core/net/rime/rime.c
+++ b/core/net/rime/rime.c
@@ -187,7 +187,7 @@ rime_output(struct channel *c)
 }
 /*---------------------------------------------------------------------------*/
 const struct network_driver rime_driver = {
-#ifndef NETSTACK_CONF_NO_DRIVER_NAMES
+#if NETSTACK_DRIVER_NAMES
   "Rime",
 #endif
   init,

--- a/core/net/sicslowpan.c
+++ b/core/net/sicslowpan.c
@@ -1879,7 +1879,7 @@ sicslowpan_init(void)
 }
 /*--------------------------------------------------------------------*/
 const struct network_driver sicslowpan_driver = {
-#ifndef NETSTACK_CONF_NO_DRIVER_NAMES
+#if NETSTACK_DRIVER_NAMES
   "sicslowpan",
 #endif
   sicslowpan_init,


### PR DESCRIPTION
It is unnecessary to have names on nodes which don't have neither a display nor debug output. Making them optional proved to save some bytes.

tadoº GmbH (www.tado.com)
