### PR TITLE
Cooja Pcap export: Reverts PR #284 to fix #420

### DIFF
--- a/tools/cooja/java/org/contikios/cooja/plugins/analyzers/PcapExporter.java
+++ b/tools/cooja/java/org/contikios/cooja/plugins/analyzers/PcapExporter.java
@@ -39,7 +39,7 @@ public class PcapExporter {
             out.writeInt((int) System.currentTimeMillis() / 1000);
             out.writeInt((int) ((System.currentTimeMillis() % 1000) * 1000));
             out.writeInt(data.length);
-            out.writeInt(data.length+2);
+            out.writeInt(data.length);
             /* and the data */
             out.write(data);
             out.flush();


### PR DESCRIPTION
This is a solution for the discussion in #420.
It reverts our hotfix of #284, which is not needed anymore as it is redundant with a cleaner solution introduced in the recent changes in COOJA. We're not exactly sure where the exact solution is, but this needs to be reverted asap because it corrupts all COOJA pcaps opened in Wireshark.
