### PR TITLE
core/net/mac: Invalid struct member u8 in PRINTADDR

### DIFF
--- a/core/net/mac/framer-802154.c
+++ b/core/net/mac/framer-802154.c
@@ -173,7 +173,7 @@ create(void)
     frame802154_create(&params, packetbuf_hdrptr(), len);
 
     PRINTF("15.4-OUT: %2X", params.fcf.frame_type);
-    PRINTADDR(params.dest_addr.u8);
+    PRINTADDR(params.dest_addr);
     PRINTF("%d %u (%u)\n", len, packetbuf_datalen(), packetbuf_totlen());
 
     return len;

--- a/core/net/mac/sicslowmac.c
+++ b/core/net/mac/sicslowmac.c
@@ -160,7 +160,7 @@ send_packet(mac_callback_t sent, void *ptr)
     frame802154_create(&params, packetbuf_hdrptr(), len);
 
     PRINTF("6MAC-UT: %2X", params.fcf.frame_type);
-    PRINTADDR(params.dest_addr.u8);
+    PRINTADDR(params.dest_addr);
     PRINTF("%u %u (%u)\n", len, packetbuf_datalen(), packetbuf_totlen());
 
     ret = NETSTACK_RADIO.send(packetbuf_hdrptr(), packetbuf_totlen());


### PR DESCRIPTION
Member `dest_addr` in struct `frame802154_t` is already `uint8_t[8]`.
