### PR TITLE
Added support for STM32w boards MB950 and MB951 revision B.

### DIFF
--- a/platform/mbxxx/board.c
+++ b/platform/mbxxx/board.c
@@ -57,7 +57,9 @@
 * - MB954 B
 * - MB954 C
 * - MB950 A
+* - MB950 B
 * - MB951 A
+* - MB951 B
 * - IDZ401V1
 */
 /*---------------------------------------------------------------------------*/
@@ -318,11 +320,33 @@ const BoardResourcesType MB950A = {
   &stlm20PA4noDiv,
 };
 
+const BoardResourcesType MB950B = {
+  "MB950 B",
+  (BOARD_HAS_MEMS | BOARD_HAS_TEMP_SENSOR | BOARD_HAS_STM32F),
+  BUTTONS_MB950B,
+  LEDS_MB950B,
+  &ioMB950A,
+  &infraRedLedMB851A,
+  &memsSensor,
+  &stlm20PA4noDiv,
+};
+
 const BoardResourcesType MB951A = {
   "MB951 A",
   (BOARD_HAS_STM32F),
   BUTTONS_MB951A,
   LEDS_MB951A,
+  &ioMB951A,
+  NULL,
+  NULL,
+  NULL,
+};
+
+const BoardResourcesType MB951B = {
+  "MB951 B",
+  (BOARD_HAS_STM32F),
+  BUTTONS_MB951B,
+  LEDS_MB951B,
   &ioMB951A,
   NULL,
   NULL,
@@ -349,7 +373,9 @@ static const BoardResourcesType *boardList [] = {
   &MB954B,
   &MB954C,
   &MB950A,
+  &MB950B,
   &MB951A,
+  &MB951B,
   &IDZ401V1
 };
 

--- a/platform/mbxxx/board.h
+++ b/platform/mbxxx/board.h
@@ -103,7 +103,15 @@ char boardName[16];
 /**
  * \brief Define the number of LEDs in the specific board revision
  */
+#define LEDS_MB950B 2
+/**
+ * \brief Define the number of LEDs in the specific board revision
+ */
 #define LEDS_MB951A 2
+/**
+ * \brief Define the number of LEDs in the specific board revision
+ */
+#define LEDS_MB951B 2
 
 
 
@@ -155,7 +163,15 @@ char boardName[16];
 /**
  * \brief Define the number of user buttons in the specific board revision
  */
+#define BUTTONS_MB950B 5
+/**
+ * \brief Define the number of user buttons in the specific board revision
+ */
 #define BUTTONS_MB951A 1
+/**
+ * \brief Define the number of user buttons in the specific board revision
+ */
+#define BUTTONS_MB951B 1
 
 
 


### PR DESCRIPTION
This board revision is included in the current version of the STM32W RF Control kit.
