### PR TITLE
Makefile.include: support make clean all

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -107,9 +107,6 @@ target_makefile := $(wildcard $(CONTIKI)/platform/$(TARGET)/Makefile.$(TARGET) $
 ifeq ($(strip $(target_makefile)),)
   ${error The target platform "$(TARGET)" does not exist (maybe it was misspelled?)}
 else
-  ifeq (${wildcard $(OBJECTDIR)},)
-    DUMMY := ${shell mkdir $(OBJECTDIR)}
-  endif
   ifneq (1, ${words $(target_makefile)})
     ${error More than one TARGET Makefile found: $(target_makefile)}
   endif
@@ -175,12 +172,14 @@ endif
 
 ifndef CUSTOM_RULE_C_TO_OBJECTDIR_O
 $(OBJECTDIR)/%.o: %.c
+	@mkdir -p $(OBJECTDIR)
 	$(CC) $(CFLAGS) -MMD -c $< -o $@
 	@$(FINALIZE_DEPENDENCY)
 endif
 
 ifndef CUSTOM_RULE_S_TO_OBJECTDIR_O
 $(OBJECTDIR)/%.o: %.S
+	@mkdir -p $(OBJECTDIR)
 	$(AS) $(ASFLAGS) -o $@ $<
 endif
 

--- a/cpu/6502/Makefile.6502
+++ b/cpu/6502/Makefile.6502
@@ -74,6 +74,7 @@ AROPTS  = a
 
 CUSTOM_RULE_C_TO_OBJECTDIR_O = 1
 $(OBJECTDIR)/%.o: %.c
+	@mkdir -p $(OBJECTDIR)
 	$(CC) -c -o $@ $(CFLAGS) --create-dep $(@:.o=.d) $<
 
 CUSTOM_RULE_C_TO_CO = 1

--- a/cpu/arm/at91sam7s/Makefile.at91sam7s
+++ b/cpu/arm/at91sam7s/Makefile.at91sam7s
@@ -96,21 +96,25 @@ CUSTOM_RULE_C_TO_O=yes
 	$(CC) $(CFLAGS) $(ARM_FLAGS) $< -c
 
 $(OBJECTDIR)/%-interrupt.o: %-interrupt.c
+	@mkdir -p $(OBJECTDIR)
 	$(CC) $(CFLAGS) $(ARM_FLAGS) -c $< -o $@
 
 %-arm.o: %-arm.c
 	$(CC) $(CFLAGS) $(ARM_FLAGS) $< -c
 
 $(OBJECTDIR)/%-arm.o: %-arm.c
+	@mkdir -p $(OBJECTDIR)
 	$(CC) $(CFLAGS) $(ARM_FLAGS) -c $< -o $@
 
 $(OBJECTDIR)/interrupt-utils.o: interrupt-utils.c
+	@mkdir -p $(OBJECTDIR)
 	$(CC) $(CFLAGS) $(ARM_FLAGS) $< -c -o $@
 
 %.o: %.c
 	$(CC) $(CFLAGS) $(THUMB_FLAGS) $< -c
 
 $(OBJECTDIR)/%.o: %.c
+	@mkdir -p $(OBJECTDIR)
 	$(CC) $(CFLAGS) $(THUMB_FLAGS) -c $< -o $@
 
 CUSTOM_RULE_S_TO_OBJECTDIR_O = yes
@@ -118,6 +122,7 @@ CUSTOM_RULE_S_TO_OBJECTDIR_O = yes
 	$(CC) $(CFLAGS) $(ARM_FLAGS) $< -c
 
 $(OBJECTDIR)/%.o: %.S
+	@mkdir -p $(OBJECTDIR)
 	$(CC) $(CFLAGS) $(ARM_FLAGS) $< -c  -o $@
 
 
@@ -189,6 +194,7 @@ ocd_reset:
 
 # Don't use core/loader/elfloader.c, use elfloader-otf.c instead
 $(OBJECTDIR)/elfloader.o: 
+	@mkdir -p $(OBJECTDIR)
 	echo -n >$@
 
 clean: clean_cpu

--- a/cpu/arm/stm32f103/Makefile.stm32f103
+++ b/cpu/arm/stm32f103/Makefile.stm32f103
@@ -95,6 +95,7 @@ CUSTOM_RULE_C_TO_O=yes
 	$(CC) $(CFLAGS) $< -c
 
 $(OBJECTDIR)/%.o: %.c
+	@mkdir -p $(OBJECTDIR)
 	$(CC) $(CFLAGS) -c $< -o $@
 
 
@@ -103,6 +104,7 @@ CUSTOM_RULE_S_TO_OBJECTDIR_O = yes
 	$(CC) $(CFLAGS) $< -c
 
 $(OBJECTDIR)/%.o: %.S
+	@mkdir -p $(OBJECTDIR)
 	$(CC) $(CFLAGS) $< -c  -o $@
 
 
@@ -176,6 +178,7 @@ ocd_reset:
 
 # Don't use core/loader/elfloader.c, use elfloader-otf.c instead
 $(OBJECTDIR)/elfloader.o: 
+	@mkdir -p $(OBJECTDIR)
 	echo -n >$@
 
 clean: clean_cpu

--- a/cpu/avr/Makefile.avr
+++ b/cpu/avr/Makefile.avr
@@ -123,6 +123,7 @@ CONTIKI_TARGET_DIRS_CONCAT = ${addprefix $(CONTIKI)/platform/$(TARGET)/, \
 ### Compilation rules
 
 $(OBJECTDIR)/%.o: %.c
+	@mkdir -p $(OBJECTDIR)
 	$(CC) $(CFLAGS) -c $< -o $@
 
 %.o: %.c

--- a/cpu/cc2430/Makefile.cc2430
+++ b/cpu/cc2430/Makefile.cc2430
@@ -117,6 +117,7 @@ SEGMENT_RULE_FILES = $(foreach dir, . $(CONTIKI_PLATFORM_DIRS) \
 	$(CONTIKI_CPU_DIRS_LIST), $(wildcard $(dir)/segment.rules) )
 
 $(SEGMENT_RULES): $(SEGMENT_RULE_FILES)
+	@mkdir -p $(OBJECTDIR)
 	cat $(SEGMENT_RULE_FILES) | \
 	   sed -e 's/#.*$$//' -e 's/^\s*//' -e '/^$$/d' > $@
 
@@ -125,10 +126,12 @@ CUSTOM_RULE_C_TO_OBJECTDIR_O=1
 CUSTOM_RULE_ALLOBJS_TO_TARGETLIB=1
 
 $(OBJECTDIR)/%.rel: %.c $(SEGMENT_RULES)
+	@mkdir -p $(OBJECTDIR)
 	$(CC) $(call c_seg,$<,$@) $(CFLAGS) -c $< -o $@ -Wp,-MMD,$(@:.rel=.d),-MQ,$@
 	@$(FINALIZE_SDCC_DEPENDENCY)
 
 $(OBJECTDIR)/%.rel: %.cS
+	@mkdir -p $(OBJECTDIR)
 	cp $< $(OBJECTDIR)/$*.c
 	$(CC) $(CFLAGS) -E $(OBJECTDIR)/$*.c > $(OBJECTDIR)/tmp
 	perl -pe "s/^#(.*)/;$$1/" $(OBJECTDIR)/tmp > $(OBJECTDIR)/$*.S
@@ -145,6 +148,7 @@ contiki-$(TARGET).lib: $(CONTIKI_OBJECTFILES) $(PROJECT_OBJECTFILES) \
 # build app/example local object files. We need a separate rule so that we can
 # pass -DAUTOSTART_ENABLE for those files only
 $(OBJECTDIR)/%.app.rel: %.c $(SEGMENT_RULES)
+	@mkdir -p $(OBJECTDIR)
 	$(CC) $(call c_seg,$<,$@) -DAUTOSTART_ENABLE $(CFLAGS) -c $< -o $@
 
 # .ihx is the sdcc binary output file

--- a/cpu/cc2538/Makefile.cc2538
+++ b/cpu/cc2538/Makefile.cc2538
@@ -60,6 +60,7 @@ CONTIKI_SOURCEFILES += $(USB_CORE_SOURCEFILES) $(USB_ARCH_SOURCEFILES)
 FORCE:
 
 $(OBJECTDIR)/ieee-addr.o: ieee-addr.c FORCE
+	@mkdir -p $(OBJECTDIR)
 	$(CC) $(CFLAGS) -c $< -o $@
 
 ### Compilation rules
@@ -83,4 +84,5 @@ LDGENFLAGS += -imacros "contiki-conf.h"
 LDGENFLAGS += -P -E
 
 $(LDSCRIPT): $(CONTIKI_CPU)/cc2538.lds FORCE
+	@mkdir -p $(dir $(LDSCRIPT))
 	$(CPP) $(LDGENFLAGS) $< -o $@

--- a/cpu/cc253x/Makefile.cc253x
+++ b/cpu/cc253x/Makefile.cc253x
@@ -146,10 +146,12 @@ CUSTOM_RULE_C_TO_OBJECTDIR_O=1
 CUSTOM_RULE_ALLOBJS_TO_TARGETLIB=1
 
 $(OBJECTDIR)/%.rel: %.c $(SEGMENT_RULES)
+	@mkdir -p $(OBJECTDIR)
 	$(CC) $(call c_seg,$<,$@) $(CFLAGS) -c $< -o $@ -Wp,-MMD,$(@:.rel=.d),-MQ,$@
 	@$(FINALIZE_SDCC_DEPENDENCY)
 
 $(OBJECTDIR)/%.rel: %.cS
+	@mkdir -p $(OBJECTDIR)
 	cp $< $(OBJECTDIR)/$*.c
 	$(CC) $(CFLAGS) -E $(OBJECTDIR)/$*.c > $(OBJECTDIR)/tmp
 	perl -pe "s/^#(.*)/;$$1/" $(OBJECTDIR)/tmp > $(OBJECTDIR)/$*.S
@@ -166,6 +168,7 @@ contiki-$(TARGET).lib: $(CONTIKI_OBJECTFILES) $(PROJECT_OBJECTFILES) \
 # build app/example local object files. We need a separate rule so that we can
 # pass -DAUTOSTART_ENABLE for those files only
 $(OBJECTDIR)/%.app.rel: %.c $(SEGMENT_RULES)
+	@mkdir -p $(OBJECTDIR)
 	$(CC) $(call c_seg,$<,$@) -DAUTOSTART_ENABLE $(CFLAGS) -c $< -o $@
 
 # .ihx is the sdcc binary output file

--- a/cpu/mc1322x/Makefile.mc1322x
+++ b/cpu/mc1322x/Makefile.mc1322x
@@ -81,20 +81,24 @@ else
 endif
 
 $(OBJECTDIR)/%.lds: $(CONTIKI_CPU)/%.lds.S
+	@mkdir -p $(OBJECTDIR)
 	$(CPP) $(CPPFLAGS) $< > $@
 
 $(OBJECTDIR)/isr.o: $(CONTIKI_CPU)/src/isr.c
+	@mkdir -p $(OBJECTDIR)
 	$(CC) $(CFLAGS) $(ARM_FLAGS) $< -c -o $@
 
 %.o: %.c
 	$(CC) $(CFLAGS) $(THUMB_FLAGS) $< -c
 
 $(OBJECTDIR)/%.o: %.c
+	@mkdir -p $(OBJECTDIR)
 	$(CC) $(CFLAGS) $(THUMB_FLAGS) -c $< -o $@
 
 CUSTOM_RULE_S_TO_OBJECTDIR_O = yes
 
 $(OBJECTDIR)/%.o: %.S
+	@mkdir -p $(OBJECTDIR)
 	$(CC) $(CFLAGS) $(AFLAGS) $(ARM_FLAGS) $< -c  -o $@
 
 CUSTOM_RULE_C_TO_CO=yes

--- a/cpu/msp430/Makefile.msp430
+++ b/cpu/msp430/Makefile.msp430
@@ -98,6 +98,7 @@ endef
 
 CUSTOM_RULE_C_TO_OBJECTDIR_O = 1
 $(OBJECTDIR)/%.o: %.c
+	@mkdir -p $(OBJECTDIR)
 	$(CC) $(CFLAGS) $< --dependencies=m $(@:.o=.P) -o $@
 ifeq ($(HOST_OS),Windows)
 	@$(FINALIZE_CYGWIN_DEPENDENCY)

--- a/cpu/stm32w108/Makefile.stm32w108
+++ b/cpu/stm32w108/Makefile.stm32w108
@@ -217,6 +217,7 @@ endif
 
 CUSTOM_RULE_C_TO_OBJECTDIR_O = 1
 $(OBJECTDIR)/%.o: %.c
+	@mkdir -p $(OBJECTDIR)
 	$(CC) $(CFLAGS) $< --dependencies=m $(@:.o=.P) -o $@
 	@$(SEDCOMMAND); rm -f $(@:.o=.P)
 	@$(FINALIZE_DEPENDENCY)
@@ -271,9 +272,11 @@ stm-motes:
 	@echo $(MOTES)
 
 $(OBJECTDIR)/%.o: %.s79
+	@mkdir -p $(OBJECTDIR)
 	$(AS) $(ASFLAGS) -o $@ $<
 
 $(OBJECTDIR)/%.o: %.s
+	@mkdir -p $(OBJECTDIR)
 	$(AS) $(ASFLAGS) -o $@ $<
 
 %.bin: %.$(TARGET)

--- a/cpu/z80/Makefile.z80
+++ b/cpu/z80/Makefile.z80
@@ -57,10 +57,12 @@ vpath %.cS $(CONTIKI_PLATFORM_DIRS)
 
 #option -MMD doesn't work well on SDCC as of 2.9.0
 $(OBJECTDIR)/%.o: %.c
+	@mkdir -p $(OBJECTDIR)
 	$(CC) $(CFLAGS) -c $< -o $@
 
 ifndef CUSTOM_RULE_CS_TO_OBJECTDIR_O
 $(OBJECTDIR)/%.o: %.cS
+	@mkdir -p $(OBJECTDIR)
 	cp $< $(OBJECTDIR)/$*.c
 	$(CC) $(CFLAGS) -E $(OBJECTDIR)/$*.c > $(OBJECTDIR)/tmp
 	perl -pe "s/^#(.*)/;$$1/" $(OBJECTDIR)/tmp > $(OBJECTDIR)/$*.S

--- a/platform/cooja/Makefile.cooja
+++ b/platform/cooja/Makefile.cooja
@@ -92,9 +92,11 @@ REDEF_PRINTF=1 # Redefine functions to enable printf()s inside Cooja
 
 ### Define custom targets
 $(ARCHIVE): ${addprefix $(OBJECTDIR)/, $(CONTIKI_SOURCEFILES:.c=.o)}
+	@mkdir -p $(dir $(ARCHIVE))
 	$(AR_COMMAND_1) $^ $(AR_COMMAND_2)
 
 $(JNILIB): $(CONTIKI_APP_OBJ) $(MAIN_OBJ) $(PROJECT_OBJECTFILES) $(ARCHIVE)
+	@mkdir -p $(dir $(JNILIB))
 ifdef SYMBOLS
 	@echo Generating symbols
 	# Recreate symbols file and relink with final memory layout (twice)

--- a/platform/win32/Makefile.win32
+++ b/platform/win32/Makefile.win32
@@ -84,6 +84,7 @@ VCFLAGS = -Od -Z7 $(filter-out -Wall -g -O,$(CFLAGS))
 
 CUSTOM_RULE_C_TO_OBJECTDIR_O = 1
 $(OBJECTDIR)/%.o: %.c
+	@mkdir -p $(OBJECTDIR)
 	cl -nologo $(VCFLAGS) -c $< -Fo$@
 	@makedepend $(CFLAGS) -o.o -f- $< 2> nul: | sed -e s!$(<:.c=.o)!$@! -e s!\\!/!g > $(@:.o=.d)
 

--- a/tools/z80/hex2bin/Makefile
+++ b/tools/z80/hex2bin/Makefile
@@ -14,10 +14,6 @@ OBJECTS		= ${addprefix $(OBJECTDIR)/,$(SOURCES:.c=.o)}
 
 vpath %.c $(SOURCEDIR)
 
-ifeq (${wildcard $(OBJECTDIR)},)
-  DUMMY := ${shell mkdir $(OBJECTDIR)}
-endif
-
 hexameter: $(OBJECTS)
 	$(CC) $(CFLAGS) -o $@ $(OBJECTS)
 
@@ -27,5 +23,6 @@ clean:
 	rm -f *~ hexameter hexameter.exe
 
 $(OBJECTDIR)/%.o: %.c
+	@mkdir -p $(OBJECTDIR)
 	$(CC) $(CFLAGS) -c $< -o $@
 


### PR DESCRIPTION
(Feature requested in discussion of #254)

Historically $(OBJECTDIR) was created when Makefile.include is read.  A consequence is that combining "clean" with "all" (or any other build target) results in an error because the clean removes the object directory that is required to exist when building dependencies.  Creating $(OBJECTDIR) on-demand ensures it is present when needed.

Removed creation of $(OBJECTDIR) on initial read, and added creation of destination directory to all Makefile\* rules that include $(OBJECTDIR) in the target but do not clearly require $(OBJECTDIR) to exist in the dependencies.  Note that some of these occur when the target is a make variable that defaults to a value that includes $(OBJECTDIR).
