### PR TITLE
cc2538: Enable workaround for Cortex-M3 erratum #602117

### DIFF
--- a/cpu/cc2538/Makefile.cc2538
+++ b/cpu/cc2538/Makefile.cc2538
@@ -10,7 +10,7 @@ SOURCE_LDSCRIPT = $(CONTIKI_CPU)/cc2538.lds
 endif
 LDSCRIPT = $(OBJECTDIR)/cc2538.ld
 
-CFLAGS += -O2 -mcpu=cortex-m3 -mthumb -mlittle-endian
+CFLAGS += -O2 -mcpu=cortex-m3 -mthumb -mlittle-endian -mfix-cortex-m3-ldrd
 CFLAGS += -fshort-enums -fomit-frame-pointer -fno-strict-aliasing
 CFLAGS += -Wall
 LDFLAGS += -mcpu=cortex-m3 -mthumb -nostartfiles


### PR DESCRIPTION
The core of the CC2538 SoC is the ARM Cortex-M3 r2p0, which is affected by the
erratum #602117 'LDRD with base in list may result in incorrect base register
when interrupted or faulted'. The conditions triggering this issue are not very
likely to occur, but as a matter of precaution, it is better to enable
GCC's -mfix-cortex-m3-ldrd option as a workaround, all the more it can only make
the compiler choose other CPU registers to use with LDRD.
