### PR TITLE
settings: Correct a problem where sometimes CC_INLINE is not defined properly

### DIFF
--- a/core/lib/settings.h
+++ b/core/lib/settings.h
@@ -108,6 +108,7 @@
 #include <stdint.h>
 #include <string.h>
 #include "dev/eeprom.h"
+#include "sys/cc.h"
 
 /*****************************************************************************/
 // MARK: - Types

--- a/platform/avr-atmega128rfa1/contiki-conf.h
+++ b/platform/avr-atmega128rfa1/contiki-conf.h
@@ -341,6 +341,9 @@ typedef unsigned short uip_stats_t;
 
 #define CCIF
 #define CLIF
+#ifndef CC_CONF_INLINE
+#define CC_CONF_INLINE inline
+#endif
 
 /* include the project config */
 /* PROJECT_CONF_H might be defined in the project Makefile */

--- a/platform/avr-raven/contiki-conf.h
+++ b/platform/avr-raven/contiki-conf.h
@@ -356,6 +356,9 @@ typedef unsigned short uip_stats_t;
 
 #define CCIF
 #define CLIF
+#ifndef CC_CONF_INLINE
+#define CC_CONF_INLINE inline
+#endif
 
 /* include the project config */
 /* PROJECT_CONF_H might be defined in the project Makefile */

--- a/platform/avr-zigbit/contiki-conf.h
+++ b/platform/avr-zigbit/contiki-conf.h
@@ -91,6 +91,9 @@ void clock_adjust_ticks(clock_time_t howmany);
 
 #define CCIF
 #define CLIF
+#ifndef CC_CONF_INLINE
+#define CC_CONF_INLINE inline
+#endif
 
 #define RIMEADDR_CONF_SIZE       8
 #define PACKETBUF_CONF_HDR_SIZE    0


### PR DESCRIPTION
Not sure how I missed this the first time around.
