### PR TITLE
resolv: Fix for bad NSEC record on announce

### DIFF
--- a/core/net/resolv.c
+++ b/core/net/resolv.c
@@ -635,6 +635,8 @@ mdns_prep_host_announce_packet(void)
 
   memcpy((void *)queryptr, (void *)&nsec_record, sizeof(nsec_record));
 
+  queryptr += sizeof(nsec_record);
+
   /* This platform might be picky about alignment. To avoid the possibility
    * of doing an unaligned write, we are going to do this manually. */
   ((uint8_t*)&hdr->numanswers)[1] = total_answers;


### PR DESCRIPTION
Forgot to move the pointer to past the NSEC record. This was causing the incorrect packet length to be returned.
