### PR TITLE
Makefile.include (clean): ignore rm -f failing (e.g., on "core")

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -192,7 +192,7 @@ rm -f $(@:.o=.$$$$)
 endef
 
 clean:
-	rm -f *~ *core core *.srec \
+	-rm -f *~ *core core *.srec \
 	*.lst *.map \
 	*.cprg *.bin *.data contiki*.a *.firmware core-labels.S *.ihex *.ini \
 	*.ce *.co


### PR DESCRIPTION
rm -f can still fail, e.g., if trying to delete a directory.

If there was, say, a directory called "core", a "make clean" would
therefore only try to delete the files listed in the first command but
not proceed with the rest of the cleanup.

"make clean" itself failing may also affect any outside build process
that invokes it.
