### PR TITLE
Added SPI driver for CC2538

### DIFF
--- a/cpu/cc2538/Makefile.cc2538
+++ b/cpu/cc2538/Makefile.cc2538
@@ -40,7 +40,7 @@ CONTIKI_CPU_DIRS += ../cc253x/usb/common ../cc253x/usb/common/cdc-acm
 
 ### CPU-dependent source files
 CONTIKI_CPU_SOURCEFILES += clock.c rtimer-arch.c uart.c watchdog.c
-CONTIKI_CPU_SOURCEFILES += nvic.c cpu.c sys-ctrl.c gpio.c ioc.c
+CONTIKI_CPU_SOURCEFILES += nvic.c cpu.c sys-ctrl.c gpio.c ioc.c spi.c
 CONTIKI_CPU_SOURCEFILES += cc2538-rf.c udma.c lpm.c
 CONTIKI_CPU_SOURCEFILES += dbg.c ieee-addr.c
 CONTIKI_CPU_SOURCEFILES += slip-arch.c slip.c

--- a/cpu/cc2538/dev/gpio.h
+++ b/cpu/cc2538/dev/gpio.h
@@ -185,6 +185,14 @@ typedef void (* gpio_callback_t)(uint8_t port, uint8_t pin);
  * in this category
  */
 #define GPIO_PIN_MASK(PIN) (1 << PIN)
+
+/**
+ * \brief Converts a port number to the port base address
+ * \param The port number in the range 0 - 3. Likely GPIO_X_NUM.
+ * \return The base address for the registers corresponding to that port
+ * number.
+ */
+#define GPIO_PORT_TO_BASE(PORT) (GPIO_A_BASE + (PORT << 12))
 /** @} */
 /*---------------------------------------------------------------------------*/
 /** \name GPIO Register offset declarations

--- a/cpu/cc2538/dev/spi.c
+++ b/cpu/cc2538/dev/spi.c
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2013, University of Michigan.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+/**
+ * \addtogroup cc2538-spi
+ * @{
+ *
+ * \file
+ * Implementation of the cc2538 SPI peripheral
+ */
+#include "contiki.h"
+#include "reg.h"
+#include "dev/ioc.h"
+#include "dev/sys-ctrl.h"
+#include "dev/spi.h"
+#include "dev/ssi.h"
+#include "dev/gpio.h"
+#include "spi-arch.h"
+
+/**
+ * \brief Initialize the SPI bus.
+ *
+ * This SPI init() function uses the following #defines to set the pins:
+ *    CC2538_SPI_CLK_PORT_NUM    CC2538_SPI_CLK_PIN_NUM
+ *    CC2538_SPI_MOSI_PORT_NUM   CC2538_SPI_MOSI_PIN_NUM
+ *    CC2538_SPI_MISO_PORT_NUM   CC2538_SPI_MISO_PIN_NUM
+ *    CC2538_SPI_SEL_PORT_NUM    CC2538_SPI_SEL_PIN_NUM
+ *
+ * This sets the SPI data width to 8 bits and the mode to Freescale mode 3.
+ */
+void
+spi_init(void)
+{
+  /* Enable the SSI peripheral */
+  REG(SYS_CTRL_RCGCSSI) |= 1;
+
+  /* Start by disabling the peripheral before configuring it */
+  REG(SSI0_BASE + SSI_CR1) = 0;
+
+  /* Set the IO clock as the SSI clock */
+  REG(SSI0_BASE + SSI_CC) = 1;
+
+  /* Set the mux correctly to connect the SSI pins to the correct GPIO pins */
+  ioc_set_sel(CC2538_SPI_CLK_PORT_NUM, CC2538_SPI_CLK_PIN_NUM, IOC_PXX_SEL_SSI0_CLKOUT);
+  ioc_set_sel(CC2538_SPI_MOSI_PORT_NUM, CC2538_SPI_MOSI_PIN_NUM, IOC_PXX_SEL_SSI0_TXD);
+  REG(IOC_SSIRXD_SSI0) = (CC2538_SPI_MISO_PORT_NUM * 8) + CC2538_SPI_MISO_PIN_NUM;
+  ioc_set_sel(CC2538_SPI_SEL_PORT_NUM, CC2538_SPI_SEL_PIN_NUM, IOC_PXX_SEL_SSI0_FSSOUT);
+
+  /* Put all the SSI gpios into peripheral mode */
+  GPIO_PERIPHERAL_CONTROL(GPIO_PORT_TO_BASE(CC2538_SPI_CLK_PORT_NUM), GPIO_PIN_MASK(CC2538_SPI_CLK_PIN_NUM));
+  GPIO_PERIPHERAL_CONTROL(GPIO_PORT_TO_BASE(CC2538_SPI_MOSI_PORT_NUM), GPIO_PIN_MASK(CC2538_SPI_MOSI_PIN_NUM));
+  GPIO_PERIPHERAL_CONTROL(GPIO_PORT_TO_BASE(CC2538_SPI_MISO_PORT_NUM), GPIO_PIN_MASK(CC2538_SPI_MISO_PIN_NUM));
+  GPIO_PERIPHERAL_CONTROL(GPIO_PORT_TO_BASE(CC2538_SPI_SEL_PORT_NUM), GPIO_PIN_MASK(CC2538_SPI_SEL_PIN_NUM));
+
+  /* Disable any pull ups or the like */
+  ioc_set_over(CC2538_SPI_CLK_PORT_NUM, CC2538_SPI_CLK_PIN_NUM, IOC_OVERRIDE_DIS);
+  ioc_set_over(CC2538_SPI_MOSI_PORT_NUM, CC2538_SPI_MOSI_PIN_NUM, IOC_OVERRIDE_DIS);
+  ioc_set_over(CC2538_SPI_MISO_PORT_NUM, CC2538_SPI_MISO_PIN_NUM, IOC_OVERRIDE_DIS);
+  ioc_set_over(CC2538_SPI_SEL_PORT_NUM, CC2538_SPI_SEL_PIN_NUM, IOC_OVERRIDE_DIS);
+
+  /* Configure the clock */
+  REG(SSI0_BASE + SSI_CPSR) = 2;
+
+  /* Put the ssi in motorola SPI mode with 8 bit data */
+  REG(SSI0_BASE + SSI_CR0) = SSI_CR0_SPH_M | SSI_CR0_SPO_M | (7);
+
+  /* Enable the SSI */
+  REG(SSI0_BASE + SSI_CR1) |= SSI_CR1_SSE;
+
+  /* Clear the RX FIFO */
+  SPI_WAITFOREORx();
+}
+/** @} */

