### PR TITLE
fixed crc16 implementation according to CITT CRC16 specification

### DIFF
--- a/core/lib/crc16.c
+++ b/core/lib/crc16.c
@@ -46,19 +46,12 @@
 unsigned short
 crc16_add(unsigned char b, unsigned short acc)
 {
-  /*
-    acc  = (unsigned char)(acc >> 8) | (acc << 8);
-    acc ^= b;
-    acc ^= (unsigned char)(acc & 0xff) >> 4;
-    acc ^= (acc << 8) << 4;
-    acc ^= ((acc & 0xff) << 4) << 1;
-  */
-
+  acc  = (unsigned char)(acc >> 8) | (acc << 8);
   acc ^= b;
-  acc  = (acc >> 8) | (acc << 8);
-  acc ^= (acc & 0xff00) << 4;
-  acc ^= (acc >> 8) >> 4;
-  acc ^= (acc & 0xff00) >> 5;
+  acc ^= (unsigned char)(acc & 0xff) >> 4;
+  acc ^= (acc << 8) << 4;
+  acc ^= ((acc & 0xff) << 4) << 1;
+
   return acc;
 }
 /*---------------------------------------------------------------------------*/


### PR DESCRIPTION
This fixes the crc16 implementation according to the CITT CRC16 standard.
