### PR TITLE
Add 6502 tests to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,12 @@ before_script:
        https://raw.github.com/wiki/g-oikonomou/contiki-sensinode/files/sdcc.tar.gz \
          | tar xzf - -C /tmp/ && sudo cp -f -r /tmp/sdcc/* /usr/local/ && rm -rf /tmp/sdcc && sdcc --version || true"
   - "[ ${BUILD_ARCH:-0} = 8051 ] && sudo apt-get -qq install srecord || true"
+  
+  ## Clone and build cc65 when testing 6502 ports
+  - "[ ${BUILD_ARCH:-0} = 6502 ] && git clone \
+       https://github.com/oliverschmidt/cc65 /tmp/cc65 && \
+       make -C /tmp/cc65 && sudo make -C /tmp/cc65 avail && \
+       export CC65_HOME=/tmp/cc65/ && cc65 --version || true"
 
   ## Compile cooja.jar only when it's going to be needed
   - "[ ${BUILD_CATEGORY:-sim} = sim ] && java -version && ant -q -f tools/cooja/build.xml jar || true"
@@ -62,3 +68,4 @@ env:
   - BUILD_TYPE='ipv6-apps'
   - BUILD_TYPE='compile-8051-ports' BUILD_CATEGORY='compile' BUILD_ARCH='8051'
   - BUILD_TYPE='compile-arm-ports' BUILD_CATEGORY='compile' BUILD_ARCH='arm'
+  - BUILD_TYPE='compile-6502-ports' BUILD_CATEGORY='compile' BUILD_ARCH='6502'

--- a/regression-tests/16-compile-6502-ports/Makefile
+++ b/regression-tests/16-compile-6502-ports/Makefile
@@ -1,0 +1,36 @@
+EXAMPLESDIR=../../examples
+TOOLSDIR=../../tools
+
+EXAMPLES = \
+email/c64 \
+email/c128 \
+email/atarixl \
+email/apple2enh \
+ftp/c64 \
+ftp/c128 \
+ftp/atarixl \
+ftp/apple2enh \
+irc/c64 \
+irc/c128 \
+irc/atarixl \
+irc/apple2enh \
+telnet-server/c64 \
+telnet-server/c128 \
+telnet-server/atarixl \
+telnet-server/apple2enh \
+webbrowser/c64 \
+webbrowser/c128 \
+webbrowser/atarixl \
+webbrowser/apple2enh \
+webserver/c64 \
+webserver/c128 \
+webserver/atarixl \
+webserver/apple2enh \
+wget/c64 \
+wget/c128 \
+wget/atarixl \
+wget/apple2enh \
+
+TOOLS=
+
+include ../Makefile.compile-test


### PR DESCRIPTION
This pull adds travis tests for the following platforms:

`apple2enh`, `atarixl`, `c64` and `c128`

Currently, travis will clone cc65 from oliverschmidt/cc65 and build it. The problem with this approach is:
- If cc65's master branch breaks, our tests here also break
- It's a bit slow but that's not a huge deal. The entire 6502 test suite takes 6-7 mins on travis

Ideally, we'd be able to simply download a pre-built and tested cc65 bundle. Failing that, we can checkout a certain cc65 tag/branch/hash and build that one instead of master's HEAD

Nevertheless, this works at the moment.
