### PR TITLE
core/sys/rtimer.h, rtimer.c: support multiple timers; allow cancellation

### DIFF
--- a/core/sys/rtimer.c
+++ b/core/sys/rtimer.c
@@ -113,7 +113,7 @@ set_locked(struct rtimer *rtimer, rtimer_clock_t time,
   }
   rtimer->time = time;
   rtimer->func = func;
-  rtimer->ptr = func;
+  rtimer->ptr = ptr;
   rtimer->cancel = 0;
 
   for(anchor = &next_rtimer; *anchor; anchor = &(*anchor)->next) {

--- a/core/sys/rtimer.c
+++ b/core/sys/rtimer.c
@@ -140,7 +140,9 @@ next_timer_locked(void)
   while(next_rtimer && !RTIMER_CLOCK_LT(now, next_rtimer->time)) {
     t = next_rtimer;   
     next_rtimer = t->next;
-    if(!t->cancel) {
+    if(t->cancel) {
+      need_sched = 1;
+    } else {
       t->func(t, t->ptr);
       need_sched |= t != next_rtimer;
     }

--- a/core/sys/rtimer.h
+++ b/core/sys/rtimer.h
@@ -88,6 +88,13 @@ struct rtimer {
   void *ptr;
   struct rtimer *next;
   bool cancel;
+
+  /* the fields below are for timer updates from interrupts */
+  rtimer_clock_t set_time;
+  rtimer_callback_t set_func;
+  void *set_ptr;
+  bool set_cancel;
+  struct rtimer *more[2];	/* more timers with delayed setting */
 };
 
 enum {


### PR DESCRIPTION
This rewrite of rtimers introduces the following changes:
- more than one rtimer can be used concurrently
  
  Some operations are O(n) for the number of active rtimers, so
  their number should still not be excessive.
- when setting an rtimer, the handler is guaranteed to be called
  exactly once. Before, it could also happen that it was never
  called or that it was only called with a very large delay,
  depending on the underlying architecture support.
- rtimers can be cancelled with rtimer_cancel. Cancellation means
  that the handler function will not be invoked after rtimer_cancel
  returns. The rtimer structure may still be used internally and
  must not be overwritten or deallocated.
