### PR TITLE
Drop incoming DIO when RPL Root

### DIFF
--- a/core/net/rpl/rpl-dag.c
+++ b/core/net/rpl/rpl-dag.c
@@ -1173,6 +1173,11 @@ rpl_process_dio(uip_ipaddr_t *from, rpl_dio_t *dio)
     return;
   }
 
+  if(instance->current_dag->rank == ROOT_RANK(instance) && instance->current_dag != dag) {
+    PRINTF("RPL: Root ignored DIO for different DAG\n");
+    return;
+  }
+
   if(dag == NULL) {
     PRINTF("RPL: Adding new DAG to known instance.\n");
     rpl_add_dag(from, dio);


### PR DESCRIPTION
Workaround for the bug discussed in the ML today with @laurentderu, where a RPL Root processes a DIO from the same instance but different DODAG, and switches to that DODAG, disrupting the original one.

See http://sourceforge.net/mailarchive/message.php?msg_id=31615552
