### PR TITLE
exp5438: support CC2520EMK as option

### DIFF
--- a/platform/exp5438/Makefile.exp5438
+++ b/platform/exp5438/Makefile.exp5438
@@ -6,12 +6,31 @@ CFLAGS+=-e --vla -Ohz --multiplier=32 --multiplier_location=4C0 --hw_workaround=
 #CFLAGS+=--no_cse --no_unroll --no_inline --no_code_motion --no_tbaa --debug -D__MSP430F5438A__ -e --double=32 --dlib_config 'C:\Program Files (x86)\IAR Systems\Embedded Workbench 6.0 Evaluation\430\LIB\DLIB\dl430xsfn.h' --core=430X --data_model=small -Ol --multiplier=32 --multiplier_location=4C0 --hw_workaround=CPU40
 endif
 
+# EXP5438_RFEM : Identify the RF module installed on the EXP430F5438.
+#
+# The original Contiki port used what's identified here as 2420, but other
+# modules may be selected.  Module selection is made in platform
+# contiki-conf.h and supporting macros are defined in platform-conf.h.
+#
+# 2420 (default): Original port, does not use RFEM macros
+# CC2520EMK : Baseline Contiki cc2520 driver with CC2520EMK
+#
+EXP5438_RFEM=2420
+CFLAGS += -DEXP5438_RFEM_$(EXP5438_RFEM)
+
 CLEAN += *.exp5438 symbols.c symbols.h
 
 ARCH=msp430.c leds.c watchdog.c \
-     spix.c cc2420.c cc2420-arch.c \
+     spix.c \
      rtimer-arch.c node-id.c leds-arch.c uart1x.c lcd.c \
      hal_lcd.c hal_lcd_fonts.c duty-cycle-scroller.c cfs-ram.c
+
+ifeq ($(EXP5438_RFEM),2420)
+ARCH += cc2420.c cc2420-arch.c
+endif # EXP5438_RFEM = 2420
+ifeq ($(EXP5438_RFEM),CC2520EMK)
+ARCH += cc2520.c cc2520-arch.c
+endif # EXP5438_RFEM = CC2520EMK
 
 ifeq ($(WITH_SLIP),1)
 ARCH += slip_uart0.c

--- a/platform/exp5438/contiki-conf.h
+++ b/platform/exp5438/contiki-conf.h
@@ -22,7 +22,11 @@
 #endif /* NETSTACK_CONF_RDC_CHANNEL_CHECK_RATE */
 
 #ifndef NETSTACK_CONF_RADIO
+#if (EXP5438_RFEM_CC2520EMK - 0)
+#define NETSTACK_CONF_RADIO   cc2520_driver
+#else /* use default RF module */
 #define NETSTACK_CONF_RADIO   cc2420_driver
+#endif /* RF module selection */
 #endif /* NETSTACK_CONF_RADIO */
 
 #ifndef NETSTACK_CONF_FRAMER

--- a/platform/exp5438/contiki-exp5438-main.c
+++ b/platform/exp5438/contiki-exp5438-main.c
@@ -34,7 +34,17 @@
 #include <stdarg.h>
 
 #include "dev/button-sensor.h"
+#if (EXP5438_RFEM_CC2520EMK - 0)
+#include "dev/cc2520.h"
+#define RFEM_INIT() do { cc2520_init(); } while(0)
+#define RFEM_SET_PAN_ADDR(pid,sa,la) do { cc2520_set_pan_addr(pid, sa, la); } while(0)
+#define RFEM_SET_CHANNEL(ch) do { cc2520_set_channel(ch); } while(0)
+#else  /* RF selection */
 #include "dev/cc2420.h"
+#define RFEM_INIT() do { cc2420_init(); } while(0)
+#define RFEM_SET_PAN_ADDR(pid,sa,la) do { cc2420_set_pan_addr(pid, sa, la); } while(0)
+#define RFEM_SET_CHANNEL(ch) do { cc2420_set_channel(ch); } while(0)
+#endif /* RF selection */
 #include "dev/flash.h"
 #include "dev/leds.h"
 #include "dev/serial-line.h"
@@ -183,7 +193,7 @@ main(int argc, char **argv)
 
   set_rime_addr();
 
-  cc2420_init();
+  RFEM_INIT();
 
   {
     uint8_t longaddr[8];
@@ -197,10 +207,10 @@ main(int argc, char **argv)
            longaddr[0], longaddr[1], longaddr[2], longaddr[3],
            longaddr[4], longaddr[5], longaddr[6], longaddr[7]);
 
-    cc2420_set_pan_addr(IEEE802154_PANID, shortaddr, longaddr);
+    RFEM_SET_PAN_ADDR(IEEE802154_PANID, shortaddr, longaddr);
   }
 
-  cc2420_set_channel(RF_CHANNEL);
+  RFEM_SET_CHANNEL(RF_CHANNEL);
 
   leds_off(LEDS_ALL);
 

