### PR TITLE
ADC driver for cc2538 (re-pull request)

### DIFF
--- a/cpu/cc2538/Makefile.cc2538
+++ b/cpu/cc2538/Makefile.cc2538
@@ -42,7 +42,7 @@ CONTIKI_CPU_DIRS += ../cc253x/usb/common ../cc253x/usb/common/cdc-acm
 CONTIKI_CPU_SOURCEFILES += clock.c rtimer-arch.c uart.c watchdog.c
 CONTIKI_CPU_SOURCEFILES += nvic.c cpu.c sys-ctrl.c gpio.c ioc.c spi.c
 CONTIKI_CPU_SOURCEFILES += cc2538-rf.c udma.c lpm.c
-CONTIKI_CPU_SOURCEFILES += dbg.c ieee-addr.c
+CONTIKI_CPU_SOURCEFILES += dbg.c ieee-addr.c adc.c
 CONTIKI_CPU_SOURCEFILES += slip-arch.c slip.c
 
 DEBUG_IO_SOURCEFILES += dbg-printf.c dbg-snprintf.c dbg-sprintf.c strformat.c

--- a/cpu/cc2538/dev/adc.c
+++ b/cpu/cc2538/dev/adc.c
@@ -1,0 +1,263 @@
+/*
+ * Copyright (c) 2013, elarm Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ */
+/**
+ * \addtogroup cc2538-adc
+ * @{
+ *
+ * \file
+ * Implementation of the cc2538 ADC driver
+ *
+ * \author
+ *           Adam Rea <areairs@gmail.com>
+ */
+#include "contiki.h"
+#include "sys/energest.h"
+#include "dev/sys-ctrl.h"
+#include "dev/ioc.h"
+#include "dev/gpio.h"
+#include "dev/adc.h"
+#include "dev/nvic.h"
+#include "reg.h"
+
+#include <stdio.h>
+
+/* Fire the ADC at 128 Hz */
+#define ADC_TIC_TIMER_VAL    1
+/* Use the first 12 ADC ports (AIN0 - AIN67) */ 
+#define ADC_NUM_PORTS        12
+
+static struct etimer adc_tic_timer;
+typedef struct adc_element {
+  uint8_t active;
+  uint8_t tics_to_fire;
+  uint8_t resolution;
+  uint8_t counter_reset_val;
+  uint8_t waiting_for_service;
+  int (*callback_fn)(int, uint8_t);
+} adc_element_t;
+
+static adc_element_t adc_pin_status [ADC_NUM_PORTS];
+static uint8_t tic_timer_started, current_service;
+/*---------------------------------------------------------------------------*/
+PROCESS(adc_process,"ADC process");
+/*---------------------------------------------------------------------------*/
+void
+adc_init(void)
+{
+  /* do any GLOBAL setup stuff here */
+  tic_timer_started = 0;
+  current_service = 0;
+  
+  /* Enable ADC Interrupts */
+  nvic_interrupt_enable(NVIC_INT_ADC);
+}
+/*---------------------------------------------------------------------------*/
+uint8_t
+adc_register_pin(uint8_t pin, uint8_t samples_per_second, 
+		 uint8_t decimation_rate, int (*cb)(int, uint8_t) )
+{
+  uint8_t diff_pin;
+  
+  /* check arguments only doing AIN0 - AIN67 (single ended and differential) */
+  if ((pin < ADC_AIN0) || (pin > ADC_AIN67))
+    return 0;
+
+  /* bound by clock seconds for granularity */
+  if(samples_per_second > CLOCK_SECOND)
+    return 0;
+
+  if(!((decimation_rate == ADC_7_BIT) || (decimation_rate == ADC_9_BIT)
+	|| (decimation_rate == ADC_10_BIT) || (decimation_rate == ADC_12_BIT)))
+    return 0;
+
+  /* Set up the pads and functions for ADC */
+  if(pin < ADC_AIN01) { /* Single ended */
+    /* set input */
+    REG(GPIO_A_BASE + GPIO_DIR) &= ~(0x01 << pin);
+    
+    /* set alt function to none */
+    REG(GPIO_A_BASE + GPIO_AFSEL) &= ~(0x01 << pin); 
+    
+    /* set overrides to !OE, !PUE, !PDE, ANA */
+    REG(IOC_PA0_OVER + (0x04 * pin)) = 0x01; 
+  
+  } else if(pin < ADC_GND) { /* differential setting */
+    
+    diff_pin = (pin - ADC_AIN01) * 2;
+    /* set inputs on the 2 differential pads */
+    REG(GPIO_A_BASE + GPIO_DIR) &= ~(0x03 << diff_pin);
+    
+    /* set alt functions on the 2 pads to none */
+    REG(GPIO_A_BASE + GPIO_AFSEL) &= ~(0x03 << diff_pin); 
+    
+    /* set overrides to !OE, !PUE, !PDE, ANA */
+    REG(IOC_PA0_OVER + (0x04 * diff_pin)) = 0x01;
+    REG(IOC_PA0_OVER + (0x04 * (diff_pin+1))) = 0x01;
+    
+  }
+
+
+  /* Set up the array element fields for the registration */
+  adc_pin_status[pin].active = 1;
+  adc_pin_status[pin].tics_to_fire = 1; /* fire next pass */
+  
+  /* Convert samples per second to periodicity and normalize with
+   * the TIC timer */
+  adc_pin_status[pin].counter_reset_val = CLOCK_SECOND / samples_per_second / ADC_TIC_TIMER_VAL;
+  adc_pin_status[pin].waiting_for_service = 0;
+  adc_pin_status[pin].resolution = decimation_rate;
+  adc_pin_status[pin].callback_fn = cb;
+
+  /* start the timer to make the process thread pass yeild */
+  if(!tic_timer_started){
+    tic_timer_started = 1;
+    etimer_set(&adc_tic_timer,ADC_TIC_TIMER_VAL); 
+  }
+  
+  /* added 1 to avoid collision with error condition */
+  return pin+1; 
+
+}
+/*---------------------------------------------------------------------------*/
+static void
+adc_service_requests(void)
+{
+  static uint8_t c;
+  
+  /* Re-enter where you left off */
+  for(c = current_service; c < ADC_NUM_PORTS; c++){
+    if(adc_pin_status[c].waiting_for_service == 1) {
+	/* clear the waiting status and capture our current iteration */
+	adc_pin_status[c].waiting_for_service = 0;
+	current_service = c;
+
+	/* fire a single read event and exit ... isr will recall to finish */
+	REG(ADC_ADCCON3) = adc_pin_status[c].resolution + c;
+	return;
+    }
+  }  
+}
+/*---------------------------------------------------------------------------*/
+PROCESS_THREAD(adc_process, ev, data)
+{
+  static uint8_t c, need_service;
+  
+  PROCESS_BEGIN();
+  
+  etimer_set(&adc_tic_timer,ADC_TIC_TIMER_VAL);
+  
+  while(1) {
+    PROCESS_WAIT_EVENT();
+    if(ev == PROCESS_EVENT_TIMER) {
+      if(data == &adc_tic_timer) {
+	
+    	/* Catch the tic timer early to ensure clean reset */
+	if(tic_timer_started) {
+	  etimer_reset(&adc_tic_timer);
+	} 
+	
+	need_service = 0;
+	
+	for(c = 0; c < ADC_NUM_PORTS; c++) {
+	  if(adc_pin_status[c].active) {
+	    adc_pin_status[c].tics_to_fire--;
+	    if(adc_pin_status[c].tics_to_fire == 0){
+	      adc_pin_status[c].tics_to_fire = adc_pin_status[c].counter_reset_val;
+	      adc_pin_status[c].waiting_for_service = 1;
+	      need_service = 1;
+	    }
+	  }
+	}
+		
+	/* If any number of the active pins need serviced, call the helper */
+	if(need_service){
+	  current_service = 0;
+	  adc_service_requests();
+	}
+      }
+    }
+  }
+  PROCESS_END();
+}
+/*---------------------------------------------------------------------------*/
+void
+adc_unregister_pin(uint8_t uid)
+{
+  uint8_t c, any_active;
+  
+  adc_pin_status[uid-1].active = 0;
+
+  for(c = 0; c < ADC_NUM_PORTS; c++) {
+    if(adc_pin_status[c].active) {
+      any_active = 1;
+    }
+  }
+
+  if(!any_active) {
+    tic_timer_started = 0;
+  }
+
+  return;
+}
+/*---------------------------------------------------------------------------*/
+void
+adc_isr(void)
+{
+  int resultant;
+  uint8_t shift, temp_dec; 
+
+  ENERGEST_ON(ENERGEST_TYPE_IRQ);
+
+  /* Get the low and the high (reading high last as it clears the int) */
+  resultant = (REG(ADC_ADCL) & 0xFF) + ((REG(ADC_ADCH) & 0xFF)<<8);
+  
+  temp_dec = adc_pin_status[current_service].resolution;
+
+  if(temp_dec == ADC_7_BIT) {
+    shift = ADC_7_BIT_RSHIFT;
+  } else if (temp_dec == ADC_9_BIT) {
+    shift = ADC_9_BIT_RSHIFT;
+  } else if (temp_dec == ADC_10_BIT) {
+    shift = ADC_10_BIT_RSHIFT;
+  } else {
+    shift = ADC_12_BIT_RSHIFT;
+  }
+
+  resultant >>= shift;
+  if(adc_pin_status[current_service].callback_fn != NULL) {
+    adc_pin_status[current_service].callback_fn(resultant,current_service+1);
+  }
+  
+  /* Recall the helper to get the next pin */  
+  adc_service_requests();
+  ENERGEST_OFF(ENERGEST_TYPE_IRQ);
+}
+
+/** @} */