--- a/cpu/cc2538/dev/ssi.h
+++ b/cpu/cc2538/dev/ssi.h
@@ -1,0 +1,175 @@
+/*
+ * Copyright (c) 2013, University of Michigan.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+/**
+ * \addtogroup cc2538
+ * @{
+ *
+ * \defgroup cc2538-spi cc2538 Synchronous Serial Interface
+ *
+ * Driver for the cc2538 SPI peripheral
+ *
+ * Register and bitmask definitions based on the Foundation Firmware from
+ * Texas Instruments.
+ * @{
+ *
+ * \file
+ * Header file for the cc2538 Synchronous Serial Interface
+ */
+
+#ifndef SSI_H_
+#define SSI_H_
+
+/*---------------------------------------------------------------------------*/
+/** \name Base register memory locations.
+ * @{
+ */
+#define SSI0_BASE               0x40008000 /**< Base address for SSI0 */
+#define SSI1_BASE               0x40009000 /**< Base address for SSI1 */
+/** @} */
+/*---------------------------------------------------------------------------*/
+/** \name SSI register offsets
+ * @{
+ */
+#define SSI_CR0                 0x00000000 /**< Control register 0 */
+#define SSI_CR1                 0x00000004 /**< Control register 1 */
+#define SSI_DR                  0x00000008 /**< Access the TX and RX FIFO */
+#define SSI_SR                  0x0000000C /**< Meta information about FIFO */
+#define SSI_CPSR                0x00000010 /**< Clock divider */
+#define SSI_IM                  0x00000014 /**< Interrupt mask */
+#define SSI_RIS                 0x00000018 /**< Raw interrupt status */
+#define SSI_MIS                 0x0000001C /**< Masked interrupt status */
+#define SSI_ICR                 0x00000020 /**< Interrupt clear register */
+#define SSI_DMACTL              0x00000024 /**< DMA control register */
+#define SSI_CC                  0x00000FC8 /**< Clock configuration */
+/** @} */
+/*---------------------------------------------------------------------------*/
+/** \name SSI Bitmasks and shifts
+ * @{
+ */
+#define SSI_CR0_SCR_M           0x0000FF00 /**< Serial clock rate mask */
+#define SSI_CR0_SCR_S           8          /**< Serial clock rate shift */
+#define SSI_CR0_SPH             0x00000080 /**< Serial clock phase (H) */
+#define SSI_CR0_SPH_M           0x00000080 /**< Serial clock phase (H) mask */
+#define SSI_CR0_SPH_S           7          /**< Serial clock phase (H) shift */
+#define SSI_CR0_SPO             0x00000040 /**< Serial clock phase (O) */
+#define SSI_CR0_SPO_M           0x00000040 /**< Serial clock phase (O) mask */
+#define SSI_CR0_SPO_S           6          /**< Serial clock phase (O) shift */
+#define SSI_CR0_FRF_M           0x00000030 /**< Frame format select mask */
+#define SSI_CR0_FRF_S           4          /**< Frame format select shift */
+#define SSI_CR0_DSS_M           0x0000000F /**< Data size select mask */
+#define SSI_CR0_DSS_S           0          /**< Data size select shift */
+#define SSI_CR1_SOD             0x00000008 /**< Slave mode output disable */
+#define SSI_CR1_SOD_M           0x00000008 /**< Slave mode output disable mask */
+#define SSI_CR1_SOD_S           3          /**< Slave mode output disable shift */
+#define SSI_CR1_MS              0x00000004 /**< Master and slave select */
+#define SSI_CR1_MS_M            0x00000004 /**< Master and slave select mask */
+#define SSI_CR1_MS_S            2          /**< Master and slave select shift */
+#define SSI_CR1_SSE             0x00000002 /**< Synchronous serial port enable */
+#define SSI_CR1_SSE_M           0x00000002 /**< Synchronous serial port enable mask */
+#define SSI_CR1_SSE_S           1          /**< Synchronous serial port enable shift */
+#define SSI_CR1_LBM             0x00000001 /**< Loop-back mode */
+#define SSI_CR1_LBM_M           0x00000001 /**< Loop-back mode mask */
+#define SSI_CR1_LBM_S           0          /**< Loop-back mode shift */
+#define SSI_DR_DATA_M           0x0000FFFF /**< FIFO data mask */
+#define SSI_DR_DATA_S           0          /**< FIFO data shift */
+#define SSI_SR_BSY              0x00000010 /**< Busy bit */
+#define SSI_SR_BSY_M            0x00000010 /**< Busy bit mask */
+#define SSI_SR_BSY_S            4          /**< Busy bit shift */
+#define SSI_SR_RFF              0x00000008 /**< Receive FIFO full */
+#define SSI_SR_RFF_M            0x00000008 /**< Receive FIFO full mask */
+#define SSI_SR_RFF_S            3          /**< Receive FIFO full shift */
+#define SSI_SR_RNE              0x00000004 /**< Receive FIFO not empty */
+#define SSI_SR_RNE_M            0x00000004 /**< Receive FIFO not empty mask */
+#define SSI_SR_RNE_S            2          /**< Receive FIFO not empty shift */
+#define SSI_SR_TNF              0x00000002 /**< Transmit FIFO not full */
+#define SSI_SR_TNF_M            0x00000002 /**< Transmit FIFO not full mask */
+#define SSI_SR_TNF_S            1          /**< Transmit FIFO not full shift */
+#define SSI_SR_TFE              0x00000001 /**< Transmit FIFO empty */
+#define SSI_SR_TFE_M            0x00000001 /**< Transmit FIFO empty mask */
+#define SSI_SR_TFE_S            0          /**< Transmit FIFO empty shift */
+#define SSI_CPSR_CPSDVSR_M      0x000000FF /**< Clock prescale divisor mask */
+#define SSI_CPSR_CPSDVSR_S      0          /**< Clock prescale divisor shift */
+#define SSI_IM_TXIM             0x00000008 /**< Transmit FIFO interrupt mask */
+#define SSI_IM_TXIM_M           0x00000008 /**< Transmit FIFO interrupt mask mask */
+#define SSI_IM_TXIM_S           3          /**< Transmit FIFO interrupt mask shift */
+#define SSI_IM_RXIM             0x00000004 /**< Receive FIFO interrupt mask */
+#define SSI_IM_RXIM_M           0x00000004 /**< Receive FIFO interrupt mask mask */
+#define SSI_IM_RXIM_S           2          /**< Receive FIFO interrupt mask shift */
+#define SSI_IM_RTIM             0x00000002 /**< Receive time-out interrupt mask */
+#define SSI_IM_RTIM_M           0x00000002 /**< Receive time-out interrupt mask mask */
+#define SSI_IM_RTIM_S           1          /**< Receive time-out interrupt mask shift */
+#define SSI_IM_RORIM            0x00000001 /**< Receive overrun interrupt mask */
+#define SSI_IM_RORIM_M          0x00000001 /**< Receive overrun interrupt mask mask */
+#define SSI_IM_RORIM_S          0          /**< Receive overrun interrupt mask shift */
+#define SSI_RIS_TXRIS           0x00000008 /**< SSITXINTR raw state */
+#define SSI_RIS_TXRIS_M         0x00000008 /**< SSITXINTR raw state mask */
+#define SSI_RIS_TXRIS_S         3          /**< SSITXINTR raw state shift */
+#define SSI_RIS_RXRIS           0x00000004 /**< SSIRXINTR raw state */
+#define SSI_RIS_RXRIS_M         0x00000004 /**< SSIRXINTR raw state mask */
+#define SSI_RIS_RXRIS_S         2          /**< SSIRXINTR raw state shift */
+#define SSI_RIS_RTRIS           0x00000002 /**< SSIRTINTR raw state */
+#define SSI_RIS_RTRIS_M         0x00000002 /**< SSIRTINTR raw state mask */
+#define SSI_RIS_RTRIS_S         1          /**< SSIRTINTR raw state shift */
+#define SSI_RIS_RORRIS          0x00000001 /**< SSIRORINTR raw state */
+#define SSI_RIS_RORRIS_M        0x00000001 /**< SSIRORINTR raw state mask */
+#define SSI_RIS_RORRIS_S        0          /**< SSIRORINTR raw state shift */
+#define SSI_MIS_TXMIS           0x00000008 /**< SSITXINTR masked state */
+#define SSI_MIS_TXMIS_M         0x00000008 /**< SSITXINTR masked state mask */
+#define SSI_MIS_TXMIS_S         3          /**< SSITXINTR masked state shift */
+#define SSI_MIS_RXMIS           0x00000004 /**< SSIRXINTR masked state */
+#define SSI_MIS_RXMIS_M         0x00000004 /**< SSIRXINTR masked state mask */
+#define SSI_MIS_RXMIS_S         2          /**< SSIRXINTR masked state shift */
+#define SSI_MIS_RTMIS           0x00000002 /**< SSIRTINTR masked state */
+#define SSI_MIS_RTMIS_M         0x00000002 /**< SSIRTINTR masked state mask */
+#define SSI_MIS_RTMIS_S         1          /**< SSIRTINTR masked state shift */
+#define SSI_MIS_RORMIS          0x00000001 /**< SSIRORINTR masked state */
+#define SSI_MIS_RORMIS_M        0x00000001 /**< SSIRORINTR masked state mask */
+#define SSI_MIS_RORMIS_S        0          /**< SSIRORINTR masked state shift */
+#define SSI_ICR_RTIC            0x00000002 /**< Receive time-out interrupt clear */
+#define SSI_ICR_RTIC_M          0x00000002 /**< Receive time-out interrupt clear mask */
+#define SSI_ICR_RTIC_S          1          /**< Receive time-out interrupt clear shift */
+#define SSI_ICR_RORIC           0x00000001 /**< Receive overrun interrupt clear */
+#define SSI_ICR_RORIC_M         0x00000001 /**< Receive overrun interrupt clear mask */
+#define SSI_ICR_RORIC_S         0          /**< Receive overrun interrupt clear shift */
+#define SSI_DMACTL_TXDMAE       0x00000002 /**< Transmit DMA enable */
+#define SSI_DMACTL_TXDMAE_M     0x00000002 /**< Transmit DMA enable mask */
+#define SSI_DMACTL_TXDMAE_S     1          /**< Transmit DMA enable shift */
+#define SSI_DMACTL_RXDMAE       0x00000001 /**< Receive DMA enable */
+#define SSI_DMACTL_RXDMAE_M     0x00000001 /**< Receive DMA enable mask */
+#define SSI_DMACTL_RXDMAE_S     0          /**< Receive DMA enable shift */
+#define SSI_CC_CS_M             0x00000007 /**< Baud and system clock source mask */
+#define SSI_CC_CS_S             0          /**< Baud and system clock source shift */
+/** @} */
+
+#endif
+/**
+ * @}
+ * @}
+ */
+

