### PR TITLE
Fix for coap_get_header_token() always returning 0 when using CoAP draft v13

### DIFF
--- a/apps/er-coap-13/er-coap-13.c
+++ b/apps/er-coap-13/er-coap-13.c
@@ -822,8 +822,6 @@ coap_get_header_token(void *packet, const uint8_t **token)
 {
   coap_packet_t *const coap_pkt = (coap_packet_t *) packet;
 
-  if (!IS_OPTION(coap_pkt, COAP_OPTION_TOKEN)) return 0;
-
   *token = coap_pkt->token;
   return coap_pkt->token_len;
 }
@@ -836,7 +834,6 @@ coap_set_header_token(void *packet, const uint8_t *token, size_t token_len)
   coap_pkt->token_len = MIN(COAP_TOKEN_LEN, token_len);
   memcpy(coap_pkt->token, token, coap_pkt->token_len);
 
-  SET_OPTION(coap_pkt, COAP_OPTION_TOKEN);
   return coap_pkt->token_len;
 }
 /*-----------------------------------------------------------------------------------*/

--- a/apps/er-coap-13/er-coap-13.h
+++ b/apps/er-coap-13/er-coap-13.h
@@ -172,7 +172,6 @@ typedef enum {
   COAP_OPTION_MAX_AGE = 14,       /* 0-4 B */
   COAP_OPTION_URI_QUERY = 15,     /* 0-270 B */
   COAP_OPTION_ACCEPT = 16,        /* 0-2 B */
-  COAP_OPTION_TOKEN = 19,         /* 1-8 B */
   COAP_OPTION_LOCATION_QUERY = 20, /* 1-270 B */
   COAP_OPTION_BLOCK2 = 23,        /* 1-3 B */
   COAP_OPTION_BLOCK1 = 27,        /* 1-3 B */


### PR DESCRIPTION
CoAP draft v13 promoted the Token Option to a field following the CoAP Header. However the function `coap_get_header_token()` has not been updated to take into account this change. As a consequence the function behaves incorrectly (it always returns 0 and does not retrieve the token value).
This commit fixes the bug and removes every reference to the old Token Option.
