### PR TITLE
Default route not removed

### DIFF
--- a/core/net/rpl/rpl-dag.c
+++ b/core/net/rpl/rpl-dag.c
@@ -703,8 +703,8 @@ rpl_remove_parent(rpl_dag_t *dag, rpl_parent_t *parent)
 void
 rpl_nullify_parent(rpl_dag_t *dag, rpl_parent_t *parent)
 {
-  // local repair calls nullification because the preferred parent is NULL!
-  // So check if parent is NULL to trigger uip_ds6_defrt_rm.
+  /* This function can be called when the preferred parent is NULL, so we
+     need to handle this condition in order to trigger uip_ds6_defrt_rm. */
   if(parent == dag->preferred_parent || dag->preferred_parent == NULL) {
     dag->preferred_parent = NULL;
     dag->rank = INFINITE_RANK;


### PR DESCRIPTION
If a node leaves the DAG, the default route is not removed correctly. Therefore the node cannot return to the network. This leads to an "unacceptable rank" error.

In _rpl-dag.c_, function _rpl_process_parent_event_:
- the function _rpl_select_dag_ sets the preferred dag to _NULL_ (line 637)
- _rpl_local_repair_ cannot nullify the parents, because _parent == dag->preferred_parent_ fails (zero pointer)
- This fix checks if _dag->preferred_parent_ equals _NULL_ and starts the local repair

This fix solves this problem. Tested with sky and z1 in cooja.