--- a/cpu/cc2538/spi-arch.h
+++ b/cpu/cc2538/spi-arch.h
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2013, University of Michigan.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+/**
+ * \addtogroup cc2538
+ * @{
+ *
+ * Implementation of the low-level SPI primitives such as waiting for the TX
+ * FIFO to be ready, inserting into the TX FIFO, etc.
+ * @{
+ */
+/**
+ * \file
+ * Header file for the cc2538 SPI commands
+ */
+#ifndef SPI_ARCH_H_
+#define SPI_ARCH_H_
+
+#include "contiki.h"
+#include "dev/ssi.h"
+
+#define SPI_WAITFORTxREADY() do { \
+  while(!(REG(SSI0_BASE + SSI_SR) & SSI_SR_TNF)); \
+} while (0)
+
+#define SPI_TXBUF REG(SSI0_BASE + SSI_DR)
+#define SPI_RXBUF REG(SSI0_BASE + SSI_DR)
+
+#define SPI_WAITFOREOTx() do { \
+  while(REG(SSI0_BASE + SSI_SR) & SSI_SR_BSY); \
+} while (0)
+#define SPI_WAITFOREORx() do { \
+  while(!(REG(SSI0_BASE + SSI_SR) & SSI_SR_RNE)); \
+} while (0)
+
+#endif /* SPI_ARCH_H_ */
+
+/**
+ * @}
+ * @}
+ */

