### PR TITLE
Adjust a config define to its new name

### DIFF
--- a/platform/cc2538dk/contiki-conf.h
+++ b/platform/cc2538dk/contiki-conf.h
@@ -207,7 +207,7 @@ typedef uint32_t rtimer_clock_t;
 
 /* Configure ContikiMAC for when it's selected */
 #define CONTIKIMAC_CONF_WITH_CONTIKIMAC_HEADER  0
-#define WITH_PHASE_OPTIMIZATION                 0
+#define CONTIKIMAC_CONF_WITH_PHASE_OPTIMIZATION 0
 #define WITH_FAST_SLEEP                         1
 
 #ifndef NETSTACK_CONF_RDC_CHANNEL_CHECK_RATE


### PR DESCRIPTION
c9de0e4 changed the way we turn contikimac's phase optimisation on and off. This pull request adjusts the CC2538DK `contiki-conf.h` to reflect this change. The change also eradicates a `warning: "WITH_PHASE_OPTIMIZATION" redefined`.
