### PR TITLE
Undo the change that made IPv6 the default

### DIFF
--- a/core/contiki-default-conf.h
+++ b/core/contiki-default-conf.h
@@ -114,7 +114,7 @@
 /* UIP_CONF_IPV6 specifies whether or not IPv6 should be used. If IPv6
    is not used, IPv4 is used instead. */
 #ifndef UIP_CONF_IPV6
-#define UIP_CONF_IPV6 1
+#define UIP_CONF_IPV6 0
 #endif /* UIP_CONF_IPV6 */
 
 /* UIP_CONF_BUFFER_SIZE specifies how much memory should be reserved


### PR DESCRIPTION
#178 (2d50a40) has changed the default from IPv4 to IPv6.

This change has introduced various build problems to various platforms and it was not intentional in the first place: (http://thread.gmane.org/gmane.os.contiki.devel/18010)

This commit reverts the default back to IPv4
