### PR TITLE
Update of RPL MRHOF (use no metric container with ETX [RFC6719])

### DIFF
--- a/core/net/rpl/Makefile.rpl
+++ b/core/net/rpl/Makefile.rpl
@@ -1,2 +1,2 @@
 CONTIKI_SOURCEFILES += rpl.c rpl-dag.c rpl-icmp6.c rpl-timers.c \
-	rpl-of-etx.c rpl-ext-header.c
+	rpl-mrhof.c rpl-ext-header.c

--- a/core/net/rpl/rpl-conf.h
+++ b/core/net/rpl/rpl-conf.h
@@ -49,23 +49,25 @@
  * Select routing metric supported at runtime. This must be a valid
  * DAG Metric Container Object Type (see below). Currently, we only 
  * support RPL_DAG_MC_ETX and RPL_DAG_MC_ENERGY.
+ * When MRHOF (RFC6719) is used with ETX, no metric container must
+ * be used; instead the rank carries ETX directly.
  */
 #ifdef RPL_CONF_DAG_MC
 #define RPL_DAG_MC RPL_CONF_DAG_MC
 #else
-#define RPL_DAG_MC RPL_DAG_MC_ETX
+#define RPL_DAG_MC RPL_DAG_MC_NONE
 #endif /* RPL_CONF_DAG_MC */
 
 /*
  * The objective function used by RPL is configurable through the 
  * RPL_CONF_OF parameter. This should be defined to be the name of an 
- * rpl_of_t object linked into the system image, e.g., rpl_of0.
+ * rpl_of object linked into the system image, e.g., rpl_of0.
  */
 #ifdef RPL_CONF_OF
 #define RPL_OF RPL_CONF_OF
 #else
 /* ETX is the default objective function. */
-#define RPL_OF rpl_of_etx
+#define RPL_OF rpl_mrhof
 #endif /* RPL_CONF_OF */
 
 /* This value decides which DAG instance we should participate in by default. */

--- a/core/net/rpl/rpl-dag.c
+++ b/core/net/rpl/rpl-dag.c
@@ -518,7 +518,9 @@ rpl_add_parent(rpl_dag_t *dag, rpl_dio_t *dio, uip_ipaddr_t *addr)
   p->rank = dio->rank;
   p->dtsn = dio->dtsn;
   p->link_metric = RPL_INIT_LINK_METRIC;
+#if RPL_DAG_MC != RPL_DAG_MC_NONE
   memcpy(&p->mc, &dio->mc, sizeof(p->mc));
+#endif /* RPL_DAG_MC != RPL_DAG_MC_NONE */
   list_add(dag->parents, p);
   return p;
 }
@@ -1238,7 +1240,9 @@ rpl_process_dio(uip_ipaddr_t *from, rpl_dio_t *dio)
 
   /* We have allocated a candidate parent; process the DIO further. */
 
+#if RPL_DAG_MC != RPL_DAG_MC_NONE
   memcpy(&p->mc, &dio->mc, sizeof(p->mc));
