### PR TITLE
cpu/avr/radio/rf230bb/rf230bb.c (rf230_transmit): extend comment on tx s...

### DIFF
--- a/cpu/avr/radio/rf230bb/rf230bb.c
+++ b/cpu/avr/radio/rf230bb/rf230bb.c
@@ -965,8 +965,8 @@ rf230_transmit(unsigned short payload_len)
   HAL_ENTER_CRITICAL_REGION();
 
   /* Toggle the SLP_TR pin to initiate the frame transmission, then transfer
-   * the frame (we have about 16 us + 40 bit times before the transceiver sends
-   * the PHR.) */
+   * the frame. We have about 16 us + the on-air transmission time of 40 bits
+   * (for the synchronization header) before the transceiver sends the PHR. */
   hal_set_slptr_high();
   hal_set_slptr_low();
   hal_frame_write(buffer, total_len);


### PR DESCRIPTION
...equence

Explain that the transmission is intentionally started before copying the
frame to the buffer.

This is to clarify the sequence erroneously reported as buggy in
https://github.com/contiki-os/contiki/pull/295
