### PR TITLE
Received UDP packet was counted twice in statistics, first in udp_input ...

### DIFF
--- a/core/net/uip6.c
+++ b/core/net/uip6.c
@@ -1460,7 +1460,6 @@ uip_process(uint8_t flag)
   remove_ext_hdr();
 
   PRINTF("Receiving UDP packet\n");
-  UIP_STAT(++uip_stat.udp.recv);
  
   /* UDP processing is really just a hack. We don't do anything to the
      UDP/IP headers, but let the UDP application do all the hard


### PR DESCRIPTION
...and then again in udp_found.

Fix this to use same logic as in uip.c: valid packet is counted only in udp_found.
