### PR TITLE
Makefile.include: add verbosity control (make V=1 for old behaviour)

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -131,6 +131,21 @@ ifdef PLATFORMAPPS
   APPDS += $(PLATFORMAPPDS)
 endif
 
+### Verbosity control. Use  make V=1  to get verbose builds.
+
+CC_normal	:= $(CC)
+AR_normal	:= $(AR)
+
+CC_quiet	= @echo "  CC       " $< && $(CC_normal)
+AR_quiet	= @echo "  AR       " $@ && $(AR_normal)
+
+ifeq ($(V),1)
+  CC		= $(CC_normal)
+  AR		= $(AR_normal)
+else
+  CC		= $(CC_quiet)
+  AR		= $(AR_quiet)
+endif
 
 ### Forward comma-separated list of arbitrary defines to the compiler
 


### PR DESCRIPTION
The Contiki build is rather chatty, which makes it very difficult to spot compiler warnings. This adds short $(CC) and $(AR) invocations that don't show the entire command. The old behaviour can be obtained by running make with V=1.

I suggested this on the mailing list a few weeks ago but didn't get a response.
