### PR TITLE
contikimac: restore lost minimum transmission length

### DIFF
--- a/core/net/mac/contikimac.c
+++ b/core/net/mac/contikimac.c
@@ -656,8 +656,6 @@ send_packet(mac_callback_t mac_callback, void *mac_callback_ptr,
   NETSTACK_ENCRYPT();
 #endif /* NETSTACK_ENCRYPT */
 
-  transmit_len = packetbuf_totlen();
-
   NETSTACK_RADIO.prepare(packetbuf_hdrptr(), transmit_len);
 
   /* Remove the MAC-layer header since it will be recreated next time around. */


### PR DESCRIPTION
The padding documented by SICS TR T2011:13 to ensure activity detection was
discarded by commit cb7842bd16086048c729ce22105fa0b801be784c.
