### PR TITLE
Implementation of strncasecmp() which returns the case-insensitive difference between two strings

### DIFF
--- a/core/lib/strncasecmp.c
+++ b/core/lib/strncasecmp.c
@@ -42,15 +42,16 @@
 
 #include <stdio.h>
 #include <ctype.h>
+#include <strings.h>
 
 /*---------------------------------------------------------------------------*/
 /* Compare strings s1 and s2 in a case-insensitive way*/
 
-char
+int
 strncasecmp(const char *s1, const char *s2, unsigned char n)
 {
   unsigned char i = 0;
-  char diff;
+  int diff;
 
   if(s1 == NULL && s2 == NULL) {
     return 0;


### PR DESCRIPTION
To begin with, this is my first Pull Request. So sincere apologies if I missed anything.

This change applies to compilers that do not implement strncasecmp(). The modification implements this function and returns the difference between the first two non-matching characters in the strings. It also implements and uses upcase(), which is the equivalent of the toupper() function. This is target-specific and not built by default for the "native" target.
