### PR TITLE
Inserts missing IPv6 Hop-By-Hop RPL Option at first hop

### DIFF
--- a/core/net/rpl/rpl-ext-header.c
+++ b/core/net/rpl/rpl-ext-header.c
@@ -343,4 +343,16 @@ rpl_invert_header(void)
   }
 }
 /*---------------------------------------------------------------------------*/
+void
+rpl_insert_header(void)
+{
+  uint8_t uip_ext_opt_offset;
+  if(default_instance != NULL) {
+    uip_ext_opt_offset = 2;
+    if(UIP_EXT_HDR_OPT_BUF->type == UIP_EXT_HDR_OPT_RPL) {
+      rpl_update_header_empty();
+    }
+  }
+}
+/*---------------------------------------------------------------------------*/
 #endif /* UIP_CONF_IPV6 */

--- a/core/net/rpl/rpl.h
+++ b/core/net/rpl/rpl.h
@@ -240,6 +240,7 @@ rpl_instance_t *rpl_get_instance(uint8_t instance_id);
 void rpl_update_header_empty(void);
 int rpl_update_header_final(uip_ipaddr_t *addr);
 int rpl_verify_header(int);
+void rpl_insert_header(void);
 void rpl_remove_header(void);
 uint8_t rpl_invert_header(void);
 uip_ipaddr_t *rpl_get_parent_ipaddr(rpl_parent_t *nbr);

--- a/core/net/uip6.c
+++ b/core/net/uip6.c
@@ -1557,6 +1557,10 @@ uip_process(uint8_t flag)
 
   uip_appdata = &uip_buf[UIP_LLH_LEN + UIP_IPTCPH_LEN];
 
+#if UIP_CONF_IPV6_RPL
+  rpl_insert_header();
+#endif /* UIP_CONF_IPV6_RPL */
+
 #if UIP_UDP_CHECKSUMS
   /* Calculate UDP checksum. */
   UIP_UDP_BUF->udpchksum = ~(uip_udpchksum());


### PR DESCRIPTION
Currently, the RPL Hop-by-Hop option [**RFC6553**](http://tools.ietf.org/html/rfc6553#section-3) is not inserted at the IP sender. It is only inserted at the first hop, by the first forwarder, then updated along the path.

**RFC6553** allows to carry information on RPL in the data packet IPv6 headers, which are needed for datapath validation. For example, the `O` (Down) bit + SenderRank allows a forwarder to detect loops.

```
  0                   1                   2                   3
  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
                                 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
                                 |  Option Type  |  Opt Data Len |
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 |O|R|F|0|0|0|0|0| RPLInstanceID |          SenderRank           |
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 |                         (sub-TLVs)                            |
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
```

As you can see there's also the **RPLInstanceID** field, which tells the forwarder on which instance the packet is meant to be routed. It is there for multi-instance networks where routers are expected to maintain a route for each destination, on each instance. The Instance reflects a routing objective - it's expected that the IP sender chooses on which Instance to send a packet based on the application needs (QoS).

This fix inserts the option at the first hop, since the first forwarder cannot guess what Instance to route on. The `default_instance->instance_id` is used, as before. Choosing a specific instance would need to be adressed in a larger contribution (we would need to provide interfaces for applications to register instances and use them...).

I have exported 2 pcap files to show what I'm talking about. Node 4 sends a UDP packet to node 1 along a 3-hop path (`4 --> 3 --> 2 --> 1`). Compare the first message of each:
- [**bad.pcap**](https://docs.google.com/file/d/0B7eNZa51wTU0Z2g3X3F4dnZNWTQ/edit?usp=sharing)
- [**good.pcap**](https://docs.google.com/file/d/0B7eNZa51wTU0ckFlcXMtNGY0ZkE/edit?usp=sharing)
