### PR TITLE
Fix Bridge handling in sicslowpan network driver

### DIFF
--- a/core/net/sicslowpan.c
+++ b/core/net/sicslowpan.c
@@ -1325,8 +1325,8 @@ send_packet(rimeaddr_t *dest)
    */
   packetbuf_set_addr(PACKETBUF_ADDR_RECEIVER, dest);
 
-#if NETSTACK_CONF_BRIDGE_MODE
-  /* This needs to be explicitly set here for bridge mode to work */
+#if !NETSTACK_CONF_BRIDGE_MODE
+  /* In bridge mode this should be set by a higher level layer */
   packetbuf_set_addr(PACKETBUF_ADDR_SENDER,(void*)&uip_lladdr);
 #endif
 


### PR DESCRIPTION
In case the node is a bridge it should not set the local lladdr as sending
address, but it should be set in any other case.
