### PR TITLE
Basic NETSTACK_CONF_RADIO based on kernel 802.15.4

### DIFF
--- a/cpu/native/net/linuxradio-drv.c
+++ b/cpu/native/net/linuxradio-drv.c
@@ -89,6 +89,7 @@ transmit(unsigned short transmit_len)
   sent = send(sockfd, sockbuf, buflen, 0);
   if (sent < 0) {
     perror("linuxradio send()");
+    return RADIO_TX_ERR;
   }
   buflen = 0;
   return RADIO_TX_OK;

--- a/cpu/native/net/linuxradio-drv.c
+++ b/cpu/native/net/linuxradio-drv.c
@@ -144,7 +144,7 @@ static void
 handle_fd(fd_set *rset, fd_set *wset)
 {
   if (FD_ISSET(sockfd, rset)) {
-    int bytes = read(sockfd, sockbuf, 256);
+    int bytes = read(sockfd, sockbuf, MAX_PACKET_SIZE);
     buflen = bytes;
     memcpy(packetbuf_dataptr(), sockbuf, bytes);
     packetbuf_set_datalen(bytes);

--- a/cpu/native/net/linuxradio-drv.c
+++ b/cpu/native/net/linuxradio-drv.c
@@ -1,0 +1,179 @@
+#include "contiki.h"
+
+#include "linuxradio-drv.h"
+
+#include "net/packetbuf.h"
+#include "net/netstack.h"
+
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <unistd.h>
+#include <netinet/if_ether.h>
+#include <netpacket/packet.h>
+#include <net/if.h>
+#include <linux/sockios.h>
+
+#define DEBUG 0
+#if DEBUG
+#include <stdio.h>
+#define PRINTF(...) printf(__VA_ARGS__)
+#else
+#define PRINTF(...)
+#endif
+
+static int sockfd = -1;
+static char *sockbuf;
+static int buflen;
+
+#if 0
+static void my_memmove(char *s1, char *s2, int len)
+{
+  int i;
+  for(i=0; i<len; ++i) {
+    *s1++ = *s2++;
+  }
+}
+#endif
+
+static int
+init(void)
+{
+  sockbuf = malloc(256);
+  return 0;
+}
+
+static int
+prepare(const void *payload, unsigned short payload_len)
+{
+  if(payload_len > 256) {
+    return 0;
+  }
+  memcpy(sockbuf, payload, payload_len);
+  buflen = payload_len;
+
+  return 0;
+}
+
+static int
+transmit(unsigned short transmit_len)
+{
+  int sent=0;
+  sent = send(sockfd, sockbuf, buflen, 0);
+  if(sent < 0) {
+    perror ("linuxradio send()");
+  }
+  buflen = 0;
+  return RADIO_TX_OK;
+}
+
+static int
+my_send(const void *payload, unsigned short payload_len)
+{
+  int ret = -1;
+
+  PRINTF("PREPARE & TRANSMIT %u bytes\n", payload_len);
+
+  if(prepare(payload, payload_len)) {
+    return ret;
+  }
+
+  ret = transmit(payload_len);
+
+  return ret;
+}
+
+static int
+my_read(void *buf, unsigned short buf_len)
+{
+  return 0;
+}
+
+static int
+channel_clear(void)
+{
+  return 1;
+}
+
+static int
+receiving_packet(void)
+{
+  return 0;
+}
+
+static int
+pending_packet(void)
+{
+  return 0;
+}
+
+static int
+set_fd(fd_set *rset, fd_set *wset)
+{
+  FD_SET(sockfd, rset);
+  return 1;
+}
+
+static void
+handle_fd(fd_set *rset, fd_set *wset)
+{
+  if(FD_ISSET(sockfd, rset)) {
+    int bytes = read(sockfd, sockbuf, 256);
+    buflen = bytes;
+    PRINTF("linuxradio: read %d bytes\n", bytes);
+    memcpy(packetbuf_dataptr(), sockbuf, bytes);
+    packetbuf_set_datalen(bytes);
+    NETSTACK_RDC.input();
+  }
+}
+
+static const struct select_callback linuxradio_sock_callback = { set_fd, handle_fd };
+
+static int
+on(void)
+{
+  sockfd = socket(PF_PACKET, SOCK_RAW, htons(ETH_P_IEEE802154));
+  if(sockfd < 0) {
+    perror ("linuxradio socket()");
+    return 0;
+  } else {
+    struct ifreq ifr;
+    strncpy((char *)ifr.ifr_name, "wpan0", IFNAMSIZ); // TODO: make interface configurable
+    ioctl(sockfd, SIOCGIFINDEX, &ifr);
+
+    struct sockaddr_ll sll;
+    sll.sll_family = AF_PACKET;
+    sll.sll_ifindex = ifr.ifr_ifindex;
+    sll.sll_protocol = htons(ETH_P_IEEE802154);
+
+    if(bind(sockfd, (struct sockaddr *)&sll, sizeof(sll)) < 0) {
+      perror("linuxradio bind()");
+      return 0;
+    }
+
+    select_set_callback(sockfd, &linuxradio_sock_callback);
+    return 1;
+  }
+}
+
+static int
+off(void)
+{
+  close(sockfd);
+  sockfd = -1;
+  return 1;
+}
+
+const struct radio_driver linuxradio_driver =
+  {
+    init,
+    prepare,
+    transmit,
+    my_send,
+    my_read,
+    channel_clear,
+    receiving_packet,
+    pending_packet,
+    on,
+    off,
+  };

--- a/cpu/native/net/linuxradio-drv.c
+++ b/cpu/native/net/linuxradio-drv.c
@@ -67,16 +67,15 @@ static int
 init(void)
 {
   sockbuf = malloc(MAX_PACKET_SIZE);
-  if (sockbuf == 0) {
+  if(sockbuf == 0) {
     return 1;
   }
   return 0;
 }
-
 static int
 prepare(const void *payload, unsigned short payload_len)
 {
-  if (payload_len > MAX_PACKET_SIZE) {
+  if(payload_len > MAX_PACKET_SIZE) {
     return 0;
   }
   memcpy(sockbuf, payload, payload_len);
@@ -84,26 +83,24 @@ prepare(const void *payload, unsigned short payload_len)
 
   return 0;
 }
-
 static int
 transmit(unsigned short transmit_len)
 {
-  int sent=0;
+  int sent = 0;
   sent = send(sockfd, sockbuf, buflen, 0);
-  if (sent < 0) {
+  if(sent < 0) {
     perror("linuxradio send()");
     return RADIO_TX_ERR;
   }
   buflen = 0;
   return RADIO_TX_OK;
 }
-
 static int
 my_send(const void *payload, unsigned short payload_len)
 {
   int ret = -1;
 
-  if (prepare(payload, payload_len)) {
+  if(prepare(payload, payload_len)) {
     return ret;
   }
 
@@ -111,42 +108,36 @@ my_send(const void *payload, unsigned short payload_len)
 
   return ret;
 }
-
 static int
 my_read(void *buf, unsigned short buf_len)
 {
   return 0;
 }
-
 static int
 channel_clear(void)
 {
   return 1;
 }
-
 static int
 receiving_packet(void)
 {
   return 0;
 }
-
 static int
 pending_packet(void)
 {
   return 0;
 }
-
 static int
 set_fd(fd_set *rset, fd_set *wset)
 {
   FD_SET(sockfd, rset);
   return 1;
 }
-
 static void
 handle_fd(fd_set *rset, fd_set *wset)
 {
-  if (FD_ISSET(sockfd, rset)) {
+  if(FD_ISSET(sockfd, rset)) {
     int bytes = read(sockfd, sockbuf, MAX_PACKET_SIZE);
     buflen = bytes;
     memcpy(packetbuf_dataptr(), sockbuf, bytes);
@@ -154,32 +145,32 @@ handle_fd(fd_set *rset, fd_set *wset)
     NETSTACK_RDC.input();
   }
 }
-
 static const struct select_callback linuxradio_sock_callback = { set_fd, handle_fd };
 
 static int
 on(void)
 {
+  struct ifreq ifr;
+  int err;
+  struct sockaddr_ll sll;
+
   sockfd = socket(PF_PACKET, SOCK_RAW, htons(ETH_P_IEEE802154));
-  if (sockfd < 0) {
-    perror ("linuxradio socket()");
+  if(sockfd < 0) {
+    perror("linuxradio socket()");
     return 0;
   } else {
-    struct ifreq ifr;
-    // TODO: interface should not be hard-coded
+    /* TODO: interface should not be hard-coded */
     strncpy((char *)ifr.ifr_name, "wpan0", IFNAMSIZ);
-    int err = ioctl(sockfd, SIOCGIFINDEX, &ifr);
-    if (err == -1) {
-      perror ("linuxradio ioctl()");
+    err = ioctl(sockfd, SIOCGIFINDEX, &ifr);
+    if(err == -1) {
+      perror("linuxradio ioctl()");
       return 0;
     }
-
-    struct sockaddr_ll sll;
     sll.sll_family = AF_PACKET;
     sll.sll_ifindex = ifr.ifr_ifindex;
     sll.sll_protocol = htons(ETH_P_IEEE802154);
 
-    if (bind(sockfd, (struct sockaddr *)&sll, sizeof(sll)) < 0) {
+    if(bind(sockfd, (struct sockaddr *)&sll, sizeof(sll)) < 0) {
       perror("linuxradio bind()");
       return 0;
     }
@@ -188,7 +179,6 @@ on(void)
     return 1;
   }
 }
-
 static int
 off(void)
 {
@@ -196,17 +186,16 @@ off(void)
   sockfd = -1;
   return 1;
 }
-
 const struct radio_driver linuxradio_driver =
-  {
-    init,
-    prepare,
-    transmit,
-    my_send,
-    my_read,
-    channel_clear,
-    receiving_packet,
-    pending_packet,
-    on,
-    off,
-  };
+{
+  init,
+  prepare,
+  transmit,
+  my_send,
+  my_read,
+  channel_clear,
+  receiving_packet,
+  pending_packet,
+  on,
+  off,
+};

--- a/cpu/native/net/linuxradio-drv.c
+++ b/cpu/native/net/linuxradio-drv.c
@@ -67,6 +67,9 @@ static int
 init(void)
 {
   sockbuf = malloc(MAX_PACKET_SIZE);
+  if (sockbuf == 0) {
+    return 1;
+  }
   return 0;
 }
 
@@ -163,8 +166,13 @@ on(void)
     return 0;
   } else {
     struct ifreq ifr;
-    strncpy((char *)ifr.ifr_name, "wpan0", IFNAMSIZ); // TODO: make interface configurable
-    ioctl(sockfd, SIOCGIFINDEX, &ifr);
+    // TODO: interface should not be hard-coded
+    strncpy((char *)ifr.ifr_name, "wpan0", IFNAMSIZ);
+    int err = ioctl(sockfd, SIOCGIFINDEX, &ifr);
+    if (err == -1) {
+      perror ("linuxradio ioctl()");
+      return 0;
+    }
 
     struct sockaddr_ll sll;
     sll.sll_family = AF_PACKET;

--- a/cpu/native/net/linuxradio-drv.c
+++ b/cpu/native/net/linuxradio-drv.c
@@ -34,8 +34,9 @@
  */
 
 #include "contiki.h"
+#include "contiki-conf.h"
 
-#ifdef linux
+#if defined(linux) && UIP_CONF_IPV6
 
 #include "linuxradio-drv.h"
 

--- a/cpu/native/net/linuxradio-drv.c
+++ b/cpu/native/net/linuxradio-drv.c
@@ -35,11 +35,15 @@
 
 #include "contiki.h"
 
+#ifdef linux
+
 #include "linuxradio-drv.h"
 
 #include "net/packetbuf.h"
 #include "net/netstack.h"
 
+#include <sys/ioctl.h>
+#include <string.h>
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <netinet/in.h>
@@ -145,6 +149,7 @@ handle_fd(fd_set *rset, fd_set *wset)
     NETSTACK_RDC.input();
   }
 }
+
 static const struct select_callback linuxradio_sock_callback = { set_fd, handle_fd };
 
 static int
@@ -199,3 +204,5 @@ const struct radio_driver linuxradio_driver =
   on,
   off,
 };
+
+#endif

--- a/cpu/native/net/linuxradio-drv.c
+++ b/cpu/native/net/linuxradio-drv.c
@@ -1,3 +1,38 @@
+/*
+ * Copyright (c) 2013, Google
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * Author: Vladimir Pouzanov <farcaller@gmail.com>
+ *
+ */
+
 #include "contiki.h"
 
 #include "linuxradio-drv.h"
@@ -26,27 +61,19 @@ static int sockfd = -1;
 static char *sockbuf;
 static int buflen;
 
-#if 0
-static void my_memmove(char *s1, char *s2, int len)
-{
-  int i;
-  for(i=0; i<len; ++i) {
-    *s1++ = *s2++;
-  }
-}
-#endif
+#define MAX_PACKET_SIZE 256
 
 static int
 init(void)
 {
-  sockbuf = malloc(256);
+  sockbuf = malloc(MAX_PACKET_SIZE);
   return 0;
 }
 
 static int
 prepare(const void *payload, unsigned short payload_len)
 {
-  if(payload_len > 256) {
+  if (payload_len > MAX_PACKET_SIZE) {
     return 0;
   }
   memcpy(sockbuf, payload, payload_len);
@@ -60,8 +87,8 @@ transmit(unsigned short transmit_len)
 {
   int sent=0;
   sent = send(sockfd, sockbuf, buflen, 0);
-  if(sent < 0) {
-    perror ("linuxradio send()");
+  if (sent < 0) {
+    perror("linuxradio send()");
   }
   buflen = 0;
   return RADIO_TX_OK;
@@ -72,9 +99,7 @@ my_send(const void *payload, unsigned short payload_len)
 {
   int ret = -1;
 
-  PRINTF("PREPARE & TRANSMIT %u bytes\n", payload_len);
-
-  if(prepare(payload, payload_len)) {
+  if (prepare(payload, payload_len)) {
     return ret;
   }
 
@@ -117,10 +142,9 @@ set_fd(fd_set *rset, fd_set *wset)
 static void
 handle_fd(fd_set *rset, fd_set *wset)
 {
-  if(FD_ISSET(sockfd, rset)) {
+  if (FD_ISSET(sockfd, rset)) {
     int bytes = read(sockfd, sockbuf, 256);
     buflen = bytes;
-    PRINTF("linuxradio: read %d bytes\n", bytes);
     memcpy(packetbuf_dataptr(), sockbuf, bytes);
     packetbuf_set_datalen(bytes);
     NETSTACK_RDC.input();
@@ -133,7 +157,7 @@ static int
 on(void)
 {
   sockfd = socket(PF_PACKET, SOCK_RAW, htons(ETH_P_IEEE802154));
-  if(sockfd < 0) {
+  if (sockfd < 0) {
     perror ("linuxradio socket()");
     return 0;
   } else {
@@ -146,7 +170,7 @@ on(void)
     sll.sll_ifindex = ifr.ifr_ifindex;
     sll.sll_protocol = htons(ETH_P_IEEE802154);
 
-    if(bind(sockfd, (struct sockaddr *)&sll, sizeof(sll)) < 0) {
+    if (bind(sockfd, (struct sockaddr *)&sll, sizeof(sll)) < 0) {
       perror("linuxradio bind()");
       return 0;
     }

--- a/cpu/native/net/linuxradio-drv.c
+++ b/cpu/native/net/linuxradio-drv.c
@@ -164,8 +164,7 @@ on(void)
     perror("linuxradio socket()");
     return 0;
   } else {
-    /* TODO: interface should not be hard-coded */
-    strncpy((char *)ifr.ifr_name, "wpan0", IFNAMSIZ);
+    strncpy((char *)ifr.ifr_name, NETSTACK_CONF_LINUXRADIO_DEV, IFNAMSIZ);
     err = ioctl(sockfd, SIOCGIFINDEX, &ifr);
     if(err == -1) {
       perror("linuxradio ioctl()");

--- a/cpu/native/net/linuxradio-drv.h
+++ b/cpu/native/net/linuxradio-drv.h
@@ -1,3 +1,38 @@
+/*
+ * Copyright (c) 2013, Google
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * Author: Vladimir Pouzanov <farcaller@gmail.com>
+ *
+ */
+
 #ifndef __LINUXRADIO_DRV_H__
 #define __LINUXRADIO_DRV_H__
 

--- a/cpu/native/net/linuxradio-drv.h
+++ b/cpu/native/net/linuxradio-drv.h
@@ -1,0 +1,8 @@
+#ifndef __LINUXRADIO_DRV_H__
+#define __LINUXRADIO_DRV_H__
+
+#include "dev/radio.h"
+
+extern const struct radio_driver linuxradio_driver;
+
+#endif

--- a/platform/minimal-net/Makefile.minimal-net
+++ b/platform/minimal-net/Makefile.minimal-net
@@ -14,7 +14,7 @@ CONTIKI_TARGET_SOURCEFILES = contiki-main.c clock.c leds.c leds-arch.c cfs-posix
 ifeq ($(HOST_OS),Windows)
 CONTIKI_TARGET_SOURCEFILES += wpcap-drv.c wpcap.c
 else
-CONTIKI_TARGET_SOURCEFILES += tapdev-drv.c tapdev.c tapdev6.c
+CONTIKI_TARGET_SOURCEFILES += tapdev-drv.c tapdev.c tapdev6.c linuxradio-drv.c
 endif
 
 CONTIKI_SOURCEFILES += $(CONTIKI_TARGET_SOURCEFILES)

--- a/platform/minimal-net/contiki-conf.h
+++ b/platform/minimal-net/contiki-conf.h
@@ -35,6 +35,9 @@
 
 #include <inttypes.h>
 #include <limits.h>
+#ifndef WIN32_LEAN_AND_MEAN
+#include <sys/select.h>
+#endif
 
 struct select_callback {
   int  (* set_fd)(fd_set *fdr, fd_set *fdw);
@@ -157,6 +160,8 @@ typedef unsigned short uip_stats_t;
 /* Not used but avoids compile errors while sicslowpan.c is being developed */
 #define SICSLOWPAN_CONF_COMPRESSION       SICSLOWPAN_COMPRESSION_HC06
 
+#define NETSTACK_CONF_LINUXRADIO_DEV "wpan0"
+
 #define UIP_CONF_UDP                  1
 #define UIP_CONF_TCP                  1
 
@@ -175,8 +180,6 @@ typedef unsigned short uip_stats_t;
 #define UIP_CONF_DS6_MADDR_NBU   0
 #define UIP_CONF_DS6_AADDR_NBU   0
 #endif /* UIP_CONF_IPV6 */
-
-#define NETSTACK_CONF_LINUXRADIO_DEV "wpan0"
 
 typedef unsigned long clock_time_t;
 #define CLOCK_CONF_SECOND 1000

--- a/platform/minimal-net/contiki-conf.h
+++ b/platform/minimal-net/contiki-conf.h
@@ -176,6 +176,8 @@ typedef unsigned short uip_stats_t;
 #define UIP_CONF_DS6_AADDR_NBU   0
 #endif /* UIP_CONF_IPV6 */
 
+#define NETSTACK_CONF_LINUXRADIO_DEV "wpan0"
+
 typedef unsigned long clock_time_t;
 #define CLOCK_CONF_SECOND 1000
 #define INFINITE_TIME ULONG_MAX

--- a/platform/minimal-net/contiki-conf.h
+++ b/platform/minimal-net/contiki-conf.h
@@ -36,6 +36,12 @@
 #include <inttypes.h>
 #include <limits.h>
 
+struct select_callback {
+  int  (* set_fd)(fd_set *fdr, fd_set *fdw);
+  void (* handle_fd)(fd_set *fdr, fd_set *fdw);
+};
+int select_set_callback(int fd, const struct select_callback *callback);
+
 #define CC_CONF_REGISTER_ARGS          1
 #define CC_CONF_FUNCTION_POINTER_ARGS  1
 #define CC_CONF_FASTCALL
@@ -88,10 +94,10 @@ typedef unsigned short uip_stats_t;
  */
 #define WEBSERVER_CONF_STATUSPAGE   1
 
-/* RPL currently works only on Windows. *nix would require converting the tun interface to two pcap tees. */ 
+/* RPL currently works only on Windows. *nix would require converting the tun interface to two pcap tees. */
 //#define UIP_CONF_IPV6_RPL           0
 //#define RPL_BORDER_ROUTER           0
-#endif   
+#endif
 
 #if UIP_CONF_IPV6_RPL
 /* RPL motes use the uip.c link layer address or optionally the harded coded address (but without the prefix!)
@@ -122,7 +128,7 @@ typedef unsigned short uip_stats_t;
  * e.g. the jackdaw RNDIS <->  repeater. Then RPL will configure on the radio network and the RF motes will
  * be reached through bbbb::<mote link layer address>.
  * Possibly minimal-net RPL motes could also be added to this interface?
- * 
+ *
  */
 #undef UIP_CONF_ROUTER
 #define UIP_CONF_ROUTER             1

--- a/platform/native/Makefile.native
+++ b/platform/native/Makefile.native
@@ -21,7 +21,7 @@ ifeq ($(HOST_OS),Windows)
 CONTIKI_TARGET_SOURCEFILES += wpcap-drv.c wpcap.c
 TARGET_LIBFILES = /lib/w32api/libws2_32.a /lib/w32api/libiphlpapi.a
 else
-CONTIKI_TARGET_SOURCEFILES += tapdev-drv.c
+CONTIKI_TARGET_SOURCEFILES += tapdev-drv.c linuxradio-drv.c
 #math
 ifneq ($(UIP_CONF_IPV6),1)
 CONTIKI_TARGET_SOURCEFILES += tapdev.c

--- a/platform/native/contiki-conf.h
+++ b/platform/native/contiki-conf.h
@@ -101,6 +101,8 @@ typedef unsigned short uip_stats_t;
 
 #define NETSTACK_CONF_NETWORK sicslowpan_driver
 
+#define NETSTACK_CONF_LINUXRADIO_DEV "wpan0"
+
 #define UIP_CONF_ROUTER                 1
 #ifndef UIP_CONF_IPV6_RPL
 #define UIP_CONF_IPV6_RPL               1


### PR DESCRIPTION
This CL adds a basic NETSTACK_CONF_RADIO implementation based on linux kernel 802.15.4 radio stack, allowing to offload 802.15.4 to kernelspace, e.g. use native contiki in router mode with mrf24j40 sitting in SPI and being handled by kernel.

The patch is WIP, so your advice on how to clean it up for submission would be much appreciated.