### PR TITLE
Fix DNS lookups if mDNS is not enabled.

### DIFF
--- a/core/net/resolv.c
+++ b/core/net/resolv.c
@@ -1138,17 +1138,17 @@ PROCESS_THREAD(resolv_process, ev, data)
 
   PRINTF("resolver: Process started.\n");
 
+#if RESOLV_CONF_SUPPORTS_MDNS
   resolv_conn = udp_new(NULL, 0, NULL);
   resolv_conn->rport = 0;
 
-#if RESOLV_CONF_SUPPORTS_MDNS
   PRINTF("resolver: Supports MDNS.\n");
   uip_udp_bind(resolv_conn, UIP_HTONS(MDNS_PORT));
 
 #if UIP_CONF_IPV6
   uip_ds6_maddr_add(&resolv_mdns_addr);
 #else
-  /* TODO: Is there anything we need to do here for IPv4 multicast? */
+  resolv_conn = NULL;
 #endif
 
   resolv_set_hostname(CONTIKI_CONF_DEFAULT_HOSTNAME);
@@ -1159,6 +1159,13 @@ PROCESS_THREAD(resolv_process, ev, data)
 
     if(ev == PROCESS_EVENT_TIMER) {
       tcpip_poll_udp(resolv_conn);
+#if !RESOLV_CONF_SUPPORTS_MDNS
+    } else if(ev == EVENT_NEW_SERVER) {
+      if(resolv_conn != NULL) {
+        uip_udp_remove(resolv_conn);
+      }
+      resolv_conn = udp_new((uip_ipaddr_t *)data, UIP_HTONS(53), NULL);
+#endif
     } else if(ev == tcpip_event) {
       if(uip_udp_conn == resolv_conn) {
         if(uip_newdata()) {


### PR DESCRIPTION
DNS lookups didn't work on targets which set RESOLV_CONF_SUPPORTS_MDNS to 0. I've noticed with the atari and atarixl targets.
This patch fixes it.
