### PR TITLE
Disable the IPv4 travis job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,8 @@ env:
 #  - BUILD_TYPE='netperf' MAKE_TARGETS='cooja'
   - BUILD_TYPE='shell'
   - BUILD_TYPE='elfloader'
-  - BUILD_TYPE='ipv4'
+# Tests under the ipv4 dir are individually disabled. Thus the entire job can be off
+#  - BUILD_TYPE='ipv4'
   - BUILD_TYPE='ipv6-apps'
   - BUILD_TYPE='compile-8051-ports' BUILD_CATEGORY='compile' BUILD_ARCH='8051'
   - BUILD_TYPE='compile-arm-ports' BUILD_CATEGORY='compile' BUILD_ARCH='arm'


### PR DESCRIPTION
All individual regression tests under IPv4 are individually turned off. Thus, we are currently spawning a job which does exactly nothing.

This pull disables the entire job altogether to save a little time.
