### PR TITLE
Adds a Headless Radio Logger plugin for COOJA

### DIFF
--- a/tools/cooja/apps/radiologger-headless/PROJECT-INFO.TXT
+++ b/tools/cooja/apps/radiologger-headless/PROJECT-INFO.TXT
@@ -1,0 +1,13 @@
+Name: COOJA Headless Radio Logger
+Contact: Laurent Deru <laurent.deru@cetic.be>, Sébastien Dawans <sebastien.dawans@cetic.be>
+URL:
+License: BSD http://www.opensource.org/licenses/bsd-license.php
+Screenshot:
+Contiki version: 2.6+
+Intended platforms: Any platform supported by COOJA
+Tested platforms: Sky
+Description:
+This is a standalone plugin for COOJA to log the radio packets
+in headless mode. It is a stripped-down version of COOJA's 
+graphical Radio Logger. It allows to generate PCAPs while 
+executing COOJA from the command line with the --no-gui option.

--- a/tools/cooja/apps/radiologger-headless/README.txt
+++ b/tools/cooja/apps/radiologger-headless/README.txt
@@ -1,0 +1,39 @@
+To install this plugin in COOJA:
+
+1) (optional, recommended) Copy the 'cooja-radiologger-headless' folder to your CONTIKI_DIR/tools/cooja/apps folder.
+2) (optional, recommended) Rename it to 'radiologger-headless'
+3) Build the plugin
+  - goto the plugin folder in a console
+  - type 'ant jar'
+4) Add that folder to the DEFAULT_PROJECTDIRS variable, in one of the following ways:
+  a) Via the GUI.
+    - Open COOJA in graphical mode
+    - Go to Settings > Cooja Extensions
+    - In the file browser in the left panel, browse to the CONTIKI_DIR/tools/cooja/apps folder
+    - Check the box next to radiologger-headless (it should appear green)
+    - 'Save' the window, click OK to permanently apply the change
+  b) By hand:
+    - Open ~/.cooja.user.properties
+    - Append ';[APPS_DIR]/radiologger-headless' at the end of the DEFAULT_PROJECTDIRS line
+    - Note: this file is created the very first time you use COOJA in GUI mode, and is user-specific.
+5) To enable this in your simulation, do it in one of 2 ways:
+  a) Via the GUI:
+    - Open your simulation in COOJA
+    - Select Tools > Headless radio logger...
+    - You will see an empty window titled Radio logger headless. Do not close it.
+    - Save your simulation and close COOJA.
+  b) By hand
+    - Added the following snippet to the obvious place in the .csc file:
+
+  <plugin>
+    be.cetic.cooja.plugins.RadioLoggerHeadless
+    <width>150</width>
+    <z>0</z>
+    <height>300</height>
+    <location_x>1</location_x>
+    <location_y>403</location_y>
+  </plugin> 
+
+Feel free to report bugs or errors in this how-to to: 6lbr@cetic.be
+
+Enjoy.

--- a/tools/cooja/apps/radiologger-headless/build.xml
+++ b/tools/cooja/apps/radiologger-headless/build.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0"?>
+
+<project name="Headless Radio Logger" default="jar" basedir=".">
+  <property name="src" location="java"/>
+  <property name="build" location="build"/>
+  <property name="lib" location="lib"/>
+  <property name="cooja" location="../.."/>
+  <property name="cooja_jar" value="${cooja}/dist/cooja.jar"/>
+  <condition property="cooja_jar_exists">
+    <available file="${cooja_jar}"/>
+  </condition>
+
+  <target name="check_jar" unless="cooja_jar_exists">
+    <echo message="Contiki's cooja.jar not found! Edit build.xml, and update the cooja_jar property"/>
+    <fail/>
+  </target>
+  
+  <target name="init" depends="check_jar">
+    <tstamp/>
+  </target>
+
+  <target name="compile" depends="init">
+    <mkdir dir="${build}"/>
+    <javac srcdir="${src}" destdir="${build}" debug="on">
+      <classpath>
+        <pathelement path="."/>
+        <pathelement location="${cooja_jar}"/>
+      </classpath>
+    </javac>
+  </target>
+
+  <target name="clean" depends="init">
+    <delete dir="${build}"/>
+    <delete dir="${lib}"/>
+  </target>
+
+  <target name="jar" depends="init, compile, copy">
+    <mkdir dir="${lib}"/>
+    <jar destfile="${lib}/headless_radiologger.jar" basedir="${build}">
+      <manifest>
+        <attribute name="Class-Path" value="."/>
+      </manifest>
+    </jar>
+  </target>
+
+  <target name="copy" depends="init">
+    <mkdir dir="${build}"/>
+  </target>
+
+</project>