--- a/platform/cc2538dk/dev/board.h
+++ b/platform/cc2538dk/dev/board.h
@@ -179,6 +179,22 @@
 /** @} */
 /*---------------------------------------------------------------------------*/
 /**
+ * \name SPI configuration
+ *
+ * These values configure which CC2538 pins to use for the SPI lines.
+ * @{
+ */
+#define CC2538_SPI_CLK_PORT_NUM  GPIO_A_NUM
+#define CC2538_SPI_CLK_PIN_NUM   2
+#define CC2538_SPI_MOSI_PORT_NUM GPIO_A_NUM
+#define CC2538_SPI_MOSI_PIN_NUM  4
+#define CC2538_SPI_MISO_PORT_NUM GPIO_A_NUM
+#define CC2538_SPI_MISO_PIN_NUM  5
+#define CC2538_SPI_SEL_PORT_NUM  GPIO_B_NUM
+#define CC2538_SPI_SEL_PIN_NUM   5
+/** @} */
+/*---------------------------------------------------------------------------*/
+/**
  * \name Device string used on startup
  * @{
  */


### PR DESCRIPTION
This uses the `core/dev/spi.h` header and implements the `spi_init()` function and the various macros for SPI operation. ssi.h contains all of the register locations and information.

This implementation is not very versatile, mostly because I don't how to make it flexible in the contiki system. It supports pin muxing for the four spi pins, but other than that picks sensible defaults.

The SPI macros (like `SPI_READ()`) are defined in `platform/cc2538dk/contiki-conf.h`. Is there a better place for them? They are CPU specific so I think they should be in cpu/cc2538, but there doesn't seem to be a logical place given that spi.h is already defined.
