### PR TITLE
Fix the bug in the IPv6 bugfix

### DIFF
--- a/core/net/uipopt.h
+++ b/core/net/uipopt.h
@@ -481,9 +481,9 @@ void uip_log(char *msg);
 #error UIP_CONF_TCP_MSS is too large for the current UIP_BUFSIZE
 #endif /* UIP_CONF_TCP_MSS > (UIP_BUFSIZE - UIP_LLH_LEN - UIP_TCPIP_HLEN) */
 #define UIP_TCP_MSS     (UIP_CONF_TCP_MSS)
-#else
+#else /* UIP_CONF_TCP_MSS */
 #define UIP_TCP_MSS     (UIP_BUFSIZE - UIP_LLH_LEN - UIP_TCPIP_HLEN)
-#endif
+#endif /* UIP_CONF_TCP_MSS */
 
 /**
  * The size of the advertised receiver's window.


### PR DESCRIPTION
This patch fixes a bug in the comment in the https://github.com/contiki-os/contiki/pull/502 bugfix: the comment on the `#endif` was not updated when the `#if` was fixed. This fixes it.
