### PR TITLE
Fixed fail to build from source due to a bad &nbr->lladdr

### DIFF
--- a/core/net/uip-nd6.c
+++ b/core/net/uip-nd6.c
@@ -819,9 +819,10 @@ uip_nd6_ra_input(void)
         if(nbr->state == NBR_INCOMPLETE) {
           nbr->state = NBR_STALE;
         }
+        uip_lladdr_t *lladdr = uip_ds6_nbr_get_ll(nbr);
         if(memcmp(&nd6_opt_llao[UIP_ND6_OPT_DATA_OFFSET],
-		  &nbr->lladdr, UIP_LLADDR_LEN) != 0) {
-          memcpy(&nbr->lladdr, &nd6_opt_llao[UIP_ND6_OPT_DATA_OFFSET],
+		  lladdr, UIP_LLADDR_LEN) != 0) {
+          memcpy(lladdr, &nd6_opt_llao[UIP_ND6_OPT_DATA_OFFSET],
 		 UIP_LLADDR_LEN);
           nbr->state = NBR_STALE;
         }


### PR DESCRIPTION
Hi Contiki developers,

this commit fixes the fail to build from source introduced in commit
https://github.com/ismb-pert/contiki/commit/ec609b49eb5300b6c21c0fe1d962092c7d15b87c

Seems to be this has been forgotten in that commit
