### PR TITLE
Cooja/DGRM: Allow setting the RSSI value when sending or during silence.

### DIFF
--- a/tools/cooja/java/se/sics/cooja/radiomediums/DirectedGraphMedium.java
+++ b/tools/cooja/java/se/sics/cooja/radiomediums/DirectedGraphMedium.java
@@ -36,6 +36,7 @@ import java.util.Enumeration;
 import java.util.Hashtable;
 import java.util.List;
 import java.util.Random;
+import java.util.WeakHashMap;
 
 import org.apache.log4j.Logger;
 import org.jdom.Element;
@@ -70,6 +71,8 @@ public class DirectedGraphMedium extends AbstractRadioMedium {
 
   private ArrayList<Edge> edges = new ArrayList<Edge>();
   private boolean edgesDirty = true;
+  private WeakHashMap<Radio, Double> baseRssi = new WeakHashMap<Radio, Double>();
+  private WeakHashMap<Radio, Double> sendRssi = new WeakHashMap<Radio, Double>();
 
   /* Used for optimizing lookup time */
   private Hashtable<Radio,DGRMDestinationRadio[]> edgesTable = new Hashtable<Radio,DGRMDestinationRadio[]>();
@@ -155,21 +158,76 @@ public class DirectedGraphMedium extends AbstractRadioMedium {
     }
   }
 
+  /**
+   * Get the RSSI value that is set when there is "silence"
+   * 
+   * @param radio
+   *          The radio to get the base RSSI for
+   * @return The base RSSI value; Default: SS_NOTHING
+   */
+  public double getBaseRssi(Radio radio) {
+    Double rssi = baseRssi.get(radio);
+    if (rssi == null) {
+      rssi = SS_NOTHING;
+    }
+    return rssi;
+  }
+
+  /**
+   * Set the base RSSI for a radio. This value is set when there is "silence"
+   * 
+   * @param radio
+   *          The radio to set the RSSI value for
+   * @param rssi
+   *          The RSSI value to set during silence
+   */
+  public void setBaseRssi(Radio radio, double rssi) {
+    baseRssi.put(radio, rssi);
+  }
+
+  /**
+   * Get the minimum RSSI value that is set when the radio is sending
+   * 
+   * @param radio
+   *          The radio to get the send RSSI for
+   * @return The send RSSI value; Default: SS_STRONG
+   */
+  public double getSendRssi(Radio radio) {
+    Double rssi = sendRssi.get(radio);
+    if (rssi == null) {
+      rssi = SS_STRONG;
+    }
+    return rssi;
+  }
+
+  /**
+   * Set the send RSSI for a radio. This is the minimum value when the radio is
+   * sending
+   * 
+   * @param radio
+   *          The radio to set the RSSI value for
+   * @param rssi
+   *          The minimum RSSI value to set when sending
+   */
+  public void setSendRssi(Radio radio, double rssi) {
+    sendRssi.put(radio, rssi);
+  }
+  
   public void updateSignalStrengths() {
 
-    /* Reset signal strengths */
+    /* Reset signal strengths (Default: SS_NOTHING) */
     for (Radio radio : getRegisteredRadios()) {
-      radio.setCurrentSignalStrength(SS_NOTHING);
+      radio.setCurrentSignalStrength(getBaseRssi(radio));
     }
 
     /* Set signal strengths */
     RadioConnection[] conns = getActiveConnections();
     for (RadioConnection conn : conns) {
-      /* When sending RSSI is Strong!
-       * TODO: is this reasonable
+      /*
+       * Set sending RSSI. (Default: SS_STRONG)
        */
-      if (conn.getSource().getCurrentSignalStrength() < SS_STRONG) {
-        conn.getSource().setCurrentSignalStrength(SS_STRONG);
+      if (conn.getSource().getCurrentSignalStrength() < getSendRssi(conn.getSource())) {
+        conn.getSource().setCurrentSignalStrength(getSendRssi(conn.getSource()));
       }
       //Maximum reception signal of all possible radios received
       DGRMDestinationRadio dstRadios[] =  getPotentialDestinations(conn.getSource());


### PR DESCRIPTION
There is no GUI yet, but plugins can use the interface to set the RSSI value while sending or during silence. 