--- a/cpu/cc2538/dev/adc.h
+++ b/cpu/cc2538/dev/adc.h
@@ -1,0 +1,239 @@
+/*
+ * Copyright (c) 2012, Texas Instruments Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ */
+/**
+ * \addtogroup cc2538
+ * @{
+ *
+ * \defgroup cc2538-adc cc2538 ADC
+ *
+ * Driver for the cc2538 ADC controller
+ * @{
+ *
+ * \file
+ * Header file for the cc2538 ADC driver
+ *
+ * \author
+ *  Adam Rea <areairs@gmail.com>
+ */
+#ifndef ADC_H_
+#define ADC_H_
+
+#include "contiki.h"
+
+#include <stdint.h>
+#include "reg.h"
+
+/*---------------------------------------------------------------------------*/
+/** \name ADC register offsets
+ * @{
+ */
+#define ADC_ADCCON1         0x400D7000  /**< ADC control register 1 */ 
+#define ADC_ADCCON2         0x400D7004  /**< ADC control register 2 */ 
+#define ADC_ADCCON3         0x400D7008  /**< ADC control register 3 */ 
+#define ADC_ADCL            0x400D700C  /**< LSB's of ADC conversion */ 
+#define ADC_ADCH            0x400D7010  /**< MSB's of ADC conversion */ 
+#define ADC_RNDL            0x400D7014  /**< Lower half of RNG data */
+#define ADC_RNDH            0x400D7018  /**< Upper half of RNG data */
+#define ADC_CMPCTL          0x400D7024  /**< Analog comparator control register */ 
+/** @} */
+/*---------------------------------------------------------------------------*/
+/** \name ADCCON1 bit fields
+ * @{
+ */
+#define ADC_ADCCON1_EOC     0x00000080  /**< End of conversion bit */
+#define ADC_ADCCON1_EOC_M   0x00000080  /**< End of conversion bit mask */
+#define ADC_ADCCON1_EOC_S   7           /**< End of conversion bit shift */
+#define ADC_ADCCON1_ST      0x00000040  /**< Start converstion bit */
+#define ADC_ADCCON1_ST_M    0x00000040  /**< Start converstion bit mask */
+#define ADC_ADCCON1_ST_S    6           /**< Start converstion bit shift */
+#define ADC_ADCCON1_STSEL_M 0x00000030  /**< Start conversion style mask */
+#define ADC_ADCCON1_STSEL_S 4           /**< Start conversion style shift */
+#define ADC_ADCCON1_RCTRL_M 0x0000000C  /**< RNG control mask */
+#define ADC_ADCCON1_RCTRL_S 2           /**< RNG control shift */
+/** @} */
+/*---------------------------------------------------------------------------*/
+/** \name ADCCON2 bit fields
+ * @{
+ */
+#define ADC_ADCCON2_SREF_M  0x000000C0  /**< Reference voltage mask */
+#define ADC_ADCCON2_SREF_S  6           /**< Reference voltage shift */
+#define ADC_ADCCON2_SDIV_M  0x00000030  /**< Decimation rate (ENOBs) mask */
+#define ADC_ADCCON2_SDIV_S  4           /**< Decimation rate (ENOBs) shift */
+#define ADC_ADCCON2_SCH_M   0x0000000F  /**< Sequence channel select mask */
+#define ADC_ADCCON2_SCH_S   0           /**< Sequence channel select mask */
+/** @} */
+/*---------------------------------------------------------------------------*/
+/** \name ADCCON3 bit fields
+ * @{
+ */
+#define ADC_ADCCON3_EREF_M  0x000000C0  /**< Reference voltage mask */
+#define ADC_ADCCON3_EREF_S  6           /**< Reference voltage shift */
+#define ADC_ADCCON3_EDIV_M  0x00000030  /**< Decimation rate (ENOBs) mask */
+#define ADC_ADCCON3_EDIV_S  4           /**< Decimation rate (ENOBs) shift */
+#define ADC_ADCCON3_ECH_M   0x0000000F  /**< Single channel select mask */
+#define ADC_ADCCON3_ECH_S   0           /**< Single channel select shift */
+/** @} */
+/*---------------------------------------------------------------------------*/
+/** \name ADC_ADCL (resultant LSBs) bit fields
+ * @{
+ */
+#define ADC_ADCL_ADC_M      0x000000FC  /**< LSB's of ADC conversion result mask */
+#define ADC_ADCL_ADC_S      2           /**< LSB's of ADC conversion result mask */
+/** @} */
+/*---------------------------------------------------------------------------*/
+/** \name ADC_ADCH (resultant MSBs) bit fields
+ * @{
+ */
+#define ADC_ADCH_ADC_M      0x000000FF  /**< MSB's of ADC conversion result mask */
+#define ADC_ADCH_ADC_S      0           /**< MSB's of ADC conversion result shift */
+/** @} */
+/*---------------------------------------------------------------------------*/
+/** \name ADC_RNDL (random value LSBs) bit fields
+ * @{
+ */
+#define ADC_RNDL_RNDL_M     0x000000FF  /**< LSB's of RNG or CRC result mask */ 
+#define ADC_RNDL_RNDL_S     0           /**< LSB's of RNG or CRC result shift */ 
+/** @} */
+/*---------------------------------------------------------------------------*/
+/** \name ADC_RNDH (random value MSBs) bit fields
+ * @{
+ */
+#define ADC_RNDH_RNDH_M     0x000000FF  /**< MSB's of RNG or CRC result mask */ 
+#define ADC_RNDH_RNDH_S     0           /**< LSB's of RNG or CRC result shift */ 
+/** @} */
+/*---------------------------------------------------------------------------*/
+/** \name ADC_CMPCTL bit fields
+ * @{
+ */
+#define ADC_CMPCTL_EN       0x00000002  /**< Comparator enable bit */ 
+#define ADC_CMPCTL_EN_M     0x00000002  /**< Comparator enable bit mask */ 
+#define ADC_CMPCTL_EN_S     1           /**< Comparator enable bit shift */ 
+#define ADC_CMPCTL_OUTPUT   0x00000001  /**< Comparator output bit */ 
+#define ADC_CMPCTL_OUTPUT_M 0x00000001  /**< Comparator output bit mask */ 
+#define ADC_CMPCTL_OUTPUT_S 0           /**< Comparator output bit shift */ 
+/** @} */
+/*---------------------------------------------------------------------------*/
+/** \name ADC resolution settings
+ * @{
+ */
+#define ADC_7_BIT      0x00000000 /**< ADC 7 bit resolution */
+#define ADC_9_BIT      0x00000010 /**< ADC 9 bit resolution */
+#define ADC_10_BIT     0x00000020 /**< ADC 10 bit resolution */
+#define ADC_12_BIT     0x00000030 /**< ADC 12 bit resolution */
+/** @} */
+/*---------------------------------------------------------------------------*/
+/** \name ADC bit mask definitions and related right shift values
+ * @{
+ */
+#define ADC_7_BIT_MASK     0xfe00 /**< ADC 7 bit bit mask */
+#define ADC_9_BIT_MASK     0xff80 /**< ADC 9 bit bit mask */
+#define ADC_10_BIT_MASK    0xffc0 /**< ADC 10 bit bit mask */
+#define ADC_12_BIT_MASK    0xfff0 /**< ADC 12 bit bit mask */
+#define ADC_7_BIT_RSHIFT        9 /**< ADC 7 bit right shift value */
+#define ADC_9_BIT_RSHIFT        7 /**< ADC 9 bit right shift value */
+#define ADC_10_BIT_RSHIFT       6 /**< ADC 10 bit right shift value */
+#define ADC_12_BIT_RSHIFT       4 /**< ADC 12 bit right shift value */
+/** @} */
+/*---------------------------------------------------------------------------*/
+/** \name ADC values for setting Vref reference levels
+ * @{
+ */
+#define ADC_REF_INTERNAL    0x00000000 /**< ADC use internal reference */
+#define ADC_REF_EXT_AIN7    0x00000040 /**< ADC use external reference on AIN7 pin */
+#define ADC_REF_AVDD5       0x00000080 /**< ADC use AVDD5 pin */
+#define ADC_REF_EXT_AIN67   0x000000c0 /**< ADC use external reference on 
+					*  AIN6-AIN7 differential input pins
+					*/
+/** @} */
+/*---------------------------------------------------------------------------*/
+/** \name ADC commands for reading single and differential signals 
+ * @{
+ */
+#define ADC_AIN0       0x00000000  /**< ADC single ended read PA0 */
+#define ADC_AIN1       0x00000001  /**< ADC single ended read PA1 */
+#define ADC_AIN2       0x00000002  /**< ADC single ended read PA2 */
+#define ADC_AIN3       0x00000003  /**< ADC single ended read PA3 */
+#define ADC_AIN4       0x00000004  /**< ADC single ended read PA4 */
+#define ADC_AIN5       0x00000005  /**< ADC single ended read PA5 */
+#define ADC_AIN6       0x00000006  /**< ADC single ended read PA6 */
+#define ADC_AIN7       0x00000007  /**< ADC single ended read PA7 */
+#define ADC_AIN01      0x00000008  /**< ADC differential reads PA0-PA1 */
+#define ADC_AIN23      0x00000009  /**< ADC differential reads PA2-PA3 */
+#define ADC_AIN45      0x0000000a  /**< ADC differential reads PA4-PA5 */
+#define ADC_AIN67      0x0000000b  /**< ADC differential reads PA6-PA7 */
+#define ADC_GND        0x0000000c  /**< ADC ground */
+#define ADC_TEMP_SENS  0x0000000e  /**< ADC on-chip temperature sensor */
+#define ADC_VDD        0x0000000f  /**< ADC Vdd/3 */
+/** @} */
+/*---------------------------------------------------------------------------*/
+/** \name ADC reading kickoff commands
+ * @{
+ */
+#define ADC_FULLSPEED  0x00000010  /**< Full speed */
+#define ADC_TIMER_COMP 0x00000020  /**< GP Timer 0, Timer A compare event */
+#define ADC_ONE_SHOT   0x00000030  /**< Single sample */
+/** @} */
+
+/*---------------------------------------------------------------------------*/
+/** \name ADC external function prototypes
+ * @{
+ */
+
+/** \brief Initialises the ADC controller, configures base operation
+ * and interrupts */
+void adc_init(void);
+
+/** \brief registers a pin for periodic ADC readings
+ * \param port The port of the registered pin
+ * \param pin The pin number of the registered pin
+ * \param samples_per_second The desired samples per second on this pin
+ * \param input A pointer to the callback function for asynch handling
+ *
+ * \retval Returns a 'uid' used for identifing/unregistering the pin
+ */
+uint8_t adc_register_pin(uint8_t pin, uint8_t samples_per_second,
+			 uint8_t decimation_rate,
+			     int(*input)(int, uint8_t) );
+
+
+/** \brief Unregisters a pin from sampling
+ * \param uid The ID issued by adc_register_service
+ */
+void adc_unregister_pin(uint8_t uid);
+
+PROCESS_NAME(adc_process);
+/** @} */
+
+#endif /* ADC_H_ */
+
+/**
+ * @}
+ * @}
+ */

