### PR TITLE
Bugfix: Corrected wireshark bad FCS errors in COOJA Pcap export

### DIFF
--- a/tools/cooja/java/se/sics/cooja/plugins/analyzers/PcapExporter.java
+++ b/tools/cooja/java/se/sics/cooja/plugins/analyzers/PcapExporter.java
@@ -39,7 +39,7 @@ public class PcapExporter {
             out.writeInt((int) System.currentTimeMillis() / 1000);
             out.writeInt((int) ((System.currentTimeMillis() % 1000) * 1000));
             out.writeInt(data.length);
-            out.writeInt(data.length);
+            out.writeInt(data.length+2);
             /* and the data */
             out.write(data);
             out.flush();


### PR DESCRIPTION
Corrects the "Bad FCS" error in Wireshark, which is due to the difference in size between the captured packet and the expected packet when FCS is not captured. Wireshark simply ignores the missing FCS when the size of the captured packet correctly reflects the missing FCS.

See http://www.winpcap.org/ntar/draft/PCAP-DumpFileFormat.html#sectionepb

```
Packet Len: actual length of the packet when it was transmitted on the network. 
Can be different from captured len if the packet has been truncated by the capture process.
```
