### PR TITLE
Cooja: Make updateGUIComponentState public.

### DIFF
--- a/tools/cooja/java/org/contikios/cooja/Cooja.java
+++ b/tools/cooja/java/org/contikios/cooja/Cooja.java
@@ -665,7 +665,7 @@ public class Cooja extends Observable {
   /**
    * Enables/disables menues and menu items depending on whether a simulation is loaded etc.
    */
-  private void updateGUIComponentState() {
+  void updateGUIComponentState() {
     if (!isVisualized()) {
       return;
     }
@@ -2639,7 +2639,6 @@ public class Cooja extends Observable {
           mySimulation.addMote(newMote);
         }
       }
-      updateGUIComponentState();
 
     } else {
       logger.warn("No simulation active");

--- a/tools/cooja/java/org/contikios/cooja/Simulation.java
+++ b/tools/cooja/java/org/contikios/cooja/Simulation.java
@@ -841,6 +841,7 @@ public class Simulation extends Observable implements Runnable {
 
         setChanged();
         notifyObservers(mote);
+        cooja.updateGUIComponentState();
       }
     };
 


### PR DESCRIPTION
This is required if plugins want to create motes as the screen is not updated otherwise.
