### PR TITLE
Make the CC2538 UART driver more configurable

### DIFF
--- a/cpu/cc2538/dev/uart.h
+++ b/cpu/cc2538/dev/uart.h
@@ -52,6 +52,13 @@
  */
 #define UART_0_BASE           0x4000C000
 #define UART_1_BASE           0x4000D000
+
+/* Default to UART 0 unless the configuration tells us otherwise */
+#ifdef UART_CONF_BASE
+#define UART_BASE             UART_CONF_BASE
+#else
+#define UART_BASE             UART_0_BASE
+#endif
 /** @} */
 /*---------------------------------------------------------------------------*/
 /**

--- a/platform/cc2538dk/dev/board.h
+++ b/platform/cc2538dk/dev/board.h
@@ -111,8 +111,11 @@
  * - CTS: PB0 (Can only be used with UART1)
  * - RTS: PD3 (Can only be used with UART1)
  *
+ * We configure the port to use UART0. To use UART1, change UART_CONF_BASE
  * @{
  */
+#define UART_CONF_BASE           UART_0_BASE
+
 #define UART_RX_PORT             GPIO_A_NUM
 #define UART_RX_PIN              0
 

--- a/platform/cc2538dk/startup-gcc.c
+++ b/platform/cc2538dk/startup-gcc.c
@@ -38,6 +38,7 @@
  */
 #include "contiki.h"
 #include "reg.h"
+#include "uart.h"
 
 #include <stdint.h>
 
@@ -71,12 +72,22 @@ void usb_isr(void);
 #define usb_isr default_handler
 #endif
 
-/* Likewise for the UART ISR */
+/* Likewise for the UART[01] ISRs */
 #if UART_CONF_ENABLE
 void uart_isr(void);
+
+#if UART_BASE==UART_1_BASE
+#define uart0_isr default_handler
+#define uart1_isr uart_isr
 #else
-#define uart_isr default_handler
+#define uart0_isr uart_isr
+#define uart1_isr default_handler
 #endif
+
+#else /* UART_CONF_ENABLE */
+#define uart0_isr default_handler
+#define uart1_isr default_handler
+#endif /* UART_CONF_ENABLE */
 /*---------------------------------------------------------------------------*/
 /* Allocate stack space */
 static unsigned long stack[512];
@@ -123,8 +134,8 @@ void(*const vectors[])(void) =
   gpio_port_c_isr,            /* 18 GPIO Port C */
   gpio_port_d_isr,            /* 19 GPIO Port D */
   0,                          /* 20 none */
-  uart_isr,                   /* 21 UART0 Rx and Tx */
-  default_handler,            /* 22 UART1 Rx and Tx */
+  uart0_isr,                  /* 21 UART0 Rx and Tx */
+  uart1_isr,                  /* 22 UART1 Rx and Tx */
   default_handler,            /* 23 SSI0 Rx and Tx */
   default_handler,            /* 24 I2C Master and Slave */
   0,                          /* 25 Reserved */


### PR DESCRIPTION
`platform/cc2538dk/dev/board.h` included defines for `UART_RX_PORT`, `UART_RX_PIN` and so on, suggesting that it was possible to configure the CC2538 UART driver with custom port/pin assignments for RX/TX etc through defines.

It wasn't possible. Now it is.

This pull request allows us to use defines to:
- Easily configure a cc2538-based platform to switch between UART0 and UART1.
- Configure the UART RX and TX port/pin assignment
