### PR TITLE
core/dev/led: Allow platform to provide LED color map

### DIFF
--- a/core/dev/leds.h
+++ b/core/dev/leds.h
@@ -47,6 +47,9 @@
 #ifndef __LEDS_H__
 #define __LEDS_H__
 
+/* Allow platform to override LED numbering */
+#include "contiki-conf.h"
+
 void leds_init(void);
 
 /**


### PR DESCRIPTION
This is the patch that kicked off #280.

Although they are not standard FEATURE_CONF_FOO variables, the use of `#ifndef` in dev/leds.h suggests that a platform can override the bit values associated with various colored LEDs.  I think this should be allowed because the platform can ensure the order in the mask corresponds to the order in the board, simplifying the display of binary values.  I want to use this feature for the bsp430 platform, but it doesn't work because certain files (e.g. cxmac.c) include dev/leds.h before including contiki-conf.h resulting in a conflicting definition.

Explicitly including "contiki-conf.h" first fixes this.  I'm not including "contiki-default-conf.h" because it does not affect LED configuration and nobody else includes it either.
