### PR TITLE
native/net/tapdev: Fix for new `UIP_CONF_IPV6` handling.

### DIFF
--- a/cpu/native/net/tapdev-drv.c
+++ b/cpu/native/net/tapdev-drv.c
@@ -31,6 +31,8 @@
  */
 
 #include "contiki-net.h"
+#include "net/uip.h"
+#include "net/uipopt.h"
 
 #if UIP_CONF_IPV6
 #include "tapdev6.h"

--- a/cpu/native/net/tapdev.c
+++ b/cpu/native/net/tapdev.c
@@ -33,6 +33,11 @@
  *
  */
 
+#include "net/uip.h"
+#include "net/uipopt.h"
+
+#if !UIP_CONF_IPV6
+
 #include <fcntl.h>
 #include <stdlib.h>
 #include <stdio.h>
@@ -198,3 +203,5 @@ tapdev_exit(void)
 {
 }
 /*---------------------------------------------------------------------------*/
+
+#endif /* !UIP_CONF_IPV6 */

--- a/cpu/native/net/tapdev6.c
+++ b/cpu/native/net/tapdev6.c
@@ -33,6 +33,10 @@
  *
  */
 
+#include "net/uip.h"
+#include "net/uipopt.h"
+
+#if UIP_CONF_IPV6
 
 #include <fcntl.h>
 #include <stdlib.h>
@@ -413,3 +417,5 @@ tapdev_exit(void)
   close(fd);
 }
 /*---------------------------------------------------------------------------*/
+
+#endif /* UIP_CONF_IPV6 */

--- a/platform/minimal-net/Makefile.minimal-net
+++ b/platform/minimal-net/Makefile.minimal-net
@@ -14,13 +14,7 @@ CONTIKI_TARGET_SOURCEFILES = contiki-main.c clock.c leds.c leds-arch.c cfs-posix
 ifeq ($(HOST_OS),Windows)
 CONTIKI_TARGET_SOURCEFILES += wpcap-drv.c wpcap.c
 else
-CONTIKI_TARGET_SOURCEFILES += tapdev-drv.c
-#math
-ifneq ($(UIP_CONF_IPV6),1)
-CONTIKI_TARGET_SOURCEFILES += tapdev.c
-else
-CONTIKI_TARGET_SOURCEFILES += tapdev6.c
-endif
+CONTIKI_TARGET_SOURCEFILES += tapdev-drv.c tapdev.c tapdev6.c
 endif
 
 CONTIKI_SOURCEFILES += $(CONTIKI_TARGET_SOURCEFILES)


### PR DESCRIPTION
I noticed that IPv6 with tapdev on the minimal-net platform was busted.
