### PR TITLE
Hotfix contikimac inter packet interval

### DIFF
--- a/core/net/mac/contikimac.c
+++ b/core/net/mac/contikimac.c
@@ -194,7 +194,7 @@ static int we_are_receiving_burst = 0;
 #ifdef CONTIKIMAC_CONF_INTER_PACKET_INTERVAL
 #define INTER_PACKET_INTERVAL              CONTIKIMAC_CONF_INTER_PACKET_INTERVAL
 #else
-#define INTER_PACKET_INTERVAL              RTIMER_ARCH_SECOND / 5000
+#define INTER_PACKET_INTERVAL              RTIMER_ARCH_SECOND / 2500
 #endif
 
 /* AFTER_ACK_DETECTECT_WAIT_TIME is the time to wait after a potential


### PR DESCRIPTION
While doing range estimations with Zolertia Z1 motes, we observed important (>50%) message losses when using contikimac as RDC layer, while, with nullrdc, no message losses occurred in identical circumstances.

Setting debuging on in contikimac and in csma, we observed that, in fact all transmitted messages were correctly received, but the ack messages got lost, causing the transmitter to resend the messages a large number of times, with as result, dropping of new messages in the transmitter.

In the contikiMAC paper, Adam writes that the INTER_PACKET_INTERVAL should be 0.4 ms. However, in the current version of contikimac, this constant  is defined as`#define INTER_PACKET_INTERVAL  RTIMER_ARCH_SECOND / 5000`, which gives 0.2 ms.

Changing the 5000 by 2500 solved the problem. The ack messages no longer collide with the retransmitted frames and the contikimac protocol seems to work properly.

Bug found by Marie-Paule Uwase puwase@gmail.com, i'm just transmitting the pull request for her.
