### PR TITLE
RPL bugfix: don't ignore infinite rank DIOs

### DIFF
--- a/core/net/rpl/rpl-dag.c
+++ b/core/net/rpl/rpl-dag.c
@@ -1027,11 +1027,13 @@ rpl_recalculate_ranks(void)
    * than RPL protocol messages. This periodical recalculation is called
    * from a timer in order to keep the stack depth reasonably low.
    */
-  for(instance = &instance_table[0], end = instance + RPL_MAX_INSTANCES; instance < end; ++instance) {
+  for(instance = &instance_table[0], end = instance + RPL_MAX_INSTANCES;
+      instance < end; ++instance) {
     if(instance->used) {
       for(i = 0; i < RPL_MAX_DAG_PER_INSTANCE; i++) {
         if(instance->dag_table[i].used) {
-          for(p = list_head(instance->dag_table[i].parents); p != NULL; p = p->next) {
+          for(p = list_head(instance->dag_table[i].parents);
+              p != NULL; p = p->next) {
             if(p->updated) {
               p->updated = 0;
               if(!rpl_process_parent_event(instance, p)) {


### PR DESCRIPTION
RPL nodes send infinite rank DIOs to let others know that they don't have a good network connection and expect to get a DIO back with some good network information, but the current code explicitly ignored the infinite rank DIOs. This made new nodes join networks too slowly: they basically needed to wait for a random DIO timer to expire to get information about the network and there was no way for them to signal that they wanted to join the network.