--- a/platform/exp5438/platform-conf.h
+++ b/platform/exp5438/platform-conf.h
@@ -66,7 +66,11 @@ typedef unsigned long clock_time_t;
 typedef unsigned long off_t;
 
 /* the low-level radio driver */
+#if (EXP5438_RFEM_CC2520EMK - 0)
+#define NETSTACK_CONF_RADIO   cc2520_driver
+#else
 #define NETSTACK_CONF_RADIO   cc2420_driver
+#endif
 
 /*
  * Definitions below are dictated by the hardware and not really
@@ -128,6 +132,118 @@ typedef unsigned long off_t;
 #define SPI_FLASH_HOLD()                ( P5OUT &= ~BV(FLASH_HOLD) )
 #define SPI_FLASH_UNHOLD()              ( P5OUT |=  BV(FLASH_HOLD) )
 
+/* RF Evaluation Module Header pin-to-MCU mapping.
+ *
+ * Different modules associate different functions with the RF pins.
+ * These macros access the primary headers RF1 and RF2; the eZ-RF
+ * header RF3 is currently not described here. */
+#define RFEM_RF1_3_PORT(type)  P1##type
+#define RFEM_RF1_3_PIN         4
+#define RFEM_RF1_5_PORT(type)  P1##type
+#define RFEM_RF1_5_PIN         2
+#define RFEM_RF1_6_PORT(type)  P1##type
+#define RFEM_RF1_6_PIN         5
+#define RFEM_RF1_7_PORT(type)  P1##type
+#define RFEM_RF1_7_PIN         5
+#define RFEM_RF1_8_PORT(type)  P1##type
+#define RFEM_RF1_8_PIN         6
+#define RFEM_RF1_9_PORT(type)  P1##type
+#define RFEM_RF1_9_PIN         6
+#define RFEM_RF1_10_PORT(type) P7##type
+#define RFEM_RF1_10_PIN        6
+#define RFEM_RF1_12_PORT(type) P1##type
+#define RFEM_RF1_12_PIN        3
+#define RFEM_RF1_14_PORT(type) P3##type
+#define RFEM_RF1_14_PIN        0
+#define RFEM_RF1_16_PORT(type) P3##type
+#define RFEM_RF1_16_PIN        3
+#define RFEM_RF1_18_PORT(type) P3##type
+#define RFEM_RF1_18_PIN        1
+#define RFEM_RF1_20_PORT(type) P3##type
+#define RFEM_RF1_20_PIN        2
+#define RFEM_RF2_15_PORT(type) P1##type
+#define RFEM_RF2_15_PIN        2
+#define RFEM_RF2_18_PORT(type) P8##type
+#define RFEM_RF2_18_PIN        1
+#define RFEM_RF2_19_PORT(type) P8##type
+#define RFEM_RF2_19_PIN        2
+
+/* MSP430 headers define OUT as a macro with the value used in timer
+ * capture/compare control registers to output the timer signal.  This
+ * use interferes with the double macro expansion of CCFOO(OUT) passed
+ * to the RFEM_RFX_Y_PORT(TYPE) macros above. */
+#undef OUT
+
+#ifndef EXP5438_RFEM_CC2520EMK
+/** Define to true preprocessor value to indicate that the RFEM header
+ * has a <a href="http://www.ti.com/tool/cc2520emk">CC2520 Evaluation
+ * Module</a> plugged into it.  This sets the CC2520 as the radio
+ * layer for Contiki on this platform. */
+#define EXP5438_RFEM_CC2520EMK 0
+#endif /* EXP5438_RFEM_CC2520EMK */
+
+#if (EXP5438_RFEM_CC2520EMK - 0)
+
+/* Default fifop signal on GPIO2 @ RF1.9.  This is P1.6, and we need
+ * its interrupt. */
+#define CC2520_FIFOP_PORT(type) RFEM_RF1_9_PORT(type)
+#define CC2520_FIFOP_PIN RFEM_RF1_9_PIN
+/* Default fifo signal on GPIO1 @ RF1.7 */
+#define CC2520_FIFO_PORT(type) RFEM_RF1_7_PORT(type)
+#define CC2520_FIFO_PIN RFEM_RF1_7_PIN
+/* Default cca signal on GPIO3 @ RF1.12 */
+#define CC2520_CCA_PORT(type) RFEM_RF1_12_PORT(type)
+#define CC2520_CCA_PIN RFEM_RF1_12_PIN
+/* Default sfd signal on GPIO4 @ RF2.18 */
+#define CC2520_SFD_PORT(type) RFEM_RF2_18_PORT(type)
+#define CC2520_SFD_PIN RFEM_RF2_18_PIN
+/* SFD on P8.1 maps to TA0.CCI1B.  Record the CCIS; SFD can't actually
+ * be captured until sfd-arch-sfd.c is updated to support TA0 as well
+ * as TB0. */
+#define CC2520_SFD_CCIS (1 * CCIS0)
+/* CSn on RF1.14 */
+#define CC2520_CSN_PORT(type) RFEM_RF1_14_PORT(type)
+#define CC2520_CSN_PIN RFEM_RF1_14_PIN
+/* VREGen on RF1.10 */
+#define CC2520_VREG_PORT(type) RFEM_RF1_10_PORT(type)
+#define CC2520_VREG_PIN RFEM_RF1_10_PIN
+/* RESETn on RF2.15 */
+#define CC2520_RESET_PORT(type) RFEM_RF2_15_PORT(type)
+#define CC2520_RESET_PIN RFEM_RF2_15_PIN
+
+#define CC2520_FIFOP_IS_1 (!!(CC2520_FIFOP_PORT(IN) & BV(CC2520_FIFOP_PIN)))
+#define CC2520_FIFO_IS_1  (!!(CC2520_FIFO_PORT(IN) & BV(CC2520_FIFO_PIN)))
+#define CC2520_CCA_IS_1   (!!(CC2520_CCA_PORT(IN) & BV(CC2520_CCA_PIN)))
+#define CC2520_SFD_IS_1   (!!(CC2520_SFD_PORT(IN) & BV(CC2520_SFD_PIN)))
+
+#define SET_RESET_INACTIVE() do { CC2520_RESET_PORT(OUT) |=  BV(CC2520_RESET_PIN); } while(0)
+#define SET_RESET_ACTIVE()   do { CC2520_RESET_PORT(OUT) &= ~BV(CC2520_RESET_PIN); } while(0)
+#define SET_VREG_ACTIVE()    do { CC2520_VREG_PORT(OUT) |=  BV(CC2520_VREG_PIN); } while(0)
+#define SET_VREG_INACTIVE()  do { CC2520_VREG_PORT(OUT) &= ~BV(CC2520_VREG_PIN); } while(0)
+
+#define CC2520_FIFOP_INT_INIT() do {                  \
+    CC2520_FIFOP_PORT(IES) &= ~BV(CC2520_FIFOP_PIN);  \
+    CC2520_CLEAR_FIFOP_INT();                         \
+  } while(0)
+#define CC2520_ENABLE_FIFOP_INT()  do { CC2520_FIFOP_PORT(IE) |= BV(CC2520_FIFOP_PIN); } while(0)
+#define CC2520_DISABLE_FIFOP_INT() do { CC2520_FIFOP_PORT(IE) &= ~BV(CC2520_FIFOP_PIN); } while(0)
+#define CC2520_CLEAR_FIFOP_INT()   do { CC2520_FIFOP_PORT(IFG) &= ~BV(CC2520_FIFOP_PIN); } while(0)
+
+#define CC2520_SPI_ENABLE()     do { CC2520_CSN_PORT(OUT) &= ~BV(CC2520_CSN_PIN); } while(0)
+#define CC2520_SPI_DISABLE()    do { CC2520_CSN_PORT(OUT) |=  BV(CC2520_CSN_PIN); } while(0)
+#define CC2520_SPI_IS_ENABLED() ((CC2520_CSN_PORT(OUT) & BV(CC2520_CSN_PIN)) != BV(CC2520_CSN_PIN))
+
+/* @todo@ Both these need to be fixed.  The driver shouldn't assume it
+ * has sole control of the entire port register, nor should it have
+ * loop values that depend on the MCU clock speed. */
+
+/* FIFOP on RF1.9 is P1.6 ; need its interrupt vector. */
+#define CC2520_IRQ_VECTOR PORT1_VECTOR
+/* Magic delay */
+#define CC2520_CONF_SYMBOL_LOOP_COUNT 1302      /* 326us msp430X @ 8MHz */
+
+#else
+/* Port for CC2420 support on EXP430F5438 */
 
 /*
  * SPI bus - CC2420 pin configuration.
@@ -196,5 +312,7 @@ typedef unsigned long off_t;
  /* DISABLE CSn (active low) */
 #define CC2420_SPI_DISABLE()    (CC2420_CSN_PORT(OUT) |=  BV(CC2420_CSN_PIN))
 #define CC2420_SPI_IS_ENABLED() ((CC2420_CSN_PORT(OUT) & BV(CC2420_CSN_PIN)) != BV(CC2420_CSN_PIN))
+
+#endif /* RF module selection */
 
 #endif /* __PLATFORM_CONF_H__ */


### PR DESCRIPTION
This platform assumes a CC2420 is installed.  Other radio modules are available in the RFEM form factor.  Add basic infrastructure for supporting them, using macros to map from RF header pins to MCU functions.

Tested with both transmit and receive to confirm compatibility with examples-runicast and a tmote sky.