+#endif /* RPL_DAG_MC != RPL_DAG_MC_NONE */
   if(rpl_process_parent_event(instance, p) == 0) {
     PRINTF("RPL: The candidate parent is rejected\n");
     return;

--- a/core/net/rpl/rpl-icmp6.c
+++ b/core/net/rpl/rpl-icmp6.c
@@ -311,7 +311,9 @@ dio_input(void)
       dio.mc.prec = buffer[i + 4] & 0xf;
       dio.mc.length = buffer[i + 5];
 
-      if(dio.mc.type == RPL_DAG_MC_ETX) {
+      if(dio.mc.type == RPL_DAG_MC_NONE) {
+        /* No metric container: do nothing */
+      } else if(dio.mc.type == RPL_DAG_MC_ETX) {
         dio.mc.obj.etx = get16(buffer, i + 6);
 
         PRINTF("RPL: DAG MC: type %u, flags %u, aggr %u, prec %u, length %u, ETX %u\n",

--- a/core/net/rpl/rpl.h
+++ b/core/net/rpl/rpl.h
@@ -110,7 +110,9 @@ struct rpl_dag;
 struct rpl_parent {
   struct rpl_parent *next;
   struct rpl_dag *dag;
+#if RPL_DAG_MC != RPL_DAG_MC_NONE
   rpl_metric_container_t mc;
+#endif /* RPL_DAG_MC != RPL_DAG_MC_NONE */
   uip_ipaddr_t addr;
   rpl_rank_t rank;
   uint8_t link_metric;

--- a/platform/avr-ravenusb/Makefile.avr-ravenusb
+++ b/platform/avr-ravenusb/Makefile.avr-ravenusb
@@ -22,7 +22,7 @@ USB +=       scsi_decoder.c ctrl_access.c storage_task.c avr_flash.c
 
 #As of September 2010 the following are needed for rpl. They need explicit inclusion if CONTIKI_NO_NET=1
 #If CONTIKI_NO_NET=1 the tcpip_input routine in tcpip.c must be commented out; it expects a tcpip process and conflicts with the one in fakeuip.c
-#RPL      = rpl.c rpl-dag.c rpl-icmp6.c rpl-timers.c rpl-of-etx.c uip-ds6.c uip-icmp6.c uip-nd6.c uip6.c neighbor-info.c neighbor-attr.c tcpip.c uip-split.c psock.c
+#RPL      = rpl.c rpl-dag.c rpl-icmp6.c rpl-timers.c rpl-mrhof.c uip-ds6.c uip-icmp6.c uip-nd6.c uip6.c neighbor-info.c neighbor-attr.c tcpip.c uip-split.c psock.c
 
 CONTIKI_TARGET_SOURCEFILES +=   cfs-eeprom.c eeprom.c random.c \
                                 mmem.c contiki-raven-default-init-lowlevel.c \

--- a/platform/cc2530dk/contiki-conf.h
+++ b/platform/cc2530dk/contiki-conf.h
@@ -208,7 +208,7 @@
 #define RPL_CONF_STATS                       0
 #define RPL_CONF_MAX_DAG_ENTRIES             1
 #ifndef RPL_CONF_OF
-#define RPL_CONF_OF rpl_of_etx
+#define RPL_CONF_OF rpl_mrhof
 #endif
 
 #define UIP_CONF_ND6_REACHABLE_TIME     600000

--- a/platform/cc2538dk/contiki-conf.h
+++ b/platform/cc2538dk/contiki-conf.h
@@ -335,7 +335,7 @@ typedef uint32_t rtimer_clock_t;
 #define RPL_CONF_STATS                       0
 #define RPL_CONF_MAX_DAG_ENTRIES             1
 #ifndef RPL_CONF_OF
-#define RPL_CONF_OF rpl_of_etx
+#define RPL_CONF_OF rpl_mrhof
 #endif
 
 #define UIP_CONF_ND6_REACHABLE_TIME     600000

--- a/platform/sensinode/contiki-conf.h
+++ b/platform/sensinode/contiki-conf.h
@@ -214,7 +214,7 @@
 #define RPL_CONF_STATS                       0
 #define RPL_CONF_MAX_DAG_ENTRIES             1
 #ifndef RPL_CONF_OF
-#define RPL_CONF_OF rpl_of_etx
+#define RPL_CONF_OF rpl_mrhof
 #endif
 
 #define UIP_CONF_ND6_REACHABLE_TIME     600000


### PR DESCRIPTION
Update MRHOF implementation so it doesn't use a metric container when the metric is ETX, as specified by RFC6719. Remove the metric container from rpl_parent_t in that specific case, which saves 7-8 bytes per neighbor. The space saved in RPL DIO messages allows for non-fragmented 6LoWPAN broadcast. Renamed the rpl-of-etx to rpl-mrhof (as the file implements a rank hysteresis framework supporting different metrics, rather than simply ETX).
