### PR TITLE
Add mspgcc 4.7.x flags to the wismote makefile

### DIFF
--- a/platform/wismote/Makefile.wismote
+++ b/platform/wismote/Makefile.wismote
@@ -22,6 +22,15 @@ ifeq ($(UIP_CONF_IPV6),1)
 CFLAGS += -DWITH_UIP6=1
 endif
 
+ifndef IAR
+  ifneq (,$(findstring 4.7.,$(shell msp430-gcc -dumpversion)))
+  TARGET_MEMORY_MODEL ?= medium
+  CFLAGS += -mmemory-model=$(TARGET_MEMORY_MODEL)
+  CFLAGS += -ffunction-sections -fdata-sections -mcode-region=far
+  LDFLAGS += -mmemory-model=$(TARGET_MEMORY_MODEL) -Wl,-gc-sections
+endif
+endif
+
 ifdef IAR
 CFLAGS += -D__MSP430F5437__=1 -e --vla -Ohz --multiplier=32 --multiplier_location=4C0 --hw_workaround=CPU40 --core=430X --double=32
 else


### PR DESCRIPTION
This pull request adds mspgcc 4.7.x flags to the wismote makefile (similar to what has been done by @adamdunkels for the exp5438 makefile in e147c63).
