### PR TITLE
cc2538: lpm: Give access to the SRAM non-retention area for PM2

### DIFF
--- a/cpu/cc2538/cc2538.lds
+++ b/cpu/cc2538/cc2538.lds
@@ -34,17 +34,22 @@
  * ld script, which is called cc2538.ld and will be in the project directory
  */
 #if (LPM_CONF_MAX_PM==2) && (LPM_CONF_ENABLE != 0)
-#define SRAM_START  0x20004000
-#define SRAM_LEN    0x00004000
+#define NRSRAM_START    0x20000000
+#define NRSRAM_LEN      0x00004000
+#define SRAM_START      0x20004000
+#define SRAM_LEN        0x00004000
 #else
-#define SRAM_START  0x20000000
-#define SRAM_LEN    0x00008000
+#define SRAM_START      0x20000000
+#define SRAM_LEN        0x00008000
 #endif
 
 MEMORY
 {
     FLASH (rx) : ORIGIN = 0x200000, LENGTH = 0x0007FFD4
     FLASH_CCA (RX) : ORIGIN = 0x0027FFD4, LENGTH = 12
+#if (LPM_CONF_MAX_PM==2) && (LPM_CONF_ENABLE != 0)
+    NRSRAM (RWX) : ORIGIN = NRSRAM_START, LENGTH = NRSRAM_LEN
+#endif
     SRAM (RWX) : ORIGIN = SRAM_START, LENGTH = SRAM_LEN
 }
 
@@ -79,6 +84,15 @@ SECTIONS
         *(COMMON)
         _ebss = .;
     } > SRAM
+
+#if (LPM_CONF_MAX_PM==2) && (LPM_CONF_ENABLE != 0)
+    .nrdata :
+    {
+        _nrdata = .;
+        *(.nrdata*)
+        _enrdata = .;
+    } > NRSRAM
+#endif
 
     .flashcca :
     {

--- a/cpu/cc2538/lpm.h
+++ b/cpu/cc2538/lpm.h
@@ -126,6 +126,12 @@ void lpm_init(void);
  * lpm_exit(), which will always be called from within the Sleep Timer ISR
  * context.
  *
+ * \note Dropping to PM2 means that data in the SRAM non-retention area will
+ * be lost. It is recommended to disable PM2 if the total RAM footprint is
+ * larger than what will fit in the retention area.
+ * .nrdata* sections can be used to place uninitialized data in the SRAM
+ * non-retention area.
+ *
  * \sa main(), rtimer_arch_next_trigger(), lpm_exit(), lpm_set_max_pm()
  */
 void lpm_enter(void);


### PR DESCRIPTION
If PM2 is enabled with LPM_CONF_MAX_PM, but not active, the non-retention area
of the SRAM can be useful to place temporary data that does not fit in the
low-leakage SRAM, typically after having called lpm_set_max_pm(LPM_PM1). Hence,
give access to this non-retention area thanks to .nrdata\* sections.
