### PR TITLE
Initialize tcpip process before resolver process.

### DIFF
--- a/platform/apple2enh/contiki-main.c
+++ b/platform/apple2enh/contiki-main.c
@@ -45,15 +45,15 @@
 #endif /* WITH_GUI */
 
 #if WITH_DNS
-#define RESOLV_PROCESS &resolv_process,
+#define RESOLV_PROCESS ,&resolv_process
 #else /* WITH_DNS */
 #define RESOLV_PROCESS
 #endif /* WITH_DNS */
 
 PROCINIT(&etimer_process,
          CTK_PROCESS
-         RESOLV_PROCESS
-         &tcpip_process);
+         &tcpip_process
+         RESOLV_PROCESS);
 
 void clock_update(void);
 

--- a/platform/atari/contiki-main.c
+++ b/platform/atari/contiki-main.c
@@ -45,15 +45,15 @@
 #endif /* WITH_GUI */
 
 #if WITH_DNS
-#define RESOLV_PROCESS &resolv_process,
+#define RESOLV_PROCESS ,&resolv_process
 #else /* WITH_DNS */
 #define RESOLV_PROCESS
 #endif /* WITH_DNS */
 
 PROCINIT(&etimer_process,
          CTK_PROCESS
-         RESOLV_PROCESS
-         &tcpip_process);
+         &tcpip_process
+         RESOLV_PROCESS);
 
 /*-----------------------------------------------------------------------------------*/
 void

--- a/platform/atarixl/contiki-main.c
+++ b/platform/atarixl/contiki-main.c
@@ -45,15 +45,15 @@
 #endif /* WITH_GUI */
 
 #if WITH_DNS
-#define RESOLV_PROCESS &resolv_process,
+#define RESOLV_PROCESS ,&resolv_process
 #else /* WITH_DNS */
 #define RESOLV_PROCESS
 #endif /* WITH_DNS */
 
 PROCINIT(&etimer_process,
          CTK_PROCESS
-         RESOLV_PROCESS
-         &tcpip_process);
+         &tcpip_process
+         RESOLV_PROCESS);
 
 /*-----------------------------------------------------------------------------------*/
 void

--- a/platform/c128/contiki-main.c
+++ b/platform/c128/contiki-main.c
@@ -47,15 +47,15 @@
 #endif /* WITH_GUI */
 
 #if WITH_DNS
-#define RESOLV_PROCESS &resolv_process,
+#define RESOLV_PROCESS ,&resolv_process
 #else /* WITH_DNS */
 #define RESOLV_PROCESS
 #endif /* WITH_DNS */
 
 PROCINIT(&etimer_process,
          CTK_PROCESS
-         RESOLV_PROCESS
-         &tcpip_process);
+         &tcpip_process
+         RESOLV_PROCESS);
 
 /*-----------------------------------------------------------------------------------*/
 void

--- a/platform/c64/contiki-main.c
+++ b/platform/c64/contiki-main.c
@@ -47,15 +47,15 @@
 #endif /* WITH_GUI */
 
 #if WITH_DNS
-#define RESOLV_PROCESS &resolv_process,
+#define RESOLV_PROCESS ,&resolv_process
 #else /* WITH_DNS */
 #define RESOLV_PROCESS
 #endif /* WITH_DNS */
 
 PROCINIT(&etimer_process,
          CTK_PROCESS
-         RESOLV_PROCESS
-         &tcpip_process);
+         &tcpip_process
+         RESOLV_PROCESS);
 
 /*-----------------------------------------------------------------------------------*/
 void


### PR DESCRIPTION
Since introduction of mDNS (https://github.com/contiki-os/contiki/commit/f145c17039b778cde1d53b6828757cd91dc8480a)
the resolver process initialization depends on the tcpip process
already being initialized (because of the call to udp_new()).
