### PR TITLE
platform/avr-ravenusb: Move management of LED status to dedicated thread.

### DIFF
--- a/platform/avr-ravenusb/Makefile.avr-ravenusb
+++ b/platform/avr-ravenusb/Makefile.avr-ravenusb
@@ -28,6 +28,7 @@ CONTIKI_TARGET_SOURCEFILES +=   cfs-eeprom.c eeprom.c random.c \
                                 mmem.c contiki-raven-default-init-lowlevel.c \
                                 contiki-raven-default-init-net.c contiki-raven-main.c httpd-simple-avr.c \
                                 sicslow_ethernet.c queuebuf.c packetbuf.c rng.c \
+                                status-leds.c \
                 $(RPL) \
                 $(USB)
 

--- a/platform/avr-ravenusb/cdc_task.c
+++ b/platform/avr-ravenusb/cdc_task.c
@@ -747,14 +747,14 @@ uint16_t p=(uint16_t)&__bss_end;
 							accRSSI[i-11]+=RSSI;
 						}
 						if(j&(1<<7)) {
-							LedVCP_on();
+							jackdaw_led_VCP_on();
 							if(!(j&((1<<7)-1))) {
 								PRINTF_P(PSTR("."));
 								uart_usb_flush();
 							}
 						}
 						else
-							LedVCP_off();
+							jackdaw_led_VCP_off();
 						watchdog_periodic();
 					}
 #if RF230BB

--- a/platform/avr-ravenusb/cdc_task.c
+++ b/platform/avr-ravenusb/cdc_task.c
@@ -104,10 +104,6 @@ extern char usb_busy;
 //! Counter for USB Serial port
 extern U8    tx_counter;
 
-//! Timers for LEDs
-uint8_t led3_timer;
-
-
 //! previous configuration
 static uint8_t previous_uart_usb_control_line_state = 0;
 
@@ -148,10 +144,6 @@ PROCESS_THREAD(cdc_process, ev, data_proc)
 #endif
 
 	while(1) {
-	    // turn off LED's if necessary
-		if (led3_timer) led3_timer--;
-		else			Led3_off();
-		
  		if(Is_device_enumerated()) {
 			// If the configuration is different than the last time we checked...
 			if((uart_usb_get_control_line_state()&1)!=previous_uart_usb_control_line_state) {
@@ -755,14 +747,14 @@ uint16_t p=(uint16_t)&__bss_end;
 							accRSSI[i-11]+=RSSI;
 						}
 						if(j&(1<<7)) {
-							Led3_on();
+							LedVCP_on();
 							if(!(j&((1<<7)-1))) {
 								PRINTF_P(PSTR("."));
 								uart_usb_flush();
 							}
 						}
 						else
-							Led3_off();
+							LedVCP_off();
 						watchdog_periodic();
 					}
 #if RF230BB
@@ -856,14 +848,5 @@ uint16_t p=(uint16_t)&__bss_end;
 
 }
 
-
-/**
-    @brief This will enable the VCP_TRX_END LED for a period
-*/
-void vcptx_end_led(void)
-{
-    Led3_on();
-    led3_timer = 5;
-}
 /** @}  */
 

--- a/platform/avr-ravenusb/contiki-conf.h
+++ b/platform/avr-ravenusb/contiki-conf.h
@@ -94,6 +94,11 @@ void clock_adjust_ticks(clock_time_t howmany);
 #define RNG_CONF_USE_RADIO_CLOCK	    1
 //#define RNG_CONF_USE_ADC	1
 
+/* Enable the alternate LED scheme, which avoids burning out your retina with the blue LED. */
+#ifndef JACKDAW_CONF_ALT_LED_SCHEME
+#define JACKDAW_CONF_ALT_LED_SCHEME		1
+#endif
+
 /* COM port to be used for SLIP connection. Not tested on Jackdaw. */
 #define SLIP_PORT RS232_PORT_0
 
