### PR TITLE
Add support for subdirectories in CLEAN and for "make clean all"

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -86,6 +86,10 @@ CONTIKI_OBJECTFILES = ${addprefix $(OBJECTDIR)/,${call oname, $(CONTIKI_SOURCEFI
 
 PROJECT_OBJECTFILES = ${addprefix $(OBJECTDIR)/,${call oname, $(PROJECT_SOURCEFILES)}}
 
+# Provide way to create $(OBJECTDIR) if it has been removed by make clean
+$(OBJECTDIR):
+	mkdir $@
+
 ### Include application makefiles
 
 ifdef APPS
@@ -108,9 +112,6 @@ target_makefile := $(wildcard $(CONTIKI)/platform/$(TARGET)/Makefile.$(TARGET) $
 ifeq ($(strip $(target_makefile)),)
   ${error The target platform "$(TARGET)" does not exist (maybe it was misspelled?)}
 else
-  ifeq (${wildcard $(OBJECTDIR)},)
-    DUMMY := ${shell mkdir $(OBJECTDIR)}
-  endif
   ifneq (1, ${words $(target_makefile)})
     ${error More than one TARGET Makefile found: $(target_makefile)}
   endif
@@ -190,13 +191,13 @@ ifndef CUSTOM_RULE_C_TO_CE
 endif
 
 ifndef CUSTOM_RULE_C_TO_OBJECTDIR_O
-$(OBJECTDIR)/%.o: %.c
+$(OBJECTDIR)/%.o: %.c | $(OBJECTDIR)
 	$(CC) $(CFLAGS) -MMD -c $< -o $@
 	@$(FINALIZE_DEPENDENCY)
 endif
 
 ifndef CUSTOM_RULE_S_TO_OBJECTDIR_O
-$(OBJECTDIR)/%.o: %.S
+$(OBJECTDIR)/%.o: %.S | $(OBJECTDIR)
 	$(AS) $(ASFLAGS) -o $@ $<
 endif
 

--- a/cpu/6502/Makefile.6502
+++ b/cpu/6502/Makefile.6502
@@ -73,7 +73,7 @@ AROPTS  = a
 .SUFFIXES:
 
 CUSTOM_RULE_C_TO_OBJECTDIR_O = 1
-$(OBJECTDIR)/%.o: %.c
+$(OBJECTDIR)/%.o: %.c | $(OBJECTDIR)
 	$(CC) -c -o $@ $(CFLAGS) --create-dep $(@:.o=.d) $<
 
 CUSTOM_RULE_C_TO_CO = 1

--- a/cpu/arm/at91sam7s/Makefile.at91sam7s
+++ b/cpu/arm/at91sam7s/Makefile.at91sam7s
@@ -95,29 +95,29 @@ CUSTOM_RULE_C_TO_O=yes
 %-interrupt.o: %-interrupt.c
 	$(CC) $(CFLAGS) $(ARM_FLAGS) $< -c
 
-$(OBJECTDIR)/%-interrupt.o: %-interrupt.c
+$(OBJECTDIR)/%-interrupt.o: %-interrupt.c | $(OBJECTDIR)
 	$(CC) $(CFLAGS) $(ARM_FLAGS) -c $< -o $@
 
 %-arm.o: %-arm.c
 	$(CC) $(CFLAGS) $(ARM_FLAGS) $< -c
 
-$(OBJECTDIR)/%-arm.o: %-arm.c
+$(OBJECTDIR)/%-arm.o: %-arm.c | $(OBJECTDIR)
 	$(CC) $(CFLAGS) $(ARM_FLAGS) -c $< -o $@
 
-$(OBJECTDIR)/interrupt-utils.o: interrupt-utils.c
+$(OBJECTDIR)/interrupt-utils.o: interrupt-utils.c | $(OBJECTDIR)
 	$(CC) $(CFLAGS) $(ARM_FLAGS) $< -c -o $@
 
 %.o: %.c
 	$(CC) $(CFLAGS) $(THUMB_FLAGS) $< -c
 
-$(OBJECTDIR)/%.o: %.c
+$(OBJECTDIR)/%.o: %.c | $(OBJECTDIR)
 	$(CC) $(CFLAGS) $(THUMB_FLAGS) -c $< -o $@
 
 CUSTOM_RULE_S_TO_OBJECTDIR_O = yes
 %.o: %.S
 	$(CC) $(CFLAGS) $(ARM_FLAGS) $< -c
 
-$(OBJECTDIR)/%.o: %.S
+$(OBJECTDIR)/%.o: %.S | $(OBJECTDIR)
 	$(CC) $(CFLAGS) $(ARM_FLAGS) $< -c  -o $@
 
 
@@ -188,7 +188,7 @@ ocd_reset:
 	cd $(CONTIKI_CPU)/openocd;$(OPENOCD) -f $(OPENOCD_CFG) -c init -c reset -c exit
 
 # Don't use core/loader/elfloader.c, use elfloader-otf.c instead
-$(OBJECTDIR)/elfloader.o: 
+$(OBJECTDIR)/elfloader.o: | $(OBJECTDIR)
 	echo -n >$@
 
 clean: clean_cpu

--- a/cpu/arm/stm32f103/Makefile.stm32f103
+++ b/cpu/arm/stm32f103/Makefile.stm32f103
@@ -94,7 +94,7 @@ CUSTOM_RULE_C_TO_O=yes
 %.o: %.c
 	$(CC) $(CFLAGS) $< -c
 
-$(OBJECTDIR)/%.o: %.c
+$(OBJECTDIR)/%.o: %.c | $(OBJECTDIR)
 	$(CC) $(CFLAGS) -c $< -o $@
 
 
@@ -102,7 +102,7 @@ CUSTOM_RULE_S_TO_OBJECTDIR_O = yes
 %.o: %.S
 	$(CC) $(CFLAGS) $< -c
 
-$(OBJECTDIR)/%.o: %.S
+$(OBJECTDIR)/%.o: %.S | $(OBJECTDIR)
 	$(CC) $(CFLAGS) $< -c  -o $@
 
 
@@ -175,7 +175,7 @@ ocd_reset:
 	$(OPENOCD) -s $(OPENOCD_DIR) -f $(OPENOCD_CFG) -c init -c "reset halt;resume" -c exit
 
 # Don't use core/loader/elfloader.c, use elfloader-otf.c instead
-$(OBJECTDIR)/elfloader.o: 
+$(OBJECTDIR)/elfloader.o: | $(OBJECTDIR)
 	echo -n >$@
 
 clean: clean_cpu

--- a/cpu/avr/Makefile.avr
+++ b/cpu/avr/Makefile.avr
@@ -122,7 +122,7 @@ CONTIKI_TARGET_DIRS_CONCAT = ${addprefix $(CONTIKI)/platform/$(TARGET)/, \
 
 ### Compilation rules
 
-$(OBJECTDIR)/%.o: %.c
+$(OBJECTDIR)/%.o: %.c | $(OBJECTDIR)
 	$(CC) $(CFLAGS) -c $< -o $@
 
 %.o: %.c

--- a/cpu/cc2430/Makefile.cc2430
+++ b/cpu/cc2430/Makefile.cc2430
@@ -116,7 +116,8 @@ PROJECT_OBJECTFILES = $(addprefix $(OBJECTDIR)/, \
 SEGMENT_RULE_FILES = $(foreach dir, . $(CONTIKI_PLATFORM_DIRS) \
 	$(CONTIKI_CPU_DIRS_LIST), $(wildcard $(dir)/segment.rules) )
 
-$(SEGMENT_RULES): $(SEGMENT_RULE_FILES)
+# NB: Assumes SEGMENT_RULES was not overridden and is in $(OBJECTDIR)
+$(SEGMENT_RULES): $(SEGMENT_RULE_FILES) | $(OBJECTDIR)
 	cat $(SEGMENT_RULE_FILES) | \
 	   sed -e 's/#.*$$//' -e 's/^\s*//' -e '/^$$/d' > $@
 
@@ -124,11 +125,11 @@ CUSTOM_RULE_LINK=1
 CUSTOM_RULE_C_TO_OBJECTDIR_O=1
 CUSTOM_RULE_ALLOBJS_TO_TARGETLIB=1
 
-$(OBJECTDIR)/%.rel: %.c $(SEGMENT_RULES)
+$(OBJECTDIR)/%.rel: %.c $(SEGMENT_RULES) | $(OBJECTDIR)
 	$(CC) $(call c_seg,$<,$@) $(CFLAGS) -c $< -o $@ -Wp,-MMD,$(@:.rel=.d),-MQ,$@
 	@$(FINALIZE_SDCC_DEPENDENCY)
 
-$(OBJECTDIR)/%.rel: %.cS
+$(OBJECTDIR)/%.rel: %.cS | $(OBJECTDIR)
 	cp $< $(OBJECTDIR)/$*.c
 	$(CC) $(CFLAGS) -E $(OBJECTDIR)/$*.c > $(OBJECTDIR)/tmp
 	perl -pe "s/^#(.*)/;$$1/" $(OBJECTDIR)/tmp > $(OBJECTDIR)/$*.S
@@ -144,7 +145,7 @@ contiki-$(TARGET).lib: $(CONTIKI_OBJECTFILES) $(PROJECT_OBJECTFILES) \
 
 # build app/example local object files. We need a separate rule so that we can
 # pass -DAUTOSTART_ENABLE for those files only
-$(OBJECTDIR)/%.app.rel: %.c $(SEGMENT_RULES)
+$(OBJECTDIR)/%.app.rel: %.c $(SEGMENT_RULES) | $(OBJECTDIR)
 	$(CC) $(call c_seg,$<,$@) -DAUTOSTART_ENABLE $(CFLAGS) -c $< -o $@
 
 # .ihx is the sdcc binary output file

--- a/cpu/cc2538/Makefile.cc2538
+++ b/cpu/cc2538/Makefile.cc2538
@@ -59,7 +59,7 @@ CONTIKI_SOURCEFILES += $(USB_CORE_SOURCEFILES) $(USB_ARCH_SOURCEFILES)
 ### Always re-build ieee-addr.o in case the command line passes a new NODEID
 FORCE:
 
-$(OBJECTDIR)/ieee-addr.o: ieee-addr.c FORCE
+$(OBJECTDIR)/ieee-addr.o: ieee-addr.c FORCE | $(OBJECTDIR)
 	$(CC) $(CFLAGS) -c $< -o $@
 
 ### Compilation rules
@@ -82,5 +82,6 @@ LDGENFLAGS += $(addprefix -I,$(SOURCEDIRS))
 LDGENFLAGS += -imacros "contiki-conf.h"
 LDGENFLAGS += -P -E
 
-$(LDSCRIPT): $(CONTIKI_CPU)/cc2538.lds FORCE
+# NB: Assumes LDSCRIPT was not overridden and is in $(OBJECTDIR)
+$(LDSCRIPT): $(CONTIKI_CPU)/cc2538.lds FORCE | $(OBJECTDIR)
 	$(CPP) $(LDGENFLAGS) $< -o $@

--- a/cpu/cc253x/Makefile.cc253x
+++ b/cpu/cc253x/Makefile.cc253x
@@ -137,7 +137,8 @@ PROJECT_OBJECTFILES = $(addprefix $(OBJECTDIR)/, \
 SEGMENT_RULE_FILES = $(foreach dir, . $(CONTIKI_PLATFORM_DIRS) \
 	$(CONTIKI_CPU_DIRS_LIST), $(wildcard $(dir)/segment.rules) )
 
-$(SEGMENT_RULES): $(SEGMENT_RULE_FILES)
+# NB: Assumes SEGMENT_RULES was not overridden and is in $(OBJECTDIR)
+$(SEGMENT_RULES): $(SEGMENT_RULE_FILES) | $(OBJECTDIR)
 	cat $(SEGMENT_RULE_FILES) | \
 	   sed -e 's/#.*$$//' -e 's/^\s*//' -e '/^$$/d' > $@
 
@@ -145,11 +146,11 @@ CUSTOM_RULE_LINK=1
 CUSTOM_RULE_C_TO_OBJECTDIR_O=1
 CUSTOM_RULE_ALLOBJS_TO_TARGETLIB=1
 
-$(OBJECTDIR)/%.rel: %.c $(SEGMENT_RULES)
+$(OBJECTDIR)/%.rel: %.c $(SEGMENT_RULES) | $(OBJECTDIR)
 	$(CC) $(call c_seg,$<,$@) $(CFLAGS) -c $< -o $@ -Wp,-MMD,$(@:.rel=.d),-MQ,$@
 	@$(FINALIZE_SDCC_DEPENDENCY)
 
-$(OBJECTDIR)/%.rel: %.cS
+$(OBJECTDIR)/%.rel: %.cS | $(OBJECTDIR)
 	cp $< $(OBJECTDIR)/$*.c
 	$(CC) $(CFLAGS) -E $(OBJECTDIR)/$*.c > $(OBJECTDIR)/tmp
 	perl -pe "s/^#(.*)/;$$1/" $(OBJECTDIR)/tmp > $(OBJECTDIR)/$*.S
@@ -165,7 +166,7 @@ contiki-$(TARGET).lib: $(CONTIKI_OBJECTFILES) $(PROJECT_OBJECTFILES) \
 
 # build app/example local object files. We need a separate rule so that we can
 # pass -DAUTOSTART_ENABLE for those files only
-$(OBJECTDIR)/%.app.rel: %.c $(SEGMENT_RULES)
+$(OBJECTDIR)/%.app.rel: %.c $(SEGMENT_RULES) | $(OBJECTDIR)
 	$(CC) $(call c_seg,$<,$@) -DAUTOSTART_ENABLE $(CFLAGS) -c $< -o $@
 
 # .ihx is the sdcc binary output file

--- a/cpu/mc1322x/Makefile.mc1322x
+++ b/cpu/mc1322x/Makefile.mc1322x
@@ -73,28 +73,28 @@ CFLAGS += -I$(OBJECTDIR) -I$(CONTIKI_CPU)/board -DBOARD=$(TARGET)
 CPPFLAGS += -P -C ${addprefix -D,${subst $(COMMA), ,$(DEFINES)}}
 
 
-$(OBJECTDIR)/board.h: $(OBJECTDIR) 
+$(OBJECTDIR)/board.h: $(CONTIKI_CPU)/board/board.h | $(OBJECTDIR)
 ifeq ($(HOST_OS),Windows)
-	ln -f $(CONTIKI_CPU)/board/board.h $(OBJECTDIR)/board.h
+	ln -f $< $@
 else
-	ln -sf ../$(CONTIKI_CPU)/board/board.h $(OBJECTDIR)/board.h
+	ln -sf ../$< $@
 endif
 
-$(OBJECTDIR)/%.lds: $(CONTIKI_CPU)/%.lds.S
+$(OBJECTDIR)/%.lds: $(CONTIKI_CPU)/%.lds.S | $(OBJECTDIR)
 	$(CPP) $(CPPFLAGS) $< > $@
 
-$(OBJECTDIR)/isr.o: $(CONTIKI_CPU)/src/isr.c
+$(OBJECTDIR)/isr.o: $(CONTIKI_CPU)/src/isr.c | $(OBJECTDIR)
 	$(CC) $(CFLAGS) $(ARM_FLAGS) $< -c -o $@
 
 %.o: %.c
 	$(CC) $(CFLAGS) $(THUMB_FLAGS) $< -c
 
-$(OBJECTDIR)/%.o: %.c
+$(OBJECTDIR)/%.o: %.c | $(OBJECTDIR)
 	$(CC) $(CFLAGS) $(THUMB_FLAGS) -c $< -o $@
 
 CUSTOM_RULE_S_TO_OBJECTDIR_O = yes
 
-$(OBJECTDIR)/%.o: %.S
+$(OBJECTDIR)/%.o: %.S | $(OBJECTDIR)
 	$(CC) $(CFLAGS) $(AFLAGS) $(ARM_FLAGS) $< -c  -o $@
 
 CUSTOM_RULE_C_TO_CO=yes

--- a/cpu/msp430/Makefile.msp430
+++ b/cpu/msp430/Makefile.msp430
@@ -97,7 +97,7 @@ rm -f $(@:.o=.P)
 endef
 
 CUSTOM_RULE_C_TO_OBJECTDIR_O = 1
-$(OBJECTDIR)/%.o: %.c
+$(OBJECTDIR)/%.o: %.c | $(OBJECTDIR)
 	$(CC) $(CFLAGS) $< --dependencies=m $(@:.o=.P) -o $@
 ifeq ($(HOST_OS),Windows)
 	@$(FINALIZE_CYGWIN_DEPENDENCY)

--- a/cpu/stm32w108/Makefile.stm32w108
+++ b/cpu/stm32w108/Makefile.stm32w108
@@ -216,7 +216,7 @@ endif
 
 
 CUSTOM_RULE_C_TO_OBJECTDIR_O = 1
-$(OBJECTDIR)/%.o: %.c
+$(OBJECTDIR)/%.o: %.c | $(OBJECTDIR)
 	$(CC) $(CFLAGS) $< --dependencies=m $(@:.o=.P) -o $@
 	@$(SEDCOMMAND); rm -f $(@:.o=.P)
 	@$(FINALIZE_DEPENDENCY)
@@ -270,10 +270,10 @@ stm-motelist:
 stm-motes:
 	@echo $(MOTES)
 
-$(OBJECTDIR)/%.o: %.s79
+$(OBJECTDIR)/%.o: %.s79 | $(OBJECTDIR)
 	$(AS) $(ASFLAGS) -o $@ $<
 
-$(OBJECTDIR)/%.o: %.s
+$(OBJECTDIR)/%.o: %.s | $(OBJECTDIR)
 	$(AS) $(ASFLAGS) -o $@ $<
 
 %.bin: %.$(TARGET)

--- a/cpu/z80/Makefile.z80
+++ b/cpu/z80/Makefile.z80
@@ -56,11 +56,11 @@ CONTIKI_PLATFORM_DIRS = $(PLATFORM_APPDIRS) \
 vpath %.cS $(CONTIKI_PLATFORM_DIRS)
 
 #option -MMD doesn't work well on SDCC as of 2.9.0
-$(OBJECTDIR)/%.o: %.c
+$(OBJECTDIR)/%.o: %.c | $(OBJECTDIR)
 	$(CC) $(CFLAGS) -c $< -o $@
 
 ifndef CUSTOM_RULE_CS_TO_OBJECTDIR_O
-$(OBJECTDIR)/%.o: %.cS
+$(OBJECTDIR)/%.o: %.cS | $(OBJECTDIR)
 	cp $< $(OBJECTDIR)/$*.c
 	$(CC) $(CFLAGS) -E $(OBJECTDIR)/$*.c > $(OBJECTDIR)/tmp
 	perl -pe "s/^#(.*)/;$$1/" $(OBJECTDIR)/tmp > $(OBJECTDIR)/$*.S

--- a/platform/cooja/Makefile.cooja
+++ b/platform/cooja/Makefile.cooja
@@ -91,10 +91,13 @@ endif # UIP_CONF_IPV6
 REDEF_PRINTF=1 # Redefine functions to enable printf()s inside Cooja
 
 ### Define custom targets
-$(ARCHIVE): ${addprefix $(OBJECTDIR)/, $(CONTIKI_SOURCEFILES:.c=.o)}
+
+# NB: Assumes ARCHIVE was not overridden and is in $(OBJECTDIR)
+$(ARCHIVE): ${addprefix $(OBJECTDIR)/, $(CONTIKI_SOURCEFILES:.c=.o)} | $(OBJECTDIR)
 	$(AR_COMMAND_1) $^ $(AR_COMMAND_2)
 
-$(JNILIB): $(CONTIKI_APP_OBJ) $(MAIN_OBJ) $(PROJECT_OBJECTFILES) $(ARCHIVE)
+# NB: Assumes JNILIB was not overridden and is in $(OBJECTDIR)
+$(JNILIB): $(CONTIKI_APP_OBJ) $(MAIN_OBJ) $(PROJECT_OBJECTFILES) $(ARCHIVE) | $(OBJECTDIR)
 ifdef SYMBOLS
 	@echo Generating symbols
 	# Recreate symbols file and relink with final memory layout (twice)
@@ -117,7 +120,9 @@ $(CONTIKI_APP).cooja: $(JNILIB)
 	cp $(JNILIB) $@
 	rm $(CONTIKI_APP_OBJ)
 
-mtype%.o: contiki-cooja-main.o
+# Trickiness: GNU make matches this against the file base name.
+# Assume that the directory part is the standard location.
+mtype%.o: contiki-cooja-main.o | $(OBJECTDIR)
 	mv contiki-cooja-main.o $@
 
 symbols.c:

--- a/platform/win32/Makefile.win32
+++ b/platform/win32/Makefile.win32
@@ -83,7 +83,7 @@ ifdef VCINSTALLDIR
 VCFLAGS = -Od -Z7 $(filter-out -Wall -g -O,$(CFLAGS))
 
 CUSTOM_RULE_C_TO_OBJECTDIR_O = 1
-$(OBJECTDIR)/%.o: %.c
+$(OBJECTDIR)/%.o: %.c | $(OBJECTDIR)
 	cl -nologo $(VCFLAGS) -c $< -Fo$@
 	@makedepend $(CFLAGS) -o.o -f- $< 2> nul: | sed -e s!$(<:.c=.o)!$@! -e s!\\!/!g > $(@:.o=.d)
 

--- a/tools/z80/hex2bin/Makefile
+++ b/tools/z80/hex2bin/Makefile
@@ -14,10 +14,6 @@ OBJECTS		= ${addprefix $(OBJECTDIR)/,$(SOURCES:.c=.o)}
 
 vpath %.c $(SOURCEDIR)
 
-ifeq (${wildcard $(OBJECTDIR)},)
-  DUMMY := ${shell mkdir $(OBJECTDIR)}
-endif
-
 hexameter: $(OBJECTS)
 	$(CC) $(CFLAGS) -o $@ $(OBJECTS)
 
@@ -26,6 +22,9 @@ clean:
 	rm -f *~ *.stackdump
 	rm -f *~ hexameter hexameter.exe
 
-$(OBJECTDIR)/%.o: %.c
+$(OBJECTDIR):
+	mkdir $@
+
+$(OBJECTDIR)/%.o: %.c | $(OBJECTDIR)
 	$(CC) $(CFLAGS) -c $< -o $@
 


### PR DESCRIPTION
This supersedes pull request 272, incorporating changes requested during review.

The effect of the change is to ensure the destination directory for object files is created before any make recipe attempts to write into it; this failed in the previous approach if the specified make targets included "clean" which removed that directory after Makefile.include had created it.  This had been requested during the discussion of issue #254.

The new version includes a separate commit that enables CLEAN to have directories in it, a feature I need for an application that builds libraries it needs in a subdirectory.

Please let me know if you have further concerns, and if not please merge this.  Thanks.