--- a/tools/cooja/apps/radiologger-headless/cooja.config
+++ b/tools/cooja/apps/radiologger-headless/cooja.config
@@ -1,0 +1,3 @@
+DESCRIPTION = Headless radio logger plugin
+se.sics.cooja.GUI.JARFILES = + headless_radiologger.jar
+se.sics.cooja.GUI.PLUGINS = + be.cetic.cooja.plugins.RadioLoggerHeadless

--- a/tools/cooja/apps/radiologger-headless/java/be/cetic/cooja/plugins/RadioLoggerHeadless.java
+++ b/tools/cooja/apps/radiologger-headless/java/be/cetic/cooja/plugins/RadioLoggerHeadless.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2013, CETIC.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ */
+
+package be.cetic.cooja.plugins;
+
+import java.io.IOException;
+import java.util.Observable;
+import java.util.Observer;
+import java.util.Properties;
+
+import se.sics.cooja.ClassDescription;
+import se.sics.cooja.GUI;
+import se.sics.cooja.Plugin;
+import se.sics.cooja.PluginType;
+import se.sics.cooja.RadioConnection;
+import se.sics.cooja.RadioMedium;
+import se.sics.cooja.RadioPacket;
+import se.sics.cooja.Simulation;
+import se.sics.cooja.VisPlugin;
+import se.sics.cooja.interfaces.Radio;
+//import se.sics.cooja.plugins.analyzers.PacketAnalyser;
+import se.sics.cooja.plugins.analyzers.PcapExporter;
+
+import se.sics.cooja.util.StringUtils;
+
+/**
+ * Radio Logger which exports a pcap file only.
+ * It was designed to support radio logging in COOJA's headless mode.
+ * Based on Fredrik Osterlind's RadioLogger.java
+ *
+ * @author Laurent Deru
+ */
+@ClassDescription("Headless radio logger")
+@PluginType(PluginType.SIM_PLUGIN)
+public class RadioLoggerHeadless extends VisPlugin {
+  private static final long serialVersionUID = -6927091711697081353L;
+
+  private final Simulation simulation;
+  private RadioMedium radioMedium;
+  private Observer radioMediumObserver;
+  private PcapExporter pcapExporter;
+
+  public RadioLoggerHeadless(final Simulation simulationToControl, final GUI gui) {
+    super("Radio messages", gui, false);
+    System.err.println("Starting headless radio logger");
+    try {
+        pcapExporter = new PcapExporter();
+    } catch (IOException e) {
+        e.printStackTrace();
+    }
+    simulation = simulationToControl;
+    radioMedium = simulation.getRadioMedium();
+
+    radioMedium.addRadioMediumObserver(radioMediumObserver = new Observer() {
+      public void update(Observable obs, Object obj) {
+        RadioConnection conn = radioMedium.getLastConnection();
+        if (conn == null) {
+          return;
+        }
+        RadioPacket radioPacket = conn.getSource().getLastPacketTransmitted();
+        //PacketAnalyser.Packet packet = new PacketAnalyser.Packet(radioPacket.getData(), PacketAnalyser.MAC_LEVEL);
+        try {
+            //pcapExporter.exportPacketData(packet.getPayload());
+            pcapExporter.exportPacketData(radioPacket.getPacketData());
+        } catch (IOException e) {
+            System.err.println("Could not export PCap data");
+            e.printStackTrace();
+        }
+      }
+    });
+  }
+
+  public void closePlugin() {
+    if (radioMediumObserver != null) {
+      radioMedium.deleteRadioMediumObserver(radioMediumObserver);
+    }
+  }
+}


### PR DESCRIPTION
This is a new COOJA plugin enabling the generation of a PCAP in headless mode.
I'm submitting as a pull request because several people have been merging our branch to get this feature.
The documentation on how to use the plugin is in `README.txt`.

If you prefer not to merge this in the main repository, I can contribute to Contiki-Projects instead or leave it on our repo and add it to the Contiki-OS wiki.