@@ -137,6 +142,9 @@ static inline uint8_t radio_is_ready_to_send_() {
 #define	USB_ETH_HOOK_IS_READY_FOR_INBOUND_PACKET()		radio_is_ready_to_send_()
 #endif
 #endif
+#define USB_HOOK_UNENUMERATED()		status_leds_unenumerated()
+#define USB_ETH_HOOK_READY()		status_leds_ready()
+#define USB_ETH_HOOK_INACTIVE()		status_leds_inactive()
 
 #ifndef USB_ETH_HOOK_HANDLE_INBOUND_PACKET
 #define USB_ETH_HOOK_HANDLE_INBOUND_PACKET(buffer,len)	do { uip_len = len ; mac_ethernetToLowpan(buffer); } while(0)
@@ -158,8 +166,8 @@ static inline uint8_t radio_is_ready_to_send_() {
 //#pragma mark RF230BB Hooks
 /* ************************************************************************** */
 
-//#define RF230BB_HOOK_RADIO_OFF()	Led1_off()
-//#define RF230BB_HOOK_RADIO_ON()		Led1_on()
+#define RF230BB_HOOK_RADIO_OFF()                 status_leds_radio_off()
+#define RF230BB_HOOK_RADIO_ON()                  status_leds_radio_on()
 #define RF230BB_HOOK_TX_PACKET(buffer,total_len) mac_log_802_15_4_tx(buffer,total_len)
 #define RF230BB_HOOK_RX_PACKET(buffer,total_len) mac_log_802_15_4_rx(buffer,total_len)
 #define	RF230BB_HOOK_IS_SEND_ENABLED()	mac_is_send_enabled()
@@ -172,9 +180,10 @@ extern void mac_log_802_15_4_rx(const uint8_t* buffer, size_t total_len);
 //#pragma mark USB CDC-ACM (UART) Hooks
 /* ************************************************************************** */
 
-#define USB_CDC_ACM_HOOK_TX_END(char)			vcptx_end_led()
-#define USB_CDC_ACM_HOOK_CLS_CHANGED(state)		vcptx_end_led()
-#define USB_CDC_ACM_HOOK_CONFIGURED()			vcptx_end_led()
+#define USB_CDC_ACM_HOOK_RX(char)				status_leds_serial_rx()
+#define USB_CDC_ACM_HOOK_TX_END(char)			status_leds_serial_tx()
+#define USB_CDC_ACM_HOOK_CLS_CHANGED(state)		status_leds_serial_rx()
+#define USB_CDC_ACM_HOOK_CONFIGURED()			status_leds_serial_rx()
 
 /* ************************************************************************** */
 //#pragma mark Serial Port Settings

--- a/platform/avr-ravenusb/contiki-raven-main.c
+++ b/platform/avr-ravenusb/contiki-raven-main.c
@@ -64,6 +64,8 @@
 #include "contiki-lib.h"
 #include "contiki-raven.h"
 
+#include "status-leds.h"
+
 /* Set ANNOUNCE to send boot messages to USB or RS232 serial port */
 #define ANNOUNCE 1
 
@@ -560,6 +562,8 @@ uint16_t p=(uint16_t)&__bss_end;
 #if USB_CONF_STORAGE
   process_start(&storage_process, NULL);
 #endif
+
+  process_start(&status_leds_process, NULL);
 
   /* Autostart other processes */
   /* There are none in the default build so autostart_processes will be unresolved in the link. */

--- a/platform/avr-ravenusb/contiki-raven.h
+++ b/platform/avr-ravenusb/contiki-raven.h
@@ -43,7 +43,12 @@
 #include "contiki-net.h"
 #include "contiki-lib.h"
 
-// LED's for Raven USB
+/* LED's for Raven USB
+ * Led0 = Blue
+ * Led1 = Red
+ * Led2 = Green
+ * Led3 = Orange
+ */
 #define Leds_init()                 (DDRD  |=  0xA0, DDRE  |=  0xC0)
 #define Led0_on()                   (PORTD |=  0x80)
 #define Led1_on()                   (PORTD &= ~0x20)
@@ -60,6 +65,67 @@
 #define Leds_on()                   (Led0_on(),Led1_on(),Led2_on(),Led3_on())
 #define Leds_off()                  (Led0_off(),Led1_off(),Led2_off(),Led3_off())
 
+#if I_HATE_BLUE_LEDS || JACKDAW_CONF_ALT_LED_SCHEME
+/*	The original LED scheme of this platform
+ *	used the blue LED pretty much as a power light,
+ *	leaving it on continuously after USB enumeration.
+ *	This was driving me CRAZY, so I changed the scheme
+ *	around a bit so that the orange LED is now used
+ *	for status. I think this is much better, and
+ *	here is why:
+ *
+ *	* Blue LEDs are annoyingly blury to look at,
+ *	  causing eye strain in the long term.
+ *	* The Rods (the non-color sensitive cells) on your
+ *	  retina are more sensitive to blue wavelengths than
+ *	  any other wavelength. This is what makes blue
+ *	  LEDs seem so blindingly bright in a dark room. This
+ *	  is called the Purkinje effect.
+ *
+ *	Thus, I think it is best to reserve the blue LED
+ *	for the *least* used function: the VCP activity LED.
+ *
+ *	My scheme also reverses the red and green LEDs, so that
+ *	(R)ed is (R)eceive (from the radio's perspective).
+ *
+ *	References:
+ *	 * <http://van.physics.illinois.edu/qa/listing.php?id=1871>
+ *	 * <http://texyt.com/bright+blue+leds+annoyance+health+risks>
+ *	 * <http://en.wikipedia.org/wiki/Purkinje_effect>
+ *
+ *	- darco (11-15-2010)
+ */
+#define LedRX_on()          Led1_on()
+#define LedRX_off()         Led1_off()
+
+#define LedTX_on()          Led2_on()
+#define LedTX_off()         Led2_off()
+
+#define LedSTAT_on()        Led3_on()
+#define LedSTAT_off()       Led3_off()
+#define LedSTAT_toggle()    Led3_toggle()
+
+#define LedVCP_on()         Led0_on()
+#define LedVCP_off()        Led0_off()
+#define LedVCP_toggle()     Led0_toggle()
+
+#else /* !(I_HATE_BLUE_LEDS || JACKDAW_CONF_ALT_LED_SCHEME) */
+
+#define LedRX_on()          Led1_on()
+#define LedRX_off()         Led1_off()
+
+#define LedTX_on()          Led2_on()
+#define LedTX_off()         Led2_off()
+
+#define LedSTAT_on()        Led0_on()
+#define LedSTAT_off()       Led0_off()
+#define LedSTAT_toggle()    Led0_toggle()
+
+#define LedVCP_on()         Led3_on()
+#define LedVCP_off()        Led3_off()
+#define LedVCP_toggle()     Led3_toggle()
+
+#endif /* !(I_HATE_BLUE_LEDS || JACKDAW_CONF_ALT_LED_SCHEME) */
 
 void init_lowlevel(void);
 void init_net(void);

--- a/platform/avr-ravenusb/contiki-raven.h
+++ b/platform/avr-ravenusb/contiki-raven.h
@@ -95,35 +95,35 @@
  *
  *	- darco (11-15-2010)
  */
-#define LedRX_on()          Led1_on()
-#define LedRX_off()         Led1_off()
+#define jackdaw_led_RX_on()          Led1_on()
+#define jackdaw_led_RX_off()         Led1_off()
 
-#define LedTX_on()          Led2_on()
-#define LedTX_off()         Led2_off()
+#define jackdaw_led_TX_on()          Led2_on()
+#define jackdaw_led_TX_off()         Led2_off()
 
-#define LedSTAT_on()        Led3_on()
-#define LedSTAT_off()       Led3_off()
-#define LedSTAT_toggle()    Led3_toggle()
+#define jackdaw_led_STAT_on()        Led3_on()
+#define jackdaw_led_STAT_off()       Led3_off()
+#define jackdaw_led_STAT_toggle()    Led3_toggle()
 
-#define LedVCP_on()         Led0_on()
-#define LedVCP_off()        Led0_off()
-#define LedVCP_toggle()     Led0_toggle()
+#define jackdaw_led_VCP_on()         Led0_on()
+#define jackdaw_led_VCP_off()        Led0_off()
+#define jackdaw_led_VCP_toggle()     Led0_toggle()
 
 #else /* !(I_HATE_BLUE_LEDS || JACKDAW_CONF_ALT_LED_SCHEME) */
 
-#define LedRX_on()          Led1_on()
-#define LedRX_off()         Led1_off()
+#define jackdaw_led_RX_on()          Led1_on()
+#define jackdaw_led_RX_off()         Led1_off()
 
-#define LedTX_on()          Led2_on()
-#define LedTX_off()         Led2_off()
+#define jackdaw_led_TX_on()          Led2_on()
+#define jackdaw_led_TX_off()         Led2_off()
 
-#define LedSTAT_on()        Led0_on()
-#define LedSTAT_off()       Led0_off()
-#define LedSTAT_toggle()    Led0_toggle()
+#define jackdaw_led_STAT_on()        Led0_on()
+#define jackdaw_led_STAT_off()       Led0_off()
+#define jackdaw_led_STAT_toggle()    Led0_toggle()
 
-#define LedVCP_on()         Led3_on()
-#define LedVCP_off()        Led3_off()
-#define LedVCP_toggle()     Led3_toggle()
+#define jackdaw_led_VCP_on()         Led3_on()
+#define jackdaw_led_VCP_off()        Led3_off()
+#define jackdaw_led_VCP_toggle()     Led3_toggle()
 
 #endif /* !(I_HATE_BLUE_LEDS || JACKDAW_CONF_ALT_LED_SCHEME) */
 

--- a/platform/avr-ravenusb/sicslow_ethernet.c
+++ b/platform/avr-ravenusb/sicslow_ethernet.c
@@ -236,6 +236,7 @@
 #endif
 #include "rndis/rndis_protocol.h"
 #include "rndis/rndis_task.h"
+#include "status-leds.h"
 
 #include <stdint.h>
 #include <stdio.h>
@@ -964,6 +965,7 @@ void slide(uint8_t * data, uint8_t length, int16_t slide)
 
 void
 mac_log_802_15_4_tx(const uint8_t* buffer, size_t total_len) {
+  status_leds_radio_tx();
   if (usbstick_mode.raw != 0) {
     uint8_t sendlen;
 
@@ -1007,6 +1009,7 @@ mac_log_802_15_4_tx(const uint8_t* buffer, size_t total_len) {
 
 void
 mac_log_802_15_4_rx(const uint8_t* buf, size_t len) {
+  status_leds_radio_rx();
   if (usbstick_mode.raw != 0) {
     uint8_t sendlen;
 

--- a/platform/avr-ravenusb/status-leds.c
+++ b/platform/avr-ravenusb/status-leds.c
@@ -71,12 +71,12 @@ PROCESS_THREAD(status_leds_process, ev, data_proc)
 
     if(etimer_expired(&et_indicator)) {
       if(device_status_indicator == STATUS_LED_READY) {
-        LedSTAT_on();
+        jackdaw_led_STAT_on();
       } else if(device_status_indicator == STATUS_LED_INACTIVE) {
-        LedSTAT_toggle();
+        jackdaw_led_STAT_toggle();
         etimer_set(&et_indicator, (CLOCK_SECOND / 8));
       } else {
-        LedSTAT_toggle();
+        jackdaw_led_STAT_toggle();
         etimer_set(&et_indicator, (CLOCK_SECOND / 3));
       }
     }
@@ -84,33 +84,38 @@ PROCESS_THREAD(status_leds_process, ev, data_proc)
     if(etimer_expired(&et)) {
       if(0 != ledRX_timer) {
         ledRX_timer--;
-        if(ledRX_timer & (1 << 1))
-          LedRX_on();
-        else
-          LedRX_off();
+        if(ledRX_timer & (1 << 1)) {
+          jackdaw_led_RX_on();
+        } else {
+          jackdaw_led_RX_off();
+        }
       } else
-        LedRX_off();
+        jackdaw_led_RX_off();
 
       if(0 != ledTX_timer) {
         ledTX_timer--;
-        if(ledTX_timer & (1 << 1))
-          LedTX_on();
-        else
-          LedTX_off();
+        if(ledTX_timer & (1 << 1)) {
+          jackdaw_led_TX_on();
+        } else {
+          jackdaw_led_TX_off();
+        }
       } else
-        LedTX_off();
+        jackdaw_led_TX_off();
 
       if(0 != ledVCP_timer) {
         ledVCP_timer--;
-        if(ledVCP_timer & (1 << 2))
-          LedVCP_on();
-        else
-          LedVCP_off();
-      } else
-        LedVCP_off();
+        if(ledVCP_timer & (1 << 2)) {
+          jackdaw_led_VCP_on();
+        } else {
+          jackdaw_led_VCP_off();
+        }
+      } else {
+        jackdaw_led_VCP_off();
+      }
 
-      if(ledRX_timer || ledTX_timer || ledVCP_timer)
+      if(ledRX_timer || ledTX_timer || ledVCP_timer) {
         etimer_restart(&et);
+      }
     }
   } /* while(1) */
 
@@ -121,33 +126,39 @@ PROCESS_THREAD(status_leds_process, ev, data_proc)
 void
 status_leds_radio_tx()
 {
-  if(!(ledRX_timer || ledTX_timer || ledVCP_timer))
+  if(!(ledRX_timer || ledTX_timer || ledVCP_timer)) {
     process_poll(&status_leds_process);
+  }
   ledTX_timer |= (1 << 2);
-  if(((ledTX_timer - 1) & (1 << 1)))
-    LedTX_on();
+  if(((ledTX_timer - 1) & (1 << 1))) {
+    jackdaw_led_TX_on();
+  }
 }
 
 /*---------------------------------------------------------------------------*/
 void
 status_leds_radio_rx()
 {
-  if(!(ledRX_timer || ledTX_timer || ledVCP_timer))
+  if(!(ledRX_timer || ledTX_timer || ledVCP_timer)) {
     process_poll(&status_leds_process);
+  }
   ledRX_timer |= (1 << 2);
-  if(((ledRX_timer - 1) & (1 << 1)))
-    LedRX_on();
+  if(((ledRX_timer - 1) & (1 << 1))) {
+    jackdaw_led_RX_on();
+  }
 }
 
 /*---------------------------------------------------------------------------*/
 void
 status_leds_serial_tx()
 {
-  if(!(ledRX_timer || ledTX_timer || ledVCP_timer))
+  if(!(ledRX_timer || ledTX_timer || ledVCP_timer)) {
     process_poll(&status_leds_process);
+  }
   ledVCP_timer |= (1 << 3);
-  if(((ledVCP_timer - 1) & (1 << 2)))
-    LedVCP_on();
+  if(((ledVCP_timer - 1) & (1 << 2))) {
+    jackdaw_led_VCP_on();
+  }
 }
 
 /*---------------------------------------------------------------------------*/
@@ -163,8 +174,9 @@ static bool radio_is_on;
 void
 status_leds_radio_on()
 {
-  if(!radio_is_on)
+  if(!radio_is_on) {
     status_leds_serial_tx();
+  }
   radio_is_on = true;
 }
 
@@ -200,14 +212,16 @@ status_leds_ready()
 void
 status_leds_will_sleep()
 {
-  if(STATUS_LED_READY == device_status_indicator)
-    LedSTAT_off();
+  if(STATUS_LED_READY == device_status_indicator) {
+    jackdaw_led_STAT_off();
+  }
 }
 
 /*---------------------------------------------------------------------------*/
 void
 status_leds_did_wake()
 {
-  if(STATUS_LED_READY == device_status_indicator)
-    LedSTAT_on();
+  if(STATUS_LED_READY == device_status_indicator) {
+    jackdaw_led_STAT_on();
+  }
 }

--- a/platform/avr-ravenusb/status-leds.c
+++ b/platform/avr-ravenusb/status-leds.c
@@ -1,0 +1,213 @@
+/**
+ * \file
+ *         Controls the status LEDs on the RZUSBStick.
+ * \author
+ *         Robert Quattlebaum <darco@deepdarc.com>
+ *
+ */
+
+/*
+ * Copyright (c) 2013, Robert Quattlebaum.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * This file is part of the Contiki operating system.
+ *
+ * Author: Robert Quattlebaum <darco@deepdarc.com>
+ *
+ */
+
+#include "status-leds.h"
+
+PROCESS(status_leds_process, "Status LEDs");
+
+static uint8_t ledRX_timer, ledTX_timer, ledVCP_timer;
+
+static enum {
+  STATUS_LED_UNENUMERATED,
+  STATUS_LED_INACTIVE,
+  STATUS_LED_READY
+} device_status_indicator;
+
+/*---------------------------------------------------------------------------*/
+PROCESS_THREAD(status_leds_process, ev, data_proc)
+{
+  static struct etimer et;
+
+  static struct etimer et_indicator;
+
+  PROCESS_BEGIN();
+
+  Leds_init();
+
+  etimer_set(&et, CLOCK_SECOND / 30);
+  etimer_set(&et_indicator, CLOCK_SECOND / 8);
+
+  while(1) {
+    PROCESS_YIELD();
+
+    if(etimer_expired(&et_indicator)) {
+      if(device_status_indicator == STATUS_LED_READY) {
+        LedSTAT_on();
+      } else if(device_status_indicator == STATUS_LED_INACTIVE) {
+        LedSTAT_toggle();
+        etimer_set(&et_indicator, (CLOCK_SECOND / 8));
+      } else {
+        LedSTAT_toggle();
+        etimer_set(&et_indicator, (CLOCK_SECOND / 3));
+      }
+    }
+
+    if(etimer_expired(&et)) {
+      if(0 != ledRX_timer) {
+        ledRX_timer--;
+        if(ledRX_timer & (1 << 1))
+          LedRX_on();
+        else
+          LedRX_off();
+      } else
+        LedRX_off();
+
+      if(0 != ledTX_timer) {
+        ledTX_timer--;
+        if(ledTX_timer & (1 << 1))
+          LedTX_on();
+        else
+          LedTX_off();
+      } else
+        LedTX_off();
+
+      if(0 != ledVCP_timer) {
+        ledVCP_timer--;
+        if(ledVCP_timer & (1 << 2))
+          LedVCP_on();
+        else
+          LedVCP_off();
+      } else
+        LedVCP_off();
+
+      if(ledRX_timer || ledTX_timer || ledVCP_timer)
+        etimer_restart(&et);
+    }
+  } /* while(1) */
+
+  PROCESS_END();
+}
+
+/*---------------------------------------------------------------------------*/
+void
+status_leds_radio_tx()
+{
+  if(!(ledRX_timer || ledTX_timer || ledVCP_timer))
+    process_poll(&status_leds_process);
+  ledTX_timer |= (1 << 2);
+  if(((ledTX_timer - 1) & (1 << 1)))
+    LedTX_on();
+}
+
+/*---------------------------------------------------------------------------*/
+void
+status_leds_radio_rx()
+{
+  if(!(ledRX_timer || ledTX_timer || ledVCP_timer))
+    process_poll(&status_leds_process);
+  ledRX_timer |= (1 << 2);
+  if(((ledRX_timer - 1) & (1 << 1)))
+    LedRX_on();
+}
+
+/*---------------------------------------------------------------------------*/
+void
+status_leds_serial_tx()
+{
+  if(!(ledRX_timer || ledTX_timer || ledVCP_timer))
+    process_poll(&status_leds_process);
+  ledVCP_timer |= (1 << 3);
+  if(((ledVCP_timer - 1) & (1 << 2)))
+    LedVCP_on();
+}
+
+/*---------------------------------------------------------------------------*/
+void
+status_leds_serial_rx()
+{
+  status_leds_serial_tx();
+}
+
+static bool radio_is_on;
+
+/*---------------------------------------------------------------------------*/
+void
+status_leds_radio_on()
+{
+  if(!radio_is_on)
+    status_leds_serial_tx();
+  radio_is_on = true;
+}
+
+/*---------------------------------------------------------------------------*/
+void
+status_leds_radio_off()
+{
+  radio_is_on = false;
+}
+
+/*---------------------------------------------------------------------------*/
+void
+status_leds_unenumerated()
+{
+  device_status_indicator = STATUS_LED_UNENUMERATED;
+}
+
+/*---------------------------------------------------------------------------*/
+void
+status_leds_inactive()
+{
+  device_status_indicator = STATUS_LED_INACTIVE;
+}
+
+/*---------------------------------------------------------------------------*/
+void
+status_leds_ready()
+{
+  device_status_indicator = STATUS_LED_READY;
+}
+
+/*---------------------------------------------------------------------------*/
+void
+status_leds_will_sleep()
+{
+  if(STATUS_LED_READY == device_status_indicator)
+    LedSTAT_off();
+}
+
+/*---------------------------------------------------------------------------*/
+void
+status_leds_did_wake()
+{
+  if(STATUS_LED_READY == device_status_indicator)
+    LedSTAT_on();
+}

--- a/platform/avr-ravenusb/status-leds.h
+++ b/platform/avr-ravenusb/status-leds.h
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2013, Robert Quattlebaum.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * This file is part of the Contiki operating system.
+ *
+ * Author: Robert Quattlebaum <darco@deepdarc.com>
+ *
+ */
+
+#ifndef __STATUS_LEDS_H__
+#define __STATUS_LEDS_H__
+
+#include "contiki.h"
+#include "config.h"
+
+PROCESS_NAME(status_leds_process);
+
+void status_leds_radio_tx();
+
+void status_leds_radio_rx();
+
+void status_leds_radio_on();
+
+void status_leds_radio_off();
+
+void status_leds_serial_tx();
+
+void status_leds_serial_rx();
+
+void status_leds_unenumerated();
+
+void status_leds_inactive();
+
+void status_leds_ready();
+
+void status_leds_will_sleep();
+
+void status_leds_did_wake();
+
+#endif // __STATUS_LEDS_H__


### PR DESCRIPTION
This change creates a new thread for managing the LEDs on the Atmel
RZUSBStick hardware. It provides a simple interface for manipulating
the LEDs and makes sure that they are managed in a visually-pleasing
manner, while also providing a hardware abstraction layer.

I've been holding onto this one for a while. Once this is merged in, I think it
will be time for some of the more significant jackdaw patches.