### PR TITLE
Faster collect-lossy travis test

### DIFF
--- a/regression-tests/09-collect-lossy/01-sky-shell-collect-lossy.csc
+++ b/regression-tests/09-collect-lossy/01-sky-shell-collect-lossy.csc
@@ -398,6 +398,7 @@ booted = new Array();
 received = new Array();
 hops = new Array();
 nrNodes = 20;
+toReceive = 8;
 total_received = 0;
 total_lost = 0;
 total_hops = 0;
@@ -411,7 +412,10 @@ total_latency = 0;
 nodes_starting = true;
 for(i = 1; i &lt;= nrNodes; i++) {
   booted[i] = false;
-  received[i] = "__________";
+  received[i] = '';
+  for(var j = 0; j &lt; toReceive; j++) {
+     received[i] += '_';
+  }
   hops[i] = received[i];
 }
 
@@ -495,20 +499,20 @@ while(true) {
         dups++;
     }
     received[source] = received[source].substr(0, seqno) + dups +
-        received[source].substr(seqno + 1, 10 - seqno);
+        received[source].substr(seqno + 1, toReceive - seqno);
 
     if(hop &gt; 9) {
         hop = "+";
     }
     hops[source] = hops[source].substr(0, seqno) + hop +
-        hops[source].substr(seqno + 1, 10 - seqno);
+        hops[source].substr(seqno + 1, toReceive - seqno);
 
     total_received++;
     total_hops += hop;
     
     print_stats();
   }
-  /* Signal OK if all nodes have reported 10 messages. */
+  /* Signal OK if all nodes have reported toReceive messages. */
   num_reported = 0;
   for(i = 1; i &lt;= nrNodes; i++) {
       if(i != sink) {


### PR DESCRIPTION
The travis test `regression-tests/09-collect-lossy/01-sky-shell-collect-lossy.csc` often takes too long for travis and needs to be manually restarted every now and then. This patch reduces the total amount of packets that the test needs to succeed from 10 to 8, thus reducing the test runtime. Lets hope this will result in fewer travis timeouts on the `collect-lossy` test.
