### PR TITLE
gitignore CC2538dk firmwares

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@
 *.atari
 *.c128
 *.c64
+*.cc2538dk
 *.report
 summary
 *.summary


### PR DESCRIPTION
Nothing to write home about. This adds the CC2538DK firmwares to .gitignore
