### PR TITLE
cc2538dk: Make it possible to override SLIP_ARCH_CONF_ENABLED

### DIFF
--- a/platform/cc2538dk/contiki-conf.h
+++ b/platform/cc2538dk/contiki-conf.h
@@ -112,6 +112,7 @@ typedef uint32_t rtimer_clock_t;
 #define SLIP_BRIDGE_CONF_NO_PUTCHAR 1
 #define SLIP_RADIO_CONF_NO_PUTCHAR  1
 
+#ifndef SLIP_ARCH_CONF_ENABLED
 /*
  * Determine whether we need SLIP
  * This will keep working while UIP_FALLBACK_INTERFACE and CMD_CONF_OUTPUT
@@ -119,6 +120,7 @@ typedef uint32_t rtimer_clock_t;
  */
 #if defined (UIP_FALLBACK_INTERFACE) || defined (CMD_CONF_OUTPUT)
 #define SLIP_ARCH_CONF_ENABLED      1
+#endif
 #endif
 
 /*


### PR DESCRIPTION
As the comment in contiki-conf.h says, the automatic definition of
SLIP_ARCH_CONF_ENABLED works only if UIP_FALLBACK_INTERFACE is tied to SLIP. If
UIP_FALLBACK_INTERFACE is set to another interface, SLIP_ARCH_CONF_ENABLED is
still automatically set to 1, leading to unwanted SLIP_END characters from
dbg.c:putchar() being printed on the UART.

This change makes it possible to force the definition of SLIP_ARCH_CONF_ENABLED
(e.g. from project-conf.h), so that it can be disabled if UIP_FALLBACK_INTERFACE
is used with something else than SLIP.
