### PR TITLE
Fix a typo that prevents the native target from building the example

### DIFF
--- a/platform/native/contiki-conf.h
+++ b/platform/native/contiki-conf.h
@@ -79,7 +79,7 @@ typedef unsigned short uip_stats_t;
 #define NETSTACK_CONF_RDC_CHANNEL_CHECK_RATE 8
 #endif /* NETSTACK_CONF_RDC_CHANNEL_CHECK_RATE */
 
-#if UIP_CONF_IPV6
+#if WITH_UIP6
 
 #define RIMEADDR_CONF_SIZE              8
 
@@ -100,6 +100,8 @@ typedef unsigned short uip_stats_t;
 #endif /* NETSTACK_CONF_FRAMER */
 
 #define NETSTACK_CONF_NETWORK sicslowpan_driver
+
+#define UIP_CONF_IPV6                   1
 
 #define UIP_CONF_ROUTER                 1
 #ifndef UIP_CONF_IPV6_RPL
@@ -165,7 +167,7 @@ typedef unsigned short uip_stats_t;
 
 
 
-#endif /* UIP_CONF_IPV6 */
+#endif /* WITH_UIP6 */
 
 #include <ctype.h>
 #define ctk_arch_isprint isprint


### PR DESCRIPTION
For the past few months, I tried to build the IPv6 examples (for example ipv6/rpl-udp) without much success. In order to get it to build, I had to modify the example Makefiles and add a -DUIP_CONF_IPV6 to the build command. This approach did not seem clean to me (as the build should work for all target without any modification), so I tried to see why the build would fail on the native architecture. It would appear that there is a small typo and one #define missing (see the patch), but I could be wrong.

How to reproduce the build errors:

```
cd examples/ipv6/rpl-udp
make TARGET=contiki
```

This build will fail because references to uip_ds6\* functions are missing (full build error at the end of the pull request).

Regards,
Tony

---

```
[...]
cp ../../../tools/empty-symbols.h symbols.h
  CC        symbols.c
  AR        contiki-native.a
  CC        udp-client.c
  LD        udp-client.native
udp-client.co: In function `set_global_address':
/users/tcheneau/work/project/contiki/examples/ipv6/rpl-udp/udp-client.c:120: undefined reference to `uip_ds6_set_addr_iid'
/users/tcheneau/work/project/contiki/examples/ipv6/rpl-udp/udp-client.c:121: undefined reference to `uip_ds6_addr_add'
udp-client.co: In function `print_local_addresses':
/users/tcheneau/work/project/contiki/examples/ipv6/rpl-udp/udp-client.c:99: undefined reference to `uip_ds6_if'
/users/tcheneau/work/project/contiki/examples/ipv6/rpl-udp/udp-client.c:104: undefined reference to `uip_ds6_if'
contiki-native.a(contiki-main.o): In function `main':
/users/tcheneau/work/project/contiki/examples/ipv6/rpl-udp/../../../platform/native/./contiki-main.c:203: undefined reference to `rime_driver'
/users/tcheneau/work/project/contiki/examples/ipv6/rpl-udp/../../../platform/native/./contiki-main.c:216: undefined reference to `uip_ds6_get_link_local'
contiki-native.a(nullmac.o): In function `packet_input':
/users/tcheneau/work/project/contiki/examples/ipv6/rpl-udp/../../../core/net/mac/nullmac.c:54: undefined reference to `rime_driver'
contiki-native.a(netstack.o): In function `netstack_init':
/users/tcheneau/work/project/contiki/examples/ipv6/rpl-udp/../../../core/net/netstack.c:48: undefined reference to `rime_driver'
collect2: ld returned 1 exit status
make: *** [udp-client.native] Error 1
```
