### PR TITLE
Add some missing casts, sdcc is picky about it.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@
 *.ihex
 *.pyc
 *.redbee-econotag
-*.econotag 
+*.econotag
 *.native
 *.z1
 *.minimal-net
@@ -84,3 +84,6 @@ contiki-cc2530dk.lib
 
 #regression tests artifacts
 *.testlog
+
+# vim
+*.swp

--- a/core/lib/memb.c
+++ b/core/lib/memb.c
@@ -51,8 +51,8 @@
 void
 memb_init(struct memb *m)
 {
-  memset(m->count, 0, m->num);
-  memset(m->mem, 0, m->size * m->num);
+  memset((void *)m->count, 0, m->num);
+  memset((void *)m->mem, 0, m->size * m->num);
 }
 /*---------------------------------------------------------------------------*/
 void *
@@ -85,7 +85,7 @@ memb_free(struct memb *m, void *ptr)
      which the pointer "ptr" points to. */
   ptr2 = (char *)m->mem;
   for(i = 0; i < m->num; ++i) {
-    
+
     if(ptr2 == (char *)ptr) {
       /* We've found to block to which "ptr" points so we decrease the
 	 reference count and return the new value of it. */

--- a/core/loader/elfloader.c
+++ b/core/loader/elfloader.c
@@ -181,7 +181,7 @@ find_local_symbol(int fd, const char *symbol,
   unsigned int a;
   char name[30];
   struct relevant_section *sect;
-  
+
   for(a = symtab; a < symtab + symtabsize; a += sizeof(s)) {
     seek_read(fd, a, (char *)&s, sizeof(s));
 
@@ -231,7 +231,7 @@ relocate_section(int fd,
   } else {
     rel_size = sizeof(struct elf32_rel);
   }
-  
+
   for(a = section; a < section + size; a += rel_size) {
     seek_read(fd, a, (char *)&rela, rel_size);
     seek_read(fd,
@@ -276,7 +276,7 @@ relocate_section(int fd,
       } else {
 	return ELFLOADER_SEGMENT_NOT_FOUND;
       }
-      
+
       addr = sect->address;
     }
 
@@ -298,7 +298,7 @@ find_program_processes(int fd,
   struct elf32_sym s;
   unsigned int a;
   char name[30];
-  
+
   for(a = symtab; a < symtab + size; a += sizeof(s)) {
     seek_read(fd, a, (char *)&s, sizeof(s));
 
@@ -345,7 +345,7 @@ elfloader_load(int fd)
   unsigned int shdrptr;
   unsigned int nameptr;
   char name[12];
-  
+
   int i;
   unsigned short shdrnum, shdrsize;
 
@@ -376,13 +376,13 @@ elfloader_load(int fd)
   /* Grab the section header. */
   shdrptr = ehdr.e_shoff;
   seek_read(fd, shdrptr, (char *)&shdr, sizeof(shdr));
-  
+
   /* Get the size and number of entries of the section header. */
   shdrsize = ehdr.e_shentsize;
   shdrnum = ehdr.e_shnum;
 
   PRINTF("Section header: size %d num %d\n", shdrsize, shdrnum);
-  
+
   /* The string table section: holds the names of the sections. */
   seek_read(fd, ehdr.e_shoff + shdrsize * ehdr.e_shstrndx,
 	    (char *)&strtable, sizeof(strtable));
@@ -393,7 +393,7 @@ elfloader_load(int fd)
   strs = strtable.sh_offset;
 
   PRINTF("Strtable offset %d\n", strs);
-  
+
   /* Go through all sections and pick out the relevant ones. The
      ".text" segment holds the actual code from the ELF file, the
      ".data" segment contains initialized data, the ".bss" segment
@@ -416,12 +416,12 @@ elfloader_load(int fd)
     rodatasize = rodatarelasize = symtabsize = strtabsize = 0;
 
   bss.number = data.number = rodata.number = text.number = -1;
-		
+
   shdrptr = ehdr.e_shoff;
   for(i = 0; i < shdrnum; ++i) {
 
     seek_read(fd, shdrptr, (char *)&shdr, sizeof(shdr));
-    
+
     /* The name of the section is contained in the strings table. */
     nameptr = strs + shdr.sh_name;
     seek_read(fd, nameptr, name, sizeof(name));
@@ -510,7 +510,7 @@ elfloader_load(int fd)
   PRINTF("before allocate rom\n");
   text.address = (char *)elfloader_arch_allocate_rom(textsize + rodatasize);
   rodata.address = (char *)text.address + textsize;
-  
+
 
   PRINTF("bss base address: bss.address = 0x%08x\n", bss.address);
   PRINTF("data base address: data.address = 0x%08x\n", data.address);
@@ -568,8 +568,8 @@ elfloader_load(int fd)
   /* Write text and rodata segment into flash and data segment into RAM. */
   elfloader_arch_write_rom(fd, textoff, textsize, text.address);
   elfloader_arch_write_rom(fd, rodataoff, rodatasize, rodata.address);
-  
-  memset(bss.address, 0, bsssize);
+
+  memset((void *)bss.address, 0, bsssize);
   seek_read(fd, dataoff, data.address, datasize);
 
   PRINTF("elfloader: autostart search\n");

--- a/core/net/dhcpc.c
+++ b/core/net/dhcpc.c
@@ -149,17 +149,17 @@ create_msg(CC_REGISTER_ARG struct dhcp_msg *m)
   m->flags = UIP_HTONS(BOOTP_BROADCAST); /*  Broadcast bit. */
   /*  uip_ipaddr_copy(m->ciaddr, uip_hostaddr);*/
   memcpy(m->ciaddr, uip_hostaddr.u16, sizeof(m->ciaddr));
-  memset(m->yiaddr, 0, sizeof(m->yiaddr));
-  memset(m->siaddr, 0, sizeof(m->siaddr));
-  memset(m->giaddr, 0, sizeof(m->giaddr));
+  memset((void *)m->yiaddr, 0, sizeof(m->yiaddr));
+  memset((void *)m->siaddr, 0, sizeof(m->siaddr));
+  memset((void *)m->giaddr, 0, sizeof(m->giaddr));
   memcpy(m->chaddr, s.mac_addr, s.mac_len);
-  memset(&m->chaddr[s.mac_len], 0, sizeof(m->chaddr) - s.mac_len);
+  memset((void *)&m->chaddr[s.mac_len], 0, sizeof(m->chaddr) - s.mac_len);
 #ifndef UIP_CONF_DHCP_LIGHT
-  memset(m->sname, 0, sizeof(m->sname));
-  memset(m->file, 0, sizeof(m->file));
+  memset((void *)m->sname, 0, sizeof(m->sname));
+  memset((void *)m->file, 0, sizeof(m->file));
 #endif
 
-  memcpy(m->options, magic_cookie, sizeof(magic_cookie));
+  memcpy((void *)m->options, magic_cookie, sizeof(magic_cookie));
 }
 /*---------------------------------------------------------------------------*/
 static void
@@ -184,12 +184,12 @@ send_request(void)
   struct dhcp_msg *m = (struct dhcp_msg *)uip_appdata;
 
   create_msg(m);
-  
+
   end = add_msg_type(&m->options[4], DHCPREQUEST);
   end = add_server_id(end);
   end = add_req_ipaddr(end);
   end = add_end(end);
-  
+
   uip_send(uip_appdata, (int)(end - (uint8_t *)uip_appdata));
 }
 /*---------------------------------------------------------------------------*/
@@ -232,7 +232,7 @@ static uint8_t
 parse_msg(void)
 {
   struct dhcp_msg *m = (struct dhcp_msg *)uip_appdata;
-  
+
   if(m->op == DHCP_REPLY &&
      memcmp(m->xid, &xid, sizeof(xid)) == 0 &&
      memcmp(m->chaddr, s.mac_addr, s.mac_len) == 0) {
@@ -251,7 +251,7 @@ msg_for_me(void)
   struct dhcp_msg *m = (struct dhcp_msg *)uip_appdata;
   uint8_t *optptr = &m->options[4];
   uint8_t *end = (uint8_t*)uip_appdata + uip_datalen();
-  
+
   if(m->op == DHCP_REPLY &&
      memcmp(m->xid, &xid, sizeof(xid)) == 0 &&
      memcmp(m->chaddr, s.mac_addr, s.mac_len) == 0) {
@@ -273,7 +273,7 @@ PT_THREAD(handle_dhcp(process_event_t ev, void *data))
   clock_time_t ticks;
 
   PT_BEGIN(&s.pt);
-  
+
  init:
   xid++;
   s.state = STATE_SENDING;
@@ -298,7 +298,7 @@ PT_THREAD(handle_dhcp(process_event_t ev, void *data))
       s.ticks *= 2;
     }
   }
-  
+
  selecting:
   xid++;
   s.ticks = CLOCK_SECOND;
@@ -324,7 +324,7 @@ PT_THREAD(handle_dhcp(process_event_t ev, void *data))
       goto init;
     }
   } while(s.state != STATE_CONFIG_RECEIVED);
-  
+
  bound:
 #if 0
   printf("Got IP address %d.%d.%d.%d\n", uip_ipaddr_to_quad(&s.ipaddr));
@@ -337,7 +337,7 @@ PT_THREAD(handle_dhcp(process_event_t ev, void *data))
 #endif
 
   dhcpc_configured(&s);
-  
+
 #define MAX_TICKS (~((clock_time_t)0) / 2)
 #define MAX_TICKS32 (~((uint32_t)0))
 #define IMIN(a, b) ((a) < (b) ? (a) : (b))
@@ -398,7 +398,7 @@ void
 dhcpc_init(const void *mac_addr, int mac_len)
 {
   uip_ipaddr_t addr;
-  
+
   s.mac_addr = mac_addr;
   s.mac_len  = mac_len;
 
@@ -423,7 +423,7 @@ void
 dhcpc_request(void)
 {
   uip_ipaddr_t ipaddr;
-  
+
   if(s.state == STATE_INITIAL) {
     uip_ipaddr(&ipaddr, 0,0,0,0);
     uip_sethostaddr(&ipaddr);

--- a/core/net/mac/contikimac.c
+++ b/core/net/mac/contikimac.c
@@ -335,7 +335,7 @@ powercycle_turn_radio_off(void)
 #if CONTIKIMAC_CONF_COMPOWER
   uint8_t was_on = radio_is_on;
 #endif /* CONTIKIMAC_CONF_COMPOWER */
-  
+
   if(we_are_sending == 0 && we_are_receiving_burst == 0) {
     off();
 #if CONTIKIMAC_CONF_COMPOWER
@@ -546,7 +546,7 @@ send_packet(mac_callback_t mac_callback, void *mac_callback_ptr,
     PRINTF("contikimac: radio is turned off\n");
     return MAC_TX_ERR_FATAL;
   }
- 
+
   if(packetbuf_totlen() == 0) {
     PRINTF("contikimac: send_packet data len 0\n");
     return MAC_TX_ERR_FATAL;
@@ -595,7 +595,7 @@ send_packet(mac_callback_t mac_callback, void *mac_callback_ptr,
   chdr = packetbuf_hdrptr();
   chdr->id = CONTIKIMAC_ID;
   chdr->len = hdrlen;
-  
+
   /* Create the MAC header for the data packet. */
   hdrlen = NETSTACK_FRAMER.create();
   if(hdrlen < 0) {
@@ -622,7 +622,7 @@ send_packet(mac_callback_t mac_callback, void *mac_callback_ptr,
     /* Pad with zeroes */
     uint8_t *ptr;
     ptr = packetbuf_dataptr();
-    memset(ptr + packetbuf_datalen(), 0, SHORTEST_PACKET_SIZE - packetbuf_totlen());
+    memset((void *)(ptr + packetbuf_datalen()), 0, SHORTEST_PACKET_SIZE - packetbuf_totlen());
 
     PRINTF("contikimac: shorter than shortest (%d)\n", packetbuf_totlen());
     transmit_len = SHORTEST_PACKET_SIZE;
@@ -653,9 +653,9 @@ send_packet(mac_callback_t mac_callback, void *mac_callback_ptr,
     if(ret != PHASE_UNKNOWN) {
       is_known_receiver = 1;
     }
-#endif /* WITH_PHASE_OPTIMIZATION */ 
+#endif /* WITH_PHASE_OPTIMIZATION */
   }
-  
+
 
 
   /* By setting we_are_sending to one, we ensure that the rtimer
@@ -673,7 +673,7 @@ send_packet(mac_callback_t mac_callback, void *mac_callback_ptr,
            NETSTACK_RADIO.receiving_packet(), NETSTACK_RADIO.pending_packet());
     return MAC_TX_COLLISION;
   }
-  
+
   /* Switch off the radio to ensure that we didn't start sending while
      the radio was doing a channel check. */
   off();
@@ -869,7 +869,7 @@ qsend_list(mac_callback_t sent, void *ptr, struct rdc_buf_list *buf_list)
   struct rdc_buf_list *next;
   int ret;
   int is_receiver_awake;
-  
+
   if(curr == NULL) {
     return;
   }

--- a/core/net/mac/frame802154.c
+++ b/core/net/mac/frame802154.c
@@ -95,7 +95,7 @@ static void
 field_len(frame802154_t *p, field_length_t *flen)
 {
   /* init flen to zeros */
-  memset(flen, 0, sizeof(field_length_t));
+  memset((void *)flen, 0, sizeof(field_length_t));
 
   /* Determine lengths of each field based on fcf and other args */
   if(p->fcf.dest_addr_mode & 3) {

--- a/core/net/resolv.c
+++ b/core/net/resolv.c
@@ -702,7 +702,7 @@ check_entries(void)
         namemapptr->retries = 0;
       }
       hdr = (struct dns_hdr *)uip_appdata;
-      memset(hdr, 0, sizeof(struct dns_hdr));
+      memset((void *)hdr, 0, sizeof(struct dns_hdr));
       hdr->id = RESOLV_ENCODE_INDEX(i);
 #if RESOLV_CONF_SUPPORTS_MDNS
       if(!namemapptr->is_mdns || namemapptr->is_probe) {
@@ -1262,7 +1262,7 @@ resolv_query(const char *name)
 
   PRINTF("resolver: Starting query for \"%s\".\n", name);
 
-  memset(nameptr, 0, sizeof(*nameptr));
+  memset((void *)nameptr, 0, sizeof(*nameptr));
 
   strncpy(nameptr->name, name, sizeof(nameptr->name));
   nameptr->state = STATE_NEW;

--- a/core/net/rime/chameleon-bitopt.c
+++ b/core/net/rime/chameleon-bitopt.c
@@ -81,7 +81,7 @@ get_bits_in_byte(uint8_t *from, int bitpos, int vallen)
 	(((shifted_val << bitpos) >> 8) & bitmask[vallen]) >> (8 - vallen),
 	vallen
 	);*/
-  
+
   return (((shifted_val << bitpos) >> 8) & bitmask[vallen]) >> (8 - vallen);
 }
 /*---------------------------------------------------------------------------*/
@@ -89,8 +89,8 @@ void
 get_bits(uint8_t *to, uint8_t *from, int bitpos, int vallen)
 {
   int i, bits;
-  
-  
+
+
   if(vallen < 8) {
     *to = get_bits_in_byte(from, bitpos, vallen);
   } else {
@@ -122,10 +122,10 @@ static int
 header_size(const struct packetbuf_attrlist *a)
 {
   int size, len;
-  
+
   /* Compute the total size of the final header by summing the size of
      all attributes that are used on this channel. */
-  
+
   size = 0;
   for(; a->type != PACKETBUF_ATTR_NONE; ++a) {
 #if CHAMELEON_WITH_MAC_LINK_ADDRESSES
@@ -198,13 +198,13 @@ printbin(int n, int digits)
 {
   int i;
   char output[128];
-  
+
   for(i = 0; i < digits; ++i) {
     output[digits - i - 1] = (n & 1) + '0';
     n >>= 1;
   }
   output[i] = 0;
-  
+
   printf(output);
 }
 
@@ -238,7 +238,7 @@ pack_header(struct channel *c)
   int byteptr, bitptr, len;
   uint8_t *hdrptr;
   struct bitopt_hdr *hdr;
-  
+
   /* Compute the total size of the final header by summing the size of
      all attributes that are used on this channel. */
 
@@ -252,10 +252,10 @@ pack_header(struct channel *c)
   hdr->channel[1] = (c->channelno >> 8) & 0xff;
 
   hdrptr = ((uint8_t *)packetbuf_hdrptr()) + sizeof(struct bitopt_hdr);
-  memset(hdrptr, 0, hdrbytesize);
-  
+  memset((void *)hdrptr, 0, hdrbytesize);
+
   byteptr = bitptr = 0;
-  
+
   for(a = c->attrlist; a->type != PACKETBUF_ATTR_NONE; ++a) {
 #if CHAMELEON_WITH_MAC_LINK_ADDRESSES
     if(a->type == PACKETBUF_ADDR_SENDER ||
@@ -304,7 +304,7 @@ unpack_header(void)
   uint8_t *hdrptr;
   struct bitopt_hdr *hdr;
   struct channel *c;
-  
+
 
   /* The packet has a header that tells us what channel the packet is
      for. */

--- a/core/net/rime/collect.c
+++ b/core/net/rime/collect.c
@@ -433,7 +433,7 @@ update_rtmetric(struct collect_conn *tc)
     PRINTF("%d.%d: new rtmetric %d\n",
            rimeaddr_node_addr.u8[0], rimeaddr_node_addr.u8[1],
            tc->rtmetric);
-    
+
     /* We got a new, working, route we send any queued packets we may have. */
     if(old_rtmetric == RTMETRIC_MAX && new_rtmetric != RTMETRIC_MAX) {
       PRINTF("Sending queued packet because rtmetric was max\n");
@@ -451,7 +451,7 @@ static int
 enqueue_dummy_packet(struct collect_conn *c, int rexmits)
 {
   struct collect_neighbor *n;
-  
+
   packetbuf_clear();
   packetbuf_set_attr(PACKETBUF_ATTR_EPACKET_ID, c->eseqno - 1);
   packetbuf_set_addr(PACKETBUF_ADDR_ESENDER, &rimeaddr_node_addr);
@@ -684,7 +684,7 @@ retransmit_current_packet(struct collect_conn *c)
   if(q != NULL) {
 
     update_rtmetric(c);
-    
+
     /* Place the queued packet into the packetbuf. */
     queuebuf_to_packetbuf(q);
 
@@ -781,7 +781,7 @@ handle_ack(struct collect_conn *tc)
            (int)CLOCK_SECOND,
            (int)((clock_time() - tc->send_time) / CLOCK_SECOND),
            (int)(((100 * (clock_time() - tc->send_time)) / CLOCK_SECOND) % 100));*/
-    
+
     stats.ackrecv++;
     memcpy(&msg, packetbuf_dataptr(), sizeof(struct ack_msg));
 
@@ -869,7 +869,7 @@ send_ack(struct collect_conn *tc, const rimeaddr_t *to, int flags)
   packetbuf_clear();
   packetbuf_set_datalen(sizeof(struct ack_msg));
   ack = packetbuf_dataptr();
-  memset(ack, 0, sizeof(struct ack_msg));
+  memset((void *)ack, 0, sizeof(struct ack_msg));
   ack->rtmetric = tc->rtmetric;
   ack->flags = flags;
 
@@ -1120,7 +1120,7 @@ node_packet_sent(struct unicast_conn *c, int status, int transmissions)
      PACKETBUF_ATTR_PACKET_TYPE_DATA) {
 
     tc->transmissions += transmissions;
-    PRINTF("tx %d\n", tc->transmissions);    
+    PRINTF("tx %d\n", tc->transmissions);
     PRINTF("%d.%d: MAC sent %d transmissions to %d.%d, status %d, total transmissions %d\n",
            rimeaddr_node_addr.u8[0], rimeaddr_node_addr.u8[1],
            transmissions,
@@ -1206,7 +1206,7 @@ adv_received(struct neighbor_discovery_conn *c, const rimeaddr_t *from,
     if(rtmetric == RTMETRIC_MAX &&
        collect_neighbor_rtmetric(n) != RTMETRIC_MAX) {
       bump_advertisement(tc);
-    } 
+    }
     collect_neighbor_update_rtmetric(n, rtmetric);
     PRINTF("%d.%d: updating neighbor %d.%d, etx %d\n",
 	   rimeaddr_node_addr.u8[0], rimeaddr_node_addr.u8[1],
@@ -1407,7 +1407,7 @@ collect_send(struct collect_conn *tc, int rexmits)
 {
   struct collect_neighbor *n;
   int ret;
-  
+
   packetbuf_set_attr(PACKETBUF_ATTR_EPACKET_ID, tc->eseqno);
 
   /* Increase the sequence number for the packet we send out. We
@@ -1464,7 +1464,7 @@ collect_send(struct collect_conn *tc, int rexmits)
       ret = 0;
     }
 
-    
+
     n = collect_neighbor_list_find(&tc->neighbor_list, &tc->parent);
     if(n != NULL) {
       PRINTF("%d.%d: sending to %d.%d\n",

--- a/core/net/uip-debug.c
+++ b/core/net/uip-debug.c
@@ -43,7 +43,7 @@
 void
 uip_debug_ipaddr_print(const uip_ipaddr_t *addr)
 {
-  if(addr == NULL || addr->u8 == NULL) {
+  if(addr == NULL || (void *)addr->u8 == NULL) {
     printf("(NULL IP addr)");
     return;
   }

--- a/core/net/uip.c
+++ b/core/net/uip.c
@@ -243,15 +243,15 @@ uip_add32(uint8_t *op32, uint16_t op16)
   uip_acc32[2] = op32[2] + (op16 >> 8);
   uip_acc32[1] = op32[1];
   uip_acc32[0] = op32[0];
-  
+
   if(uip_acc32[2] < (op16 >> 8)) {
     ++uip_acc32[1];
     if(uip_acc32[1] == 0) {
       ++uip_acc32[0];
     }
   }
-  
-  
+
+
   if(uip_acc32[3] < (op16 & 0xff)) {
     ++uip_acc32[2];
     if(uip_acc32[2] == 0) {
@@ -276,7 +276,7 @@ chksum(uint16_t sum, const uint8_t *data, uint16_t len)
 
   dataptr = data;
   last_byte = data + len - 1;
-  
+
   while(dataptr < last_byte) {	/* At least two more bytes */
     t = (dataptr[0] << 8) + dataptr[1];
     sum += t;
@@ -285,7 +285,7 @@ chksum(uint16_t sum, const uint8_t *data, uint16_t len)
     }
     dataptr += 2;
   }
-  
+
   if(dataptr == last_byte) {
     t = (dataptr[0] << 8) + 0;
     sum += t;
@@ -321,15 +321,15 @@ upper_layer_chksum(uint8_t proto)
 {
   uint16_t upper_layer_len;
   uint16_t sum;
-  
+
 #if UIP_CONF_IPV6
   upper_layer_len = (((uint16_t)(BUF->len[0]) << 8) + BUF->len[1]);
 #else /* UIP_CONF_IPV6 */
   upper_layer_len = (((uint16_t)(BUF->len[0]) << 8) + BUF->len[1]) - UIP_IPH_LEN;
 #endif /* UIP_CONF_IPV6 */
-  
+
   /* First sum pseudoheader. */
-  
+
   /* IP protocol and length fields. This addition cannot carry. */
   sum = upper_layer_len + proto;
   /* Sum IP source and destination addresses. */
@@ -338,7 +338,7 @@ upper_layer_chksum(uint8_t proto)
   /* Sum TCP header and data. */
   sum = chksum(sum, &uip_buf[UIP_IPH_LEN + UIP_LLH_LEN],
 	       upper_layer_len);
-    
+
   return (sum == 0) ? 0xffff : uip_htons(sum);
 }
 /*---------------------------------------------------------------------------*/
@@ -347,7 +347,7 @@ uint16_t
 uip_icmp6chksum(void)
 {
   return upper_layer_chksum(UIP_PROTO_ICMP6);
-  
+
 }
 #endif /* UIP_CONF_IPV6 */
 /*---------------------------------------------------------------------------*/
@@ -384,7 +384,7 @@ uip_init(void)
     uip_udp_conns[c].lport = 0;
   }
 #endif /* UIP_UDP */
-  
+
 
   /* IPv4 initialization. */
 #if UIP_FIXEDADDR == 0
@@ -398,7 +398,7 @@ struct uip_conn *
 uip_connect(uip_ipaddr_t *ripaddr, uint16_t rport)
 {
   register struct uip_conn *conn, *cconn;
-  
+
   /* Find an unused local port. */
  again:
   ++lastport;
@@ -435,7 +435,7 @@ uip_connect(uip_ipaddr_t *ripaddr, uint16_t rport)
   if(conn == 0) {
     return 0;
   }
-  
+
   conn->tcpstateflags = UIP_SYN_SENT;
 
   conn->snd_nxt[0] = iss[0];
@@ -444,7 +444,7 @@ uip_connect(uip_ipaddr_t *ripaddr, uint16_t rport)
   conn->snd_nxt[3] = iss[3];
 
   conn->initialmss = conn->mss = UIP_TCP_MSS;
-  
+
   conn->len = 1;   /* TCP length of the SYN is one. */
   conn->nrtx = 0;
   conn->timer = 1; /* Send the SYN next time around. */
@@ -454,7 +454,7 @@ uip_connect(uip_ipaddr_t *ripaddr, uint16_t rport)
   conn->lport = uip_htons(lastport);
   conn->rport = rport;
   uip_ipaddr_copy(&conn->ripaddr, ripaddr);
-  
+
   return conn;
 }
 #endif /* UIP_ACTIVE_OPEN */
@@ -464,7 +464,7 @@ struct uip_udp_conn *
 uip_udp_new(const uip_ipaddr_t *ripaddr, uint16_t rport)
 {
   register struct uip_udp_conn *conn;
-  
+
   /* Find an unused local port. */
  again:
   ++lastport;
@@ -472,7 +472,7 @@ uip_udp_new(const uip_ipaddr_t *ripaddr, uint16_t rport)
   if(lastport >= 32000) {
     lastport = 4096;
   }
-  
+
   for(c = 0; c < UIP_UDP_CONNS; ++c) {
     if(uip_udp_conns[c].lport == uip_htons(lastport)) {
       goto again;
@@ -491,16 +491,16 @@ uip_udp_new(const uip_ipaddr_t *ripaddr, uint16_t rport)
   if(conn == 0) {
     return 0;
   }
-  
+
   conn->lport = UIP_HTONS(lastport);
   conn->rport = rport;
   if(ripaddr == NULL) {
-    memset(&conn->ripaddr, 0, sizeof(uip_ipaddr_t));
+    memset((void *)&conn->ripaddr, 0, sizeof(uip_ipaddr_t));
   } else {
     uip_ipaddr_copy(&conn->ripaddr, ripaddr);
   }
   conn->ttl = UIP_TTL;
-  
+
   return conn;
 }
 #endif /* UIP_UDP */
@@ -585,12 +585,12 @@ uip_reass(void)
     memcpy(&uip_reassbuf[UIP_IPH_LEN + offset],
 	   (char *)BUF + (int)((BUF->vhl & 0x0f) * 4),
 	   len);
-      
+
     /* Update the bitmap. */
     if(offset / (8 * 8) == (offset + len) / (8 * 8)) {
       /* If the two endpoints are in the same byte, we only update
 	 that byte. */
-	     
+
       uip_reassbitmap[offset / (8 * 8)] |=
 	     bitmap_bits[(offset / 8 ) & 7] &
 	     ~bitmap_bits[((offset + len) / 8 ) & 7];
@@ -606,7 +606,7 @@ uip_reass(void)
       uip_reassbitmap[(offset + len) / (8 * 8)] |=
 	~bitmap_bits[((offset + len) / 8 ) & 7];
     }
-    
+
     /* If this fragment has the More Fragments flag set to zero, we
        know that this is the last fragment, so we can calculate the
        size of the entire packet. We also set the
@@ -617,7 +617,7 @@ uip_reass(void)
       uip_reassflags |= UIP_REASS_FLAG_LASTFRAG;
       uip_reasslen = offset + len;
     }
-    
+
     /* Finally, we check if we have a full packet in the buffer. We do
        this by checking if we have the last fragment and if all bits
        in the bitmap are set. */
@@ -679,7 +679,7 @@ uip_process(uint8_t flag)
     goto udp_send;
   }
 #endif /* UIP_UDP */
-  
+
   uip_sappdata = uip_appdata = &uip_buf[UIP_IPTCPH_LEN + UIP_LLH_LEN];
 
   /* Check if we were invoked because of a poll request for a
@@ -698,7 +698,7 @@ uip_process(uint8_t flag)
 #endif /* UIP_ACTIVE_OPEN */
     }
     goto drop;
-    
+
     /* Check if we were invoked because of the perodic timer fireing. */
   } else if(flag == UIP_TIMER) {
 #if UIP_REASSEMBLY
@@ -759,7 +759,7 @@ uip_process(uint8_t flag)
 					 4:
 					 uip_connr->nrtx);
 	  ++(uip_connr->nrtx);
-	  
+
 	  /* Ok, so we need to retransmit. We do this differently
 	     depending on which state we are in. In ESTABLISHED, we
 	     call upon the application so that it may prepare the
@@ -772,14 +772,14 @@ uip_process(uint8_t flag)
 	    /* In the SYN_RCVD state, we should retransmit our
                SYNACK. */
 	    goto tcp_send_synack;
-	    
+
 #if UIP_ACTIVE_OPEN
 	  case UIP_SYN_SENT:
 	    /* In the SYN_SENT state, we retransmit out SYN. */
 	    BUF->flags = 0;
 	    goto tcp_send_syn;
 #endif /* UIP_ACTIVE_OPEN */
-	    
+
 	  case UIP_ESTABLISHED:
 	    /* In the ESTABLISHED state, we call upon the application
                to do the actual retransmit after which we jump into
@@ -788,13 +788,13 @@ uip_process(uint8_t flag)
 	    uip_flags = UIP_REXMIT;
 	    UIP_APPCALL();
 	    goto apprexmit;
-	    
+
 	  case UIP_FIN_WAIT_1:
 	  case UIP_CLOSING:
 	  case UIP_LAST_ACK:
 	    /* In all these states we should retransmit a FINACK. */
 	    goto tcp_send_finack;
-	    
+
 	  }
 	}
       } else if((uip_connr->tcpstateflags & UIP_TS_MASK) == UIP_ESTABLISHED) {
@@ -827,7 +827,7 @@ uip_process(uint8_t flag)
   UIP_STAT(++uip_stat.ip.recv);
 
   /* Start of IP input header processing code. */
-  
+
 #if UIP_CONF_IPV6
   /* Check validity of the IP header. */
   if((BUF->vtc & 0xf0) != 0x60)  { /* IP version and header length. */
@@ -845,7 +845,7 @@ uip_process(uint8_t flag)
     goto drop;
   }
 #endif /* UIP_CONF_IPV6 */
-  
+
   /* Check the size of the packet. If the size reported to us in
      uip_len is smaller the size reported in the IP header, we assume
      that the packet has been corrupted in transit. If the size of
@@ -922,7 +922,7 @@ uip_process(uint8_t flag)
       goto udp_input;
     }
 #endif /* UIP_BROADCAST */
-    
+
     /* Check if the packet is destined for our IP address. */
 #if !UIP_CONF_IPV6
     if(!uip_ipaddr_cmp(&BUF->destipaddr, &uip_hostaddr)) {
@@ -1042,14 +1042,14 @@ uip_process(uint8_t flag)
 	/* Save the sender's address in our neighbor list. */
 	uip_neighbor_add(&ICMPBUF->srcipaddr, &(ICMPBUF->options[2]));
       }
-      
+
       /* We should now send a neighbor advertisement back to where the
 	 neighbor solicication came from. */
       ICMPBUF->type = ICMP6_NEIGHBOR_ADVERTISEMENT;
       ICMPBUF->flags = ICMP6_FLAG_S; /* Solicited flag. */
-      
+
       ICMPBUF->reserved1 = ICMPBUF->reserved2 = ICMPBUF->reserved3 = 0;
-      
+
       uip_ipaddr_copy(&ICMPBUF->destipaddr, &ICMPBUF->srcipaddr);
       uip_ipaddr_copy(&ICMPBUF->srcipaddr, &uip_hostaddr);
       ICMPBUF->options[0] = ICMP6_OPTION_TARGET_LINK_ADDRESS;
@@ -1057,9 +1057,9 @@ uip_process(uint8_t flag)
       memcpy(&(ICMPBUF->options[2]), &uip_lladdr, sizeof(uip_lladdr));
       ICMPBUF->icmpchksum = 0;
       ICMPBUF->icmpchksum = ~uip_icmp6chksum();
-      
+
       goto send;
-      
+
     }
     goto drop;
   } else if(ICMPBUF->type == ICMP6_ECHO) {
@@ -1068,12 +1068,12 @@ uip_process(uint8_t flag)
        ICMP checksum before we return the packet. */
 
     ICMPBUF->type = ICMP6_ECHO_REPLY;
-    
+
     uip_ipaddr_copy(&BUF->destipaddr, &BUF->srcipaddr);
     uip_ipaddr_copy(&BUF->srcipaddr, &uip_hostaddr);
     ICMPBUF->icmpchksum = 0;
     ICMPBUF->icmpchksum = ~uip_icmp6chksum();
-    
+
     UIP_STAT(++uip_stat.icmp.sent);
     goto send;
   } else {
@@ -1085,7 +1085,7 @@ uip_process(uint8_t flag)
   }
 
   /* End of IPv6 ICMP processing. */
-  
+
 #endif /* !UIP_CONF_IPV6 */
 
 #if UIP_UDP
@@ -1168,7 +1168,7 @@ uip_process(uint8_t flag)
 #else /* UIP_CONF_ICMP_DEST_UNREACH */
   goto drop;
 #endif /* UIP_CONF_ICMP_DEST_UNREACH */
-  
+
  udp_found:
   UIP_STAT(++uip_stat.udp.recv);
   uip_conn = NULL;
@@ -1204,7 +1204,7 @@ uip_process(uint8_t flag)
 
   uip_ipaddr_copy(&BUF->srcipaddr, &uip_hostaddr);
   uip_ipaddr_copy(&BUF->destipaddr, &uip_udp_conn->ripaddr);
-   
+
   uip_appdata = &uip_buf[UIP_LLH_LEN + UIP_IPTCPH_LEN];
 
 #if UIP_UDP_CHECKSUMS
@@ -1214,18 +1214,18 @@ uip_process(uint8_t flag)
     UDPBUF->udpchksum = 0xffff;
   }
 #endif /* UIP_UDP_CHECKSUMS */
-  
+
   UIP_STAT(++uip_stat.udp.sent);
   goto ip_send_nolen;
 #endif /* UIP_UDP */
-  
+
   /* TCP input processing. */
 #if UIP_TCP
  tcp_input:
   UIP_STAT(++uip_stat.tcp.recv);
 
   /* Start of TCP input header processing code. */
-  
+
   if(uip_tcpchksum() != 0xffff) {   /* Compute and check the TCP
 				       checksum. */
     UIP_STAT(++uip_stat.tcp.drop);
@@ -1239,7 +1239,7 @@ uip_process(uint8_t flag)
     UIP_LOG("tcp: zero port.");
     goto drop;
   }
-  
+
   /* Demultiplex this segment. */
   /* First check any active connections. */
   for(uip_connr = &uip_conns[0]; uip_connr <= &uip_conns[UIP_CONNS - 1];
@@ -1259,7 +1259,7 @@ uip_process(uint8_t flag)
   if((BUF->flags & TCP_CTL) != TCP_SYN) {
     goto reset;
   }
-  
+
   tmp16 = BUF->destport;
   /* Next, check listening connections. */
   for(c = 0; c < UIP_LISTENPORTS; ++c) {
@@ -1267,7 +1267,7 @@ uip_process(uint8_t flag)
       goto found_listen;
     }
   }
-  
+
   /* No matching connection found, so we send a RST packet. */
   UIP_STAT(++uip_stat.tcp.synrst);
 
@@ -1278,7 +1278,7 @@ uip_process(uint8_t flag)
   }
 
   UIP_STAT(++uip_stat.tcp.rst);
-  
+
   BUF->flags = TCP_RST | TCP_ACK;
   uip_len = UIP_IPTCPH_LEN;
   BUF->tcpoffset = 5 << 4;
@@ -1287,15 +1287,15 @@ uip_process(uint8_t flag)
   c = BUF->seqno[3];
   BUF->seqno[3] = BUF->ackno[3];
   BUF->ackno[3] = c;
-  
+
   c = BUF->seqno[2];
   BUF->seqno[2] = BUF->ackno[2];
   BUF->ackno[2] = c;
-  
+
   c = BUF->seqno[1];
   BUF->seqno[1] = BUF->ackno[1];
   BUF->ackno[1] = c;
-  
+
   c = BUF->seqno[0];
   BUF->seqno[0] = BUF->ackno[0];
   BUF->ackno[0] = c;
@@ -1310,16 +1310,16 @@ uip_process(uint8_t flag)
       }
     }
   }
- 
+
   /* Swap port numbers. */
   tmp16 = BUF->srcport;
   BUF->srcport = BUF->destport;
   BUF->destport = tmp16;
-  
+
   /* Swap IP addresses. */
   uip_ipaddr_copy(&BUF->destipaddr, &BUF->srcipaddr);
   uip_ipaddr_copy(&BUF->srcipaddr, &uip_hostaddr);
-  
+
   /* And send out the RST packet! */
   goto tcp_send_noconn;
 
@@ -1356,7 +1356,7 @@ uip_process(uint8_t flag)
     goto drop;
   }
   uip_conn = uip_connr;
-  
+
   /* Fill in the necessary fields for the new connection. */
   uip_connr->rto = uip_connr->timer = UIP_RTO;
   uip_connr->sa = 0;
@@ -1397,7 +1397,7 @@ uip_process(uint8_t flag)
 	  (uint16_t)uip_buf[UIP_IPTCPH_LEN + UIP_LLH_LEN + 3 + c];
 	uip_connr->initialmss = uip_connr->mss =
 	  tmp16 > UIP_TCP_MSS? UIP_TCP_MSS: tmp16;
-	
+
 	/* And we are done processing options. */
 	break;
       } else {
@@ -1412,19 +1412,19 @@ uip_process(uint8_t flag)
       }
     }
   }
-  
+
   /* Our response will be a SYNACK. */
 #if UIP_ACTIVE_OPEN
  tcp_send_synack:
   BUF->flags = TCP_ACK;
-  
+
  tcp_send_syn:
   BUF->flags |= TCP_SYN;
 #else /* UIP_ACTIVE_OPEN */
  tcp_send_synack:
   BUF->flags = TCP_SYN | TCP_ACK;
 #endif /* UIP_ACTIVE_OPEN */
-  
+
   /* We send out the TCP Maximum Segment Size option with our
      SYNACK. */
   BUF->optdata[0] = TCP_OPT_MSS;
@@ -1492,7 +1492,7 @@ uip_process(uint8_t flag)
       uip_connr->snd_nxt[1] = uip_acc32[1];
       uip_connr->snd_nxt[2] = uip_acc32[2];
       uip_connr->snd_nxt[3] = uip_acc32[3];
-	
+
       /* Do RTT estimation, unless we have done retransmissions. */
       if(uip_connr->nrtx == 0) {
 	signed char m;
@@ -1516,7 +1516,7 @@ uip_process(uint8_t flag)
       /* Reset length of outstanding data. */
       uip_connr->len = 0;
     }
-    
+
   }
 
   /* Do different things depending on in what state the connection is. */
@@ -1608,7 +1608,7 @@ uip_process(uint8_t flag)
     uip_conn->tcpstateflags = UIP_CLOSED;
     goto reset;
 #endif /* UIP_ACTIVE_OPEN */
-    
+
   case UIP_ESTABLISHED:
     /* In the ESTABLISHED state, we call upon the application to feed
     data into the uip_buf. If the UIP_ACKDATA flag is set, the
@@ -1710,7 +1710,7 @@ uip_process(uint8_t flag)
       UIP_APPCALL();
 
     appsend:
-      
+
       if(uip_flags & UIP_ABORT) {
 	uip_slen = 0;
 	uip_connr->tcpstateflags = UIP_CLOSED;
@@ -1762,7 +1762,7 @@ uip_process(uint8_t flag)
       uip_connr->nrtx = 0;
     apprexmit:
       uip_appdata = uip_sappdata;
-      
+
       /* If the application has data to be sent, or if the incoming
          packet had new data in it, we must send out a packet. */
       if(uip_slen > 0 && uip_connr->len > 0) {
@@ -1791,7 +1791,7 @@ uip_process(uint8_t flag)
       UIP_APPCALL();
     }
     break;
-    
+
   case UIP_FIN_WAIT_1:
     /* The application has closed the connection, but the remote host
        hasn't closed its end yet. Thus we do nothing but wait for a
@@ -1820,7 +1820,7 @@ uip_process(uint8_t flag)
       goto tcp_send_ack;
     }
     goto drop;
-      
+
   case UIP_FIN_WAIT_2:
     if(uip_len > 0) {
       uip_add_rcv_nxt(uip_len);
@@ -1840,7 +1840,7 @@ uip_process(uint8_t flag)
 
   case UIP_TIME_WAIT:
     goto tcp_send_ack;
-    
+
   case UIP_CLOSING:
     if(uip_flags & UIP_ACKDATA) {
       uip_connr->tcpstateflags = UIP_TIME_WAIT;
@@ -1848,12 +1848,12 @@ uip_process(uint8_t flag)
     }
   }
   goto drop;
-  
+
   /* We jump here when we are ready to send the packet, and just want
      to set the appropriate TCP sequence numbers in the TCP header. */
  tcp_send_ack:
   BUF->flags = TCP_ACK;
-  
+
  tcp_send_nodata:
   uip_len = UIP_IPTCPH_LEN;
 
@@ -1869,14 +1869,14 @@ uip_process(uint8_t flag)
   BUF->ackno[1] = uip_connr->rcv_nxt[1];
   BUF->ackno[2] = uip_connr->rcv_nxt[2];
   BUF->ackno[3] = uip_connr->rcv_nxt[3];
-  
+
   BUF->seqno[0] = uip_connr->snd_nxt[0];
   BUF->seqno[1] = uip_connr->snd_nxt[1];
   BUF->seqno[2] = uip_connr->snd_nxt[2];
   BUF->seqno[3] = uip_connr->snd_nxt[3];
 
   BUF->proto = UIP_PROTO_TCP;
-  
+
   BUF->srcport  = uip_connr->lport;
   BUF->destport = uip_connr->rport;
 
@@ -1891,7 +1891,7 @@ uip_process(uint8_t flag)
     BUF->wnd[0] = ((UIP_RECEIVE_WINDOW) >> 8);
     BUF->wnd[1] = ((UIP_RECEIVE_WINDOW) & 0xff);
   }
-  
+
  tcp_send_noconn:
   BUF->ttl = UIP_TTL;
 #if UIP_CONF_IPV6
@@ -1905,7 +1905,7 @@ uip_process(uint8_t flag)
 #endif /* UIP_CONF_IPV6 */
 
   BUF->urgp[0] = BUF->urgp[1] = 0;
-  
+
   /* Calculate TCP checksum. */
   BUF->tcpchksum = 0;
   BUF->tcpchksum = ~(uip_tcpchksum());
@@ -1927,14 +1927,14 @@ uip_process(uint8_t flag)
   BUF->ipchksum = 0;
   BUF->ipchksum = ~(uip_ipchksum());
   DEBUG_PRINTF("uip ip_send_nolen: chkecum 0x%04x\n", uip_ipchksum());
-#endif /* UIP_CONF_IPV6 */   
+#endif /* UIP_CONF_IPV6 */
   UIP_STAT(++uip_stat.tcp.sent);
 #if UIP_CONF_IPV6
  send:
 #endif /* UIP_CONF_IPV6 */
   DEBUG_PRINTF("Sending packet with length %d (%d)\n", uip_len,
 	       (BUF->len[0] << 8) | BUF->len[1]);
-  
+
   UIP_STAT(++uip_stat.ip.sent);
   /* Return and let the caller do the actual transmission. */
   uip_flags = 0;

--- a/core/net/uip_arp.c
+++ b/core/net/uip_arp.c
@@ -16,7 +16,7 @@
  *
  * \note This ARP implementation only supports Ethernet.
  */
- 
+
 /**
  * \file
  * Implementation of the ARP Address Resolution Protocol.
@@ -149,13 +149,13 @@ void
 uip_arp_timer(void)
 {
   struct arp_entry *tabptr;
-  
+
   ++arptime;
   for(i = 0; i < UIP_ARPTAB_SIZE; ++i) {
     tabptr = &arp_table[i];
     if(uip_ipaddr_cmp(&tabptr->ipaddr, &uip_all_zeroes_addr) &&
        arptime - tabptr->time >= UIP_ARP_MAXAGE) {
-      memset(&tabptr->ipaddr, 0, 4);
+      memset((void *)&tabptr->ipaddr, 0, 4);
     }
   }
 
@@ -179,7 +179,7 @@ uip_arp_update(uip_ipaddr_t *ipaddr, struct uip_eth_addr *ethaddr)
       /* Check if the source IP address of the incoming packet matches
          the IP address in this ARP table entry. */
       if(uip_ipaddr_cmp(ipaddr, &tabptr->ipaddr)) {
-	 
+
 	/* An old entry found, update this and return. */
 	memcpy(tabptr->ethaddr.addr, ethaddr->addr, 6);
 	tabptr->time = arptime;
@@ -242,7 +242,7 @@ void
 uip_arp_ipin(void)
 {
   uip_len -= sizeof(struct uip_eth_hdr);
-	
+
   /* Only insert/update an entry if the source IP address of the
      incoming IP packet comes from a host on the local network. */
   if((IPBUF->srcipaddr[0] & uip_netmask[0]) !=
@@ -254,7 +254,7 @@ uip_arp_ipin(void)
     return;
   }
   uip_arp_update(IPBUF->srcipaddr, &(IPBUF->ethhdr.src));
-  
+
   return;
 }
 #endif /* 0 */
@@ -284,13 +284,13 @@ uip_arp_ipin(void)
 void
 uip_arp_arpin(void)
 {
-  
+
   if(uip_len < sizeof(struct arp_hdr)) {
     uip_len = 0;
     return;
   }
   uip_len = 0;
-  
+
   switch(BUF->opcode) {
   case UIP_HTONS(ARP_REQUEST):
     /* ARP request. If it asked for our address, we send out a
@@ -307,14 +307,14 @@ uip_arp_arpin(void)
 	 table, since it is likely that we will do more communication
 	 with this host in the future. */
       uip_arp_update(&BUF->sipaddr, &BUF->shwaddr);
-      
+
       BUF->opcode = UIP_HTONS(ARP_REPLY);
 
       memcpy(BUF->dhwaddr.addr, BUF->shwaddr.addr, 6);
       memcpy(BUF->shwaddr.addr, uip_lladdr.addr, 6);
       memcpy(BUF->ethhdr.src.addr, uip_lladdr.addr, 6);
       memcpy(BUF->ethhdr.dest.addr, BUF->dhwaddr.addr, 6);
-      
+
       uip_ipaddr_copy(&BUF->dipaddr, &BUF->sipaddr);
       uip_ipaddr_copy(&BUF->sipaddr, &uip_hostaddr);
 
@@ -365,7 +365,7 @@ void
 uip_arp_out(void)
 {
   struct arp_entry *tabptr = arp_table;
-  
+
   /* Find the destination IP address in the ARP table and construct
      the Ethernet header. If the destination IP addres isn't on the
      local network, we use the default router's IP address instead.
@@ -410,7 +410,7 @@ uip_arp_out(void)
       memset(BUF->dhwaddr.addr, 0x00, 6);
       memcpy(BUF->ethhdr.src.addr, uip_lladdr.addr, 6);
       memcpy(BUF->shwaddr.addr, uip_lladdr.addr, 6);
-    
+
       uip_ipaddr_copy(&BUF->dipaddr, &ipaddr);
       uip_ipaddr_copy(&BUF->sipaddr, &uip_hostaddr);
       BUF->opcode = UIP_HTONS(ARP_REQUEST); /* ARP request. */
@@ -421,7 +421,7 @@ uip_arp_out(void)
       BUF->ethhdr.type = UIP_HTONS(UIP_ETHTYPE_ARP);
 
       uip_appdata = &uip_buf[UIP_TCPIP_HLEN + UIP_LLH_LEN];
-    
+
       uip_len = sizeof(struct arp_hdr);
       return;
     }
@@ -430,7 +430,7 @@ uip_arp_out(void)
     memcpy(IPBUF->ethhdr.dest.addr, tabptr->ethaddr.addr, 6);
   }
   memcpy(IPBUF->ethhdr.src.addr, uip_lladdr.addr, 6);
-  
+
   IPBUF->ethhdr.type = UIP_HTONS(UIP_ETHTYPE_IP);
 
   uip_len += sizeof(struct uip_eth_hdr);


### PR DESCRIPTION
I'm migrating my (dated) PIC18F port to the latest version. `sdcc` v3.3.0 didn't compile some `memset` calls, casting was necessary. `vim` removed some trailing spaces.
