### PR TITLE
Fixing minimal-net for Cygwin.

### DIFF
--- a/platform/minimal-net/contiki-main.c
+++ b/platform/minimal-net/contiki-main.c
@@ -358,7 +358,11 @@ main(void)
 	serial_line_input_byte(c);
       }
     }
+#ifdef __CYGWIN__
+    process_poll(&wpcap_process);
+#else
     process_poll(&tapdev_process);
+#endif
     etimer_request_poll();
   }
   


### PR DESCRIPTION
minimal-net did not compile under Cygwin because of a missing #ifdef **CYGWIN**.

There are still issues for many examples related to #249. The build system parameters require a clean-up throughout all platforms and examples (UIP_CONF_IPV6, WITH_UIPV6, UIP_CONF_IPV6_RPL, UIP_CONF_RPL, and make variable vs define).