--- a/platform/cc2538dk/contiki-main.c
+++ b/platform/cc2538dk/contiki-main.c
@@ -66,6 +66,7 @@
 #include "reg.h"
 #include "ieee-addr.h"
 #include "lpm.h"
+#include "dev/adc.h"
 
 #include <stdint.h>
 #include <string.h>
@@ -160,6 +161,10 @@ main(void)
 #if USB_SERIAL_CONF_ENABLE
   usb_serial_init();
   usb_serial_set_input(serial_line_input_byte);
+#endif
+
+#if ADC_CONF_ENABLE
+  adc_init();
 #endif
 
   serial_line_init();

--- a/platform/cc2538dk/startup-gcc.c
+++ b/platform/cc2538dk/startup-gcc.c
@@ -88,6 +88,14 @@ void uart_isr(void);
 #define uart0_isr default_handler
 #define uart1_isr default_handler
 #endif /* UART_CONF_ENABLE */
+
+/* And again for ADC */
+#if ADC_CONF_ENABLE
+void adc_isr(void);
+#else
+#define adc_isr default_handler
+#endif
+
 /*---------------------------------------------------------------------------*/
 /* Allocate stack space */
 static unsigned long stack[512];
@@ -143,7 +151,7 @@ void(*const vectors[])(void) =
   0,                          /* 27 Reserved */
   0,                          /* 28 Reserved */
   0,                          /* 29 Reserved */
