### PR TITLE
Allow user configuration of RadioLogger pcap file

### DIFF
--- a/tools/cooja/java/org/contikios/cooja/plugins/RadioLogger.java
+++ b/tools/cooja/java/org/contikios/cooja/plugins/RadioLogger.java
@@ -144,6 +144,8 @@ public class RadioLogger extends VisPlugin {
   private HashMap<String,Action> analyzerMap = new HashMap<String,Action>();
   private String analyzerName = null;
   private ArrayList<PacketAnalyzer> analyzers = null;
+  private IEEE802154Analyzer analyzerWithPcap;
+  private File pcapFile;
 
   private JTextField searchField = new JTextField(30);
 
@@ -174,8 +176,9 @@ public class RadioLogger extends VisPlugin {
     lowpanAnalyzers.add(new IPv6PacketAnalyzer());
     lowpanAnalyzers.add(new ICMPv6Analyzer());
 
+    analyzerWithPcap = new IEEE802154Analyzer(true);
     ArrayList<PacketAnalyzer> lowpanAnalyzersPcap = new ArrayList<PacketAnalyzer>();
-    lowpanAnalyzersPcap.add(new IEEE802154Analyzer(true));
+    lowpanAnalyzersPcap.add(analyzerWithPcap);
     lowpanAnalyzersPcap.add(new IPHCPacketAnalyzer());
     lowpanAnalyzersPcap.add(new IPv6PacketAnalyzer());
     lowpanAnalyzersPcap.add(new ICMPv6Analyzer());
@@ -801,6 +804,14 @@ public class RadioLogger extends VisPlugin {
       }
     }
 
+    if (pcapFile != null) {
+      element = new Element("pcap_file");
+      File file = simulation.getCooja().createPortablePath(pcapFile);
+      element.setText(pcapFile.getPath().replaceAll("\\\\", "/"));
+      element.setAttribute("EXPORT", "discard");
+      config.add(element);
+    }
+
     return config;
   }
 
@@ -833,6 +844,9 @@ public class RadioLogger extends VisPlugin {
             }
           });
         }
+      } else if (name.equals("pcap_file")) {
+        pcapFile = simulation.getCooja().restorePortablePath(new File(element.getText()));
+        analyzerWithPcap.setPcapFile(pcapFile);
       }
     }
     return true;

--- a/tools/cooja/java/org/contikios/cooja/plugins/analyzers/IEEE802154Analyzer.java
+++ b/tools/cooja/java/org/contikios/cooja/plugins/analyzers/IEEE802154Analyzer.java
@@ -1,6 +1,7 @@
 package org.contikios.cooja.plugins.analyzers;
 
 import java.io.IOException;
+import java.io.File;
 
 import org.contikios.cooja.util.StringUtils;
 
@@ -34,6 +35,17 @@ public class IEEE802154Analyzer extends PacketAnalyzer {
         } catch (IOException e) {
             e.printStackTrace();
         }
+    }
+
+    public void setPcapFile(File pcapFile) {
+      if (pcapExporter != null) {
+        try {
+          pcapExporter.openPcap(pcapFile);
+        } catch (IOException e) {
+          System.err.println("Could not open pcap file");
+          e.printStackTrace();
+        }
+      }
     }
 
     public boolean matchPacket(Packet packet) {

--- a/tools/cooja/java/org/contikios/cooja/plugins/analyzers/PcapExporter.java
+++ b/tools/cooja/java/org/contikios/cooja/plugins/analyzers/PcapExporter.java
@@ -41,6 +41,7 @@ public class PcapExporter {
 
     public void exportPacketData(byte[] data) throws IOException {
         if (out == null) {
+            /* pcap file never set, open default */
             openPcap(null);
         }
         try {


### PR DESCRIPTION
Fix for issue #252. It adds a new entry (pcap_file) in RadioLogger configuration in .csc file allowing to specify the pcap file for "Analyzer with PCAP". If the entry is not defined it falls back on the legacy file name (radiolog-<timestamp>.pcap)

Two remarks : 
- I'm not sure if the discard attribute is really needed :
  <pre>element.setAttribute("EXPORT", "discard");</pre>
- I had to make an explicit reference to the instance of IEEE802154Analyzer that output the pcap and I'm not really happy with that.

Once this PR is accepted and merged, I'll have a look at the file dialog (still not sure where to put it in the GUI)
