### PR TITLE
Document alternative toolchain for the CC2538DK

### DIFF
--- a/platform/cc2538dk/README.md
+++ b/platform/cc2538dk/README.md
@@ -60,7 +60,7 @@ The platform has been developed and tested under Windows XP, Mac OS X 10.7 and U
 
 Install a Toolchain
 -------------------
-The toolchain used to build contiki is arm-gcc (Sourcery CodeBench), also used by other arm-based Contiki ports. If you are using Instant Contiki, you will have this pre-installed in your system. To find out if this is the case, try this:
+The toolchain used to build contiki is arm-gcc, also used by other arm-based Contiki ports. If you are using Instant Contiki, you will have a version pre-installed in your system. To find out if this is the case, try this:
 
     $ arm-none-eabi-gcc -v
     Using built-in specs.
@@ -72,12 +72,13 @@ The toolchain used to build contiki is arm-gcc (Sourcery CodeBench), also used b
     Thread model: single
     gcc version 4.3.2 (Sourcery G++ Lite 2008q3-66)
 
-If the toolchain is not installed, download and install one of the following two versions:
+If the toolchain is not installed, download and install one of the following versions:
 
-* Sourcery Codebench Lite for ARM processors from the URL below. Make sure to select the EABI Release. <http://www.mentor.com/embedded-software/sourcery-tools/sourcery-codebench/editions/lite-edition/>
+* GNU Tools for ARM Embedded Processors. Works nicely on OS X. <https://launchpad.net/gcc-arm-embedded>
 * Alternatively, you can use this older version for Linux. At the time of writing, this is the version used by Contiki's regression tests. <https://sourcery.mentor.com/public/gnu_toolchain/arm-none-eabi/arm-2008q3-66-arm-none-eabi-i686-pc-linux-gnu.tar.bz2>
+* Lastly: Sourcery Codebench Lite for ARM processors from the URL below. Make sure to select the EABI Release. <http://www.mentor.com/embedded-software/sourcery-tools/sourcery-codebench/editions/lite-edition/>
 
-The former is newer. The latter has been in use for a longer period of time and the Contiki code has been tested with it more extensively. The CC2538DK port code has been developed and tested with both.
+The first one is newer. The second has been in use for a longer period of time and the Contiki code has been tested with it more extensively.
 
 Drivers
 -------


### PR DESCRIPTION
A few weeks ago I installed https://launchpad.net/gcc-arm-embedded on OS X. It has been working very nicely so far, so I'm documenting this as a valid alternative for the CC2538DK platform.