-  default_handler,            /* 30 ADC Sequence 0 */
+  adc_isr,            /* 30 ADC Sequence 0 */
   0,                          /* 31 Reserved */
   0,                          /* 32 Reserved */
   0,                          /* 33 Reserved */

--- a/platform/cc2538dk/startup-gcc.c
+++ b/platform/cc2538dk/startup-gcc.c
@@ -151,7 +151,7 @@ void(*const vectors[])(void) =
   0,                          /* 27 Reserved */
   0,                          /* 28 Reserved */
   0,                          /* 29 Reserved */
-  adc_isr,            /* 30 ADC Sequence 0 */
+  adc_isr,                    /* 30 ADC Sequence 0 */
   0,                          /* 31 Reserved */
   0,                          /* 32 Reserved */
   0,                          /* 33 Reserved */


### PR DESCRIPTION
Here is an ADC driver for the cc2538.  It is a arch specific implementation right now, but I think the method is definitely scalable and abstractable.  General flow of the driver:

adc_init() does very little but set flags and the interrupt.  The real setup of each pin happens in the adc_register_pin() function.  It currently supports single ended reads on A0:7 or differential reads on A01:67.  The register function sets up an element that allows the pins to be tracked and serviced independently from each other.  A callback function is registered for the independent pin such that any number of modules can register the pin and the ADC driver needs no information on data handling itself. The upside is that you can fire all the pins on different time scales and from different modules.  The down side is there is a fundamental limit of 128sps and rounding make *exact* *jitter-free* measurements difficult (although power of 2 sps rates should have limited jitter.) 

 There is a process that runs for the driver that fires at 128Hz and counts down all the 'timers' of all  the active pins. When any (or all) pins need servicing, there is a helper function that handles the traversing of the structure and the isr() dispatches the data to the related cb function.

Was related to the discussion I tried to start in #384 but maybe an actual implementation will aid that discussion.