### PR TITLE
Remove Sensinode tests from travis

### DIFF
--- a/regression-tests/14-compile-8051-ports/Makefile
+++ b/regression-tests/14-compile-8051-ports/Makefile
@@ -2,12 +2,7 @@ EXAMPLESDIR=../../examples
 TOOLSDIR=../../tools
 
 EXAMPLES = \
-hello-world/sensinode \
 hello-world/cc2530dk \
-sensinode/sensinode \
-sensinode/border-router/sensinode \
-sensinode/udp-ipv6/sensinode \
-sensinode/sniffer/sensinode \
 cc2530dk/cc2530dk \
 cc2530dk/border-router/cc2530dk \
 cc2530dk/udp-ipv6/cc2530dk \


### PR DESCRIPTION
Contiki has outgrown the Sensinode platform. Basic IPv6 examples will no longer fit in flash, causing all sorts of problems with travis regression testing.

With this pull request, we remove all Sensinode tests from Travis.

I originally thought of disabling IPv6 tests only, but the main objective of the test suite for the two 8051-based platforms was to test the Contiki core under SDCC. The CC2530DK tests can achieve this objective by themselves.

In terms of the Sensinode platform itself, we will undoubtedly obsolete it in the near future. Until we do, this pull will stop Travis from failing in tests which are no longer of relevance.
