### PR TITLE
avr/radio/rf230bb: Cleanup and add hooks.

### DIFF
--- a/cpu/avr/radio/Makefile.radio
+++ b/cpu/avr/radio/Makefile.radio
@@ -7,7 +7,7 @@ endif
 
 ### Define RF230BB in the base makefile, or use $make RF230BB=1 ...
 ifeq ($(RF230BB),1)
-  CFLAGS                     += -DRF230BB
+  CFLAGS                     += -DRF230BB=1
   #Source for AT86RF230 barebones driver using the contiki core MAC
   include $(CONTIKI)/cpu/avr/radio/rf230bb/Makefile.rf230bb
 else

--- a/examples/ravenusbstick/Makefile.ravenusbstick
+++ b/examples/ravenusbstick/Makefile.ravenusbstick
@@ -8,4 +8,6 @@ CONTIKI_NO_NET=1
 
 CONTIKI = ../..
 
+CFLAGS += -DJACKDAW=1
+
 include $(CONTIKI)/Makefile.include

--- a/platform/avr-ravenusb/contiki-conf.h
+++ b/platform/avr-ravenusb/contiki-conf.h
@@ -94,6 +94,11 @@ void clock_adjust_ticks(clock_time_t howmany);
 #define RNG_CONF_USE_RADIO_CLOCK	    1
 //#define RNG_CONF_USE_ADC	1
 
+/* Turn on radio statistics */
+#ifndef RADIOSTATS
+#define RADIOSTATS	1
+#endif
+
 /* COM port to be used for SLIP connection. Not tested on Jackdaw. */
 #define SLIP_PORT RS232_PORT_0
 
@@ -142,13 +147,7 @@ static inline uint8_t radio_is_ready_to_send_() {
 #define USB_ETH_HOOK_HANDLE_INBOUND_PACKET(buffer,len)	do { uip_len = len ; mac_ethernetToLowpan(buffer); } while(0)
 #endif
 
-#ifndef USB_ETH_HOOK_SET_PROMISCIOUS_MODE
-#if RF230BB
 #define USB_ETH_HOOK_SET_PROMISCIOUS_MODE(value)	rf230_set_promiscuous_mode(value)
-#else		
-#define USB_ETH_HOOK_SET_PROMISCIOUS_MODE(value)	radio_set_trx_state(value?RX_ON:RX_AACK_ON)
-#endif
-#endif
 
 #ifndef USB_ETH_HOOK_INIT
 #define USB_ETH_HOOK_INIT()		mac_ethernetSetup()
@@ -211,11 +210,6 @@ extern void mac_log_802_15_4_rx(const uint8_t* buffer, size_t total_len);
 /* ************************************************************************** */
 /* Network setup. The new NETSTACK interface requires RF230BB (as does ip4) */
 /* These mostly have no effect when the Jackdaw is a repeater (CONTIKI_NO_NET=1 using fakeuip.c) */
-
-#if RF230BB
-#else
-#define PACKETBUF_CONF_HDR_SIZE    0         //RF230 combined driver/mac handles headers internally
-#endif /*RF230BB */
 
 #if UIP_CONF_IPV6
 #define RIMEADDR_CONF_SIZE       8

--- a/platform/avr-ravenusb/sicslow_ethernet.h
+++ b/platform/avr-ravenusb/sicslow_ethernet.h
@@ -48,11 +48,6 @@
 #ifndef SICSLOW_ETHERNET_H
 #define SICSLOW_ETHERNET_H
 
-#if !RF230BB
-#include "sicslowmac.h"
-#include "frame.h"
-#endif
-
 typedef enum {
     ll_802154_type,
 	ll_8023_type
@@ -71,7 +66,9 @@ typedef struct {
 
 #define UIP_ETHTYPE_802154 0x809A
 
-extern usbstick_mode_t usbstick_mode;
+
+extern usbstick_mode_t usbstick_mode; // TODO: Rename!
+extern uint64_t macLongAddr;
 
 
 int8_t mac_translateIcmpLinkLayer(lltype_t target);
@@ -79,10 +76,6 @@ int8_t mac_translateIPLinkLayer(lltype_t target);
 void mac_LowpanToEthernet(void);
 void mac_ethernetToLowpan(uint8_t * ethHeader);
 void mac_ethernetSetup(void);
-#if !RF230BB
-void mac_802154raw(const struct mac_driver *r);
-void mac_logTXtoEthernet(frame_create_params_t *p,frame_result_t *frame_result);
-#endif
 
 #endif
 


### PR DESCRIPTION
Removes references to the old rf230 code, which isn't being used anymore.

This commit needs a little more cleanup before merging, but I wanted to go ahead and submit the pull request to get some feedback on the changes.