### PR TITLE
Reduce travis overhead for testing 6502 ports.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ before_script:
   ## Clone and build cc65 when testing 6502 ports
   - "[ ${BUILD_ARCH:-0} = 6502 ] && git clone \
        https://github.com/oliverschmidt/cc65 /tmp/cc65 && \
-       make -C /tmp/cc65 && sudo make -C /tmp/cc65 avail && \
+       make -C /tmp/cc65 bin apple2enh atarixl c64 c128 && sudo make -C /tmp/cc65 avail && \
        export CC65_HOME=/tmp/cc65/ && cc65 --version || true"
 
   ## Compile cooja.jar only when it's going to be needed

--- a/regression-tests/16-compile-6502-ports/Makefile
+++ b/regression-tests/16-compile-6502-ports/Makefile
@@ -3,21 +3,10 @@ TOOLSDIR=../../tools
 
 EXAMPLES = \
 email/c64 \
-email/c128 \
-email/atarixl \
-email/apple2enh \
 ftp/c64 \
-ftp/c128 \
-ftp/atarixl \
-ftp/apple2enh \
 irc/c64 \
-irc/c128 \
-irc/atarixl \
-irc/apple2enh \
 telnet-server/c64 \
-telnet-server/c128 \
-telnet-server/atarixl \
-telnet-server/apple2enh \
+wget/c64 \
 webbrowser/c64 \
 webbrowser/c128 \
 webbrowser/atarixl \
@@ -26,10 +15,6 @@ webserver/c64 \
 webserver/c128 \
 webserver/atarixl \
 webserver/apple2enh \
-wget/c64 \
-wget/c128 \
-wget/atarixl \
-wget/apple2enh \
 
 TOOLS=
 


### PR DESCRIPTION
- build cc65 libraries only for target supported by Contiki
- instead of building all examples for all 6502 targets build
  - all examples for one target (c64)
  - the most demanding client example (webbrowser) for all 6502 targets
  - the most demanding server examples (webserver) for all 6502 targets
