### PR TITLE
Made use of Atari XL shadow RAM.

### DIFF
--- a/platform/atarixl/Makefile.atarixl
+++ b/platform/atarixl/Makefile.atarixl
@@ -37,6 +37,10 @@ CONTIKI_CPU = $(CONTIKI)/cpu/6502
 include $(CONTIKI_CPU)/Makefile.6502
 
 STARTADDR_FLAG = -S 0x2300
+SHADOW_RAM_SOURCEFILES = tcpip.c uip.c uip_arp.c
+
+# Set a target-specific variable value
+${addprefix $(OBJECTDIR)/,${call oname, $(SHADOW_RAM_SOURCEFILES)}}: CFLAGS += --code-name SHADOW_RAM
 
 ifeq ($(MAKECMDGOALS),disk)
   ifndef DIR2ATR

--- a/platform/atarixl/contiki-conf.h
+++ b/platform/atarixl/contiki-conf.h
@@ -59,9 +59,12 @@
 
 #define WWW_CONF_WEBPAGE_WIDTH      40
 #define WWW_CONF_WEBPAGE_HEIGHT     19
-#define WWW_CONF_HISTORY_SIZE        0
+#define WWW_CONF_HISTORY_SIZE        4
 #define WWW_CONF_MAX_URLLEN         80
 #define WWW_CONF_MAX_NUMPAGEWIDGETS 20
-#define WWW_CONF_FORMS               0
+#define WWW_CONF_FORMS               1
+#define WWW_CONF_MAX_FORMACTIONLEN  20
+#define WWW_CONF_MAX_INPUTNAMELEN   20
+#define WWW_CONF_MAX_INPUTVALUELEN  20
 
 #endif /* __CONTIKI_CONF_H__ */


### PR DESCRIPTION
The new Atari XL target allows cc65 programs to make use of
the shadow RAM. This allows to turn aon all features of the
web browser - and will allow for additional improvements to
come :-)
