### PR TITLE
Finetuned Atari XL memory layout.

### DIFF
--- a/platform/atarixl/Makefile.atarixl
+++ b/platform/atarixl/Makefile.atarixl
@@ -34,8 +34,8 @@
 CONTIKI_CPU = $(CONTIKI)/cpu/6502
 include $(CONTIKI_CPU)/Makefile.6502
 
-SHADOW_RAM_SOURCEFILES  = etimer.c procinit.c uip.c
-SHADOW_RAM2_SOURCEFILES = clock.c uip_arch.c uip_arp.c
+SHADOW_RAM_SOURCEFILES  = etimer.c uip.c
+SHADOW_RAM2_SOURCEFILES = clock.c error.c uip_arch.c uip_arp.c
 
 # Set target-specific variable values
 ${addprefix $(OBJECTDIR)/,${call oname, $(SHADOW_RAM_SOURCEFILES)}}:  CFLAGS += --code-name SHADOW_RAM


### PR DESCRIPTION
The Telent server includes both uIP logging and uIP client functionality. Therefore uip.o is somewhat larger.
