### PR TITLE
Added new platform for LPC1768

### DIFF
--- a/cpu/arm/lpc1768/Makefile.lpc1768
+++ b/cpu/arm/lpc1768/Makefile.lpc1768
@@ -1,0 +1,136 @@
+# Adapted from Makefile.msp430
+
+### Code common for all ARM CPUs
+
+CONTIKI_CPU_ARM=$(CONTIKI)/cpu/arm/
+
+### Define the CPU directory
+CONTIKI_CPU=$(CONTIKI_CPU_ARM)/lpc1768
+
+
+### Define the source files we have in the LPC1768 port
+
+CONTIKI_CPU_DIRS = . 
+
+#List of source files that interface between Contiki and the LPC17xx drivers
+LPC1768     = clock.c emac.c emac-driver.c startup-LPC1768.c \
+			  core_cm3.c debug_frmwrk.c lpc17xx_emac.c \
+			  lpc17xx_libcfg_default.c lpc17xx_pinsel.c lpc17xx_systick.c \
+		      lpc17xx_clkpwr.c lpc17xx_uart.c lpc17xx_gpio.c \
+		      system_LPC17xx.c debug-uart.c syscalls.c
+
+CONTIKI_TARGET_SOURCEFILES += $(LPC1768) $(UIPDRIVERS)
+
+CONTIKI_SOURCEFILES        += $(CONTIKI_TARGET_SOURCEFILES)
+
+
+THREADS =
+
+### Compiler definitions
+CC       = arm-none-eabi-gcc
+LD       = arm-none-eabi-ld
+AS       = arm-none-eabi-as
+AR       = arm-none-eabi-ar
+NM       = arm-none-eabi-nm
+OBJCOPY  = arm-none-eabi-objcopy
+STRIP    = arm-none-eabi-strip
+
+PROJECT_OBJECTFILES += ${addprefix $(OBJECTDIR)/,$(CONTIKI_TARGET_MAIN:.c=.o)}
+
+LINKERSCRIPT = $(CONTIKI_CPU)/lpc1768.ld
+
+STARTUP=${addprefix $(OBJECTDIR)/,startup-LPC1768.o}
+
+ARCH_FLAGS= -mthumb -mcpu=cortex-m3
+
+CFLAGSNO = -I. -I$(CONTIKI)/core -I$(CONTIKI_CPU) \
+           -I$(CONTIKI)/platform/$(TARGET) \
+           ${addprefix -I,$(APPDIRS)} \
+           -DWITH_UIP -DWITH_ASCII -DMCK=$(MCK) \
+           -Wall $(ARCH_FLAGS) -g -D SUBTARGET=$(SUBTARGET) \
+
+CFLAGS  += $(CFLAGSNO) -O -DRUN_AS_SYSTEM -DROM_RUN
+LDFLAGS += -L $(CONTIKI_CPU) -T $(LINKERSCRIPT) -nostartfiles \
+			-Wl,-Map -Xlinker contiki-$(TARGET).map
+
+CDEPFLAGS = $(CFLAGS) -D __MAKING_DEPS__
+
+
+### Setup directory search path for source files
+
+CUSTOM_RULE_C_TO_OBJECTDIR_O=yes
+CUSTOM_RULE_C_TO_O=yes
+
+%.o: %.c
+	$(CC) $(CFLAGS) $< -c
+
+$(OBJECTDIR)/%.o: %.c
+	$(CC) $(CFLAGS) -c $< -o $@
+
+
+CUSTOM_RULE_S_TO_OBJECTDIR_O = yes
+%.o: %.S
+	$(CC) $(CFLAGS) $< -c
+
+$(OBJECTDIR)/%.o: %.S
+	$(CC) $(CFLAGS) $< -c  -o $@
+
+
+CUSTOM_RULE_C_TO_CO=yes
+
+%.co: %.c
+	$(CC) $(CFLAGS) $< -c -o $@
+
+CUSTOM_RULE_C_TO_CE=yes
+
+%.ce: %.o
+	$(LD) $(LDFLAGS) --relocatable -T $(CONTIKI_CPU)/merge-rodata.ld $< -o $@
+	$(STRIP) -K _init -K _fini --strip-unneeded -g -x $@
+
+CUSTOM_RULE_LINK=yes
+
+%-stripped.o: %.c
+	$(CC) $(CFLAGS) -c $< -o $@
+	$(STRIP) --strip-unneeded -g -x $@
+
+%-stripped.o: %.o
+	$(STRIP) --strip-unneeded -g -x -o $@ $<
+
+%.o: ${CONTIKI_TARGET}/loader/%.S
+	$(AS) -o $(notdir $(<:.S=.o)) $<
+
+%-nosyms.$(TARGET): %.co $(PROJECT_OBJECTFILES) contiki-$(TARGET).a $(STARTUP) # $(OBJECTDIR)/empty-symbols.o
+	$(CC) $(LDFLAGS) $(CFLAGS) -nostartfiles -o $@ $(filter-out %.a,$^) $(filter %.a,$^) -lc $(filter %.a,$^)
+
+
+%.ihex: %.$(TARGET)
+	$(OBJCOPY) $^ -O ihex $@
+
+%.bin: %.$(TARGET)
+	$(OBJCOPY) -O binary $< $@
+ 
+.PHONY: symbols.c
+ifdef CORE
+%.$(TARGET): %.co $(PROJECT_OBJECTFILES) contiki-$(TARGET).a $(STARTUP) $(OBJECTDIR)/symbols.o
+	$(CC) $(LDFLAGS) $(CFLAGS) -nostartfiles -o $@ $(filter-out %.a,$^) $(filter %.a,$^) -lc $(filter %.a,$^)
+
+symbols.c: $(CORE)
+	$(NM) $< | awk -f $(CONTIKI_CPU)/builtins.awk -f ../../tools/mknmlist > symbols.c
+
+else
+%.$(TARGET): %-nosyms.$(TARGET)
+	ln -sf $< $@
+endif
+
+empty-symbols.c:
+	cp ${CONTIKI}/tools/empty-symbols.c symbols.c
+	cp ${CONTIKI}/tools/empty-symbols.h symbols.h
+
+clean: clean_cpu
+
+.PHONY: clean_cpu
+
+clean_cpu:
+	-rm -rf $(BUILTSRCDIR)
+
+.PRECIOUS: %-nosyms.$(TARGET)

--- a/cpu/arm/lpc1768/clock.c
+++ b/cpu/arm/lpc1768/clock.c
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2013, KTH, Royal Institute of Technology
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE UNIVERSITY AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ */
+
+#include "lpc17xx_systick.h"
+#include <sys/clock.h>
+#include <sys/cc.h>
+#include <sys/etimer.h>
+
+static volatile clock_time_t current_clock = 0;
+static volatile unsigned long current_seconds = 0;
+/* static unsigned int second_countdown = CLOCK_SECOND; */
+static unsigned int second_countdown = 100;
+
+void SysTick_handler(void) __attribute__ ((interrupt));
+
+void
+SysTick_handler(void)
+{
+  /* Clear System Tick counter flag */
+  SYSTICK_ClearCounterFlag();
+
+  current_clock++;
+  if(etimer_pending() && etimer_next_expiration_time() <= current_clock) {
+    etimer_request_poll();
+    /* printf("%d,%d\n", clock_time(),etimer_next_expiration_time   ()); */
+  }
+  if(--second_countdown == 0) {
+    current_seconds++;
+    second_countdown = CLOCK_SECOND;
+  }
+}
+void
+clock_init()
+{
+  /* Initialize System Tick with 10ms time interval */
+  SYSTICK_InternalInit(10);
+  /* Enable System Tick interrupt */
+  SYSTICK_IntCmd(ENABLE);
+  /* Enable System Tick Counter */
+  SYSTICK_Cmd(ENABLE);
+}
+clock_time_t
+clock_time(void)
+{
+  return current_clock;
+}
+unsigned long
+clock_seconds(void)
+{
+  return current_seconds;
+}
+/* Do nothing */
+void
+clock_delay(unsigned int delay)
+{
+  return;
+}

--- a/cpu/arm/lpc1768/core_cm3.c
+++ b/cpu/arm/lpc1768/core_cm3.c
@@ -1,0 +1,337 @@
+/**************************************************************************//**
+ * @file     core_cm3.c
+ * @brief    CMSIS Cortex-M3 Core Peripheral Access Layer Source File
+ * @version  V2.00
+ * @date     13. September 2010
+ *
+ * @note
+ * Copyright (C) 2009-2010 ARM Limited. All rights reserved.
+ *
+ * @par
+ * ARM Limited (ARM) is supplying this software for use with Cortex-M
+ * processor based microcontrollers.  This file can be freely distributed
+ * within development tools that are supporting such ARM based processors.
+ *
+ * @par
+ * THIS SOFTWARE IS PROVIDED "AS IS".  NO WARRANTIES, WHETHER EXPRESS, IMPLIED
+ * OR STATUTORY, INCLUDING, BUT NOT LIMITED TO, IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE APPLY TO THIS SOFTWARE.
+ * ARM SHALL NOT, IN ANY CIRCUMSTANCES, BE LIABLE FOR SPECIAL, INCIDENTAL, OR
+ * CONSEQUENTIAL DAMAGES, FOR ANY REASON WHATSOEVER.
+ *
+ ******************************************************************************/
+
+#include <stdint.h>
+
+/* define compiler specific symbols */
+#if defined(__CC_ARM)
+#define __ASM            __asm                                        /*!< asm keyword for ARM Compiler          */
+#define __INLINE         __inline                                     /*!< inline keyword for ARM Compiler       */
+
+#elif defined(__ICCARM__)
+#define __ASM           __asm                                         /*!< asm keyword for IAR Compiler          */
+#define __INLINE        inline                                        /*!< inline keyword for IAR Compiler. Only avaiable in High optimization mode! */
+
+#elif defined(__GNUC__)
+#define __ASM            __asm                                        /*!< asm keyword for GNU Compiler          */
+#define __INLINE         inline                                       /*!< inline keyword for GNU Compiler       */
+
+#elif defined(__TASKING__)
+#define __ASM            __asm                                        /*!< asm keyword for TASKING Compiler      */
+#define __INLINE         inline                                       /*!< inline keyword for TASKING Compiler   */
+
+#endif
+
+/* ##########################  Core Instruction Access  ######################### */
+
+#if defined(__CC_ARM)      /*------------------ RealView Compiler ----------------*/
+
+/** \brief  Reverse byte order (16 bit)
+
+    This function reverses the byte order in two unsigned short values.
+
+    \param [in]    value  Value to reverse
+    \return               Reversed value
+ */
+#if (__ARMCC_VERSION < 400677)
+__ASM uint32_t
+__REV16(uint32_t value)
+{
+  rev16 r0, r0
+  bx lr
+}
+#endif /* __ARMCC_VERSION  */
+
+/** \brief  Reverse byte order in signed short value
+
+    This function reverses the byte order in a signed short value with sign extension to integer.
+
+    \param [in]    value  Value to reverse
+    \return               Reversed value
+ */
+#if (__ARMCC_VERSION < 400677)
+__ASM int32_t
+__REVSH(int32_t value)
+{
+  revsh r0, r0
+  bx lr
+}
+#endif /* __ARMCC_VERSION  */
+
+/** \brief  Remove the exclusive lock
+
+    This function removes the exclusive lock which is created by LDREX.
+
+ */
+#if (__ARMCC_VERSION < 400000)
+__ASM void
+__CLREX(void)
+{
+  clrex
+}
+#endif /* __ARMCC_VERSION  */
+
+#elif (defined(__ICCARM__))  /*---------------- ICC Compiler ---------------------*/
+/* obsolete */
+#elif (defined(__GNUC__))  /*------------------ GNU Compiler ---------------------*/
+/* obsolete */
+#elif (defined(__TASKING__))  /*--------------- TASKING Compiler -----------------*/
+/* obsolete */
+#endif
+
+/* ###########################  Core Function Access  ########################### */
+
+#if defined(__CC_ARM)      /*------------------ RealView Compiler ----------------*/
+
+/** \brief  Get Control Register
+
+    This function returns the content of the Control Register.
+
+    \return               Control Register value
+ */
+#if       (__ARMCC_VERSION < 400000)
+__ASM uint32_t
+__get_CONTROL(void)
+{
+  mrs r0, control
+  bx lr
+}
+#endif /*  __ARMCC_VERSION  */
+
+/** \brief  Set Control Register
+
+    This function writes the given value to the Control Register.
+
+    \param [in]    control  Control Register value to set
+ */
+#if       (__ARMCC_VERSION < 400000)
+__ASM void
+__set_CONTROL(uint32_t control)
+{
+  msr control, r0
+  bx lr
+}
+#endif /*  __ARMCC_VERSION  */
+
+/** \brief  Get ISPR Register
+
+    This function returns the content of the ISPR Register.
+
+    \return               ISPR Register value
+ */
+#if       (__ARMCC_VERSION < 400000)
+__ASM uint32_t
+__get_IPSR(void)
+{
+  mrs r0, ipsr
+  bx lr
+}
+#endif /*  __ARMCC_VERSION  */
+
+/** \brief  Get APSR Register
+
+    This function returns the content of the APSR Register.
+
+    \return               APSR Register value
+ */
+#if       (__ARMCC_VERSION < 400000)
+__ASM uint32_t
+__get_APSR(void)
+{
+  mrs r0, apsr
+  bx lr
+}
+#endif /*  __ARMCC_VERSION  */
+
+/** \brief  Get xPSR Register
+
+    This function returns the content of the xPSR Register.
+
+    \return               xPSR Register value
+ */
+#if       (__ARMCC_VERSION < 400000)
+__ASM uint32_t
+__get_xPSR(void)
+{
+  mrs r0, xpsr
+  bx lr
+}
+#endif /*  __ARMCC_VERSION  */
+
+/** \brief  Get Process Stack Pointer
+
+    This function returns the current value of the Process Stack Pointer (PSP).
+
+    \return               PSP Register value
+ */
+#if       (__ARMCC_VERSION < 400000)
+__ASM uint32_t
+__get_PSP(void)
+{
+  mrs r0, psp
+  bx lr
+}
+#endif /*  __ARMCC_VERSION  */
+
+/** \brief  Set Process Stack Pointer
+
+    This function assigns the given value to the Process Stack Pointer (PSP).
+
+    \param [in]    topOfProcStack  Process Stack Pointer value to set
+ */
+#if       (__ARMCC_VERSION < 400000)
+__ASM void
+__set_PSP(uint32_t topOfProcStack)
+{
+  msr psp, r0
+  bx lr
+}
+#endif /*  __ARMCC_VERSION  */
+
+/** \brief  Get Main Stack Pointer
+
+    This function returns the current value of the Main Stack Pointer (MSP).
+
+    \return               MSP Register value
+ */
+#if       (__ARMCC_VERSION < 400000)
+__ASM uint32_t
+__get_MSP(void)
+{
+  mrs r0, msp
+  bx lr
+}
+#endif /*  __ARMCC_VERSION  */
+
+/** \brief  Set Main Stack Pointer
+
+    This function assigns the given value to the Main Stack Pointer (MSP).
+
+    \param [in]    topOfMainStack  Main Stack Pointer value to set
+ */
+#if       (__ARMCC_VERSION < 400000)
+__ASM void
+__set_MSP(uint32_t mainStackPointer)
+{
+  msr msp, r0
+  bx lr
+}
+#endif /*  __ARMCC_VERSION  */
+
+/** \brief  Get Base Priority
+
+    This function returns the current value of the Base Priority register.
+
+    \return               Base Priority register value
+ */
+#if       (__ARMCC_VERSION < 400000)
+__ASM uint32_t
+__get_BASEPRI(void)
+{
+  mrs r0, basepri
+  bx lr
+}
+#endif /*  __ARMCC_VERSION  */
+
+/** \brief  Set Base Priority
+
+    This function assigns the given value to the Base Priority register.
+
+    \param [in]    basePri  Base Priority value to set
+ */
+#if       (__ARMCC_VERSION < 400000)
+__ASM void
+__set_BASEPRI(uint32_t basePri)
+{
+  msr basepri, r0
+  bx lr
+}
+#endif /*  __ARMCC_VERSION  */
+
+/** \brief  Get Priority Mask
+
+    This function returns the current state of the priority mask bit from the Priority Mask Register.
+
+    \return               Priority Mask value
+ */
+#if       (__ARMCC_VERSION < 400000)
+__ASM uint32_t
+__get_PRIMASK(void)
+{
+  mrs r0, primask
+  bx lr
+}
+#endif /*  __ARMCC_VERSION  */
+
+/** \brief  Set Priority Mask
+
+    This function assigns the given value to the Priority Mask Register.
+
+    \param [in]    priMask  Priority Mask
+ */
+#if       (__ARMCC_VERSION < 400000)
+__ASM void
+__set_PRIMASK(uint32_t priMask)
+{
+  msr primask, r0
+  bx lr
+}
+#endif /*  __ARMCC_VERSION  */
+
+/** \brief  Get Fault Mask
+
+    This function returns the current value of the Fault Mask Register.
+
+    \return               Fault Mask value
+ */
+#if       (__ARMCC_VERSION < 400000)
+__ASM uint32_t
+__get_FAULTMASK(void)
+{
+  mrs r0, faultmask
+  bx lr
+}
+#endif /*  __ARMCC_VERSION  */
+
+/** \brief  Set the Fault Mask
+
+     This function assigns the given value to the Fault Mask Register.
+
+    \param [in]    faultMask  Fault Mask value value to set
+ */
+#if       (__ARMCC_VERSION < 400000)
+__ASM void
+__set_FAULTMASK(uint32_t faultMask)
+{
+  msr faultmask, r0
+  bx lr
+}
+#endif /*  __ARMCC_VERSION  */
+
+#elif (defined(__ICCARM__))  /*---------------- ICC Compiler ---------------------*/
+/* obsolete */
+#elif (defined(__GNUC__))  /*------------------ GNU Compiler ---------------------*/
+/* obsolete */
+#elif (defined(__TASKING__))  /*--------------- TASKING Compiler -----------------*/
+/* obsolete */
+#endif

--- a/cpu/arm/lpc1768/core_cm3.h
+++ b/cpu/arm/lpc1768/core_cm3.h
@@ -1,0 +1,1181 @@
+/**************************************************************************//**
+ * @file     core_cm3.h
+ * @brief    CMSIS Cortex-M3 Core Peripheral Access Layer Header File
+ * @version  V2.01
+ * @date     06. December 2010
+ *
+ * @note
+ * Copyright (C) 2009-2010 ARM Limited. All rights reserved.
+ *
+ * @par
+ * ARM Limited (ARM) is supplying this software for use with Cortex-M
+ * processor based microcontrollers.  This file can be freely distributed
+ * within development tools that are supporting such ARM based processors.
+ *
+ * @par
+ * THIS SOFTWARE IS PROVIDED "AS IS".  NO WARRANTIES, WHETHER EXPRESS, IMPLIED
+ * OR STATUTORY, INCLUDING, BUT NOT LIMITED TO, IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE APPLY TO THIS SOFTWARE.
+ * ARM SHALL NOT, IN ANY CIRCUMSTANCES, BE LIABLE FOR SPECIAL, INCIDENTAL, OR
+ * CONSEQUENTIAL DAMAGES, FOR ANY REASON WHATSOEVER.
+ *
+ ******************************************************************************/
+#if defined(__ICCARM__)
+#pragma system_include  /* treat file as system include file for MISRA check */
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifndef __CORE_CM3_H_GENERIC
+#define __CORE_CM3_H_GENERIC
+
+/*******************************************************************************
+ *                 CMSIS definitions
+ ******************************************************************************/
+/** @ingroup  CMSIS
+ * @addtogroup CMSIS_core_definitions CMSIS Core Definitions
+   This file defines all structures and symbols for CMSIS core:
+   - CMSIS version number
+   - Cortex-M core
+   - Cortex-M core Revision Number
+   @{
+ */
+
+/*  CMSIS CM3 definitions */
+#define __CM3_CMSIS_VERSION_MAIN  (0x02)                                                       /*!< [31:16] CMSIS HAL main version */
+#define __CM3_CMSIS_VERSION_SUB   (0x00)                                                       /*!< [15:0]  CMSIS HAL sub version  */
+#define __CM3_CMSIS_VERSION       ((__CM3_CMSIS_VERSION_MAIN << 16) | __CM3_CMSIS_VERSION_SUB) /*!< CMSIS HAL version number       */
+
+#define __CORTEX_M                (0x03)                                                       /*!< Cortex core                    */
+
+#if defined(__CC_ARM)
+#define __ASM            __asm                                        /*!< asm keyword for ARM Compiler          */
+#define __INLINE         __inline                                     /*!< inline keyword for ARM Compiler       */
+
+#elif defined(__ICCARM__)
+#define __ASM           __asm                                         /*!< asm keyword for IAR Compiler          */
+#define __INLINE        inline                                        /*!< inline keyword for IAR Compiler. Only avaiable in High optimization mode! */
+
+#elif defined(__GNUC__)
+#define __ASM            __asm                                        /*!< asm keyword for GNU Compiler          */
+#define __INLINE         inline                                       /*!< inline keyword for GNU Compiler       */
+
+#elif defined(__TASKING__)
+#define __ASM            __asm                                        /*!< asm keyword for TASKING Compiler      */
+#define __INLINE         inline                                       /*!< inline keyword for TASKING Compiler   */
+
+#endif
+
+#include <stdint.h>                      /*!< standard types definitions                      */
+#include "core_cmInstr.h"                /*!< Core Instruction Access                         */
+#include "core_cmFunc.h"                 /*!< Core Function Access                            */
+
+#endif /* __CORE_CM3_H_GENERIC */
+
+#ifndef __CMSIS_GENERIC
+
+#ifndef __CORE_CM3_H_DEPENDANT
+#define __CORE_CM3_H_DEPENDANT
+
+/* IO definitions (access restrictions to peripheral registers) */
+#ifdef __cplusplus
+#define     __I     volatile             /*!< defines 'read only' permissions                 */
+#else
+#define     __I     volatile const       /*!< defines 'read only' permissions                 */
+#endif
+#define     __O     volatile             /*!< defines 'write only' permissions                */
+#define     __IO    volatile             /*!< defines 'read / write' permissions              */
+
+/*@} end of group CMSIS_core_definitions */
+
+/*******************************************************************************
+ *                 Register Abstraction
+ ******************************************************************************/
+
+/** @ingroup  CMSIS
+ * @addtogroup CMSIS_core_register CMSIS Core Register
+   Core Register contain:
+   - Core Register
+   - Core NVIC Register
+   - Core SCB Register
+   - Core SysTick Register
+   - Core Debug Register
+   - Core MPU Register
+ */
+
+/** \ingroup  CMSIS_core_register
+    \defgroup CMSIS_CORE CMSIS Core
+   Type definitions for the Cortex-M Core Registers
+   @{
+ */
+
+/** \brief  Union type to access the Application Program Status Register (APSR).
+ */
+typedef union {
+  struct {
+#if (__CORTEX_M != 0x04)
+    uint32_t _reserved0 : 27;              /*!< bit:  0..26  Reserved                           */
+#else
+    uint32_t _reserved0 : 16;              /*!< bit:  0..15  Reserved                           */
+    uint32_t GE : 4;                       /*!< bit: 16..19  Greater than or Equal flags        */
+    uint32_t _reserved1 : 7;               /*!< bit: 20..26  Reserved                           */
+#endif
+    uint32_t Q : 1;                        /*!< bit:     27  Saturation condition flag          */
+    uint32_t V : 1;                        /*!< bit:     28  Overflow condition code flag       */
+    uint32_t C : 1;                        /*!< bit:     29  Carry condition code flag          */
+    uint32_t Z : 1;                        /*!< bit:     30  Zero condition code flag           */
+    uint32_t N : 1;                        /*!< bit:     31  Negative condition code flag       */
+  } b;                                   /*!< Structure used for bit  access                  */
+  uint32_t w;                            /*!< Type      used for word access                  */
+} APSR_Type;
+
+/** \brief  Union type to access the Interrupt Program Status Register (IPSR).
+ */
+typedef union {
+  struct {
+    uint32_t ISR : 9;                      /*!< bit:  0.. 8  Exception number                   */
+    uint32_t _reserved0 : 23;              /*!< bit:  9..31  Reserved                           */
+  } b;                                   /*!< Structure used for bit  access                  */
+  uint32_t w;                            /*!< Type      used for word access                  */
+} IPSR_Type;
+
+/** \brief  Union type to access the Special-Purpose Program Status Registers (xPSR).
+ */
+typedef union {
+  struct {
+    uint32_t ISR : 9;                      /*!< bit:  0.. 8  Exception number                   */
+#if (__CORTEX_M != 0x04)
+    uint32_t _reserved0 : 15;              /*!< bit:  9..23  Reserved                           */
+#else
+    uint32_t _reserved0 : 7;               /*!< bit:  9..15  Reserved                           */
+    uint32_t GE : 4;                       /*!< bit: 16..19  Greater than or Equal flags        */
+    uint32_t _reserved1 : 4;               /*!< bit: 20..23  Reserved                           */
+#endif
+    uint32_t T : 1;                        /*!< bit:     24  Thumb bit        (read 0)          */
+    uint32_t IT : 2;                       /*!< bit: 25..26  saved IT state   (read 0)          */
+    uint32_t Q : 1;                        /*!< bit:     27  Saturation condition flag          */
+    uint32_t V : 1;                        /*!< bit:     28  Overflow condition code flag       */
+    uint32_t C : 1;                        /*!< bit:     29  Carry condition code flag          */
+    uint32_t Z : 1;                        /*!< bit:     30  Zero condition code flag           */
+    uint32_t N : 1;                        /*!< bit:     31  Negative condition code flag       */
+  } b;                                   /*!< Structure used for bit  access                  */
+  uint32_t w;                            /*!< Type      used for word access                  */
+} xPSR_Type;
+
+/** \brief  Union type to access the Control Registers (CONTROL).
+ */
+typedef union {
+  struct {
+    uint32_t nPRIV : 1;                    /*!< bit:      0  Execution privilege in Thread mode */
+    uint32_t SPSEL : 1;                    /*!< bit:      1  Stack to be used                   */
+    uint32_t FPCA : 1;                     /*!< bit:      2  FP extension active flag           */
+    uint32_t _reserved0 : 29;              /*!< bit:  3..31  Reserved                           */
+  } b;                                   /*!< Structure used for bit  access                  */
+  uint32_t w;                            /*!< Type      used for word access                  */
+} CONTROL_Type;
+
+/*@} end of group CMSIS_CORE */
+
+/** \ingroup  CMSIS_core_register
+    \defgroup CMSIS_NVIC CMSIS NVIC
+   Type definitions for the Cortex-M NVIC Registers
+   @{
+ */
+
+/** \brief  Structure type to access the Nested Vectored Interrupt Controller (NVIC).
+ */
+typedef struct {
+  __IO uint32_t ISER[8];                 /*!< Offset: 0x000 (R/W)  Interrupt Set Enable Register           */
+  uint32_t RESERVED0[24];
+  __IO uint32_t ICER[8];                 /*!< Offset: 0x080 (R/W)  Interrupt Clear Enable Register         */
+  uint32_t RSERVED1[24];
+  __IO uint32_t ISPR[8];                 /*!< Offset: 0x100 (R/W)  Interrupt Set Pending Register          */
+  uint32_t RESERVED2[24];
+  __IO uint32_t ICPR[8];                 /*!< Offset: 0x180 (R/W)  Interrupt Clear Pending Register        */
+  uint32_t RESERVED3[24];
+  __IO uint32_t IABR[8];                 /*!< Offset: 0x200 (R/W)  Interrupt Active bit Register           */
+  uint32_t RESERVED4[56];
+  __IO uint8_t IP[240];                  /*!< Offset: 0x300 (R/W)  Interrupt Priority Register (8Bit wide) */
+  uint32_t RESERVED5[644];
+  __O uint32_t STIR;                     /*!< Offset: 0xE00 ( /W)  Software Trigger Interrupt Register     */
+}  NVIC_Type;
+
+/*@} end of group CMSIS_NVIC */
+
+/** \ingroup  CMSIS_core_register
+    \defgroup CMSIS_SCB CMSIS SCB
+   Type definitions for the Cortex-M System Control Block Registers
+   @{
+ */
+
+/** \brief  Structure type to access the System Control Block (SCB).
+ */
+typedef struct {
+  __I uint32_t CPUID;                    /*!< Offset: 0x000 (R/ )  CPU ID Base Register                                  */
+  __IO uint32_t ICSR;                    /*!< Offset: 0x004 (R/W)  Interrupt Control State Register                      */
+  __IO uint32_t VTOR;                    /*!< Offset: 0x008 (R/W)  Vector Table Offset Register                          */
+  __IO uint32_t AIRCR;                   /*!< Offset: 0x00C (R/W)  Application Interrupt / Reset Control Register        */
+  __IO uint32_t SCR;                     /*!< Offset: 0x010 (R/W)  System Control Register                               */
+  __IO uint32_t CCR;                     /*!< Offset: 0x014 (R/W)  Configuration Control Register                        */
+  __IO uint8_t SHP[12];                  /*!< Offset: 0x018 (R/W)  System Handlers Priority Registers (4-7, 8-11, 12-15) */
+  __IO uint32_t SHCSR;                   /*!< Offset: 0x024 (R/W)  System Handler Control and State Register             */
+  __IO uint32_t CFSR;                    /*!< Offset: 0x028 (R/W)  Configurable Fault Status Register                    */
+  __IO uint32_t HFSR;                    /*!< Offset: 0x02C (R/W)  Hard Fault Status Register                            */
+  __IO uint32_t DFSR;                    /*!< Offset: 0x030 (R/W)  Debug Fault Status Register                           */
+  __IO uint32_t MMFAR;                   /*!< Offset: 0x034 (R/W)  Mem Manage Address Register                           */
+  __IO uint32_t BFAR;                    /*!< Offset: 0x038 (R/W)  Bus Fault Address Register                            */
+  __IO uint32_t AFSR;                    /*!< Offset: 0x03C (R/W)  Auxiliary Fault Status Register                       */
+  __I uint32_t PFR[2];                   /*!< Offset: 0x040 (R/ )  Processor Feature Register                            */
+  __I uint32_t DFR;                      /*!< Offset: 0x048 (R/ )  Debug Feature Register                                */
+  __I uint32_t ADR;                      /*!< Offset: 0x04C (R/ )  Auxiliary Feature Register                            */
+  __I uint32_t MMFR[4];                  /*!< Offset: 0x050 (R/ )  Memory Model Feature Register                         */
+  __I uint32_t ISAR[5];                  /*!< Offset: 0x060 (R/ )  ISA Feature Register                                  */
+} SCB_Type;
+
+/* SCB CPUID Register Definitions */
+#define SCB_CPUID_IMPLEMENTER_Pos          24                                             /*!< SCB CPUID: IMPLEMENTER Position */
+#define SCB_CPUID_IMPLEMENTER_Msk          (0xFFUL << SCB_CPUID_IMPLEMENTER_Pos)          /*!< SCB CPUID: IMPLEMENTER Mask */
+
+#define SCB_CPUID_VARIANT_Pos              20                                             /*!< SCB CPUID: VARIANT Position */
+#define SCB_CPUID_VARIANT_Msk              (0xFUL << SCB_CPUID_VARIANT_Pos)               /*!< SCB CPUID: VARIANT Mask */
+
+#define SCB_CPUID_PARTNO_Pos                4                                             /*!< SCB CPUID: PARTNO Position */
+#define SCB_CPUID_PARTNO_Msk               (0xFFFUL << SCB_CPUID_PARTNO_Pos)              /*!< SCB CPUID: PARTNO Mask */
+
+#define SCB_CPUID_REVISION_Pos              0                                             /*!< SCB CPUID: REVISION Position */
+#define SCB_CPUID_REVISION_Msk             (0xFUL << SCB_CPUID_REVISION_Pos)              /*!< SCB CPUID: REVISION Mask */
+
+/* SCB Interrupt Control State Register Definitions */
+#define SCB_ICSR_NMIPENDSET_Pos            31                                             /*!< SCB ICSR: NMIPENDSET Position */
+#define SCB_ICSR_NMIPENDSET_Msk            (1UL << SCB_ICSR_NMIPENDSET_Pos)               /*!< SCB ICSR: NMIPENDSET Mask */
+
+#define SCB_ICSR_PENDSVSET_Pos             28                                             /*!< SCB ICSR: PENDSVSET Position */
+#define SCB_ICSR_PENDSVSET_Msk             (1UL << SCB_ICSR_PENDSVSET_Pos)                /*!< SCB ICSR: PENDSVSET Mask */
+
+#define SCB_ICSR_PENDSVCLR_Pos             27                                             /*!< SCB ICSR: PENDSVCLR Position */
+#define SCB_ICSR_PENDSVCLR_Msk             (1UL << SCB_ICSR_PENDSVCLR_Pos)                /*!< SCB ICSR: PENDSVCLR Mask */
+
+#define SCB_ICSR_PENDSTSET_Pos             26                                             /*!< SCB ICSR: PENDSTSET Position */
+#define SCB_ICSR_PENDSTSET_Msk             (1UL << SCB_ICSR_PENDSTSET_Pos)                /*!< SCB ICSR: PENDSTSET Mask */
+
+#define SCB_ICSR_PENDSTCLR_Pos             25                                             /*!< SCB ICSR: PENDSTCLR Position */
+#define SCB_ICSR_PENDSTCLR_Msk             (1UL << SCB_ICSR_PENDSTCLR_Pos)                /*!< SCB ICSR: PENDSTCLR Mask */
+
+#define SCB_ICSR_ISRPREEMPT_Pos            23                                             /*!< SCB ICSR: ISRPREEMPT Position */
+#define SCB_ICSR_ISRPREEMPT_Msk            (1UL << SCB_ICSR_ISRPREEMPT_Pos)               /*!< SCB ICSR: ISRPREEMPT Mask */
+
+#define SCB_ICSR_ISRPENDING_Pos            22                                             /*!< SCB ICSR: ISRPENDING Position */
+#define SCB_ICSR_ISRPENDING_Msk            (1UL << SCB_ICSR_ISRPENDING_Pos)               /*!< SCB ICSR: ISRPENDING Mask */
+
+#define SCB_ICSR_VECTPENDING_Pos           12                                             /*!< SCB ICSR: VECTPENDING Position */
+#define SCB_ICSR_VECTPENDING_Msk           (0x1FFUL << SCB_ICSR_VECTPENDING_Pos)          /*!< SCB ICSR: VECTPENDING Mask */
+
+#define SCB_ICSR_RETTOBASE_Pos             11                                             /*!< SCB ICSR: RETTOBASE Position */
+#define SCB_ICSR_RETTOBASE_Msk             (1UL << SCB_ICSR_RETTOBASE_Pos)                /*!< SCB ICSR: RETTOBASE Mask */
+
+#define SCB_ICSR_VECTACTIVE_Pos             0                                             /*!< SCB ICSR: VECTACTIVE Position */
+#define SCB_ICSR_VECTACTIVE_Msk            (0x1FFUL << SCB_ICSR_VECTACTIVE_Pos)           /*!< SCB ICSR: VECTACTIVE Mask */
+
+/* SCB Interrupt Control State Register Definitions */
+#define SCB_VTOR_TBLBASE_Pos               29                                             /*!< SCB VTOR: TBLBASE Position */
+#define SCB_VTOR_TBLBASE_Msk               (1UL << SCB_VTOR_TBLBASE_Pos)                  /*!< SCB VTOR: TBLBASE Mask */
+
+#define SCB_VTOR_TBLOFF_Pos                 7                                             /*!< SCB VTOR: TBLOFF Position */
+#define SCB_VTOR_TBLOFF_Msk                (0x3FFFFFUL << SCB_VTOR_TBLOFF_Pos)            /*!< SCB VTOR: TBLOFF Mask */
+
+/* SCB Application Interrupt and Reset Control Register Definitions */
+#define SCB_AIRCR_VECTKEY_Pos              16                                             /*!< SCB AIRCR: VECTKEY Position */
+#define SCB_AIRCR_VECTKEY_Msk              (0xFFFFUL << SCB_AIRCR_VECTKEY_Pos)            /*!< SCB AIRCR: VECTKEY Mask */
+
+#define SCB_AIRCR_VECTKEYSTAT_Pos          16                                             /*!< SCB AIRCR: VECTKEYSTAT Position */
+#define SCB_AIRCR_VECTKEYSTAT_Msk          (0xFFFFUL << SCB_AIRCR_VECTKEYSTAT_Pos)        /*!< SCB AIRCR: VECTKEYSTAT Mask */
+
+#define SCB_AIRCR_ENDIANESS_Pos            15                                             /*!< SCB AIRCR: ENDIANESS Position */
+#define SCB_AIRCR_ENDIANESS_Msk            (1UL << SCB_AIRCR_ENDIANESS_Pos)               /*!< SCB AIRCR: ENDIANESS Mask */
+
+#define SCB_AIRCR_PRIGROUP_Pos              8                                             /*!< SCB AIRCR: PRIGROUP Position */
+#define SCB_AIRCR_PRIGROUP_Msk             (7UL << SCB_AIRCR_PRIGROUP_Pos)                /*!< SCB AIRCR: PRIGROUP Mask */
+
+#define SCB_AIRCR_SYSRESETREQ_Pos           2                                             /*!< SCB AIRCR: SYSRESETREQ Position */
+#define SCB_AIRCR_SYSRESETREQ_Msk          (1UL << SCB_AIRCR_SYSRESETREQ_Pos)             /*!< SCB AIRCR: SYSRESETREQ Mask */
+
+#define SCB_AIRCR_VECTCLRACTIVE_Pos         1                                             /*!< SCB AIRCR: VECTCLRACTIVE Position */
+#define SCB_AIRCR_VECTCLRACTIVE_Msk        (1UL << SCB_AIRCR_VECTCLRACTIVE_Pos)           /*!< SCB AIRCR: VECTCLRACTIVE Mask */
+
+#define SCB_AIRCR_VECTRESET_Pos             0                                             /*!< SCB AIRCR: VECTRESET Position */
+#define SCB_AIRCR_VECTRESET_Msk            (1UL << SCB_AIRCR_VECTRESET_Pos)               /*!< SCB AIRCR: VECTRESET Mask */
+
+/* SCB System Control Register Definitions */
+#define SCB_SCR_SEVONPEND_Pos               4                                             /*!< SCB SCR: SEVONPEND Position */
+#define SCB_SCR_SEVONPEND_Msk              (1UL << SCB_SCR_SEVONPEND_Pos)                 /*!< SCB SCR: SEVONPEND Mask */
+
+#define SCB_SCR_SLEEPDEEP_Pos               2                                             /*!< SCB SCR: SLEEPDEEP Position */
+#define SCB_SCR_SLEEPDEEP_Msk              (1UL << SCB_SCR_SLEEPDEEP_Pos)                 /*!< SCB SCR: SLEEPDEEP Mask */
+
+#define SCB_SCR_SLEEPONEXIT_Pos             1                                             /*!< SCB SCR: SLEEPONEXIT Position */
+#define SCB_SCR_SLEEPONEXIT_Msk            (1UL << SCB_SCR_SLEEPONEXIT_Pos)               /*!< SCB SCR: SLEEPONEXIT Mask */
+
+/* SCB Configuration Control Register Definitions */
+#define SCB_CCR_STKALIGN_Pos                9                                             /*!< SCB CCR: STKALIGN Position */
+#define SCB_CCR_STKALIGN_Msk               (1UL << SCB_CCR_STKALIGN_Pos)                  /*!< SCB CCR: STKALIGN Mask */
+
+#define SCB_CCR_BFHFNMIGN_Pos               8                                             /*!< SCB CCR: BFHFNMIGN Position */
+#define SCB_CCR_BFHFNMIGN_Msk              (1UL << SCB_CCR_BFHFNMIGN_Pos)                 /*!< SCB CCR: BFHFNMIGN Mask */
+
+#define SCB_CCR_DIV_0_TRP_Pos               4                                             /*!< SCB CCR: DIV_0_TRP Position */
+#define SCB_CCR_DIV_0_TRP_Msk              (1UL << SCB_CCR_DIV_0_TRP_Pos)                 /*!< SCB CCR: DIV_0_TRP Mask */
+
+#define SCB_CCR_UNALIGN_TRP_Pos             3                                             /*!< SCB CCR: UNALIGN_TRP Position */
+#define SCB_CCR_UNALIGN_TRP_Msk            (1UL << SCB_CCR_UNALIGN_TRP_Pos)               /*!< SCB CCR: UNALIGN_TRP Mask */
+
+#define SCB_CCR_USERSETMPEND_Pos            1                                             /*!< SCB CCR: USERSETMPEND Position */
+#define SCB_CCR_USERSETMPEND_Msk           (1UL << SCB_CCR_USERSETMPEND_Pos)              /*!< SCB CCR: USERSETMPEND Mask */
+
+#define SCB_CCR_NONBASETHRDENA_Pos          0                                             /*!< SCB CCR: NONBASETHRDENA Position */
+#define SCB_CCR_NONBASETHRDENA_Msk         (1UL << SCB_CCR_NONBASETHRDENA_Pos)            /*!< SCB CCR: NONBASETHRDENA Mask */
+
+/* SCB System Handler Control and State Register Definitions */
+#define SCB_SHCSR_USGFAULTENA_Pos          18                                             /*!< SCB SHCSR: USGFAULTENA Position */
+#define SCB_SHCSR_USGFAULTENA_Msk          (1UL << SCB_SHCSR_USGFAULTENA_Pos)             /*!< SCB SHCSR: USGFAULTENA Mask */
+
+#define SCB_SHCSR_BUSFAULTENA_Pos          17                                             /*!< SCB SHCSR: BUSFAULTENA Position */
+#define SCB_SHCSR_BUSFAULTENA_Msk          (1UL << SCB_SHCSR_BUSFAULTENA_Pos)             /*!< SCB SHCSR: BUSFAULTENA Mask */
+
+#define SCB_SHCSR_MEMFAULTENA_Pos          16                                             /*!< SCB SHCSR: MEMFAULTENA Position */
+#define SCB_SHCSR_MEMFAULTENA_Msk          (1UL << SCB_SHCSR_MEMFAULTENA_Pos)             /*!< SCB SHCSR: MEMFAULTENA Mask */
+
+#define SCB_SHCSR_SVCALLPENDED_Pos         15                                             /*!< SCB SHCSR: SVCALLPENDED Position */
+#define SCB_SHCSR_SVCALLPENDED_Msk         (1UL << SCB_SHCSR_SVCALLPENDED_Pos)            /*!< SCB SHCSR: SVCALLPENDED Mask */
+
+#define SCB_SHCSR_BUSFAULTPENDED_Pos       14                                             /*!< SCB SHCSR: BUSFAULTPENDED Position */
+#define SCB_SHCSR_BUSFAULTPENDED_Msk       (1UL << SCB_SHCSR_BUSFAULTPENDED_Pos)          /*!< SCB SHCSR: BUSFAULTPENDED Mask */
+
+#define SCB_SHCSR_MEMFAULTPENDED_Pos       13                                             /*!< SCB SHCSR: MEMFAULTPENDED Position */
+#define SCB_SHCSR_MEMFAULTPENDED_Msk       (1UL << SCB_SHCSR_MEMFAULTPENDED_Pos)          /*!< SCB SHCSR: MEMFAULTPENDED Mask */
+
+#define SCB_SHCSR_USGFAULTPENDED_Pos       12                                             /*!< SCB SHCSR: USGFAULTPENDED Position */
+#define SCB_SHCSR_USGFAULTPENDED_Msk       (1UL << SCB_SHCSR_USGFAULTPENDED_Pos)          /*!< SCB SHCSR: USGFAULTPENDED Mask */
+
+#define SCB_SHCSR_SYSTICKACT_Pos           11                                             /*!< SCB SHCSR: SYSTICKACT Position */
+#define SCB_SHCSR_SYSTICKACT_Msk           (1UL << SCB_SHCSR_SYSTICKACT_Pos)              /*!< SCB SHCSR: SYSTICKACT Mask */
+
+#define SCB_SHCSR_PENDSVACT_Pos            10                                             /*!< SCB SHCSR: PENDSVACT Position */
+#define SCB_SHCSR_PENDSVACT_Msk            (1UL << SCB_SHCSR_PENDSVACT_Pos)               /*!< SCB SHCSR: PENDSVACT Mask */
+
+#define SCB_SHCSR_MONITORACT_Pos            8                                             /*!< SCB SHCSR: MONITORACT Position */
+#define SCB_SHCSR_MONITORACT_Msk           (1UL << SCB_SHCSR_MONITORACT_Pos)              /*!< SCB SHCSR: MONITORACT Mask */
+
+#define SCB_SHCSR_SVCALLACT_Pos             7                                             /*!< SCB SHCSR: SVCALLACT Position */
+#define SCB_SHCSR_SVCALLACT_Msk            (1UL << SCB_SHCSR_SVCALLACT_Pos)               /*!< SCB SHCSR: SVCALLACT Mask */
+
+#define SCB_SHCSR_USGFAULTACT_Pos           3                                             /*!< SCB SHCSR: USGFAULTACT Position */
+#define SCB_SHCSR_USGFAULTACT_Msk          (1UL << SCB_SHCSR_USGFAULTACT_Pos)             /*!< SCB SHCSR: USGFAULTACT Mask */
+
+#define SCB_SHCSR_BUSFAULTACT_Pos           1                                             /*!< SCB SHCSR: BUSFAULTACT Position */
+#define SCB_SHCSR_BUSFAULTACT_Msk          (1UL << SCB_SHCSR_BUSFAULTACT_Pos)             /*!< SCB SHCSR: BUSFAULTACT Mask */
+
+#define SCB_SHCSR_MEMFAULTACT_Pos           0                                             /*!< SCB SHCSR: MEMFAULTACT Position */
+#define SCB_SHCSR_MEMFAULTACT_Msk          (1UL << SCB_SHCSR_MEMFAULTACT_Pos)             /*!< SCB SHCSR: MEMFAULTACT Mask */
+
+/* SCB Configurable Fault Status Registers Definitions */
+#define SCB_CFSR_USGFAULTSR_Pos            16                                             /*!< SCB CFSR: Usage Fault Status Register Position */
+#define SCB_CFSR_USGFAULTSR_Msk            (0xFFFFUL << SCB_CFSR_USGFAULTSR_Pos)          /*!< SCB CFSR: Usage Fault Status Register Mask */
+
+#define SCB_CFSR_BUSFAULTSR_Pos             8                                             /*!< SCB CFSR: Bus Fault Status Register Position */
+#define SCB_CFSR_BUSFAULTSR_Msk            (0xFFUL << SCB_CFSR_BUSFAULTSR_Pos)            /*!< SCB CFSR: Bus Fault Status Register Mask */
+
+#define SCB_CFSR_MEMFAULTSR_Pos             0                                             /*!< SCB CFSR: Memory Manage Fault Status Register Position */
+#define SCB_CFSR_MEMFAULTSR_Msk            (0xFFUL << SCB_CFSR_MEMFAULTSR_Pos)            /*!< SCB CFSR: Memory Manage Fault Status Register Mask */
+
+/* SCB Hard Fault Status Registers Definitions */
+#define SCB_HFSR_DEBUGEVT_Pos              31                                             /*!< SCB HFSR: DEBUGEVT Position */
+#define SCB_HFSR_DEBUGEVT_Msk              (1UL << SCB_HFSR_DEBUGEVT_Pos)                 /*!< SCB HFSR: DEBUGEVT Mask */
+
+#define SCB_HFSR_FORCED_Pos                30                                             /*!< SCB HFSR: FORCED Position */
+#define SCB_HFSR_FORCED_Msk                (1UL << SCB_HFSR_FORCED_Pos)                   /*!< SCB HFSR: FORCED Mask */
+
+#define SCB_HFSR_VECTTBL_Pos                1                                             /*!< SCB HFSR: VECTTBL Position */
+#define SCB_HFSR_VECTTBL_Msk               (1UL << SCB_HFSR_VECTTBL_Pos)                  /*!< SCB HFSR: VECTTBL Mask */
+
+/* SCB Debug Fault Status Register Definitions */
+#define SCB_DFSR_EXTERNAL_Pos               4                                             /*!< SCB DFSR: EXTERNAL Position */
+#define SCB_DFSR_EXTERNAL_Msk              (1UL << SCB_DFSR_EXTERNAL_Pos)                 /*!< SCB DFSR: EXTERNAL Mask */
+
+#define SCB_DFSR_VCATCH_Pos                 3                                             /*!< SCB DFSR: VCATCH Position */
+#define SCB_DFSR_VCATCH_Msk                (1UL << SCB_DFSR_VCATCH_Pos)                   /*!< SCB DFSR: VCATCH Mask */
+
+#define SCB_DFSR_DWTTRAP_Pos                2                                             /*!< SCB DFSR: DWTTRAP Position */
+#define SCB_DFSR_DWTTRAP_Msk               (1UL << SCB_DFSR_DWTTRAP_Pos)                  /*!< SCB DFSR: DWTTRAP Mask */
+
+#define SCB_DFSR_BKPT_Pos                   1                                             /*!< SCB DFSR: BKPT Position */
+#define SCB_DFSR_BKPT_Msk                  (1UL << SCB_DFSR_BKPT_Pos)                     /*!< SCB DFSR: BKPT Mask */
+
+#define SCB_DFSR_HALTED_Pos                 0                                             /*!< SCB DFSR: HALTED Position */
+#define SCB_DFSR_HALTED_Msk                (1UL << SCB_DFSR_HALTED_Pos)                   /*!< SCB DFSR: HALTED Mask */
+
+/*@} end of group CMSIS_SCB */
+
+/** \ingroup  CMSIS_core_register
+    \defgroup CMSIS_SysTick CMSIS SysTick
+   Type definitions for the Cortex-M System Timer Registers
+   @{
+ */
+
+/** \brief  Structure type to access the System Timer (SysTick).
+ */
+typedef struct {
+  __IO uint32_t CTRL;                    /*!< Offset: 0x000 (R/W)  SysTick Control and Status Register */
+  __IO uint32_t LOAD;                    /*!< Offset: 0x004 (R/W)  SysTick Reload Value Register       */
+  __IO uint32_t VAL;                     /*!< Offset: 0x008 (R/W)  SysTick Current Value Register      */
+  __I uint32_t CALIB;                    /*!< Offset: 0x00C (R/ )  SysTick Calibration Register        */
+} SysTick_Type;
+
+/* SysTick Control / Status Register Definitions */
+#define SysTick_CTRL_COUNTFLAG_Pos         16                                             /*!< SysTick CTRL: COUNTFLAG Position */
+#define SysTick_CTRL_COUNTFLAG_Msk         (1UL << SysTick_CTRL_COUNTFLAG_Pos)            /*!< SysTick CTRL: COUNTFLAG Mask */
+
+#define SysTick_CTRL_CLKSOURCE_Pos          2                                             /*!< SysTick CTRL: CLKSOURCE Position */
+#define SysTick_CTRL_CLKSOURCE_Msk         (1UL << SysTick_CTRL_CLKSOURCE_Pos)            /*!< SysTick CTRL: CLKSOURCE Mask */
+
+#define SysTick_CTRL_TICKINT_Pos            1                                             /*!< SysTick CTRL: TICKINT Position */
+#define SysTick_CTRL_TICKINT_Msk           (1UL << SysTick_CTRL_TICKINT_Pos)              /*!< SysTick CTRL: TICKINT Mask */
+
+#define SysTick_CTRL_ENABLE_Pos             0                                             /*!< SysTick CTRL: ENABLE Position */
+#define SysTick_CTRL_ENABLE_Msk            (1UL << SysTick_CTRL_ENABLE_Pos)               /*!< SysTick CTRL: ENABLE Mask */
+
+/* SysTick Reload Register Definitions */
+#define SysTick_LOAD_RELOAD_Pos             0                                             /*!< SysTick LOAD: RELOAD Position */
+#define SysTick_LOAD_RELOAD_Msk            (0xFFFFFFUL << SysTick_LOAD_RELOAD_Pos)        /*!< SysTick LOAD: RELOAD Mask */
+
+/* SysTick Current Register Definitions */
+#define SysTick_VAL_CURRENT_Pos             0                                             /*!< SysTick VAL: CURRENT Position */
+#define SysTick_VAL_CURRENT_Msk            (0xFFFFFFUL << SysTick_VAL_CURRENT_Pos)        /*!< SysTick VAL: CURRENT Mask */
+
+/* SysTick Calibration Register Definitions */
+#define SysTick_CALIB_NOREF_Pos            31                                             /*!< SysTick CALIB: NOREF Position */
+#define SysTick_CALIB_NOREF_Msk            (1UL << SysTick_CALIB_NOREF_Pos)               /*!< SysTick CALIB: NOREF Mask */
+
+#define SysTick_CALIB_SKEW_Pos             30                                             /*!< SysTick CALIB: SKEW Position */
+#define SysTick_CALIB_SKEW_Msk             (1UL << SysTick_CALIB_SKEW_Pos)                /*!< SysTick CALIB: SKEW Mask */
+
+#define SysTick_CALIB_TENMS_Pos             0                                             /*!< SysTick CALIB: TENMS Position */
+#define SysTick_CALIB_TENMS_Msk            (0xFFFFFFUL << SysTick_VAL_CURRENT_Pos)        /*!< SysTick CALIB: TENMS Mask */
+
+/*@} end of group CMSIS_SysTick */
+
+/** \ingroup  CMSIS_core_register
+    \defgroup CMSIS_ITM CMSIS ITM
+   Type definitions for the Cortex-M Instrumentation Trace Macrocell (ITM)
+   @{
+ */
+
+/** \brief  Structure type to access the Instrumentation Trace Macrocell Register (ITM).
+ */
+typedef struct {
+  __O  union {
+    __O uint8_t u8;                      /*!< Offset: 0x000 ( /W)  ITM Stimulus Port 8-bit                   */
+    __O uint16_t u16;                    /*!< Offset: 0x000 ( /W)  ITM Stimulus Port 16-bit                  */
+    __O uint32_t u32;                    /*!< Offset: 0x000 ( /W)  ITM Stimulus Port 32-bit                  */
+  }  PORT[32];                           /*!< Offset: 0x000 ( /W)  ITM Stimulus Port Registers               */
+  uint32_t RESERVED0[864];
+  __IO uint32_t TER;                     /*!< Offset:       (R/W)  ITM Trace Enable Register                 */
+  uint32_t RESERVED1[15];
+  __IO uint32_t TPR;                     /*!< Offset:       (R/W)  ITM Trace Privilege Register              */
+  uint32_t RESERVED2[15];
+  __IO uint32_t TCR;                     /*!< Offset:       (R/W)  ITM Trace Control Register                */
+  uint32_t RESERVED3[29];
+  __IO uint32_t IWR;                     /*!< Offset:       (R/W)  ITM Integration Write Register            */
+  __IO uint32_t IRR;                     /*!< Offset:       (R/W)  ITM Integration Read Register             */
+  __IO uint32_t IMCR;                    /*!< Offset:       (R/W)  ITM Integration Mode Control Register     */
+  uint32_t RESERVED4[43];
+  __IO uint32_t LAR;                     /*!< Offset:       (R/W)  ITM Lock Access Register                  */
+  __IO uint32_t LSR;                     /*!< Offset:       (R/W)  ITM Lock Status Register                  */
+  uint32_t RESERVED5[6];
+  __I uint32_t PID4;                     /*!< Offset:       (R/ )  ITM Peripheral Identification Register #4 */
+  __I uint32_t PID5;                     /*!< Offset:       (R/ )  ITM Peripheral Identification Register #5 */
+  __I uint32_t PID6;                     /*!< Offset:       (R/ )  ITM Peripheral Identification Register #6 */
+  __I uint32_t PID7;                     /*!< Offset:       (R/ )  ITM Peripheral Identification Register #7 */
+  __I uint32_t PID0;                     /*!< Offset:       (R/ )  ITM Peripheral Identification Register #0 */
+  __I uint32_t PID1;                     /*!< Offset:       (R/ )  ITM Peripheral Identification Register #1 */
+  __I uint32_t PID2;                     /*!< Offset:       (R/ )  ITM Peripheral Identification Register #2 */
+  __I uint32_t PID3;                     /*!< Offset:       (R/ )  ITM Peripheral Identification Register #3 */
+  __I uint32_t CID0;                     /*!< Offset:       (R/ )  ITM Component  Identification Register #0 */
+  __I uint32_t CID1;                     /*!< Offset:       (R/ )  ITM Component  Identification Register #1 */
+  __I uint32_t CID2;                     /*!< Offset:       (R/ )  ITM Component  Identification Register #2 */
+  __I uint32_t CID3;                     /*!< Offset:       (R/ )  ITM Component  Identification Register #3 */
+} ITM_Type;
+
+/* ITM Trace Privilege Register Definitions */
+#define ITM_TPR_PRIVMASK_Pos                0                                             /*!< ITM TPR: PRIVMASK Position */
+#define ITM_TPR_PRIVMASK_Msk               (0xFUL << ITM_TPR_PRIVMASK_Pos)                /*!< ITM TPR: PRIVMASK Mask */
+
+/* ITM Trace Control Register Definitions */
+#define ITM_TCR_BUSY_Pos                   23                                             /*!< ITM TCR: BUSY Position */
+#define ITM_TCR_BUSY_Msk                   (1UL << ITM_TCR_BUSY_Pos)                      /*!< ITM TCR: BUSY Mask */
+
+#define ITM_TCR_ATBID_Pos                  16                                             /*!< ITM TCR: ATBID Position */
+#define ITM_TCR_ATBID_Msk                  (0x7FUL << ITM_TCR_ATBID_Pos)                  /*!< ITM TCR: ATBID Mask */
+
+#define ITM_TCR_TSPrescale_Pos              8                                             /*!< ITM TCR: TSPrescale Position */
+#define ITM_TCR_TSPrescale_Msk             (3UL << ITM_TCR_TSPrescale_Pos)                /*!< ITM TCR: TSPrescale Mask */
+
+#define ITM_TCR_SWOENA_Pos                  4                                             /*!< ITM TCR: SWOENA Position */
+#define ITM_TCR_SWOENA_Msk                 (1UL << ITM_TCR_SWOENA_Pos)                    /*!< ITM TCR: SWOENA Mask */
+
+#define ITM_TCR_DWTENA_Pos                  3                                             /*!< ITM TCR: DWTENA Position */
+#define ITM_TCR_DWTENA_Msk                 (1UL << ITM_TCR_DWTENA_Pos)                    /*!< ITM TCR: DWTENA Mask */
+
+#define ITM_TCR_SYNCENA_Pos                 2                                             /*!< ITM TCR: SYNCENA Position */
+#define ITM_TCR_SYNCENA_Msk                (1UL << ITM_TCR_SYNCENA_Pos)                   /*!< ITM TCR: SYNCENA Mask */
+
+#define ITM_TCR_TSENA_Pos                   1                                             /*!< ITM TCR: TSENA Position */
+#define ITM_TCR_TSENA_Msk                  (1UL << ITM_TCR_TSENA_Pos)                     /*!< ITM TCR: TSENA Mask */
+
+#define ITM_TCR_ITMENA_Pos                  0                                             /*!< ITM TCR: ITM Enable bit Position */
+#define ITM_TCR_ITMENA_Msk                 (1UL << ITM_TCR_ITMENA_Pos)                    /*!< ITM TCR: ITM Enable bit Mask */
+
+/* ITM Integration Write Register Definitions */
+#define ITM_IWR_ATVALIDM_Pos                0                                             /*!< ITM IWR: ATVALIDM Position */
+#define ITM_IWR_ATVALIDM_Msk               (1UL << ITM_IWR_ATVALIDM_Pos)                  /*!< ITM IWR: ATVALIDM Mask */
+
+/* ITM Integration Read Register Definitions */
+#define ITM_IRR_ATREADYM_Pos                0                                             /*!< ITM IRR: ATREADYM Position */
+#define ITM_IRR_ATREADYM_Msk               (1UL << ITM_IRR_ATREADYM_Pos)                  /*!< ITM IRR: ATREADYM Mask */
+
+/* ITM Integration Mode Control Register Definitions */
+#define ITM_IMCR_INTEGRATION_Pos            0                                             /*!< ITM IMCR: INTEGRATION Position */
+#define ITM_IMCR_INTEGRATION_Msk           (1UL << ITM_IMCR_INTEGRATION_Pos)              /*!< ITM IMCR: INTEGRATION Mask */
+
+/* ITM Lock Status Register Definitions */
+#define ITM_LSR_ByteAcc_Pos                 2                                             /*!< ITM LSR: ByteAcc Position */
+#define ITM_LSR_ByteAcc_Msk                (1UL << ITM_LSR_ByteAcc_Pos)                   /*!< ITM LSR: ByteAcc Mask */
+
+#define ITM_LSR_Access_Pos                  1                                             /*!< ITM LSR: Access Position */
+#define ITM_LSR_Access_Msk                 (1UL << ITM_LSR_Access_Pos)                    /*!< ITM LSR: Access Mask */
+
+#define ITM_LSR_Present_Pos                 0                                             /*!< ITM LSR: Present Position */
+#define ITM_LSR_Present_Msk                (1UL << ITM_LSR_Present_Pos)                   /*!< ITM LSR: Present Mask */
+
+/*@}*/ /* end of group CMSIS_ITM */
+
+/** \ingroup  CMSIS_core_register
+    \defgroup CMSIS_InterruptType CMSIS Interrupt Type
+   Type definitions for the Cortex-M Interrupt Type Register
+   @{
+ */
+
+/** \brief  Structure type to access the Interrupt Type Register.
+ */
+typedef struct {
+  uint32_t RESERVED0;
+  __I uint32_t ICTR;                     /*!< Offset: 0x004 (R/ )  Interrupt Control Type Register */
+#if ((defined __CM3_REV) && (__CM3_REV >= 0x200))
+  __IO uint32_t ACTLR;                   /*!< Offset: 0x008 (R/W)  Auxiliary Control Register      */
+#else
+  uint32_t RESERVED1;
+#endif
+} InterruptType_Type;
+
+/* Interrupt Controller Type Register Definitions */
+#define IntType_ICTR_INTLINESNUM_Pos  0                                                   /*!< InterruptType ICTR: INTLINESNUM Position */
+#define IntType_ICTR_INTLINESNUM_Msk (0x1FUL << IntType_ICTR_INTLINESNUM_Pos)             /*!< InterruptType ICTR: INTLINESNUM Mask */
+
+/* Auxiliary Control Register Definitions */
+#define IntType_ACTLR_DISFOLD_Pos     2                                                   /*!< InterruptType ACTLR: DISFOLD Position */
+#define IntType_ACTLR_DISFOLD_Msk    (1UL << IntType_ACTLR_DISFOLD_Pos)                   /*!< InterruptType ACTLR: DISFOLD Mask */
+
+#define IntType_ACTLR_DISDEFWBUF_Pos  1                                                   /*!< InterruptType ACTLR: DISDEFWBUF Position */
+#define IntType_ACTLR_DISDEFWBUF_Msk (1UL << IntType_ACTLR_DISDEFWBUF_Pos)                /*!< InterruptType ACTLR: DISDEFWBUF Mask */
+
+#define IntType_ACTLR_DISMCYCINT_Pos  0                                                   /*!< InterruptType ACTLR: DISMCYCINT Position */
+#define IntType_ACTLR_DISMCYCINT_Msk (1UL << IntType_ACTLR_DISMCYCINT_Pos)                /*!< InterruptType ACTLR: DISMCYCINT Mask */
+
+/*@}*/ /* end of group CMSIS_InterruptType */
+
+#if (__MPU_PRESENT == 1)
+/** \ingroup  CMSIS_core_register
+    \defgroup CMSIS_MPU CMSIS MPU
+   Type definitions for the Cortex-M Memory Protection Unit (MPU)
+   @{
+ */
+
+/** \brief  Structure type to access the Memory Protection Unit (MPU).
+ */
+typedef struct {
+  __I uint32_t TYPE;                     /*!< Offset: 0x000 (R/ )  MPU Type Register                              */
+  __IO uint32_t CTRL;                    /*!< Offset: 0x004 (R/W)  MPU Control Register                           */
+  __IO uint32_t RNR;                     /*!< Offset: 0x008 (R/W)  MPU Region RNRber Register                     */
+  __IO uint32_t RBAR;                    /*!< Offset: 0x00C (R/W)  MPU Region Base Address Register               */
+  __IO uint32_t RASR;                    /*!< Offset: 0x010 (R/W)  MPU Region Attribute and Size Register         */
+  __IO uint32_t RBAR_A1;                 /*!< Offset: 0x014 (R/W)  MPU Alias 1 Region Base Address Register       */
+  __IO uint32_t RASR_A1;                 /*!< Offset: 0x018 (R/W)  MPU Alias 1 Region Attribute and Size Register */
+  __IO uint32_t RBAR_A2;                 /*!< Offset: 0x01C (R/W)  MPU Alias 2 Region Base Address Register       */
+  __IO uint32_t RASR_A2;                 /*!< Offset: 0x020 (R/W)  MPU Alias 2 Region Attribute and Size Register */
+  __IO uint32_t RBAR_A3;                 /*!< Offset: 0x024 (R/W)  MPU Alias 3 Region Base Address Register       */
+  __IO uint32_t RASR_A3;                 /*!< Offset: 0x028 (R/W)  MPU Alias 3 Region Attribute and Size Register */
+} MPU_Type;
+
+/* MPU Type Register */
+#define MPU_TYPE_IREGION_Pos               16                                             /*!< MPU TYPE: IREGION Position */
+#define MPU_TYPE_IREGION_Msk               (0xFFUL << MPU_TYPE_IREGION_Pos)               /*!< MPU TYPE: IREGION Mask */
+
+#define MPU_TYPE_DREGION_Pos                8                                             /*!< MPU TYPE: DREGION Position */
+#define MPU_TYPE_DREGION_Msk               (0xFFUL << MPU_TYPE_DREGION_Pos)               /*!< MPU TYPE: DREGION Mask */
+
+#define MPU_TYPE_SEPARATE_Pos               0                                             /*!< MPU TYPE: SEPARATE Position */
+#define MPU_TYPE_SEPARATE_Msk              (1UL << MPU_TYPE_SEPARATE_Pos)                 /*!< MPU TYPE: SEPARATE Mask */
+
+/* MPU Control Register */
+#define MPU_CTRL_PRIVDEFENA_Pos             2                                             /*!< MPU CTRL: PRIVDEFENA Position */
+#define MPU_CTRL_PRIVDEFENA_Msk            (1UL << MPU_CTRL_PRIVDEFENA_Pos)               /*!< MPU CTRL: PRIVDEFENA Mask */
+
+#define MPU_CTRL_HFNMIENA_Pos               1                                             /*!< MPU CTRL: HFNMIENA Position */
+#define MPU_CTRL_HFNMIENA_Msk              (1UL << MPU_CTRL_HFNMIENA_Pos)                 /*!< MPU CTRL: HFNMIENA Mask */
+
+#define MPU_CTRL_ENABLE_Pos                 0                                             /*!< MPU CTRL: ENABLE Position */
+#define MPU_CTRL_ENABLE_Msk                (1UL << MPU_CTRL_ENABLE_Pos)                   /*!< MPU CTRL: ENABLE Mask */
+
+/* MPU Region Number Register */
+#define MPU_RNR_REGION_Pos                  0                                             /*!< MPU RNR: REGION Position */
+#define MPU_RNR_REGION_Msk                 (0xFFUL << MPU_RNR_REGION_Pos)                 /*!< MPU RNR: REGION Mask */
+
+/* MPU Region Base Address Register */
+#define MPU_RBAR_ADDR_Pos                   5                                             /*!< MPU RBAR: ADDR Position */
+#define MPU_RBAR_ADDR_Msk                  (0x7FFFFFFUL << MPU_RBAR_ADDR_Pos)             /*!< MPU RBAR: ADDR Mask */
+
+#define MPU_RBAR_VALID_Pos                  4                                             /*!< MPU RBAR: VALID Position */
+#define MPU_RBAR_VALID_Msk                 (1UL << MPU_RBAR_VALID_Pos)                    /*!< MPU RBAR: VALID Mask */
+
+#define MPU_RBAR_REGION_Pos                 0                                             /*!< MPU RBAR: REGION Position */
+#define MPU_RBAR_REGION_Msk                (0xFUL << MPU_RBAR_REGION_Pos)                 /*!< MPU RBAR: REGION Mask */
+
+/* MPU Region Attribute and Size Register */
+#define MPU_RASR_XN_Pos                    28                                             /*!< MPU RASR: XN Position */
+#define MPU_RASR_XN_Msk                    (1UL << MPU_RASR_XN_Pos)                       /*!< MPU RASR: XN Mask */
+
+#define MPU_RASR_AP_Pos                    24                                             /*!< MPU RASR: AP Position */
+#define MPU_RASR_AP_Msk                    (7UL << MPU_RASR_AP_Pos)                       /*!< MPU RASR: AP Mask */
+
+#define MPU_RASR_TEX_Pos                   19                                             /*!< MPU RASR: TEX Position */
+#define MPU_RASR_TEX_Msk                   (7UL << MPU_RASR_TEX_Pos)                      /*!< MPU RASR: TEX Mask */
+
+#define MPU_RASR_S_Pos                     18                                             /*!< MPU RASR: Shareable bit Position */
+#define MPU_RASR_S_Msk                     (1UL << MPU_RASR_S_Pos)                        /*!< MPU RASR: Shareable bit Mask */
+
+#define MPU_RASR_C_Pos                     17                                             /*!< MPU RASR: Cacheable bit Position */
+#define MPU_RASR_C_Msk                     (1UL << MPU_RASR_C_Pos)                        /*!< MPU RASR: Cacheable bit Mask */
+
+#define MPU_RASR_B_Pos                     16                                             /*!< MPU RASR: Bufferable bit Position */
+#define MPU_RASR_B_Msk                     (1UL << MPU_RASR_B_Pos)                        /*!< MPU RASR: Bufferable bit Mask */
+
+#define MPU_RASR_SRD_Pos                    8                                             /*!< MPU RASR: Sub-Region Disable Position */
+#define MPU_RASR_SRD_Msk                   (0xFFUL << MPU_RASR_SRD_Pos)                   /*!< MPU RASR: Sub-Region Disable Mask */
+
+#define MPU_RASR_SIZE_Pos                   1                                             /*!< MPU RASR: Region Size Field Position */
+#define MPU_RASR_SIZE_Msk                  (0x1FUL << MPU_RASR_SIZE_Pos)                  /*!< MPU RASR: Region Size Field Mask */
+
+#define MPU_RASR_ENA_Pos                     0                                            /*!< MPU RASR: Region enable bit Position */
+#define MPU_RASR_ENA_Msk                    (0x1UL << MPU_RASR_ENA_Pos)                   /*!< MPU RASR: Region enable bit Disable Mask */
+
+/*@} end of group CMSIS_MPU */
+#endif
+
+/** \ingroup  CMSIS_core_register
+    \defgroup CMSIS_CoreDebug CMSIS Core Debug
+   Type definitions for the Cortex-M Core Debug Registers
+   @{
+ */
+
+/** \brief  Structure type to access the Core Debug Register (CoreDebug).
+ */
+typedef struct {
+  __IO uint32_t DHCSR;                   /*!< Offset: 0x000 (R/W)  Debug Halting Control and Status Register    */
+  __O uint32_t DCRSR;                    /*!< Offset: 0x004 ( /W)  Debug Core Register Selector Register        */
+  __IO uint32_t DCRDR;                   /*!< Offset: 0x008 (R/W)  Debug Core Register Data Register            */
+  __IO uint32_t DEMCR;                   /*!< Offset: 0x00C (R/W)  Debug Exception and Monitor Control Register */
+} CoreDebug_Type;
+
+/* Debug Halting Control and Status Register */
+#define CoreDebug_DHCSR_DBGKEY_Pos         16                                             /*!< CoreDebug DHCSR: DBGKEY Position */
+#define CoreDebug_DHCSR_DBGKEY_Msk         (0xFFFFUL << CoreDebug_DHCSR_DBGKEY_Pos)       /*!< CoreDebug DHCSR: DBGKEY Mask */
+
+#define CoreDebug_DHCSR_S_RESET_ST_Pos     25                                             /*!< CoreDebug DHCSR: S_RESET_ST Position */
+#define CoreDebug_DHCSR_S_RESET_ST_Msk     (1UL << CoreDebug_DHCSR_S_RESET_ST_Pos)        /*!< CoreDebug DHCSR: S_RESET_ST Mask */
+
+#define CoreDebug_DHCSR_S_RETIRE_ST_Pos    24                                             /*!< CoreDebug DHCSR: S_RETIRE_ST Position */
+#define CoreDebug_DHCSR_S_RETIRE_ST_Msk    (1UL << CoreDebug_DHCSR_S_RETIRE_ST_Pos)       /*!< CoreDebug DHCSR: S_RETIRE_ST Mask */
+
+#define CoreDebug_DHCSR_S_LOCKUP_Pos       19                                             /*!< CoreDebug DHCSR: S_LOCKUP Position */
+#define CoreDebug_DHCSR_S_LOCKUP_Msk       (1UL << CoreDebug_DHCSR_S_LOCKUP_Pos)          /*!< CoreDebug DHCSR: S_LOCKUP Mask */
+
+#define CoreDebug_DHCSR_S_SLEEP_Pos        18                                             /*!< CoreDebug DHCSR: S_SLEEP Position */
+#define CoreDebug_DHCSR_S_SLEEP_Msk        (1UL << CoreDebug_DHCSR_S_SLEEP_Pos)           /*!< CoreDebug DHCSR: S_SLEEP Mask */
+
+#define CoreDebug_DHCSR_S_HALT_Pos         17                                             /*!< CoreDebug DHCSR: S_HALT Position */
+#define CoreDebug_DHCSR_S_HALT_Msk         (1UL << CoreDebug_DHCSR_S_HALT_Pos)            /*!< CoreDebug DHCSR: S_HALT Mask */
+
+#define CoreDebug_DHCSR_S_REGRDY_Pos       16                                             /*!< CoreDebug DHCSR: S_REGRDY Position */
+#define CoreDebug_DHCSR_S_REGRDY_Msk       (1UL << CoreDebug_DHCSR_S_REGRDY_Pos)          /*!< CoreDebug DHCSR: S_REGRDY Mask */
+
+#define CoreDebug_DHCSR_C_SNAPSTALL_Pos     5                                             /*!< CoreDebug DHCSR: C_SNAPSTALL Position */
+#define CoreDebug_DHCSR_C_SNAPSTALL_Msk    (1UL << CoreDebug_DHCSR_C_SNAPSTALL_Pos)       /*!< CoreDebug DHCSR: C_SNAPSTALL Mask */
+
+#define CoreDebug_DHCSR_C_MASKINTS_Pos      3                                             /*!< CoreDebug DHCSR: C_MASKINTS Position */
+#define CoreDebug_DHCSR_C_MASKINTS_Msk     (1UL << CoreDebug_DHCSR_C_MASKINTS_Pos)        /*!< CoreDebug DHCSR: C_MASKINTS Mask */
+
+#define CoreDebug_DHCSR_C_STEP_Pos          2                                             /*!< CoreDebug DHCSR: C_STEP Position */
+#define CoreDebug_DHCSR_C_STEP_Msk         (1UL << CoreDebug_DHCSR_C_STEP_Pos)            /*!< CoreDebug DHCSR: C_STEP Mask */
+
+#define CoreDebug_DHCSR_C_HALT_Pos          1                                             /*!< CoreDebug DHCSR: C_HALT Position */
+#define CoreDebug_DHCSR_C_HALT_Msk         (1UL << CoreDebug_DHCSR_C_HALT_Pos)            /*!< CoreDebug DHCSR: C_HALT Mask */
+
+#define CoreDebug_DHCSR_C_DEBUGEN_Pos       0                                             /*!< CoreDebug DHCSR: C_DEBUGEN Position */
+#define CoreDebug_DHCSR_C_DEBUGEN_Msk      (1UL << CoreDebug_DHCSR_C_DEBUGEN_Pos)         /*!< CoreDebug DHCSR: C_DEBUGEN Mask */
+
+/* Debug Core Register Selector Register */
+#define CoreDebug_DCRSR_REGWnR_Pos         16                                             /*!< CoreDebug DCRSR: REGWnR Position */
+#define CoreDebug_DCRSR_REGWnR_Msk         (1UL << CoreDebug_DCRSR_REGWnR_Pos)            /*!< CoreDebug DCRSR: REGWnR Mask */
+
+#define CoreDebug_DCRSR_REGSEL_Pos          0                                             /*!< CoreDebug DCRSR: REGSEL Position */
+#define CoreDebug_DCRSR_REGSEL_Msk         (0x1FUL << CoreDebug_DCRSR_REGSEL_Pos)         /*!< CoreDebug DCRSR: REGSEL Mask */
+
+/* Debug Exception and Monitor Control Register */
+#define CoreDebug_DEMCR_TRCENA_Pos         24                                             /*!< CoreDebug DEMCR: TRCENA Position */
+#define CoreDebug_DEMCR_TRCENA_Msk         (1UL << CoreDebug_DEMCR_TRCENA_Pos)            /*!< CoreDebug DEMCR: TRCENA Mask */
+
+#define CoreDebug_DEMCR_MON_REQ_Pos        19                                             /*!< CoreDebug DEMCR: MON_REQ Position */
+#define CoreDebug_DEMCR_MON_REQ_Msk        (1UL << CoreDebug_DEMCR_MON_REQ_Pos)           /*!< CoreDebug DEMCR: MON_REQ Mask */
+
+#define CoreDebug_DEMCR_MON_STEP_Pos       18                                             /*!< CoreDebug DEMCR: MON_STEP Position */
+#define CoreDebug_DEMCR_MON_STEP_Msk       (1UL << CoreDebug_DEMCR_MON_STEP_Pos)          /*!< CoreDebug DEMCR: MON_STEP Mask */
+
+#define CoreDebug_DEMCR_MON_PEND_Pos       17                                             /*!< CoreDebug DEMCR: MON_PEND Position */
+#define CoreDebug_DEMCR_MON_PEND_Msk       (1UL << CoreDebug_DEMCR_MON_PEND_Pos)          /*!< CoreDebug DEMCR: MON_PEND Mask */
+
+#define CoreDebug_DEMCR_MON_EN_Pos         16                                             /*!< CoreDebug DEMCR: MON_EN Position */
+#define CoreDebug_DEMCR_MON_EN_Msk         (1UL << CoreDebug_DEMCR_MON_EN_Pos)            /*!< CoreDebug DEMCR: MON_EN Mask */
+
+#define CoreDebug_DEMCR_VC_HARDERR_Pos     10                                             /*!< CoreDebug DEMCR: VC_HARDERR Position */
+#define CoreDebug_DEMCR_VC_HARDERR_Msk     (1UL << CoreDebug_DEMCR_VC_HARDERR_Pos)        /*!< CoreDebug DEMCR: VC_HARDERR Mask */
+
+#define CoreDebug_DEMCR_VC_INTERR_Pos       9                                             /*!< CoreDebug DEMCR: VC_INTERR Position */
+#define CoreDebug_DEMCR_VC_INTERR_Msk      (1UL << CoreDebug_DEMCR_VC_INTERR_Pos)         /*!< CoreDebug DEMCR: VC_INTERR Mask */
+
+#define CoreDebug_DEMCR_VC_BUSERR_Pos       8                                             /*!< CoreDebug DEMCR: VC_BUSERR Position */
+#define CoreDebug_DEMCR_VC_BUSERR_Msk      (1UL << CoreDebug_DEMCR_VC_BUSERR_Pos)         /*!< CoreDebug DEMCR: VC_BUSERR Mask */
+
+#define CoreDebug_DEMCR_VC_STATERR_Pos      7                                             /*!< CoreDebug DEMCR: VC_STATERR Position */
+#define CoreDebug_DEMCR_VC_STATERR_Msk     (1UL << CoreDebug_DEMCR_VC_STATERR_Pos)        /*!< CoreDebug DEMCR: VC_STATERR Mask */
+
+#define CoreDebug_DEMCR_VC_CHKERR_Pos       6                                             /*!< CoreDebug DEMCR: VC_CHKERR Position */
+#define CoreDebug_DEMCR_VC_CHKERR_Msk      (1UL << CoreDebug_DEMCR_VC_CHKERR_Pos)         /*!< CoreDebug DEMCR: VC_CHKERR Mask */
+
+#define CoreDebug_DEMCR_VC_NOCPERR_Pos      5                                             /*!< CoreDebug DEMCR: VC_NOCPERR Position */
+#define CoreDebug_DEMCR_VC_NOCPERR_Msk     (1UL << CoreDebug_DEMCR_VC_NOCPERR_Pos)        /*!< CoreDebug DEMCR: VC_NOCPERR Mask */
+
+#define CoreDebug_DEMCR_VC_MMERR_Pos        4                                             /*!< CoreDebug DEMCR: VC_MMERR Position */
+#define CoreDebug_DEMCR_VC_MMERR_Msk       (1UL << CoreDebug_DEMCR_VC_MMERR_Pos)          /*!< CoreDebug DEMCR: VC_MMERR Mask */
+
+#define CoreDebug_DEMCR_VC_CORERESET_Pos    0                                             /*!< CoreDebug DEMCR: VC_CORERESET Position */
+#define CoreDebug_DEMCR_VC_CORERESET_Msk   (1UL << CoreDebug_DEMCR_VC_CORERESET_Pos)      /*!< CoreDebug DEMCR: VC_CORERESET Mask */
+
+/*@} end of group CMSIS_CoreDebug */
+
+/** \ingroup  CMSIS_core_register
+   @{
+ */
+
+/* Memory mapping of Cortex-M3 Hardware */
+#define SCS_BASE            (0xE000E000UL)                            /*!< System Control Space Base Address */
+#define ITM_BASE            (0xE0000000UL)                            /*!< ITM Base Address                  */
+#define CoreDebug_BASE      (0xE000EDF0UL)                            /*!< Core Debug Base Address           */
+#define SysTick_BASE        (SCS_BASE + 0x0010UL)                     /*!< SysTick Base Address              */
+#define NVIC_BASE           (SCS_BASE + 0x0100UL)                     /*!< NVIC Base Address                 */
+#define SCB_BASE            (SCS_BASE + 0x0D00UL)                     /*!< System Control Block Base Address */
+
+#define InterruptType       ((InterruptType_Type *)SCS_BASE)          /*!< Interrupt Type Register           */
+#define SCB                 ((SCB_Type *)SCB_BASE)                    /*!< SCB configuration struct          */
+#define SysTick             ((SysTick_Type *)SysTick_BASE)            /*!< SysTick configuration struct      */
+#define NVIC                ((NVIC_Type *)NVIC_BASE)                  /*!< NVIC configuration struct         */
+#define ITM                 ((ITM_Type *)ITM_BASE)                    /*!< ITM configuration struct          */
+#define CoreDebug           ((CoreDebug_Type *)CoreDebug_BASE)        /*!< Core Debug configuration struct   */
+
+#if (__MPU_PRESENT == 1)
+#define MPU_BASE          (SCS_BASE + 0x0D90UL)                       /*!< Memory Protection Unit            */
+#define MPU               ((MPU_Type *)MPU_BASE)                      /*!< Memory Protection Unit            */
+#endif
+
+/*@} */
+
+/*******************************************************************************
+ *                Hardware Abstraction Layer
+ ******************************************************************************/
+/** \ingroup  CMSIS
+   \addtogroup CMSIS_Core_FunctionInterface CMSIS Core Function Interface
+   Core Function Interface contains:
+   - Core NVIC Functions
+   - Core SysTick Functions
+   - Core Debug Functions
+   - Core Register Access Functions
+ */
+
+/* ##########################   NVIC functions  #################################### */
+/** \ingroup  CMSIS_Core_FunctionInterface
+    \defgroup CMSIS_Core_NVICFunctions CMSIS Core NVIC Functions
+   @{
+ */
+/** @addtogroup CMSIS_Core_NVICFunctions
+ * @{
+ */
+/** \brief  Set Priority Grouping
+
+   This function sets the priority grouping field using the required unlock sequence.
+   The parameter PriorityGroup is assigned to the field SCB->AIRCR [10:8] PRIGROUP field.
+   Only values from 0..7 are used.
+   In case of a conflict between priority grouping and available
+   priority bits (__NVIC_PRIO_BITS) the smallest possible priority group is set.
+
+    \param [in]      PriorityGroup  Priority grouping field
+ */
+static __INLINE void
+NVIC_SetPriorityGrouping(uint32_t PriorityGroup)
+{
+  uint32_t reg_value;
+  uint32_t PriorityGroupTmp = (PriorityGroup & 0x07);                         /* only values 0..7 are used          */
+
+  reg_value = SCB->AIRCR;                                                     /* read old register configuration    */
+  reg_value &= ~(SCB_AIRCR_VECTKEY_Msk | SCB_AIRCR_PRIGROUP_Msk);             /* clear bits to change               */
+  reg_value = (reg_value |
+               (0x5FA << SCB_AIRCR_VECTKEY_Pos) |
+               (PriorityGroupTmp << 8));                                      /* Insert write key and priorty group */
+  SCB->AIRCR = reg_value;
+}
+/** \brief  Get Priority Grouping
+
+   This function gets the priority grouping from NVIC Interrupt Controller.
+   Priority grouping is SCB->AIRCR [10:8] PRIGROUP field.
+
+    \return                Priority grouping field
+ */
+static __INLINE uint32_t
+NVIC_GetPriorityGrouping(void)
+{
+  return (SCB->AIRCR & SCB_AIRCR_PRIGROUP_Msk) >> SCB_AIRCR_PRIGROUP_Pos;     /* read priority grouping field */
+}
+/** \brief  Enable External Interrupt
+
+    This function enables a device specific interupt in the NVIC interrupt controller.
+    The interrupt number cannot be a negative value.
+
+    \param [in]      IRQn  Number of the external interrupt to enable
+ */
+static __INLINE void
+NVIC_EnableIRQ(IRQn_Type IRQn)
+{
+  NVIC->ISER[((uint32_t)(IRQn) >> 5)] = (1 << ((uint32_t)(IRQn) & 0x1F)); /* enable interrupt */
+}
+/** \brief  Disable External Interrupt
+
+    This function disables a device specific interupt in the NVIC interrupt controller.
+    The interrupt number cannot be a negative value.
+
+    \param [in]      IRQn  Number of the external interrupt to disable
+ */
+static __INLINE void
+NVIC_DisableIRQ(IRQn_Type IRQn)
+{
+  NVIC->ICER[((uint32_t)(IRQn) >> 5)] = (1 << ((uint32_t)(IRQn) & 0x1F)); /* disable interrupt */
+}
+/** \brief  Get Pending Interrupt
+
+    This function reads the pending register in the NVIC and returns the pending bit
+    for the specified interrupt.
+
+    \param [in]      IRQn  Number of the interrupt for get pending
+    \return             0  Interrupt status is not pending
+    \return             1  Interrupt status is pending
+ */
+static __INLINE uint32_t
+NVIC_GetPendingIRQ(IRQn_Type IRQn)
+{
+  return (uint32_t)((NVIC->ISPR[(uint32_t)(IRQn) >> 5] & (1 << ((uint32_t)(IRQn) & 0x1F))) ? 1 : 0);  /* Return 1 if pending else 0 */
+}
+/** \brief  Set Pending Interrupt
+
+    This function sets the pending bit for the specified interrupt.
+    The interrupt number cannot be a negative value.
+
+    \param [in]      IRQn  Number of the interrupt for set pending
+ */
+static __INLINE void
+NVIC_SetPendingIRQ(IRQn_Type IRQn)
+{
+  NVIC->ISPR[((uint32_t)(IRQn) >> 5)] = (1 << ((uint32_t)(IRQn) & 0x1F)); /* set interrupt pending */
+}
+/** \brief  Clear Pending Interrupt
+
+    This function clears the pending bit for the specified interrupt.
+    The interrupt number cannot be a negative value.
+
+    \param [in]      IRQn  Number of the interrupt for clear pending
+ */
+static __INLINE void
+NVIC_ClearPendingIRQ(IRQn_Type IRQn)
+{
+  NVIC->ICPR[((uint32_t)(IRQn) >> 5)] = (1 << ((uint32_t)(IRQn) & 0x1F)); /* Clear pending interrupt */
+}
+/** \brief  Get Active Interrupt
+
+    This function reads the active register in NVIC and returns the active bit.
+    \param [in]      IRQn  Number of the interrupt for get active
+    \return             0  Interrupt status is not active
+    \return             1  Interrupt status is active
+ */
+static __INLINE uint32_t
+NVIC_GetActive(IRQn_Type IRQn)
+{
+  return (uint32_t)((NVIC->IABR[(uint32_t)(IRQn) >> 5] & (1 << ((uint32_t)(IRQn) & 0x1F))) ? 1 : 0);  /* Return 1 if active else 0 */
+}
+/** \brief  Set Interrupt Priority
+
+    This function sets the priority for the specified interrupt. The interrupt
+    number can be positive to specify an external (device specific)
+    interrupt, or negative to specify an internal (core) interrupt.
+
+    Note: The priority cannot be set for every core interrupt.
+
+    \param [in]      IRQn  Number of the interrupt for set priority
+    \param [in]  priority  Priority to set
+ */
+static __INLINE void
+NVIC_SetPriority(IRQn_Type IRQn, uint32_t priority)
+{
+  if(IRQn < 0) {
+    SCB->SHP[((uint32_t)(IRQn) & 0xF) - 4] = ((priority << (8 - __NVIC_PRIO_BITS)) & 0xff);   /* set Priority for Cortex-M  System Interrupts */
+  } else {
+    NVIC->IP[(uint32_t)(IRQn)] = ((priority << (8 - __NVIC_PRIO_BITS)) & 0xff);             /* set Priority for device specific Interrupts  */
+  }
+}
+/** \brief  Get Interrupt Priority
+
+    This function reads the priority for the specified interrupt. The interrupt
+    number can be positive to specify an external (device specific)
+    interrupt, or negative to specify an internal (core) interrupt.
+
+    The returned priority value is automatically aligned to the implemented
+    priority bits of the microcontroller.
+
+    \param [in]   IRQn  Number of the interrupt for get priority
+    \return             Interrupt Priority
+ */
+static __INLINE uint32_t
+NVIC_GetPriority(IRQn_Type IRQn)
+{
+
+  if(IRQn < 0) {
+    return (uint32_t)(SCB->SHP[((uint32_t)(IRQn) & 0xF) - 4] >> (8 - __NVIC_PRIO_BITS));     /* get priority for Cortex-M  system interrupts */
+  } else {
+    return (uint32_t)(NVIC->IP[(uint32_t)(IRQn)] >> (8 - __NVIC_PRIO_BITS));               /* get priority for device specific interrupts  */
+  }
+}
+/** \brief  Encode Priority
+
+    This function encodes the priority for an interrupt with the given priority group,
+    preemptive priority value and sub priority value.
+    In case of a conflict between priority grouping and available
+    priority bits (__NVIC_PRIO_BITS) the samllest possible priority group is set.
+
+    The returned priority value can be used for NVIC_SetPriority(...) function
+
+    \param [in]     PriorityGroup  Used priority group
+    \param [in]   PreemptPriority  Preemptive priority value (starting from 0)
+    \param [in]       SubPriority  Sub priority value (starting from 0)
+    \return                        Encoded priority for the interrupt
+ */
+static __INLINE uint32_t
+NVIC_EncodePriority(uint32_t PriorityGroup, uint32_t PreemptPriority, uint32_t SubPriority)
+{
+  uint32_t PriorityGroupTmp = (PriorityGroup & 0x07);          /* only values 0..7 are used          */
+  uint32_t PreemptPriorityBits;
+  uint32_t SubPriorityBits;
+
+  PreemptPriorityBits = ((7 - PriorityGroupTmp) > __NVIC_PRIO_BITS) ? __NVIC_PRIO_BITS : 7 - PriorityGroupTmp;
+  SubPriorityBits = ((PriorityGroupTmp + __NVIC_PRIO_BITS) < 7) ? 0 : PriorityGroupTmp - 7 + __NVIC_PRIO_BITS;
+
+  return
+    ((PreemptPriority & ((1 << (PreemptPriorityBits)) - 1)) << SubPriorityBits) |
+    ((SubPriority & ((1 << (SubPriorityBits)) - 1)))
+  ;
+}
+/** \brief  Decode Priority
+
+    This function decodes an interrupt priority value with the given priority group to
+    preemptive priority value and sub priority value.
+    In case of a conflict between priority grouping and available
+    priority bits (__NVIC_PRIO_BITS) the samllest possible priority group is set.
+
+    The priority value can be retrieved with NVIC_GetPriority(...) function
+
+    \param [in]         Priority   Priority value
+    \param [in]     PriorityGroup  Used priority group
+    \param [out] pPreemptPriority  Preemptive priority value (starting from 0)
+    \param [out]     pSubPriority  Sub priority value (starting from 0)
+ */
+static __INLINE void
+NVIC_DecodePriority(uint32_t Priority, uint32_t PriorityGroup, uint32_t *pPreemptPriority, uint32_t *pSubPriority)
+{
+  uint32_t PriorityGroupTmp = (PriorityGroup & 0x07);          /* only values 0..7 are used          */
+  uint32_t PreemptPriorityBits;
+  uint32_t SubPriorityBits;
+
+  PreemptPriorityBits = ((7 - PriorityGroupTmp) > __NVIC_PRIO_BITS) ? __NVIC_PRIO_BITS : 7 - PriorityGroupTmp;
+  SubPriorityBits = ((PriorityGroupTmp + __NVIC_PRIO_BITS) < 7) ? 0 : PriorityGroupTmp - 7 + __NVIC_PRIO_BITS;
+
+  *pPreemptPriority = (Priority >> SubPriorityBits) & ((1 << (PreemptPriorityBits)) - 1);
+  *pSubPriority = (Priority) & ((1 << (SubPriorityBits)) - 1);
+}
+/** \brief  System Reset
+
+    This function initiate a system reset request to reset the MCU.
+ */
+static __INLINE void
+NVIC_SystemReset(void)
+{
+  __DSB();                                                     /* Ensure all outstanding memory accesses included
+                                                                  buffered write are completed before reset */
+  SCB->AIRCR = ((0x5FA << SCB_AIRCR_VECTKEY_Pos) |
+                (SCB->AIRCR & SCB_AIRCR_PRIGROUP_Msk) |
+                SCB_AIRCR_SYSRESETREQ_Msk);                    /* Keep priority group unchanged */
+  __DSB();                                                     /* Ensure completion of memory access */
+  while(1) ;                                                   /* wait until reset */
+}
+/*@} end of CMSIS_Core_NVICFunctions */
+
+/**
+ * @}
+ */
+/* ##################################    SysTick function  ############################################ */
+/** \ingroup  CMSIS_Core_FunctionInterface
+    \defgroup CMSIS_Core_SysTickFunctions CMSIS Core SysTick Functions
+   @{
+ */
+/** @addtogroup CMSIS_Core_SysTickFunctions
+ * @{
+ */
+#if (__Vendor_SysTickConfig == 0)
+
+/** \brief  System Tick Configuration
+
+    This function initialises the system tick timer and its interrupt and start the system tick timer.
+    Counter is in free running mode to generate periodical interrupts.
+
+    \param [in]  ticks  Number of ticks between two interrupts
+    \return          0  Function succeeded
+    \return          1  Function failed
+ */
+static __INLINE uint32_t
+SysTick_Config(uint32_t ticks)
+{
+  if(ticks > SysTick_LOAD_RELOAD_Msk) {
+    return 1;                                                  /* Reload value impossible */
+  }
+  SysTick->LOAD = (ticks & SysTick_LOAD_RELOAD_Msk) - 1;       /* set reload register */
+  NVIC_SetPriority(SysTick_IRQn, (1 << __NVIC_PRIO_BITS) - 1);  /* set Priority for Cortex-M0 System Interrupts */
+  SysTick->VAL = 0;                                            /* Load the SysTick Counter Value */
+  SysTick->CTRL = SysTick_CTRL_CLKSOURCE_Msk |
+    SysTick_CTRL_TICKINT_Msk |
+    SysTick_CTRL_ENABLE_Msk;                                   /* Enable SysTick IRQ and SysTick Timer */
+  return 0;                                                    /* Function successful */
+}
+#endif
+
+/*@} end of CMSIS_Core_SysTickFunctions */
+
+/**
+ * @}
+ */
+
+/* ##################################### Debug In/Output function ########################################### */
+/** \ingroup  CMSIS_Core_FunctionInterface
+    \defgroup CMSIS_core_DebugFunctions CMSIS Core Debug Functions
+   @{
+ */
+
+extern volatile int32_t ITM_RxBuffer;                    /*!< external variable to receive characters                    */
+#define                 ITM_RXBUFFER_EMPTY    0x5AA55AA5 /*!< value identifying ITM_RxBuffer is ready for next character */
+
+/** \brief  ITM Send Character
+
+    This function transmits a character via the ITM channel 0.
+    It just returns when no debugger is connected that has booked the output.
+    It is blocking when a debugger is connected, but the previous character send is not transmitted.
+
+    \param [in]     ch  Character to transmit
+    \return             Character to transmit
+ */
+static __INLINE uint32_t
+ITM_SendChar(uint32_t ch)
+{
+  if((CoreDebug->DEMCR & CoreDebug_DEMCR_TRCENA_Msk) &&        /* Trace enabled */
+     (ITM->TCR & ITM_TCR_ITMENA_Msk) &&                        /* ITM enabled */
+     (ITM->TER & (1UL << 0))) {                                /* ITM Port #0 enabled */
+    while(ITM->PORT[0].u32 == 0) ;
+    ITM->PORT[0].u8 = (uint8_t)ch;
+  }
+  return ch;
+}
+/** \brief  ITM Receive Character
+
+    This function inputs a character via external variable ITM_RxBuffer.
+    It just returns when no debugger is connected that has booked the output.
+    It is blocking when a debugger is connected, but the previous character send is not transmitted.
+
+    \return             Received character
+    \return         -1  No character received
+ */
+static __INLINE int32_t
+ITM_ReceiveChar(void)
+{
+  int32_t ch = -1;                           /* no character available */
+
+  if(ITM_RxBuffer != ITM_RXBUFFER_EMPTY) {
+    ch = ITM_RxBuffer;
+    ITM_RxBuffer = ITM_RXBUFFER_EMPTY;       /* ready for next character */
+  }
+
+  return ch;
+}
+/** \brief  ITM Check Character
+
+    This function checks external variable ITM_RxBuffer whether a character is available or not.
+    It returns '1' if a character is available and '0' if no character is available.
+
+    \return          0  No character available
+    \return          1  Character available
+ */
+static __INLINE int32_t
+ITM_CheckChar(void)
+{
+
+  if(ITM_RxBuffer == ITM_RXBUFFER_EMPTY) {
+    return 0;                                   /* no character available */
+  } else {
+    return 1;                                   /*    character available */
+  }
+}
+/*@} end of CMSIS_core_DebugFunctions */
+/**
+ * @}
+ */
+
+#endif /* __CORE_CM3_H_DEPENDANT */
+
+#endif /* __CMSIS_GENERIC */
+
+#ifdef __cplusplus
+}
+#endif
+
+/*lint -restore */

--- a/cpu/arm/lpc1768/core_cmFunc.h
+++ b/cpu/arm/lpc1768/core_cmFunc.h
@@ -1,0 +1,802 @@
+/**************************************************************************//**
+ * @file     core_cmFunc.h
+ * @brief    CMSIS Cortex-M Core Function Access Header File
+ * @version  V2.01
+ * @date     06. December 2010
+ *
+ * @note
+ * Copyright (C) 2009-2010 ARM Limited. All rights reserved.
+ *
+ * @par
+ * ARM Limited (ARM) is supplying this software for use with Cortex-M
+ * processor based microcontrollers.  This file can be freely distributed
+ * within development tools that are supporting such ARM based processors.
+ *
+ * @par
+ * THIS SOFTWARE IS PROVIDED "AS IS".  NO WARRANTIES, WHETHER EXPRESS, IMPLIED
+ * OR STATUTORY, INCLUDING, BUT NOT LIMITED TO, IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE APPLY TO THIS SOFTWARE.
+ * ARM SHALL NOT, IN ANY CIRCUMSTANCES, BE LIABLE FOR SPECIAL, INCIDENTAL, OR
+ * CONSEQUENTIAL DAMAGES, FOR ANY REASON WHATSOEVER.
+ *
+ ******************************************************************************/
+
+#ifndef __CORE_CMFUNC_H__
+#define __CORE_CMFUNC_H__
+
+/* ###########################  Core Function Access  ########################### */
+/** \ingroup  CMSIS_Core_FunctionInterface
+    \defgroup CMSIS_Core_RegAccFunctions CMSIS Core Register Access Functions
+   @{
+ */
+
+#if defined(__CC_ARM)      /*------------------ RealView Compiler ----------------*/
+/* ARM armcc specific functions */
+
+/* intrinsic void __enable_irq();     */
+/* intrinsic void __disable_irq();    */
+
+/** \brief  Get Control Register
+
+    This function returns the content of the Control Register.
+
+    \return               Control Register value
+ */
+#if       (__ARMCC_VERSION < 400000)
+extern uint32_t __get_CONTROL(void);
+#else /* (__ARMCC_VERSION >= 400000) */
+static __INLINE uint32_t
+__get_CONTROL(void)
+{
+  register uint32_t __regControl __ASM("control");
+  return __regControl;
+}
+#endif /*  __ARMCC_VERSION  */
+
+/** \brief  Set Control Register
+
+    This function writes the given value to the Control Register.
+
+    \param [in]    control  Control Register value to set
+ */
+#if       (__ARMCC_VERSION < 400000)
+extern void __set_CONTROL(uint32_t control);
+#else /* (__ARMCC_VERSION >= 400000) */
+static __INLINE void
+__set_CONTROL(uint32_t control)
+{
+  register uint32_t __regControl __ASM("control");
+  __regControl = control;
+}
+#endif /*  __ARMCC_VERSION  */
+
+/** \brief  Get ISPR Register
+
+    This function returns the content of the ISPR Register.
+
+    \return               ISPR Register value
+ */
+#if       (__ARMCC_VERSION < 400000)
+extern uint32_t __get_IPSR(void);
+#else /* (__ARMCC_VERSION >= 400000) */
+static __INLINE uint32_t
+__get_IPSR(void)
+{
+  register uint32_t __regIPSR __ASM("ipsr");
+  return __regIPSR;
+}
+#endif /*  __ARMCC_VERSION  */
+
+/** \brief  Get APSR Register
+
+    This function returns the content of the APSR Register.
+
+    \return               APSR Register value
+ */
+#if       (__ARMCC_VERSION < 400000)
+extern uint32_t __get_APSR(void);
+#else /* (__ARMCC_VERSION >= 400000) */
+static __INLINE uint32_t
+__get_APSR(void)
+{
+  register uint32_t __regAPSR __ASM("apsr");
+  return __regAPSR;
+}
+#endif /*  __ARMCC_VERSION  */
+
+/** \brief  Get xPSR Register
+
+    This function returns the content of the xPSR Register.
+
+    \return               xPSR Register value
+ */
+#if       (__ARMCC_VERSION < 400000)
+extern uint32_t __get_xPSR(void);
+#else /* (__ARMCC_VERSION >= 400000) */
+static __INLINE uint32_t
+__get_xPSR(void)
+{
+  register uint32_t __regXPSR __ASM("xpsr");
+  return __regXPSR;
+}
+#endif /*  __ARMCC_VERSION  */
+
+/** \brief  Get Process Stack Pointer
+
+    This function returns the current value of the Process Stack Pointer (PSP).
+
+    \return               PSP Register value
+ */
+#if       (__ARMCC_VERSION < 400000)
+extern uint32_t __get_PSP(void);
+#else /* (__ARMCC_VERSION >= 400000) */
+static __INLINE uint32_t
+__get_PSP(void)
+{
+  register uint32_t __regProcessStackPointer __ASM("psp");
+  return __regProcessStackPointer;
+}
+#endif /*  __ARMCC_VERSION  */
+
+/** \brief  Set Process Stack Pointer
+
+    This function assigns the given value to the Process Stack Pointer (PSP).
+
+    \param [in]    topOfProcStack  Process Stack Pointer value to set
+ */
+#if       (__ARMCC_VERSION < 400000)
+extern void __set_PSP(uint32_t topOfProcStack);
+#else /* (__ARMCC_VERSION >= 400000) */
+static __INLINE void
+__set_PSP(uint32_t topOfProcStack)
+{
+  register uint32_t __regProcessStackPointer __ASM("psp");
+  __regProcessStackPointer = topOfProcStack;
+}
+#endif /*  __ARMCC_VERSION  */
+
+/** \brief  Get Main Stack Pointer
+
+    This function returns the current value of the Main Stack Pointer (MSP).
+
+    \return               MSP Register value
+ */
+#if       (__ARMCC_VERSION < 400000)
+extern uint32_t __get_MSP(void);
+#else /* (__ARMCC_VERSION >= 400000) */
+static __INLINE uint32_t
+__get_MSP(void)
+{
+  register uint32_t __regMainStackPointer __ASM("msp");
+  return __regMainStackPointer;
+}
+#endif /*  __ARMCC_VERSION  */
+
+/** \brief  Set Main Stack Pointer
+
+    This function assigns the given value to the Main Stack Pointer (MSP).
+
+    \param [in]    topOfMainStack  Main Stack Pointer value to set
+ */
+#if       (__ARMCC_VERSION < 400000)
+extern void __set_MSP(uint32_t topOfMainStack);
+#else /* (__ARMCC_VERSION >= 400000) */
+static __INLINE void
+__set_MSP(uint32_t topOfMainStack)
+{
+  register uint32_t __regMainStackPointer __ASM("msp");
+  __regMainStackPointer = topOfMainStack;
+}
+#endif /*  __ARMCC_VERSION  */
+
+/** \brief  Get Priority Mask
+
+    This function returns the current state of the priority mask bit from the Priority Mask Register.
+
+    \return               Priority Mask value
+ */
+#if       (__ARMCC_VERSION < 400000)
+extern uint32_t __get_PRIMASK(void);
+#else /* (__ARMCC_VERSION >= 400000) */
+static __INLINE uint32_t
+__get_PRIMASK(void)
+{
+  register uint32_t __regPriMask __ASM("primask");
+  return __regPriMask;
+}
+#endif /*  __ARMCC_VERSION  */
+
+/** \brief  Set Priority Mask
+
+    This function assigns the given value to the Priority Mask Register.
+
+    \param [in]    priMask  Priority Mask
+ */
+#if       (__ARMCC_VERSION < 400000)
+extern void __set_PRIMASK(uint32_t priMask);
+#else /* (__ARMCC_VERSION >= 400000) */
+static __INLINE void
+__set_PRIMASK(uint32_t priMask)
+{
+  register uint32_t __regPriMask __ASM("primask");
+  __regPriMask = (priMask);
+}
+#endif /*  __ARMCC_VERSION  */
+
+#if       (__CORTEX_M >= 0x03)
+
+/** \brief  Enable FIQ
+
+    This function enables FIQ interrupts by clearing the F-bit in the CPSR.
+    Can only be executed in Privileged modes.
+ */
+#define __enable_fault_irq                __enable_fiq
+
+/** \brief  Disable FIQ
+
+    This function disables FIQ interrupts by setting the F-bit in the CPSR.
+    Can only be executed in Privileged modes.
+ */
+#define __disable_fault_irq               __disable_fiq
+
+/** \brief  Get Base Priority
+
+    This function returns the current value of the Base Priority register.
+
+    \return               Base Priority register value
+ */
+#if       (__ARMCC_VERSION < 400000)
+extern uint32_t __get_BASEPRI(void);
+#else /* (__ARMCC_VERSION >= 400000) */
+static __INLINE uint32_t
+__get_BASEPRI(void)
+{
+  register uint32_t __regBasePri __ASM("basepri");
+  return __regBasePri;
+}
+#endif /*  __ARMCC_VERSION  */
+
+/** \brief  Set Base Priority
+
+    This function assigns the given value to the Base Priority register.
+
+    \param [in]    basePri  Base Priority value to set
+ */
+#if       (__ARMCC_VERSION < 400000)
+extern void __set_BASEPRI(uint32_t basePri);
+#else /* (__ARMCC_VERSION >= 400000) */
+static __INLINE void
+__set_BASEPRI(uint32_t basePri)
+{
+  register uint32_t __regBasePri __ASM("basepri");
+  __regBasePri = (basePri & 0xff);
+}
+#endif /*  __ARMCC_VERSION  */
+
+/** \brief  Get Fault Mask
+
+    This function returns the current value of the Fault Mask register.
+
+    \return               Fault Mask register value
+ */
+#if       (__ARMCC_VERSION < 400000)
+extern uint32_t __get_FAULTMASK(void);
+#else /* (__ARMCC_VERSION >= 400000) */
+static __INLINE uint32_t
+__get_FAULTMASK(void)
+{
+  register uint32_t __regFaultMask __ASM("faultmask");
+  return __regFaultMask;
+}
+#endif /*  __ARMCC_VERSION  */
+
+/** \brief  Set Fault Mask
+
+    This function assigns the given value to the Fault Mask register.
+
+    \param [in]    faultMask  Fault Mask value to set
+ */
+#if       (__ARMCC_VERSION < 400000)
+extern void __set_FAULTMASK(uint32_t faultMask);
+#else /* (__ARMCC_VERSION >= 400000) */
+static __INLINE void
+__set_FAULTMASK(uint32_t faultMask)
+{
+  register uint32_t __regFaultMask __ASM("faultmask");
+  __regFaultMask = (faultMask & 1);
+}
+#endif /*  __ARMCC_VERSION  */
+
+#endif /* (__CORTEX_M >= 0x03) */
+
+#if       (__CORTEX_M == 0x04)
+
+/** \brief  Get FPSCR
+
+    This function returns the current value of the Floating Point Status/Control register.
+
+    \return               Floating Point Status/Control register value
+ */
+static __INLINE uint32_t
+__get_FPSCR(void)
+{
+#if (__FPU_PRESENT == 1)
+  register uint32_t __regfpscr __ASM("fpscr");
+  return __regfpscr;
+#else
+  return 0;
+#endif
+}
+/** \brief  Set FPSCR
+
+    This function assigns the given value to the Floating Point Status/Control register.
+
+    \param [in]    fpscr  Floating Point Status/Control value to set
+ */
+static __INLINE void
+__set_FPSCR(uint32_t fpscr)
+{
+#if (__FPU_PRESENT == 1)
+  register uint32_t __regfpscr __ASM("fpscr");
+  __regfpscr = (fpscr);
+#endif
+}
+#endif /* (__CORTEX_M == 0x04) */
+
+#elif (defined(__ICCARM__))   /*---------------- ICC Compiler ---------------------*/
+/* IAR iccarm specific functions */
+
+#if defined(__ICCARM__)
+#include <intrinsics.h>                       /* IAR Intrinsics   */
+#endif
+
+#pragma diag_suppress=Pe940
+
+/** \brief  Enable IRQ Interrupts
+
+   This function enables IRQ interrupts by clearing the I-bit in the CPSR.
+   Can only be executed in Privileged modes.
+ */
+#define __enable_irq                              __enable_interrupt
+
+/** \brief  Disable IRQ Interrupts
+
+   This function disables IRQ interrupts by setting the I-bit in the CPSR.
+   Can only be executed in Privileged modes.
+ */
+#define __disable_irq                             __disable_interrupt
+
+/* intrinsic unsigned long __get_CONTROL( void ); (see intrinsic.h) */
+/* intrinsic void __set_CONTROL( unsigned long ); (see intrinsic.h) */
+
+/** \brief  Get ISPR Register
+
+    This function returns the content of the ISPR Register.
+
+    \return               ISPR Register value
+ */
+static uint32_t
+__get_IPSR(void)
+{
+  __ASM("mrs r0, ipsr");
+}
+/** \brief  Get APSR Register
+
+    This function returns the content of the APSR Register.
+
+    \return               APSR Register value
+ */
+static uint32_t
+__get_APSR(void)
+{
+  __ASM("mrs r0, apsr");
+}
+/** \brief  Get xPSR Register
+
+    This function returns the content of the xPSR Register.
+
+    \return               xPSR Register value
+ */
+static uint32_t
+__get_xPSR(void)
+{
+  __ASM("mrs r0, psr");           /* assembler does not know "xpsr" */
+}
+/** \brief  Get Process Stack Pointer
+
+    This function returns the current value of the Process Stack Pointer (PSP).
+
+    \return               PSP Register value
+ */
+static uint32_t
+__get_PSP(void)
+{
+  __ASM("mrs r0, psp");
+}
+/** \brief  Set Process Stack Pointer
+
+    This function assigns the given value to the Process Stack Pointer (PSP).
+
+    \param [in]    topOfProcStack  Process Stack Pointer value to set
+ */
+static void
+__set_PSP(uint32_t topOfProcStack)
+{
+  __ASM("msr psp, r0");
+}
+/** \brief  Get Main Stack Pointer
+
+    This function returns the current value of the Main Stack Pointer (MSP).
+
+    \return               MSP Register value
+ */
+static uint32_t
+__get_MSP(void)
+{
+  __ASM("mrs r0, msp");
+}
+/** \brief  Set Main Stack Pointer
+
+    This function assigns the given value to the Main Stack Pointer (MSP).
+
+    \param [in]    topOfMainStack  Main Stack Pointer value to set
+ */
+static void
+__set_MSP(uint32_t topOfMainStack)
+{
+  __ASM("msr msp, r0");
+}
+/* intrinsic unsigned long __get_PRIMASK( void ); (see intrinsic.h) */
+/* intrinsic void __set_PRIMASK( unsigned long ); (see intrinsic.h) */
+
+#if       (__CORTEX_M >= 0x03)
+
+/** \brief  Enable FIQ
+
+    This function enables FIQ interrupts by clearing the F-bit in the CPSR.
+    Can only be executed in Privileged modes.
+ */
+static __INLINE void
+__enable_fault_irq(void)
+{
+  __ASM("cpsie f");
+}
+/** \brief  Disable FIQ
+
+    This function disables FIQ interrupts by setting the F-bit in the CPSR.
+    Can only be executed in Privileged modes.
+ */
+static __INLINE void
+__disable_fault_irq(void)
+{
+  __ASM("cpsid f");
+}
+/* intrinsic unsigned long __get_BASEPRI( void );   (see intrinsic.h) */
+/* intrinsic void __set_BASEPRI( unsigned long );   (see intrinsic.h) */
+/* intrinsic unsigned long __get_FAULTMASK( void ); (see intrinsic.h) */
+/* intrinsic void __set_FAULTMASK(unsigned long);   (see intrinsic.h) */
+
+#endif /* (__CORTEX_M >= 0x03) */
+
+#if       (__CORTEX_M == 0x04)
+
+/** \brief  Get FPSCR
+
+    This function returns the current value of the Floating Point Status/Control register.
+
+    \return               Floating Point Status/Control register value
+ */
+static uint32_t
+__get_FPSCR(void)
+{
+#if (__FPU_PRESENT == 1)
+  __ASM("vmrs r0, fpscr");
+#else
+  return 0;
+#endif
+}
+/** \brief  Set FPSCR
+
+    This function assigns the given value to the Floating Point Status/Control register.
+
+    \param [in]    fpscr  Floating Point Status/Control value to set
+ */
+static void
+__set_FPSCR(uint32_t fpscr)
+{
+#if (__FPU_PRESENT == 1)
+  __ASM("vmsr fpscr, r0");
+#endif
+}
+#endif /* (__CORTEX_M == 0x04) */
+
+#pragma diag_default=Pe940
+
+#elif (defined(__GNUC__))  /*------------------ GNU Compiler ---------------------*/
+/* GNU gcc specific functions */
+
+/** \brief  Enable IRQ Interrupts
+
+   This function enables IRQ interrupts by clearing the I-bit in the CPSR.
+   Can only be executed in Privileged modes.
+ */
+__attribute__((always_inline)) static __INLINE void
+__enable_irq(void)
+{
+  __ASM volatile ("cpsie i");
+}
+/** \brief  Disable IRQ Interrupts
+
+   This function disables IRQ interrupts by setting the I-bit in the CPSR.
+   Can only be executed in Privileged modes.
+ */
+__attribute__((always_inline)) static __INLINE void
+__disable_irq(void)
+{
+  __ASM volatile ("cpsid i");
+}
+/** \brief  Get Control Register
+
+    This function returns the content of the Control Register.
+
+    \return               Control Register value
+ */
+__attribute__((always_inline)) static __INLINE uint32_t
+__get_CONTROL(void)
+{
+  uint32_t result;
+
+  __ASM volatile ("MRS %0, control" : "=r" (result));
+  return result;
+}
+/** \brief  Set Control Register
+
+    This function writes the given value to the Control Register.
+
+    \param [in]    control  Control Register value to set
+ */
+__attribute__((always_inline)) static __INLINE void
+__set_CONTROL(uint32_t control)
+{
+  __ASM volatile ("MSR control, %0" : : "r" (control));
+}
+/** \brief  Get ISPR Register
+
+    This function returns the content of the ISPR Register.
+
+    \return               ISPR Register value
+ */
+__attribute__((always_inline)) static __INLINE uint32_t
+__get_IPSR(void)
+{
+  uint32_t result;
+
+  __ASM volatile ("MRS %0, ipsr" : "=r" (result));
+  return result;
+}
+/** \brief  Get APSR Register
+
+    This function returns the content of the APSR Register.
+
+    \return               APSR Register value
+ */
+__attribute__((always_inline)) static __INLINE uint32_t
+__get_APSR(void)
+{
+  uint32_t result;
+
+  __ASM volatile ("MRS %0, apsr" : "=r" (result));
+  return result;
+}
+/** \brief  Get xPSR Register
+
+    This function returns the content of the xPSR Register.
+
+    \return               xPSR Register value
+ */
+__attribute__((always_inline)) static __INLINE uint32_t
+__get_xPSR(void)
+{
+  uint32_t result;
+
+  __ASM volatile ("MRS %0, xpsr" : "=r" (result));
+  return result;
+}
+/** \brief  Get Process Stack Pointer
+
+    This function returns the current value of the Process Stack Pointer (PSP).
+
+    \return               PSP Register value
+ */
+__attribute__((always_inline)) static __INLINE uint32_t
+__get_PSP(void)
+{
+  register uint32_t result;
+
+  __ASM volatile ("MRS %0, psp\n"  : "=r" (result));
+  return result;
+}
+/** \brief  Set Process Stack Pointer
+
+    This function assigns the given value to the Process Stack Pointer (PSP).
+
+    \param [in]    topOfProcStack  Process Stack Pointer value to set
+ */
+__attribute__((always_inline)) static __INLINE void
+__set_PSP(uint32_t topOfProcStack)
+{
+  __ASM volatile ("MSR psp, %0\n" : : "r" (topOfProcStack));
+}
+/** \brief  Get Main Stack Pointer
+
+    This function returns the current value of the Main Stack Pointer (MSP).
+
+    \return               MSP Register value
+ */
+__attribute__((always_inline)) static __INLINE uint32_t
+__get_MSP(void)
+{
+  register uint32_t result;
+
+  __ASM volatile ("MRS %0, msp\n" : "=r" (result));
+  return result;
+}
+/** \brief  Set Main Stack Pointer
+
+    This function assigns the given value to the Main Stack Pointer (MSP).
+
+    \param [in]    topOfMainStack  Main Stack Pointer value to set
+ */
+__attribute__((always_inline)) static __INLINE void
+__set_MSP(uint32_t topOfMainStack)
+{
+  __ASM volatile ("MSR msp, %0\n" : : "r" (topOfMainStack));
+}
+/** \brief  Get Priority Mask
+
+    This function returns the current state of the priority mask bit from the Priority Mask Register.
+
+    \return               Priority Mask value
+ */
+__attribute__((always_inline)) static __INLINE uint32_t
+__get_PRIMASK(void)
+{
+  uint32_t result;
+
+  __ASM volatile ("MRS %0, primask" : "=r" (result));
+  return result;
+}
+/** \brief  Set Priority Mask
+
+    This function assigns the given value to the Priority Mask Register.
+
+    \param [in]    priMask  Priority Mask
+ */
+__attribute__((always_inline)) static __INLINE void
+__set_PRIMASK(uint32_t priMask)
+{
+  __ASM volatile ("MSR primask, %0" : : "r" (priMask));
+}
+#if       (__CORTEX_M >= 0x03)
+
+/** \brief  Enable FIQ
+
+    This function enables FIQ interrupts by clearing the F-bit in the CPSR.
+    Can only be executed in Privileged modes.
+ */
+__attribute__((always_inline)) static __INLINE void
+__enable_fault_irq(void)
+{
+  __ASM volatile ("cpsie f");
+}
+/** \brief  Disable FIQ
+
+    This function disables FIQ interrupts by setting the F-bit in the CPSR.
+    Can only be executed in Privileged modes.
+ */
+__attribute__((always_inline)) static __INLINE void
+__disable_fault_irq(void)
+{
+  __ASM volatile ("cpsid f");
+}
+/** \brief  Get Base Priority
+
+    This function returns the current value of the Base Priority register.
+
+    \return               Base Priority register value
+ */
+__attribute__((always_inline)) static __INLINE uint32_t
+__get_BASEPRI(void)
+{
+  uint32_t result;
+
+  __ASM volatile ("MRS %0, basepri_max" : "=r" (result));
+  return result;
+}
+/** \brief  Set Base Priority
+
+    This function assigns the given value to the Base Priority register.
+
+    \param [in]    basePri  Base Priority value to set
+ */
+__attribute__((always_inline)) static __INLINE void
+__set_BASEPRI(uint32_t value)
+{
+  __ASM volatile ("MSR basepri, %0" : : "r" (value));
+}
+/** \brief  Get Fault Mask
+
+    This function returns the current value of the Fault Mask register.
+
+    \return               Fault Mask register value
+ */
+__attribute__((always_inline)) static __INLINE uint32_t
+__get_FAULTMASK(void)
+{
+  uint32_t result;
+
+  __ASM volatile ("MRS %0, faultmask" : "=r" (result));
+  return result;
+}
+/** \brief  Set Fault Mask
+
+    This function assigns the given value to the Fault Mask register.
+
+    \param [in]    faultMask  Fault Mask value to set
+ */
+__attribute__((always_inline)) static __INLINE void
+__set_FAULTMASK(uint32_t faultMask)
+{
+  __ASM volatile ("MSR faultmask, %0" : : "r" (faultMask));
+}
+#endif /* (__CORTEX_M >= 0x03) */
+
+#if       (__CORTEX_M == 0x04)
+
+/** \brief  Get FPSCR
+
+    This function returns the current value of the Floating Point Status/Control register.
+
+    \return               Floating Point Status/Control register value
+ */
+__attribute__((always_inline)) static __INLINE uint32_t
+__get_FPSCR(void)
+{
+#if (__FPU_PRESENT == 1)
+  uint32_t result;
+
+  __ASM volatile ("MRS %0, fpscr" : "=r" (result));
+  return result;
+#else
+  return 0;
+#endif
+}
+/** \brief  Set FPSCR
+
+    This function assigns the given value to the Floating Point Status/Control register.
+
+    \param [in]    fpscr  Floating Point Status/Control value to set
+ */
+__attribute__((always_inline)) static __INLINE void
+__set_FPSCR(uint32_t fpscr)
+{
+#if (__FPU_PRESENT == 1)
+  __ASM volatile ("MSR fpscr, %0" : : "r" (fpscr));
+#endif
+}
+#endif /* (__CORTEX_M == 0x04) */
+
+#elif (defined(__TASKING__))  /*--------------- TASKING Compiler -----------------*/
+/* TASKING carm specific functions */
+
+/*
+ * The CMSIS functions have been implemented as intrinsics in the compiler.
+ * Please use "carm -?i" to get an up to date list of all instrinsics,
+ * Including the CMSIS ones.
+ */
+
+#endif
+
+/*@} end of CMSIS_Core_RegAccFunctions */
+
+#endif /* __CORE_CMFUNC_H__ */

--- a/cpu/arm/lpc1768/core_cmInstr.h
+++ b/cpu/arm/lpc1768/core_cmInstr.h
@@ -1,0 +1,716 @@
+/**************************************************************************//**
+ * @file     core_cmInstr.h
+ * @brief    CMSIS Cortex-M Core Instruction Access Header File
+ * @version  V2.01
+ * @date     06. December 2010
+ *
+ * @note
+ * Copyright (C) 2009-2010 ARM Limited. All rights reserved.
+ *
+ * @par
+ * ARM Limited (ARM) is supplying this software for use with Cortex-M
+ * processor based microcontrollers.  This file can be freely distributed
+ * within development tools that are supporting such ARM based processors.
+ *
+ * @par
+ * THIS SOFTWARE IS PROVIDED "AS IS".  NO WARRANTIES, WHETHER EXPRESS, IMPLIED
+ * OR STATUTORY, INCLUDING, BUT NOT LIMITED TO, IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE APPLY TO THIS SOFTWARE.
+ * ARM SHALL NOT, IN ANY CIRCUMSTANCES, BE LIABLE FOR SPECIAL, INCIDENTAL, OR
+ * CONSEQUENTIAL DAMAGES, FOR ANY REASON WHATSOEVER.
+ *
+ ******************************************************************************/
+
+#ifndef __CORE_CMINSTR_H__
+#define __CORE_CMINSTR_H__
+
+/* ##########################  Core Instruction Access  ######################### */
+/** \ingroup  CMSIS
+   \addtogroup CMSIS_Core_InstructionInterface CMSIS Core Instruction Interface
+   Access to dedicated instructions
+   @{
+ */
+
+#if defined(__CC_ARM)      /*------------------ RealView Compiler ----------------*/
+/* ARM armcc specific functions */
+
+/** \brief  No Operation
+
+    No Operation does nothing. This instruction can be used for code alignment purposes.
+ */
+#define __NOP                             __nop
+
+/** \brief  Wait For Interrupt
+
+    Wait For Interrupt is a hint instruction that suspends execution
+    until one of a number of events occurs.
+ */
+#define __WFI                             __wfi
+
+/** \brief  Wait For Event
+
+    Wait For Event is a hint instruction that permits the processor to enter
+    a low-power state until one of a number of events occurs.
+ */
+#define __WFE                             __wfe
+
+/** \brief  Send Event
+
+    Send Event is a hint instruction. It causes an event to be signaled to the CPU.
+ */
+#define __SEV                             __sev
+
+/** \brief  Instruction Synchronization Barrier
+
+    Instruction Synchronization Barrier flushes the pipeline in the processor,
+    so that all instructions following the ISB are fetched from cache or
+    memory, after the instruction has been completed.
+ */
+#define __ISB()                           __isb(0xF)
+
+/** \brief  Data Synchronization Barrier
+
+    This function acts as a special kind of Data Memory Barrier.
+    It completes when all explicit memory accesses before this instruction complete.
+ */
+#define __DSB()                           __dsb(0xF)
+
+/** \brief  Data Memory Barrier
+
+    This function ensures the apparent order of the explicit memory operations before
+    and after the instruction, without ensuring their completion.
+ */
+#define __DMB()                           __dmb(0xF)
+
+/** \brief  Reverse byte order (32 bit)
+
+    This function reverses the byte order in integer value.
+
+    \param [in]    value  Value to reverse
+    \return               Reversed value
+ */
+#define __REV                             __rev
+
+/** \brief  Reverse byte order (16 bit)
+
+    This function reverses the byte order in two unsigned short values.
+
+    \param [in]    value  Value to reverse
+    \return               Reversed value
+ */
+#if (__ARMCC_VERSION < 400677)
+extern uint32_t __REV16(uint32_t value);
+#else /* (__ARMCC_VERSION >= 400677)  */
+static __INLINE __ASM uint32_t
+__REV16(uint32_t value)
+{
+  rev16 r0, r0
+  bx lr
+}
+#endif /* __ARMCC_VERSION  */
+
+/** \brief  Reverse byte order in signed short value
+
+    This function reverses the byte order in a signed short value with sign extension to integer.
+
+    \param [in]    value  Value to reverse
+    \return               Reversed value
+ */
+#if (__ARMCC_VERSION < 400677)
+extern int32_t __REVSH(int32_t value);
+#else /* (__ARMCC_VERSION >= 400677)  */
+static __INLINE __ASM int32_t
+__REVSH(int32_t value)
+{
+  revsh r0, r0
+  bx lr
+}
+#endif /* __ARMCC_VERSION  */
+
+#if       (__CORTEX_M >= 0x03)
+
+/** \brief  Reverse bit order of value
+
+    This function reverses the bit order of the given value.
+
+    \param [in]    value  Value to reverse
+    \return               Reversed value
+ */
+#define __RBIT                            __rbit
+
+/** \brief  LDR Exclusive (8 bit)
+
+    This function performs a exclusive LDR command for 8 bit value.
+
+    \param [in]    ptr  Pointer to data
+    \return             value of type uint8_t at (*ptr)
+ */
+#define __LDREXB(ptr)                     ((uint8_t)__ldrex(ptr))
+
+/** \brief  LDR Exclusive (16 bit)
+
+    This function performs a exclusive LDR command for 16 bit values.
+
+    \param [in]    ptr  Pointer to data
+    \return        value of type uint16_t at (*ptr)
+ */
+#define __LDREXH(ptr)                     ((uint16_t)__ldrex(ptr))
+
+/** \brief  LDR Exclusive (32 bit)
+
+    This function performs a exclusive LDR command for 32 bit values.
+
+    \param [in]    ptr  Pointer to data
+    \return        value of type uint32_t at (*ptr)
+ */
+#define __LDREXW(ptr)                     ((uint32_t)__ldrex(ptr))
+
+/** \brief  STR Exclusive (8 bit)
+
+    This function performs a exclusive STR command for 8 bit values.
+
+    \param [in]  value  Value to store
+    \param [in]    ptr  Pointer to location
+    \return          0  Function succeeded
+    \return          1  Function failed
+ */
+#define __STREXB(value, ptr)              __strex(value, ptr)
+
+/** \brief  STR Exclusive (16 bit)
+
+    This function performs a exclusive STR command for 16 bit values.
+
+    \param [in]  value  Value to store
+    \param [in]    ptr  Pointer to location
+    \return          0  Function succeeded
+    \return          1  Function failed
+ */
+#define __STREXH(value, ptr)              __strex(value, ptr)
+
+/** \brief  STR Exclusive (32 bit)
+
+    This function performs a exclusive STR command for 32 bit values.
+
+    \param [in]  value  Value to store
+    \param [in]    ptr  Pointer to location
+    \return          0  Function succeeded
+    \return          1  Function failed
+ */
+#define __STREXW(value, ptr)              __strex(value, ptr)
+
+/** \brief  Remove the exclusive lock
+
+    This function removes the exclusive lock which is created by LDREX.
+
+ */
+#if (__ARMCC_VERSION < 400000)
+extern void __CLREX(void);
+#else /* (__ARMCC_VERSION >= 400000)  */
+#define __CLREX                           __clrex
+#endif /* __ARMCC_VERSION  */
+
+/** \brief  Signed Saturate
+
+    This function saturates a signed value.
+
+    \param [in]  value  Value to be saturated
+    \param [in]    sat  Bit position to saturate to (1..32)
+    \return             Saturated value
+ */
+#define __SSAT                            __ssat
+
+/** \brief  Unsigned Saturate
+
+    This function saturates an unsigned value.
+
+    \param [in]  value  Value to be saturated
+    \param [in]    sat  Bit position to saturate to (0..31)
+    \return             Saturated value
+ */
+#define __USAT                            __usat
+
+/** \brief  Count leading zeros
+
+    This function counts the number of leading zeros of a data value.
+
+    \param [in]  value  Value to count the leading zeros
+    \return             number of leading zeros in value
+ */
+#define __CLZ                             __clz
+
+#endif /* (__CORTEX_M >= 0x03) */
+
+#elif (defined(__ICCARM__))  /*---------------- ICC Compiler ---------------------*/
+/* IAR iccarm specific functions */
+
+#include <intrinsics.h>                     /* IAR Intrinsics   */
+
+#pragma diag_suppress=Pe940
+
+/** \brief  No Operation
+
+    No Operation does nothing. This instruction can be used for code alignment purposes.
+ */
+#define __NOP                           __no_operation
+
+/** \brief  Wait For Interrupt
+
+    Wait For Interrupt is a hint instruction that suspends execution
+    until one of a number of events occurs.
+ */
+static __INLINE void
+__WFI(void)
+{
+  __ASM("wfi");
+}
+/** \brief  Wait For Event
+
+    Wait For Event is a hint instruction that permits the processor to enter
+    a low-power state until one of a number of events occurs.
+ */
+static __INLINE void
+__WFE(void)
+{
+  __ASM("wfe");
+}
+/** \brief  Send Event
+
+    Send Event is a hint instruction. It causes an event to be signaled to the CPU.
+ */
+static __INLINE void
+__SEV(void)
+{
+  __ASM("sev");
+}
+/* intrinsic     void __ISB(void)            (see intrinsics.h) */
+/* intrinsic     void __DSB(void)            (see intrinsics.h) */
+/* intrinsic     void __DMB(void)            (see intrinsics.h) */
+/* intrinsic uint32_t __REV(uint32_t value)  (see intrinsics.h) */
+/* intrinsic          __SSAT                 (see intrinsics.h) */
+/* intrinsic          __USAT                 (see intrinsics.h) */
+
+/** \brief  Reverse byte order (16 bit)
+
+    This function reverses the byte order in two unsigned short values.
+
+    \param [in]    value  Value to reverse
+    \return               Reversed value
+ */
+static uint32_t
+__REV16(uint32_t value)
+{
+  __ASM("rev16 r0, r0");
+}
+/* intrinsic uint32_t __REVSH(uint32_t value)  (see intrinsics.h */
+
+#if       (__CORTEX_M >= 0x03)
+
+/** \brief  Reverse bit order of value
+
+    This function reverses the bit order of the given value.
+
+    \param [in]    value  Value to reverse
+    \return               Reversed value
+ */
+static uint32_t
+__RBIT(uint32_t value)
+{
+  __ASM("rbit r0, r0");
+}
+/** \brief  LDR Exclusive (8 bit)
+
+    This function performs a exclusive LDR command for 8 bit value.
+
+    \param [in]    ptr  Pointer to data
+    \return             value of type uint8_t at (*ptr)
+ */
+static uint8_t
+__LDREXB(volatile uint8_t *addr)
+{
+  __ASM("ldrexb r0, [r0]");
+}
+/** \brief  LDR Exclusive (16 bit)
+
+    This function performs a exclusive LDR command for 16 bit values.
+
+    \param [in]    ptr  Pointer to data
+    \return        value of type uint16_t at (*ptr)
+ */
+static uint16_t
+__LDREXH(volatile uint16_t *addr)
+{
+  __ASM("ldrexh r0, [r0]");
+}
+/** \brief  LDR Exclusive (32 bit)
+
+    This function performs a exclusive LDR command for 32 bit values.
+
+    \param [in]    ptr  Pointer to data
+    \return        value of type uint32_t at (*ptr)
+ */
+/* intrinsic unsigned long __LDREX(unsigned long *)  (see intrinsics.h) */
+static uint32_t
+__LDREXW(volatile uint32_t *addr)
+{
+  __ASM("ldrex r0, [r0]");
+}
+/** \brief  STR Exclusive (8 bit)
+
+    This function performs a exclusive STR command for 8 bit values.
+
+    \param [in]  value  Value to store
+    \param [in]    ptr  Pointer to location
+    \return          0  Function succeeded
+    \return          1  Function failed
+ */
+static uint32_t
+__STREXB(uint8_t value, volatile uint8_t *addr)
+{
+  __ASM("strexb r0, r0, [r1]");
+}
+/** \brief  STR Exclusive (16 bit)
+
+    This function performs a exclusive STR command for 16 bit values.
+
+    \param [in]  value  Value to store
+    \param [in]    ptr  Pointer to location
+    \return          0  Function succeeded
+    \return          1  Function failed
+ */
+static uint32_t
+__STREXH(uint16_t value, volatile uint16_t *addr)
+{
+  __ASM("strexh r0, r0, [r1]");
+}
+/** \brief  STR Exclusive (32 bit)
+
+    This function performs a exclusive STR command for 32 bit values.
+
+    \param [in]  value  Value to store
+    \param [in]    ptr  Pointer to location
+    \return          0  Function succeeded
+    \return          1  Function failed
+ */
+/* intrinsic unsigned long __STREX(unsigned long, unsigned long)  (see intrinsics.h )*/
+static uint32_t
+__STREXW(uint32_t value, volatile uint32_t *addr)
+{
+  __ASM("strex r0, r0, [r1]");
+}
+/** \brief  Remove the exclusive lock
+
+    This function removes the exclusive lock which is created by LDREX.
+
+ */
+static __INLINE void
+__CLREX(void)
+{
+  __ASM("clrex");
+}
+/* intrinsic   unsigned char __CLZ( unsigned long )      (see intrinsics.h) */
+
+#endif /* (__CORTEX_M >= 0x03) */
+
+#pragma diag_default=Pe940
+
+#elif (defined(__GNUC__))  /*------------------ GNU Compiler ---------------------*/
+/* GNU gcc specific functions */
+
+/** \brief  No Operation
+
+    No Operation does nothing. This instruction can be used for code alignment purposes.
+ */
+__attribute__((always_inline)) static __INLINE void
+__NOP(void)
+{
+  __ASM volatile ("nop");
+}
+/** \brief  Wait For Interrupt
+
+    Wait For Interrupt is a hint instruction that suspends execution
+    until one of a number of events occurs.
+ */
+__attribute__((always_inline)) static __INLINE void
+__WFI(void)
+{
+  __ASM volatile ("wfi");
+}
+/** \brief  Wait For Event
+
+    Wait For Event is a hint instruction that permits the processor to enter
+    a low-power state until one of a number of events occurs.
+ */
+__attribute__((always_inline)) static __INLINE void
+__WFE(void)
+{
+  __ASM volatile ("wfe");
+}
+/** \brief  Send Event
+
+    Send Event is a hint instruction. It causes an event to be signaled to the CPU.
+ */
+__attribute__((always_inline)) static __INLINE void
+__SEV(void)
+{
+  __ASM volatile ("sev");
+}
+/** \brief  Instruction Synchronization Barrier
+
+    Instruction Synchronization Barrier flushes the pipeline in the processor,
+    so that all instructions following the ISB are fetched from cache or
+    memory, after the instruction has been completed.
+ */
+__attribute__((always_inline)) static __INLINE void
+__ISB(void)
+{
+  __ASM volatile ("isb");
+}
+/** \brief  Data Synchronization Barrier
+
+    This function acts as a special kind of Data Memory Barrier.
+    It completes when all explicit memory accesses before this instruction complete.
+ */
+__attribute__((always_inline)) static __INLINE void
+__DSB(void)
+{
+  __ASM volatile ("dsb");
+}
+/** \brief  Data Memory Barrier
+
+    This function ensures the apparent order of the explicit memory operations before
+    and after the instruction, without ensuring their completion.
+ */
+__attribute__((always_inline)) static __INLINE void
+__DMB(void)
+{
+  __ASM volatile ("dmb");
+}
+/** \brief  Reverse byte order (32 bit)
+
+    This function reverses the byte order in integer value.
+
+    \param [in]    value  Value to reverse
+    \return               Reversed value
+ */
+__attribute__((always_inline)) static __INLINE uint32_t
+__REV(uint32_t value)
+{
+  uint32_t result;
+
+  __ASM volatile ("rev %0, %1" : "=r" (result) : "r" (value));
+  return result;
+}
+/** \brief  Reverse byte order (16 bit)
+
+    This function reverses the byte order in two unsigned short values.
+
+    \param [in]    value  Value to reverse
+    \return               Reversed value
+ */
+__attribute__((always_inline)) static __INLINE uint32_t
+__REV16(uint32_t value)
+{
+  uint32_t result;
+
+  __ASM volatile ("rev16 %0, %1" : "=r" (result) : "r" (value));
+  return result;
+}
+/** \brief  Reverse byte order in signed short value
+
+    This function reverses the byte order in a signed short value with sign extension to integer.
+
+    \param [in]    value  Value to reverse
+    \return               Reversed value
+ */
+__attribute__((always_inline)) static __INLINE int32_t
+__REVSH(int32_t value)
+{
+  uint32_t result;
+
+  __ASM volatile ("revsh %0, %1" : "=r" (result) : "r" (value));
+  return result;
+}
+#if       (__CORTEX_M >= 0x03)
+
+/** \brief  Reverse bit order of value
+
+    This function reverses the bit order of the given value.
+
+    \param [in]    value  Value to reverse
+    \return               Reversed value
+ */
+__attribute__((always_inline)) static __INLINE uint32_t
+__RBIT(uint32_t value)
+{
+  uint32_t result;
+
+  __ASM volatile ("rbit %0, %1" : "=r" (result) : "r" (value));
+  return result;
+}
+/** \brief  LDR Exclusive (8 bit)
+
+    This function performs a exclusive LDR command for 8 bit value.
+
+    \param [in]    ptr  Pointer to data
+    \return             value of type uint8_t at (*ptr)
+ */
+__attribute__((always_inline)) static __INLINE uint8_t
+__LDREXB(volatile uint8_t *addr)
+{
+  uint8_t result;
+
+  __ASM volatile ("ldrexb %0, [%1]" : "=r" (result) : "r" (addr));
+  return result;
+}
+/** \brief  LDR Exclusive (16 bit)
+
+    This function performs a exclusive LDR command for 16 bit values.
+
+    \param [in]    ptr  Pointer to data
+    \return        value of type uint16_t at (*ptr)
+ */
+__attribute__((always_inline)) static __INLINE uint16_t
+__LDREXH(volatile uint16_t *addr)
+{
+  uint16_t result;
+
+  __ASM volatile ("ldrexh %0, [%1]" : "=r" (result) : "r" (addr));
+  return result;
+}
+/** \brief  LDR Exclusive (32 bit)
+
+    This function performs a exclusive LDR command for 32 bit values.
+
+    \param [in]    ptr  Pointer to data
+    \return        value of type uint32_t at (*ptr)
+ */
+__attribute__((always_inline)) static __INLINE uint32_t
+__LDREXW(volatile uint32_t *addr)
+{
+  uint32_t result;
+
+  __ASM volatile ("ldrex %0, [%1]" : "=r" (result) : "r" (addr));
+  return result;
+}
+/** \brief  STR Exclusive (8 bit)
+
+    This function performs a exclusive STR command for 8 bit values.
+
+    \param [in]  value  Value to store
+    \param [in]    ptr  Pointer to location
+    \return          0  Function succeeded
+    \return          1  Function failed
+ */
+__attribute__((always_inline)) static __INLINE uint32_t
+__STREXB(uint8_t value, volatile uint8_t *addr)
+{
+  uint32_t result;
+
+  __ASM volatile ("strexb %0, %2, [%1]" : "=r" (result) : "r" (addr), "r" (value));
+  return result;
+}
+/** \brief  STR Exclusive (16 bit)
+
+    This function performs a exclusive STR command for 16 bit values.
+
+    \param [in]  value  Value to store
+    \param [in]    ptr  Pointer to location
+    \return          0  Function succeeded
+    \return          1  Function failed
+ */
+__attribute__((always_inline)) static __INLINE uint32_t
+__STREXH(uint16_t value, volatile uint16_t *addr)
+{
+  uint32_t result;
+
+  __ASM volatile ("strexh %0, %2, [%1]" : "=r" (result) : "r" (addr), "r" (value));
+  return result;
+}
+/** \brief  STR Exclusive (32 bit)
+
+    This function performs a exclusive STR command for 32 bit values.
+
+    \param [in]  value  Value to store
+    \param [in]    ptr  Pointer to location
+    \return          0  Function succeeded
+    \return          1  Function failed
+ */
+__attribute__((always_inline)) static __INLINE uint32_t
+__STREXW(uint32_t value, volatile uint32_t *addr)
+{
+  uint32_t result;
+
+  __ASM volatile ("strex %0, %2, [%1]" : "=r" (result) : "r" (addr), "r" (value));
+  return result;
+}
+/** \brief  Remove the exclusive lock
+
+    This function removes the exclusive lock which is created by LDREX.
+
+ */
+__attribute__((always_inline)) static __INLINE void
+__CLREX(void)
+{
+  __ASM volatile ("clrex");
+}
+/** \brief  Signed Saturate
+
+    This function saturates a signed value.
+
+    \param [in]  value  Value to be saturated
+    \param [in]    sat  Bit position to saturate to (1..32)
+    \return             Saturated value
+ */
+#define __SSAT(ARG1, ARG2) \
+  ({ \
+     uint32_t __RES, __ARG1 = (ARG1); \
+     __ASM("ssat %0, %1, %2" : "=r" (__RES) :  "I" (ARG2), "r" (__ARG1)); \
+     __RES; \
+   })
+
+/** \brief  Unsigned Saturate
+
+    This function saturates an unsigned value.
+
+    \param [in]  value  Value to be saturated
+    \param [in]    sat  Bit position to saturate to (0..31)
+    \return             Saturated value
+ */
+#define __USAT(ARG1, ARG2) \
+  ({ \
+     uint32_t __RES, __ARG1 = (ARG1); \
+     __ASM("usat %0, %1, %2" : "=r" (__RES) :  "I" (ARG2), "r" (__ARG1)); \
+     __RES; \
+   })
+
+/** \brief  Count leading zeros
+
+    This function counts the number of leading zeros of a data value.
+
+    \param [in]  value  Value to count the leading zeros
+    \return             number of leading zeros in value
+ */
+__attribute__((always_inline)) static __INLINE uint8_t
+__CLZ(uint32_t value)
+{
+  uint8_t result;
+
+  __ASM volatile ("clz %0, %1" : "=r" (result) : "r" (value));
+  return result;
+}
+#endif /* (__CORTEX_M >= 0x03) */
+
+#elif (defined(__TASKING__))  /*--------------- TASKING Compiler -----------------*/
+/* TASKING carm specific functions */
+
+/*
+ * The CMSIS functions have been implemented as intrinsics in the compiler.
+ * Please use "carm -?i" to get an up to date list of all instrinsics,
+ * Including the CMSIS ones.
+ */
+
+#endif
+
+/*@}*/ /* end of group CMSIS_Core_InstructionInterface */
+
+#endif /* __CORE_CMINSTR_H__ */

--- a/cpu/arm/lpc1768/debug-uart.c
+++ b/cpu/arm/lpc1768/debug-uart.c
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2013, KTH, Royal Institute of Technology
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE UNIVERSITY AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ */
+
+#include "debug-uart.h"
+#include "debug_frmwrk.h"
+
+#define CR     0x0D
+
+void
+debug_uart_setup(void) /* Initialize Serial Interface       */
+{
+	debug_frmwrk_init();
+}

--- a/cpu/arm/lpc1768/debug-uart.h
+++ b/cpu/arm/lpc1768/debug-uart.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2013, KTH, Royal Institute of Technology
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE UNIVERSITY AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ */
+
+#ifndef DEBUG_UART_H_
+#define DEBUG_UART_H_
+
+/* Configures the UART defined in */
+/* contiki-conf.h as DEBUG_UART */
+void debug_uart_setup();
+
+#endif /* DEBUG_UART_H_ */

--- a/cpu/arm/lpc1768/debug_frmwrk.c
+++ b/cpu/arm/lpc1768/debug_frmwrk.c
@@ -1,0 +1,309 @@
+/**********************************************************************
+ * $Id$		debug_frmwrk.c				2010-05-21
+ *//**
+ * @file		debug_frmwrk.c
+ * @brief	Contains some utilities that used for debugging through UART
+ * @version	2.0
+ * @date		21. May. 2010
+ * @author	NXP MCU SW Application Team
+ *
+ * Copyright(C) 2010, NXP Semiconductor
+ * All rights reserved.
+ *
+ ***********************************************************************
+ * Software that is described herein is for illustrative purposes only
+ * which provides customers with programming information regarding the
+ * products. This software is supplied "AS IS" without any warranties.
+ * NXP Semiconductors assumes no responsibility or liability for the
+ * use of the software, conveys no license or title under any patent,
+ * copyright, or mask work right to the product. NXP Semiconductors
+ * reserves the right to make changes in the software without
+ * notification. NXP Semiconductors also make no representation or
+ * warranty that such application will be suitable for the specified
+ * use without further testing or modification.
+ **********************************************************************/
+
+#include "debug_frmwrk.h"
+#include "lpc17xx_pinsel.h"
+
+/* If this source file built with example, the LPC17xx FW library configuration
+ * file in each example directory ("lpc17xx_libcfg.h") must be included,
+ * otherwise the default FW library configuration file must be included instead
+ */
+#ifdef __BUILD_WITH_EXAMPLE__
+#include "lpc17xx_libcfg.h"
+#else
+#include "lpc17xx_libcfg_default.h"
+#endif /* __BUILD_WITH_EXAMPLE__ */
+
+#ifdef _DBGFWK
+/* Debug framework */
+
+void (*_db_msg)(LPC_UART_TypeDef *UARTx, const void *s);
+void (*_db_msg_)(LPC_UART_TypeDef *UARTx, const void *s);
+void (*_db_char)(LPC_UART_TypeDef *UARTx, uint8_t ch);
+void (*_db_dec)(LPC_UART_TypeDef *UARTx, uint8_t decn);
+void (*_db_dec_16)(LPC_UART_TypeDef *UARTx, uint16_t decn);
+void (*_db_dec_32)(LPC_UART_TypeDef *UARTx, uint32_t decn);
+void (*_db_hex)(LPC_UART_TypeDef *UARTx, uint8_t hexn);
+void (*_db_hex_16)(LPC_UART_TypeDef *UARTx, uint16_t hexn);
+void (*_db_hex_32)(LPC_UART_TypeDef *UARTx, uint32_t hexn);
+uint8_t (*_db_get_char)(LPC_UART_TypeDef *UARTx);
+
+/*********************************************************************//**
+ * @brief		Puts a character to UART port
+ * @param[in]	UARTx	Pointer to UART peripheral
+ * @param[in]	ch		Character to put
+ * @return		None
+ **********************************************************************/
+void
+UARTPutChar(LPC_UART_TypeDef *UARTx, uint8_t ch)
+{
+  UART_Send(UARTx, &ch, 1, BLOCKING);
+}
+/*********************************************************************//**
+ * @brief		Get a character to UART port
+ * @param[in]	UARTx	Pointer to UART peripheral
+ * @return		character value that returned
+ **********************************************************************/
+uint8_t
+UARTGetChar(LPC_UART_TypeDef *UARTx)
+{
+  uint8_t tmp = 0;
+  UART_Receive(UARTx, &tmp, 1, BLOCKING);
+  return tmp;
+}
+/*********************************************************************//**
+ * @brief		Puts a string to UART port
+ * @param[in]	UARTx   Pointer to UART peripheral
+ * @param[in]	str   string to put
+ * @return		None
+ **********************************************************************/
+void
+UARTPuts(LPC_UART_TypeDef *UARTx, const void *str)
+{
+  uint8_t *s = (uint8_t *)str;
+
+  while(*s) {
+    UARTPutChar(UARTx, *s++);
+  }
+}
+/*********************************************************************//**
+ * @brief		Puts a string to UART port and print new line
+ * @param[in]	UARTx	Pointer to UART peripheral
+ * @param[in]	str		String to put
+ * @return		None
+ **********************************************************************/
+void
+UARTPuts_(LPC_UART_TypeDef *UARTx, const void *str)
+{
+  UARTPuts(UARTx, str);
+  UARTPuts(UARTx, "\n\r");
+}
+/*********************************************************************//**
+ * @brief		Puts a decimal number to UART port
+ * @param[in]	UARTx	Pointer to UART peripheral
+ * @param[in]	decnum	Decimal number (8-bit long)
+ * @return		None
+ **********************************************************************/
+void
+UARTPutDec(LPC_UART_TypeDef *UARTx, uint8_t decnum)
+{
+  uint8_t c1 = decnum % 10;
+  uint8_t c2 = (decnum / 10) % 10;
+  uint8_t c3 = (decnum / 100) % 10;
+  UARTPutChar(UARTx, '0' + c3);
+  UARTPutChar(UARTx, '0' + c2);
+  UARTPutChar(UARTx, '0' + c1);
+}
+/*********************************************************************//**
+ * @brief		Puts a decimal number to UART port
+ * @param[in]	UARTx	Pointer to UART peripheral
+ * @param[in]	decnum	Decimal number (8-bit long)
+ * @return		None
+ **********************************************************************/
+void
+UARTPutDec16(LPC_UART_TypeDef *UARTx, uint16_t decnum)
+{
+  uint8_t c1 = decnum % 10;
+  uint8_t c2 = (decnum / 10) % 10;
+  uint8_t c3 = (decnum / 100) % 10;
+  uint8_t c4 = (decnum / 1000) % 10;
+  uint8_t c5 = (decnum / 10000) % 10;
+  UARTPutChar(UARTx, '0' + c5);
+  UARTPutChar(UARTx, '0' + c4);
+  UARTPutChar(UARTx, '0' + c3);
+  UARTPutChar(UARTx, '0' + c2);
+  UARTPutChar(UARTx, '0' + c1);
+}
+/*********************************************************************//**
+ * @brief		Puts a decimal number to UART port
+ * @param[in]	UARTx	Pointer to UART peripheral
+ * @param[in]	decnum	Decimal number (8-bit long)
+ * @return		None
+ **********************************************************************/
+void
+UARTPutDec32(LPC_UART_TypeDef *UARTx, uint32_t decnum)
+{
+  uint8_t c1 = decnum % 10;
+  uint8_t c2 = (decnum / 10) % 10;
+  uint8_t c3 = (decnum / 100) % 10;
+  uint8_t c4 = (decnum / 1000) % 10;
+  uint8_t c5 = (decnum / 10000) % 10;
+  uint8_t c6 = (decnum / 100000) % 10;
+  uint8_t c7 = (decnum / 1000000) % 10;
+  uint8_t c8 = (decnum / 10000000) % 10;
+  uint8_t c9 = (decnum / 100000000) % 10;
+  uint8_t c10 = (decnum / 1000000000) % 10;
+  UARTPutChar(UARTx, '0' + c10);
+  UARTPutChar(UARTx, '0' + c9);
+  UARTPutChar(UARTx, '0' + c8);
+  UARTPutChar(UARTx, '0' + c7);
+  UARTPutChar(UARTx, '0' + c6);
+  UARTPutChar(UARTx, '0' + c5);
+  UARTPutChar(UARTx, '0' + c4);
+  UARTPutChar(UARTx, '0' + c3);
+  UARTPutChar(UARTx, '0' + c2);
+  UARTPutChar(UARTx, '0' + c1);
+}
+/*********************************************************************//**
+ * @brief		Puts a hex number to UART port
+ * @param[in]	UARTx	Pointer to UART peripheral
+ * @param[in]	hexnum	Hex number (8-bit long)
+ * @return		None
+ **********************************************************************/
+void
+UARTPutHex(LPC_UART_TypeDef *UARTx, uint8_t hexnum)
+{
+  uint8_t nibble, i;
+
+  UARTPuts(UARTx, "0x");
+  i = 1;
+  do {
+    nibble = (hexnum >> (4 * i)) & 0x0F;
+    UARTPutChar(UARTx, (nibble > 9) ? ('A' + nibble - 10) : ('0' + nibble));
+  } while(i--);
+}
+/*********************************************************************//**
+ * @brief		Puts a hex number to UART port
+ * @param[in]	UARTx	Pointer to UART peripheral
+ * @param[in]	hexnum	Hex number (16-bit long)
+ * @return		None
+ **********************************************************************/
+void
+UARTPutHex16(LPC_UART_TypeDef *UARTx, uint16_t hexnum)
+{
+  uint8_t nibble, i;
+
+  UARTPuts(UARTx, "0x");
+  i = 3;
+  do {
+    nibble = (hexnum >> (4 * i)) & 0x0F;
+    UARTPutChar(UARTx, (nibble > 9) ? ('A' + nibble - 10) : ('0' + nibble));
+  } while(i--);
+}
+/*********************************************************************//**
+ * @brief		Puts a hex number to UART port
+ * @param[in]	UARTx	Pointer to UART peripheral
+ * @param[in]	hexnum	Hex number (32-bit long)
+ * @return		None
+ **********************************************************************/
+void
+UARTPutHex32(LPC_UART_TypeDef *UARTx, uint32_t hexnum)
+{
+  uint8_t nibble, i;
+
+  UARTPuts(UARTx, "0x");
+  i = 7;
+  do {
+    nibble = (hexnum >> (4 * i)) & 0x0F;
+    UARTPutChar(UARTx, (nibble > 9) ? ('A' + nibble - 10) : ('0' + nibble));
+  } while(i--);
+}
+/* / ********************************************************************* // ** */
+/* * @brief		print function that supports format as same as printf() */
+/* *        function of <stdio.h> library */
+/* * @param[in]	None */
+/* * @return		None */
+/* ********************************************************************** / */
+/* void  _printf (const  char *format, ...) */
+/* { */
+/*    static  char  buffer[512 + 1]; */
+/*            va_list     vArgs; */
+/*            char	*tmp; */
+/*    va_start(vArgs, format); */
+/*    vsprintf((char *)buffer, (char const *)format, vArgs); */
+/*    va_end(vArgs); */
+/* */
+/*    _DBG(buffer); */
+/* } */
+
+/*********************************************************************//**
+ * @brief		Initialize Debug frame work through initializing UART port
+ * @param[in]	None
+ * @return		None
+ **********************************************************************/
+void
+debug_frmwrk_init(void)
+{
+  UART_CFG_Type UARTConfigStruct;
+  PINSEL_CFG_Type PinCfg;
+
+#if (USED_UART_DEBUG_PORT == 0)
+  /*
+   * Initialize UART0 pin connect
+   */
+  PinCfg.Funcnum = 1;
+  PinCfg.OpenDrain = 0;
+  PinCfg.Pinmode = 0;
+  PinCfg.Pinnum = 2;
+  PinCfg.Portnum = 0;
+  PINSEL_ConfigPin(&PinCfg);
+  PinCfg.Pinnum = 3;
+  PINSEL_ConfigPin(&PinCfg);
+
+#elif (USED_UART_DEBUG_PORT == 1)
+  /*
+   * Initialize UART1 pin connect
+   */
+  PinCfg.Funcnum = 1;
+  PinCfg.OpenDrain = 0;
+  PinCfg.Pinmode = 0;
+  PinCfg.Pinnum = 15;
+  PinCfg.Portnum = 0;
+  PINSEL_ConfigPin(&PinCfg);
+  PinCfg.Pinnum = 16;
+  PINSEL_ConfigPin(&PinCfg);
+#endif
+
+  /* Initialize UART Configuration parameter structure to default state:
+   * Baudrate = 9600bps
+   * 8 data bit
+   * 1 Stop bit
+   * None parity
+   */
+  UART_ConfigStructInit(&UARTConfigStruct);
+
+  /* Re-configure baudrate to 115200bps */
+  UARTConfigStruct.Baud_rate = 115200;
+
+  /* Initialize DEBUG_UART_PORT peripheral with given to corresponding parameter */
+  UART_Init(DEBUG_UART_PORT, &UARTConfigStruct);
+
+  /* Enable UART Transmit */
+  UART_TxCmd(DEBUG_UART_PORT, ENABLE);
+
+  _db_msg = UARTPuts;
+  _db_msg_ = UARTPuts_;
+  _db_char = UARTPutChar;
+  _db_hex = UARTPutHex;
+  _db_hex_16 = UARTPutHex16;
+  _db_hex_32 = UARTPutHex32;
+  _db_dec = UARTPutDec;
+  _db_dec_16 = UARTPutDec16;
+  _db_dec_32 = UARTPutDec32;
+  _db_get_char = UARTGetChar;
+}
+#endif /*_DBGFWK */
+
+/* --------------------------------- End Of File ------------------------------ */

--- a/cpu/arm/lpc1768/debug_frmwrk.h
+++ b/cpu/arm/lpc1768/debug_frmwrk.h
@@ -1,0 +1,74 @@
+/**********************************************************************
+ * $Id$		debug_frmwrk.h		2010-05-21
+ *//**
+ * @file		debug_frmwrk.h
+ * @brief	Contains some utilities that used for debugging through UART
+ * @version	2.0
+ * @date		21. May. 2010
+ * @author	NXP MCU SW Application Team
+ *
+ * Copyright(C) 2010, NXP Semiconductor
+ * All rights reserved.
+ *
+ ***********************************************************************
+ * Software that is described herein is for illustrative purposes only
+ * which provides customers with programming information regarding the
+ * products. This software is supplied "AS IS" without any warranties.
+ * NXP Semiconductors assumes no responsibility or liability for the
+ * use of the software, conveys no license or title under any patent,
+ * copyright, or mask work right to the product. NXP Semiconductors
+ * reserves the right to make changes in the software without
+ * notification. NXP Semiconductors also make no representation or
+ * warranty that such application will be suitable for the specified
+ * use without further testing or modification.
+ **********************************************************************/
+#ifndef DEBUG_FRMWRK_H_
+#define DEBUG_FRMWRK_H_
+
+/* #include <stdarg.h> */
+#include "lpc17xx_uart.h"
+
+#define USED_UART_DEBUG_PORT  0
+
+#if (USED_UART_DEBUG_PORT == 0)
+#define DEBUG_UART_PORT LPC_UART0
+#elif (USED_UART_DEBUG_PORT == 1)
+#define DEBUG_UART_PORT LPC_UART1
+#endif
+
+#define _DBG(x)   _db_msg(DEBUG_UART_PORT, x)
+#define _DBG_(x)  _db_msg_(DEBUG_UART_PORT, x)
+#define _DBC(x)   _db_char(DEBUG_UART_PORT, x)
+#define _DBD(x)   _db_dec(DEBUG_UART_PORT, x)
+#define _DBD16(x)  _db_dec_16(DEBUG_UART_PORT, x)
+#define _DBD32(x)  _db_dec_32(DEBUG_UART_PORT, x)
+#define _DBH(x)   _db_hex(DEBUG_UART_PORT, x)
+#define _DBH16(x)  _db_hex_16(DEBUG_UART_PORT, x)
+#define _DBH32(x)  _db_hex_32(DEBUG_UART_PORT, x)
+#define _DG     _db_get_char(DEBUG_UART_PORT)
+/* void  _printf (const  char *format, ...); */
+
+extern void (*_db_msg)(LPC_UART_TypeDef *UARTx, const void *s);
+extern void (*_db_msg_)(LPC_UART_TypeDef *UARTx, const void *s);
+extern void (*_db_char)(LPC_UART_TypeDef *UARTx, uint8_t ch);
+extern void (*_db_dec)(LPC_UART_TypeDef *UARTx, uint8_t decn);
+extern void (*_db_dec_16)(LPC_UART_TypeDef *UARTx, uint16_t decn);
+extern void (*_db_dec_32)(LPC_UART_TypeDef *UARTx, uint32_t decn);
+extern void (*_db_hex)(LPC_UART_TypeDef *UARTx, uint8_t hexn);
+extern void (*_db_hex_16)(LPC_UART_TypeDef *UARTx, uint16_t hexn);
+extern void (*_db_hex_32)(LPC_UART_TypeDef *UARTx, uint32_t hexn);
+extern uint8_t (*_db_get_char)(LPC_UART_TypeDef *UARTx);
+
+void UARTPutChar(LPC_UART_TypeDef *UARTx, uint8_t ch);
+void UARTPuts(LPC_UART_TypeDef *UARTx, const void *str);
+void UARTPuts_(LPC_UART_TypeDef *UARTx, const void *str);
+void UARTPutDec(LPC_UART_TypeDef *UARTx, uint8_t decnum);
+void UARTPutDec16(LPC_UART_TypeDef *UARTx, uint16_t decnum);
+void UARTPutDec32(LPC_UART_TypeDef *UARTx, uint32_t decnum);
+void UARTPutHex(LPC_UART_TypeDef *UARTx, uint8_t hexnum);
+void UARTPutHex16(LPC_UART_TypeDef *UARTx, uint16_t hexnum);
+void UARTPutHex32(LPC_UART_TypeDef *UARTx, uint32_t hexnum);
+uint8_t UARTGetChar(LPC_UART_TypeDef *UARTx);
+void debug_frmwrk_init(void);
+
+#endif /* DEBUG_FRMWRK_H_ */

--- a/cpu/arm/lpc1768/emac-driver.c
+++ b/cpu/arm/lpc1768/emac-driver.c
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) 2013, KTH, Royal Institute of Technology
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE UNIVERSITY AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ */
+
+#include "emac-driver.h"
+#include "emac.h"
+
+#define BUF ((struct uip_eth_hdr *)&uip_buf[0])
+#define IPBUF ((struct uip_tcpip_hdr *)&uip_buf[UIP_LLH_LEN])
+
+PROCESS(emac_lpc1768, "LPC1768 EMAC Service Process");
+
+static struct etimer timer;  /* for periodic ARP processing */
+
+static void
+pollhandler(void)
+{
+
+  uip_len = tapdev_read(uip_buf);
+
+  if(uip_len > 0) {
+#if UIP_CONF_IPV6
+    if(BUF->type == uip_htons(UIP_ETHTYPE_IPV6)) {
+      tcpip_input();
+    }
+#else
+    if(BUF->type == UIP_HTONS(UIP_ETHTYPE_IP)) {
+      uip_arp_ipin();
+      uip_input();
+
+      if(uip_len > 0) {
+        uip_arp_out();
+        tapdev_send(uip_buf, uip_len);
+      }
+    } else if(BUF->type == UIP_HTONS(UIP_ETHTYPE_ARP)) {
+      uip_arp_arpin();
+      if(uip_len > 0) {
+        tapdev_send(uip_buf, uip_len);
+      }
+    }
+#endif
+    /* If we don't know how to process it, just discard the packet */
+    else {
+      uip_len = 0;
+    }
+  }
+}
+#if UIP_CONF_IPV6
+uint8_t
+send_packet(uip_lladdr_t *lladdr)
+#else
+uint8_t
+send_packet(void)
+#endif
+{
+#if UIP_CONF_IPV6
+  /*
+   * If L3 dest is multicast, build L2 multicast address
+   * as per RFC 2464 section 7
+   * else fill with th eaddrsess in argument
+   */
+  if(lladdr == NULL) {
+    /* the dest must be multicast */
+    (&BUF->dest)->addr[0] = 0x33;
+    (&BUF->dest)->addr[1] = 0x33;
+    (&BUF->dest)->addr[2] = IPBUF->destipaddr.u8[12];
+    (&BUF->dest)->addr[3] = IPBUF->destipaddr.u8[13];
+    (&BUF->dest)->addr[4] = IPBUF->destipaddr.u8[14];
+    (&BUF->dest)->addr[5] = IPBUF->destipaddr.u8[15];
+  } else {
+    memcpy(&BUF->dest, lladdr, UIP_LLADDR_LEN);
+  } memcpy(&BUF->src, &uip_lladdr, UIP_LLADDR_LEN);
+  BUF->type = UIP_HTONS(UIP_ETHTYPE_IPV6);  /* math tmp */
+
+  uip_len += sizeof(struct uip_eth_hdr);
+
+#else
+  uip_arp_out();
+#endif
+
+  tapdev_send(uip_buf, uip_len);
+}
+/* This is just a wrapper for the Ethernet module interrupt */
+/* to call a contiki process_poll function */
+void
+poll_eth_driver(void)
+{
+  process_poll(&emac_lpc1768);
+}
+PROCESS_THREAD(emac_lpc1768, ev, data)
+{
+
+  PROCESS_POLLHANDLER(pollhandler());
+
+  PROCESS_BEGIN()
+  ;
+
+  tapdev_init();
+
+  tcpip_set_outputfunc(send_packet);
+
+  process_poll(&emac_lpc1768);
+
+#if UIP_CONF_IPV6
+  PROCESS_WAIT_UNTIL(ev == PROCESS_EVENT_EXIT);
+
+#else
+  /* 10 second ARP timer */
+  etimer_set(&timer, 10 * CLOCK_SECOND);
+
+  while(ev != PROCESS_EVENT_EXIT) {
+    PROCESS_WAIT_EVENT()
+    ;
+
+    if(ev == PROCESS_EVENT_TIMER) {
+      etimer_set(&timer, 10 * CLOCK_SECOND);
+      uip_arp_timer();
+    }
+  }
+#endif
+
+  PROCESS_END();
+}
+/*---------------------------------------------------------------------------*/
+

--- a/cpu/arm/lpc1768/emac-driver.h
+++ b/cpu/arm/lpc1768/emac-driver.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2013, KTH, Royal Institute of Technology
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE UNIVERSITY AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ */
+
+#ifndef EMAC_DRIVER_H_
+#define EMAC_DRIVER_H_
+
+#include "contiki-net.h"
+#include "contiki-conf.h"
+
+PROCESS_NAME(emac_lpc1768);
+
+/* This is just a wrapper for the Ethernet module interrupt */
+/* to call a contiki poll_process */
+void
+poll_eth_driver(void);
+
+#if UIP_CONF_IPV6
+uint8_t
+send_packet(uip_lladdr_t *lladdr);
+#else
+uint8_t
+send_packet(void);
+#endif
+
+#endif /* EMAC_DRIVER_H_ */

--- a/cpu/arm/lpc1768/emac.c
+++ b/cpu/arm/lpc1768/emac.c
@@ -1,0 +1,207 @@
+/*
+ * Copyright (c) 2013, KTH, Royal Institute of Technology
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE UNIVERSITY AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ */
+
+#include "emac.h"
+#include "emac-driver.h"
+#include "lpc17xx_emac.h"
+#include "lpc17xx_pinsel.h"
+#include <stdio.h>
+
+/* Example group ----------------------------------------------------------- */
+/** @defgroup EMAC_uIP	uIP
+ * @ingroup EMAC_Examples
+ * @{
+ */
+
+#define DB  _DBG((uint8_t *)db)
+char db[64];
+
+/* Init the LPC17xx ethernet */
+BOOL_8
+tapdev_init(void)
+{
+  /* EMAC configuration type */
+  EMAC_CFG_Type emac_config;
+  /* pin configuration */
+  PINSEL_CFG_Type pincfg;
+  /* EMAC address */
+  uint8_t emac_addr[] =
+  { EMAC_ADDR0, EMAC_ADDR1, EMAC_ADDR2, EMAC_ADDR3, EMAC_ADDR4, EMAC_ADDR5 };
+
+#if AUTO_NEGOTIATION_ENA != 0
+  emac_config.Mode = EMAC_MODE_AUTO;
+#else
+#if (FIX_SPEED == SPEED_100)
+#if (FIX_DUPLEX == FULL_DUPLEX)
+  emac_config.Mode = EMAC_MODE_100M_FULL;
+#elif (FIX_DUPLEX == HALF_DUPLEX)
+  emac_config.Mode = EMAC_MODE_100M_HALF;
+#else
+#error Does not support this duplex option
+#endif
+#elif (FIX_SPEED == SPEED_10)
+#if (FIX_DUPLEX == FULL_DUPLEX)
+  emac_config.Mode = EMAC_MODE_10M_FULL;
+#elif (FIX_DUPLEX == HALF_DUPLEX)
+  emac_config.Mode = EMAC_MODE_10M_HALF;
+#else
+#error Does not support this duplex option
+#endif
+#else
+#error Does not support this speed option
+#endif
+#endif
+
+  /*
+   * Enable P1 Ethernet Pins:
+   * P1.0 - ENET_TXD0
+   * P1.1 - ENET_TXD1
+   * P1.4 - ENET_TX_EN
+   * P1.8 - ENET_CRS
+   * P1.9 - ENET_RXD0
+   * P1.10 - ENET_RXD1
+   * P1.14 - ENET_RX_ER
+   * P1.15 - ENET_REF_CLK
+   * P1.16 - ENET_MDC
+   * P1.17 - ENET_MDIO
+   */
+  pincfg.Funcnum = 1;
+  pincfg.OpenDrain = 0;
+  pincfg.Pinmode = 0;
+  pincfg.Portnum = 1;
+
+  pincfg.Pinnum = 0;
+  PINSEL_ConfigPin(&pincfg);
+  pincfg.Pinnum = 1;
+  PINSEL_ConfigPin(&pincfg);
+  pincfg.Pinnum = 4;
+  PINSEL_ConfigPin(&pincfg);
+  pincfg.Pinnum = 8;
+  PINSEL_ConfigPin(&pincfg);
+  pincfg.Pinnum = 9;
+  PINSEL_ConfigPin(&pincfg);
+  pincfg.Pinnum = 10;
+  PINSEL_ConfigPin(&pincfg);
+  pincfg.Pinnum = 14;
+  PINSEL_ConfigPin(&pincfg);
+  pincfg.Pinnum = 15;
+  PINSEL_ConfigPin(&pincfg);
+  pincfg.Pinnum = 16;
+  PINSEL_ConfigPin(&pincfg);
+  pincfg.Pinnum = 17;
+  PINSEL_ConfigPin(&pincfg);
+
+  /* printf("Init EMAC module\n"); */
+  /* printf("MAC addr: %X-%X-%X-%X-%X-%X \n", emac_addr[0], emac_addr[1], */
+  /*    emac_addr[2], emac_addr[3], emac_addr[4], emac_addr[5]); */
+
+  emac_config.Mode = EMAC_MODE_AUTO;
+  emac_config.pbEMAC_Addr = emac_addr;
+  /* Initialize EMAC module with given parameter */
+  if(EMAC_Init(&emac_config) == ERROR) {
+    return FALSE;
+    /* Disable the TX_DONE interrupt enabled by EMAC_Init */
+  }
+  EMAC_IntCmd(EMAC_INT_TX_DONE, DISABLE);
+  /* Set interrupt priority to 1, the second-highest */
+  NVIC_SetPriority(ENET_IRQn, 1);
+  /* Enable the ENET interruption */
+  NVIC_EnableIRQ(ENET_IRQn);
+
+  /* printf("Init EMAC complete\n"); */
+
+  return TRUE;
+}
+/* receive an Ethernet frame from MAC/DMA controller */
+UNS_32
+tapdev_read(void *packet_ptr)
+{
+  UNS_32 packet_size = EMAC_MAX_PACKET_SIZE;
+  UNS_32 in_size;
+  EMAC_PACKETBUF_Type packet_rx;
+
+  /* Check Receive status */
+  if(EMAC_CheckReceiveIndex() == FALSE) {
+    return 0;
+  }
+  /* Get size of receive data */
+  in_size = EMAC_GetReceiveDataSize() + 1;
+
+  packet_size = MIN(packet_size, in_size);
+
+  /* Setup Rx packet */
+  packet_rx.pbDataBuf = (uint32_t *)packet_ptr;
+  packet_rx.ulDataLen = packet_size;
+  EMAC_ReadPacketBuffer(&packet_rx);
+
+  /* update receive status */
+  EMAC_UpdateRxConsumeIndex();
+  return packet_size;
+}
+/* transmit an Ethernet frame to MAC/DMA controller */
+BOOL_8
+tapdev_send(void *packet_ptr, UNS_32 size)
+{
+  EMAC_PACKETBUF_Type packet_tx;
+
+  /* Check size */
+  if(size == 0) {
+    return TRUE;
+  }
+  /* check Tx Slot is available */
+  if(EMAC_CheckTransmitIndex() == FALSE) {
+    return FALSE;
+  }
+  size = MIN(size, EMAC_MAX_PACKET_SIZE);
+
+  /* Setup Tx Packet buffer */
+  packet_tx.ulDataLen = size;
+  packet_tx.pbDataBuf = (uint32_t *)packet_ptr;
+  EMAC_WritePacketBuffer(&packet_tx);
+  EMAC_UpdateTxProduceIndex();
+
+  return TRUE;
+}
+/* Interrupt function for the Ethernet module */
+/* We only enable the RX_DONE interrupt */
+void
+ENET_IRQHandler(void)
+{
+  /* Check which interrupt source brought us here and clear the flag */
+  /* If a packet arrived, we inform the Ethernet driver */
+
+  /* Receive Done */
+  if(EMAC_IntGetStatus(EMAC_INT_RX_DONE)) {
+    poll_eth_driver();
+  }
+}
+/*
+ * @}
+ */

--- a/cpu/arm/lpc1768/emac.h
+++ b/cpu/arm/lpc1768/emac.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2013, KTH, Royal Institute of Technology
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE UNIVERSITY AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ */
+
+#ifndef __EMAC_H
+#define __EMAC_H
+
+#include "lpc_types.h"
+#include "lpc17xx_emac.h"
+#include "contiki-conf.h"
+
+#define EMAC_MAX_PACKET_SIZE (UIP_CONF_BUFFER_SIZE + 16)  /* 1536 bytes */
+#define ENET_DMA_DESC_NUMB    3
+#define AUTO_NEGOTIATION_ENA  1     /* Enable PHY Auto-negotiation */
+#define PHY_TO                200000  /* ~10sec */
+#define RMII                    1   /* If zero, it's a MII interface */
+
+/* Configurable macro ---------------------- */
+#define SPEED_100               1
+#define SPEED_10                0
+#define FULL_DUPLEX             1
+#define HALF_DUPLEX             0
+
+#define FIX_SPEED               SPEED_100
+#define FIX_DUPLEX              FULL_DUPLEX
+
+BOOL_8
+tapdev_init(void);
+UNS_32
+tapdev_read(void *pPacket);
+BOOL_8
+tapdev_send(void *pPacket, UNS_32 size);
+
+#endif

--- a/cpu/arm/lpc1768/lpc1768.h
+++ b/cpu/arm/lpc1768/lpc1768.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2013, KTH, Royal Institute of Technology
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE UNIVERSITY AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ */
+
+#ifndef LPC1768_H_
+#define LPC1768_H_
+
+/* WARNING: Non-aligned structure copy causes a lot */
+/* of problems, that's why we need this define to get */
+/* around the issue. For an explanation, see: */
+/* http://devl.org/pipermail/mc1322x/2009-November/000105.html */
+#define uip_ipaddr_copy(dest, src) \
+  memcpy(dest, src, sizeof(*dest))
+
+#endif /* LPC1768_H_ */

--- a/cpu/arm/lpc1768/lpc1768.ld
+++ b/cpu/arm/lpc1768/lpc1768.ld
@@ -1,0 +1,119 @@
+MEMORY
+{
+  CODE (rx) : ORIGIN = 0x00000000, LENGTH = 512K
+  DATA (xrw) : ORIGIN = 0x10000000, LENGTH = 32K
+}
+
+/* Section Definitions */
+
+SECTIONS
+{
+
+/* Make sure the vector table is at address 0 */
+
+.vectrom :
+{
+	KEEP(*(.isr_vector))
+} >CODE =0
+
+.text :
+{
+	KEEP(*(.init))
+	*(.text .text.*)
+	KEEP(*(.fini))
+} >CODE
+
+. = ALIGN(4);
+
+.rodata :
+  {
+   	*(.rodata .rodata.*)
+	*(.gnu.linkonce.r.*)
+  } >CODE
+
+  _etext = . ;
+  PROVIDE (etext = .);
+   
+  .data :
+  {
+    _data = . ;
+    *(.data)
+    _edata = . ;
+    PROVIDE (edata = .);
+  } >DATA AT >CODE
+  . = ALIGN(4);
+
+
+/* .bss section which is used for uninitialized data */
+
+  .bss :
+  {
+    __bss_start = . ;
+    __bss_start__ = . ;
+    *(.bss)
+    *(COMMON)
+    __bss_end = . ;	
+    __bss_end__ = . ;
+    *(.noinit)
+  } >DATA
+  . = ALIGN(4);
+  
+   _end = .;
+  PROVIDE (end = .);
+
+Main_Stack_Size = 0x00000200;
+Process_Stack_Size = 0x00000200;
+
+Stack_Size = Main_Stack_Size + Process_Stack_Size;
+  .stack ORIGIN(DATA) + LENGTH(DATA) - Stack_Size : 
+  {
+    __stack_start__ = . ;
+    Main_Stack_Start = . ;
+    . += Main_Stack_Size;
+    Main_Stack_End = . ;	
+    Process_Stack_Start = . ;
+    . += Process_Stack_Size;
+    Process_Stack_End = . ;	
+    . = ALIGN(4);
+    __stack_end__ = . ;
+    Top_Stack = .;
+  } >DATA
+
+__heap_start__ = __bss_end__ ;
+__heap_end__ = __stack_start__ ;
+
+
+  /* Stabs debugging sections.  */
+  .stab          0 : { *(.stab) }
+  .stabstr       0 : { *(.stabstr) }
+  .stab.excl     0 : { *(.stab.excl) }
+  .stab.exclstr  0 : { *(.stab.exclstr) }
+  .stab.index    0 : { *(.stab.index) }
+  .stab.indexstr 0 : { *(.stab.indexstr) }
+  .comment       0 : { *(.comment) }
+  /* DWARF debug sections.
+     Symbols in the DWARF debugging sections are relative to the beginning
+     of the section so we begin them at 0.  */
+  /* DWARF 1 */
+  .debug          0 : { *(.debug) }
+  .line           0 : { *(.line) }
+  /* GNU DWARF 1 extensions */
+  .debug_srcinfo  0 : { *(.debug_srcinfo) }
+  .debug_sfnames  0 : { *(.debug_sfnames) }
+  /* DWARF 1.1 and DWARF 2 */
+  .debug_aranges  0 : { *(.debug_aranges) }
+  .debug_pubnames 0 : { *(.debug_pubnames) }
+  /* DWARF 2 */
+  .debug_info     0 : { *(.debug_info .gnu.linkonce.wi.*) }
+  .debug_abbrev   0 : { *(.debug_abbrev) }
+  .debug_line     0 : { *(.debug_line) }
+  .debug_frame    0 : { *(.debug_frame) }
+  .debug_str      0 : { *(.debug_str) }
+  .debug_loc      0 : { *(.debug_loc) }
+  .debug_macinfo  0 : { *(.debug_macinfo) }
+  /* SGI/MIPS DWARF 2 extensions */
+  .debug_weaknames 0 : { *(.debug_weaknames) }
+  .debug_funcnames 0 : { *(.debug_funcnames) }
+  .debug_typenames 0 : { *(.debug_typenames) }
+  .debug_varnames  0 : { *(.debug_varnames) }
+}

--- a/cpu/arm/lpc1768/lpc17xx.h
+++ b/cpu/arm/lpc1768/lpc17xx.h
@@ -1,0 +1,1048 @@
+/**************************************************************************//**
+ * @file     LPC17xx.h
+ * @brief    CMSIS Cortex-M3 Core Peripheral Access Layer Header File for
+ *           NXP LPC17xx Device Series
+ * @version: V1.09
+ * @date:    25. July. 2011
+ *
+ * @note
+ * Copyright (C) 2009 ARM Limited. All rights reserved.
+ *
+ * @par
+ * ARM Limited (ARM) is supplying this software for use with Cortex-M
+ * processor based microcontrollers.  This file can be freely distributed
+ * within development tools that are supporting such ARM based processors.
+ *
+ * @par
+ * THIS SOFTWARE IS PROVIDED "AS IS".  NO WARRANTIES, WHETHER EXPRESS, IMPLIED
+ * OR STATUTORY, INCLUDING, BUT NOT LIMITED TO, IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE APPLY TO THIS SOFTWARE.
+ * ARM SHALL NOT, IN ANY CIRCUMSTANCES, BE LIABLE FOR SPECIAL, INCIDENTAL, OR
+ * CONSEQUENTIAL DAMAGES, FOR ANY REASON WHATSOEVER.
+ *
+ ******************************************************************************/
+
+#ifndef __LPC17xx_H__
+#define __LPC17xx_H__
+
+/*
+ * ==========================================================================
+ * ---------- Interrupt Number Definition -----------------------------------
+ * ==========================================================================
+ */
+
+/** @addtogroup LPC17xx_System
+ * @{
+ */
+
+/** @brief IRQ interrupt source definition */
+typedef enum IRQn {
+/******  Cortex-M3 Processor Exceptions Numbers ***************************************************/
+  NonMaskableInt_IRQn = -14,                /*!< 2 Non Maskable Interrupt                         */
+  MemoryManagement_IRQn = -12,              /*!< 4 Cortex-M3 Memory Management Interrupt          */
+  BusFault_IRQn = -11,                      /*!< 5 Cortex-M3 Bus Fault Interrupt                  */
+  UsageFault_IRQn = -10,                    /*!< 6 Cortex-M3 Usage Fault Interrupt                */
+  SVCall_IRQn = -5,                         /*!< 11 Cortex-M3 SV Call Interrupt                   */
+  DebugMonitor_IRQn = -4,                   /*!< 12 Cortex-M3 Debug Monitor Interrupt             */
+  PendSV_IRQn = -2,                         /*!< 14 Cortex-M3 Pend SV Interrupt                   */
+  SysTick_IRQn = -1,                        /*!< 15 Cortex-M3 System Tick Interrupt               */
+
+/******  LPC17xx Specific Interrupt Numbers *******************************************************/
+  WDT_IRQn = 0,                             /*!< Watchdog Timer Interrupt                         */
+  TIMER0_IRQn = 1,                          /*!< Timer0 Interrupt                                 */
+  TIMER1_IRQn = 2,                          /*!< Timer1 Interrupt                                 */
+  TIMER2_IRQn = 3,                          /*!< Timer2 Interrupt                                 */
+  TIMER3_IRQn = 4,                          /*!< Timer3 Interrupt                                 */
+  UART0_IRQn = 5,                           /*!< UART0 Interrupt                                  */
+  UART1_IRQn = 6,                           /*!< UART1 Interrupt                                  */
+  UART2_IRQn = 7,                           /*!< UART2 Interrupt                                  */
+  UART3_IRQn = 8,                           /*!< UART3 Interrupt                                  */
+  PWM1_IRQn = 9,                            /*!< PWM1 Interrupt                                   */
+  I2C0_IRQn = 10,                           /*!< I2C0 Interrupt                                   */
+  I2C1_IRQn = 11,                           /*!< I2C1 Interrupt                                   */
+  I2C2_IRQn = 12,                           /*!< I2C2 Interrupt                                   */
+  SPI_IRQn = 13,                            /*!< SPI Interrupt                                    */
+  SSP0_IRQn = 14,                           /*!< SSP0 Interrupt                                   */
+  SSP1_IRQn = 15,                           /*!< SSP1 Interrupt                                   */
+  PLL0_IRQn = 16,                           /*!< PLL0 Lock (Main PLL) Interrupt                   */
+  RTC_IRQn = 17,                            /*!< Real Time Clock Interrupt                        */
+  EINT0_IRQn = 18,                          /*!< External Interrupt 0 Interrupt                   */
+  EINT1_IRQn = 19,                          /*!< External Interrupt 1 Interrupt                   */
+  EINT2_IRQn = 20,                          /*!< External Interrupt 2 Interrupt                   */
+  EINT3_IRQn = 21,                          /*!< External Interrupt 3 Interrupt                   */
+  ADC_IRQn = 22,                            /*!< A/D Converter Interrupt                          */
+  BOD_IRQn = 23,                            /*!< Brown-Out Detect Interrupt                       */
+  USB_IRQn = 24,                            /*!< USB Interrupt                                    */
+  CAN_IRQn = 25,                            /*!< CAN Interrupt                                    */
+  DMA_IRQn = 26,                            /*!< General Purpose DMA Interrupt                    */
+  I2S_IRQn = 27,                            /*!< I2S Interrupt                                    */
+  ENET_IRQn = 28,                           /*!< Ethernet Interrupt                               */
+  RIT_IRQn = 29,                            /*!< Repetitive Interrupt Timer Interrupt             */
+  MCPWM_IRQn = 30,                          /*!< Motor Control PWM Interrupt                      */
+  QEI_IRQn = 31,                            /*!< Quadrature Encoder Interface Interrupt           */
+  PLL1_IRQn = 32,                           /*!< PLL1 Lock (USB PLL) Interrupt                    */
+  USBActivity_IRQn = 33,          /*!< USB Activity Interrupt               */
+  CANActivity_IRQn = 34           /*!< CAN Activity Interrupt               */
+} IRQn_Type;
+
+/*
+ * ==========================================================================
+ * ----------- Processor and Core Peripheral Section ------------------------
+ * ==========================================================================
+ */
+
+/* Configuration of the Cortex-M3 Processor and Core Peripherals */
+#define __MPU_PRESENT             1         /*!< MPU present or not                               */
+#define __NVIC_PRIO_BITS          5         /*!< Number of Bits used for Priority Levels          */
+#define __Vendor_SysTickConfig    0         /*!< Set to 1 if different SysTick Config is used     */
+
+#include "core_cm3.h"                       /* Cortex-M3 processor and core peripherals           */
+#include "system_LPC17xx.h"                 /* System Header                                      */
+
+/******************************************************************************/
+/*                Device Specific Peripheral registers structures             */
+/******************************************************************************/
+
+#if defined(__CC_ARM)
+#pragma anon_unions
+#endif
+
+/*------------- System Control (SC) ------------------------------------------*/
+/** @brief System Control (SC) register structure definition */
+typedef struct {
+  __IO uint32_t FLASHCFG;               /* Flash Accelerator Module           */
+  uint32_t RESERVED0[31];
+  __IO uint32_t PLL0CON;                /* Clocking and Power Control         */
+  __IO uint32_t PLL0CFG;
+  __I uint32_t PLL0STAT;
+  __O uint32_t PLL0FEED;
+  uint32_t RESERVED1[4];
+  __IO uint32_t PLL1CON;
+  __IO uint32_t PLL1CFG;
+  __I uint32_t PLL1STAT;
+  __O uint32_t PLL1FEED;
+  uint32_t RESERVED2[4];
+  __IO uint32_t PCON;
+  __IO uint32_t PCONP;
+  uint32_t RESERVED3[15];
+  __IO uint32_t CCLKCFG;
+  __IO uint32_t USBCLKCFG;
+  __IO uint32_t CLKSRCSEL;
+  __IO uint32_t CANSLEEPCLR;
+  __IO uint32_t CANWAKEFLAGS;
+  uint32_t RESERVED4[10];
+  __IO uint32_t EXTINT;                 /* External Interrupts                */
+  uint32_t RESERVED5;
+  __IO uint32_t EXTMODE;
+  __IO uint32_t EXTPOLAR;
+  uint32_t RESERVED6[12];
+  __IO uint32_t RSID;                   /* Reset                              */
+  uint32_t RESERVED7[7];
+  __IO uint32_t SCS;                    /* Syscon Miscellaneous Registers     */
+  __IO uint32_t IRCTRIM;                /* Clock Dividers                     */
+  __IO uint32_t PCLKSEL0;
+  __IO uint32_t PCLKSEL1;
+  uint32_t RESERVED8[4];
+  __IO uint32_t USBIntSt;               /* USB Device/OTG Interrupt Register  */
+  __IO uint32_t DMAREQSEL;
+  __IO uint32_t CLKOUTCFG;              /* Clock Output Configuration         */
+} LPC_SC_TypeDef;
+
+/*------------- Pin Connect Block (PINCON) -----------------------------------*/
+/** @brief Pin Connect Block (PINCON) register structure definition */
+typedef struct {
+  __IO uint32_t PINSEL0;
+  __IO uint32_t PINSEL1;
+  __IO uint32_t PINSEL2;
+  __IO uint32_t PINSEL3;
+  __IO uint32_t PINSEL4;
+  __IO uint32_t PINSEL5;
+  __IO uint32_t PINSEL6;
+  __IO uint32_t PINSEL7;
+  __IO uint32_t PINSEL8;
+  __IO uint32_t PINSEL9;
+  __IO uint32_t PINSEL10;
+  uint32_t RESERVED0[5];
+  __IO uint32_t PINMODE0;
+  __IO uint32_t PINMODE1;
+  __IO uint32_t PINMODE2;
+  __IO uint32_t PINMODE3;
+  __IO uint32_t PINMODE4;
+  __IO uint32_t PINMODE5;
+  __IO uint32_t PINMODE6;
+  __IO uint32_t PINMODE7;
+  __IO uint32_t PINMODE8;
+  __IO uint32_t PINMODE9;
+  __IO uint32_t PINMODE_OD0;
+  __IO uint32_t PINMODE_OD1;
+  __IO uint32_t PINMODE_OD2;
+  __IO uint32_t PINMODE_OD3;
+  __IO uint32_t PINMODE_OD4;
+  __IO uint32_t I2CPADCFG;
+} LPC_PINCON_TypeDef;
+
+/*------------- General Purpose Input/Output (GPIO) --------------------------*/
+/** @brief General Purpose Input/Output (GPIO) register structure definition */
+typedef struct {
+  union {
+    __IO uint32_t FIODIR;
+    struct {
+      __IO uint16_t FIODIRL;
+      __IO uint16_t FIODIRH;
+    };
+    struct {
+      __IO uint8_t FIODIR0;
+      __IO uint8_t FIODIR1;
+      __IO uint8_t FIODIR2;
+      __IO uint8_t FIODIR3;
+    };
+  };
+  uint32_t RESERVED0[3];
+  union {
+    __IO uint32_t FIOMASK;
+    struct {
+      __IO uint16_t FIOMASKL;
+      __IO uint16_t FIOMASKH;
+    };
+    struct {
+      __IO uint8_t FIOMASK0;
+      __IO uint8_t FIOMASK1;
+      __IO uint8_t FIOMASK2;
+      __IO uint8_t FIOMASK3;
+    };
+  };
+  union {
+    __IO uint32_t FIOPIN;
+    struct {
+      __IO uint16_t FIOPINL;
+      __IO uint16_t FIOPINH;
+    };
+    struct {
+      __IO uint8_t FIOPIN0;
+      __IO uint8_t FIOPIN1;
+      __IO uint8_t FIOPIN2;
+      __IO uint8_t FIOPIN3;
+    };
+  };
+  union {
+    __IO uint32_t FIOSET;
+    struct {
+      __IO uint16_t FIOSETL;
+      __IO uint16_t FIOSETH;
+    };
+    struct {
+      __IO uint8_t FIOSET0;
+      __IO uint8_t FIOSET1;
+      __IO uint8_t FIOSET2;
+      __IO uint8_t FIOSET3;
+    };
+  };
+  union {
+    __O uint32_t FIOCLR;
+    struct {
+      __O uint16_t FIOCLRL;
+      __O uint16_t FIOCLRH;
+    };
+    struct {
+      __O uint8_t FIOCLR0;
+      __O uint8_t FIOCLR1;
+      __O uint8_t FIOCLR2;
+      __O uint8_t FIOCLR3;
+    };
+  };
+} LPC_GPIO_TypeDef;
+
+/** @brief General Purpose Input/Output interrupt (GPIOINT) register structure definition */
+typedef struct {
+  __I uint32_t IntStatus;
+  __I uint32_t IO0IntStatR;
+  __I uint32_t IO0IntStatF;
+  __O uint32_t IO0IntClr;
+  __IO uint32_t IO0IntEnR;
+  __IO uint32_t IO0IntEnF;
+  uint32_t RESERVED0[3];
+  __I uint32_t IO2IntStatR;
+  __I uint32_t IO2IntStatF;
+  __O uint32_t IO2IntClr;
+  __IO uint32_t IO2IntEnR;
+  __IO uint32_t IO2IntEnF;
+} LPC_GPIOINT_TypeDef;
+
+/*------------- Timer (TIM) --------------------------------------------------*/
+/** @brief Timer (TIM) register structure definition */
+typedef struct {
+  __IO uint32_t IR;
+  __IO uint32_t TCR;
+  __IO uint32_t TC;
+  __IO uint32_t PR;
+  __IO uint32_t PC;
+  __IO uint32_t MCR;
+  __IO uint32_t MR0;
+  __IO uint32_t MR1;
+  __IO uint32_t MR2;
+  __IO uint32_t MR3;
+  __IO uint32_t CCR;
+  __I uint32_t CR0;
+  __I uint32_t CR1;
+  uint32_t RESERVED0[2];
+  __IO uint32_t EMR;
+  uint32_t RESERVED1[12];
+  __IO uint32_t CTCR;
+} LPC_TIM_TypeDef;
+
+/*------------- Pulse-Width Modulation (PWM) ---------------------------------*/
+/** @brief Pulse-Width Modulation (PWM) register structure definition */
+typedef struct {
+  __IO uint32_t IR;
+  __IO uint32_t TCR;
+  __IO uint32_t TC;
+  __IO uint32_t PR;
+  __IO uint32_t PC;
+  __IO uint32_t MCR;
+  __IO uint32_t MR0;
+  __IO uint32_t MR1;
+  __IO uint32_t MR2;
+  __IO uint32_t MR3;
+  __IO uint32_t CCR;
+  __I uint32_t CR0;
+  __I uint32_t CR1;
+  __I uint32_t CR2;
+  __I uint32_t CR3;
+  uint32_t RESERVED0;
+  __IO uint32_t MR4;
+  __IO uint32_t MR5;
+  __IO uint32_t MR6;
+  __IO uint32_t PCR;
+  __IO uint32_t LER;
+  uint32_t RESERVED1[7];
+  __IO uint32_t CTCR;
+} LPC_PWM_TypeDef;
+
+/*------------- Universal Asynchronous Receiver Transmitter (UART) -----------*/
+/** @brief  Universal Asynchronous Receiver Transmitter (UART) register structure definition */
+typedef struct {
+  union {
+    __I uint8_t RBR;
+    __O uint8_t THR;
+    __IO uint8_t DLL;
+    uint32_t RESERVED0;
+  };
+  union {
+    __IO uint8_t DLM;
+    __IO uint32_t IER;
+  };
+  union {
+    __I uint32_t IIR;
+    __O uint8_t FCR;
+  };
+  __IO uint8_t LCR;
+  uint8_t RESERVED1[7];
+  __I uint8_t LSR;
+  uint8_t RESERVED2[7];
+  __IO uint8_t SCR;
+  uint8_t RESERVED3[3];
+  __IO uint32_t ACR;
+  __IO uint8_t ICR;
+  uint8_t RESERVED4[3];
+  __IO uint8_t FDR;
+  uint8_t RESERVED5[7];
+  __IO uint8_t TER;
+  uint8_t RESERVED6[39];
+  __I uint8_t FIFOLVL;
+} LPC_UART_TypeDef;
+
+/** @brief  Universal Asynchronous Receiver Transmitter 0 (UART0) register structure definition */
+typedef struct {
+  union {
+    __I uint8_t RBR;
+    __O uint8_t THR;
+    __IO uint8_t DLL;
+    uint32_t RESERVED0;
+  };
+  union {
+    __IO uint8_t DLM;
+    __IO uint32_t IER;
+  };
+  union {
+    __I uint32_t IIR;
+    __O uint8_t FCR;
+  };
+  __IO uint8_t LCR;
+  uint8_t RESERVED1[7];
+  __I uint8_t LSR;
+  uint8_t RESERVED2[7];
+  __IO uint8_t SCR;
+  uint8_t RESERVED3[3];
+  __IO uint32_t ACR;
+  __IO uint8_t ICR;
+  uint8_t RESERVED4[3];
+  __IO uint8_t FDR;
+  uint8_t RESERVED5[7];
+  __IO uint8_t TER;
+  uint8_t RESERVED6[39];
+  __I uint8_t FIFOLVL;
+} LPC_UART0_TypeDef;
+
+/** @brief  Universal Asynchronous Receiver Transmitter 1 (UART1) register structure definition */
+typedef struct {
+  union {
+    __I uint8_t RBR;
+    __O uint8_t THR;
+    __IO uint8_t DLL;
+    uint32_t RESERVED0;
+  };
+  union {
+    __IO uint8_t DLM;
+    __IO uint32_t IER;
+  };
+  union {
+    __I uint32_t IIR;
+    __O uint8_t FCR;
+  };
+  __IO uint8_t LCR;
+  uint8_t RESERVED1[3];
+  __IO uint8_t MCR;
+  uint8_t RESERVED2[3];
+  __I uint8_t LSR;
+  uint8_t RESERVED3[3];
+  __I uint8_t MSR;
+  uint8_t RESERVED4[3];
+  __IO uint8_t SCR;
+  uint8_t RESERVED5[3];
+  __IO uint32_t ACR;
+  uint32_t RESERVED6;
+  __IO uint32_t FDR;
+  uint32_t RESERVED7;
+  __IO uint8_t TER;
+  uint8_t RESERVED8[27];
+  __IO uint8_t RS485CTRL;
+  uint8_t RESERVED9[3];
+  __IO uint8_t ADRMATCH;
+  uint8_t RESERVED10[3];
+  __IO uint8_t RS485DLY;
+  uint8_t RESERVED11[3];
+  __I uint8_t FIFOLVL;
+} LPC_UART1_TypeDef;
+
+/*------------- Serial Peripheral Interface (SPI) ----------------------------*/
+/** @brief  Serial Peripheral Interface (SPI) register structure definition */
+typedef struct {
+  __IO uint32_t SPCR;
+  __I uint32_t SPSR;
+  __IO uint32_t SPDR;
+  __IO uint32_t SPCCR;
+  uint32_t RESERVED0[3];
+  __IO uint32_t SPINT;
+} LPC_SPI_TypeDef;
+
+/*------------- Synchronous Serial Communication (SSP) -----------------------*/
+/** @brief  Synchronous Serial Communication (SSP) register structure definition */
+typedef struct {
+  __IO uint32_t CR0;
+  __IO uint32_t CR1;
+  __IO uint32_t DR;
+  __I uint32_t SR;
+  __IO uint32_t CPSR;
+  __IO uint32_t IMSC;
+  __IO uint32_t RIS;
+  __IO uint32_t MIS;
+  __IO uint32_t ICR;
+  __IO uint32_t DMACR;
+} LPC_SSP_TypeDef;
+
+/*------------- Inter-Integrated Circuit (I2C) -------------------------------*/
+/** @brief  Inter-Integrated Circuit (I2C) register structure definition */
+typedef struct {
+  __IO uint32_t I2CONSET;
+  __I uint32_t I2STAT;
+  __IO uint32_t I2DAT;
+  __IO uint32_t I2ADR0;
+  __IO uint32_t I2SCLH;
+  __IO uint32_t I2SCLL;
+  __O uint32_t I2CONCLR;
+  __IO uint32_t MMCTRL;
+  __IO uint32_t I2ADR1;
+  __IO uint32_t I2ADR2;
+  __IO uint32_t I2ADR3;
+  __I uint32_t I2DATA_BUFFER;
+  __IO uint32_t I2MASK0;
+  __IO uint32_t I2MASK1;
+  __IO uint32_t I2MASK2;
+  __IO uint32_t I2MASK3;
+} LPC_I2C_TypeDef;
+
+/*------------- Inter IC Sound (I2S) -----------------------------------------*/
+/** @brief  Inter IC Sound (I2S) register structure definition */
+typedef struct {
+  __IO uint32_t I2SDAO;
+  __IO uint32_t I2SDAI;
+  __O uint32_t I2STXFIFO;
+  __I uint32_t I2SRXFIFO;
+  __I uint32_t I2SSTATE;
+  __IO uint32_t I2SDMA1;
+  __IO uint32_t I2SDMA2;
+  __IO uint32_t I2SIRQ;
+  __IO uint32_t I2STXRATE;
+  __IO uint32_t I2SRXRATE;
+  __IO uint32_t I2STXBITRATE;
+  __IO uint32_t I2SRXBITRATE;
+  __IO uint32_t I2STXMODE;
+  __IO uint32_t I2SRXMODE;
+} LPC_I2S_TypeDef;
+
+/*------------- Repetitive Interrupt Timer (RIT) -----------------------------*/
+/** @brief  Repetitive Interrupt Timer (RIT) register structure definition */
+typedef struct {
+  __IO uint32_t RICOMPVAL;
+  __IO uint32_t RIMASK;
+  __IO uint8_t RICTRL;
+  uint8_t RESERVED0[3];
+  __IO uint32_t RICOUNTER;
+} LPC_RIT_TypeDef;
+
+/*------------- Real-Time Clock (RTC) ----------------------------------------*/
+/** @brief  Real-Time Clock (RTC) register structure definition */
+typedef struct {
+  __IO uint8_t ILR;
+  uint8_t RESERVED0[7];
+  __IO uint8_t CCR;
+  uint8_t RESERVED1[3];
+  __IO uint8_t CIIR;
+  uint8_t RESERVED2[3];
+  __IO uint8_t AMR;
+  uint8_t RESERVED3[3];
+  __I uint32_t CTIME0;
+  __I uint32_t CTIME1;
+  __I uint32_t CTIME2;
+  __IO uint8_t SEC;
+  uint8_t RESERVED4[3];
+  __IO uint8_t MIN;
+  uint8_t RESERVED5[3];
+  __IO uint8_t HOUR;
+  uint8_t RESERVED6[3];
+  __IO uint8_t DOM;
+  uint8_t RESERVED7[3];
+  __IO uint8_t DOW;
+  uint8_t RESERVED8[3];
+  __IO uint16_t DOY;
+  uint16_t RESERVED9;
+  __IO uint8_t MONTH;
+  uint8_t RESERVED10[3];
+  __IO uint16_t YEAR;
+  uint16_t RESERVED11;
+  __IO uint32_t CALIBRATION;
+  __IO uint32_t GPREG0;
+  __IO uint32_t GPREG1;
+  __IO uint32_t GPREG2;
+  __IO uint32_t GPREG3;
+  __IO uint32_t GPREG4;
+  __IO uint8_t RTC_AUXEN;
+  uint8_t RESERVED12[3];
+  __IO uint8_t RTC_AUX;
+  uint8_t RESERVED13[3];
+  __IO uint8_t ALSEC;
+  uint8_t RESERVED14[3];
+  __IO uint8_t ALMIN;
+  uint8_t RESERVED15[3];
+  __IO uint8_t ALHOUR;
+  uint8_t RESERVED16[3];
+  __IO uint8_t ALDOM;
+  uint8_t RESERVED17[3];
+  __IO uint8_t ALDOW;
+  uint8_t RESERVED18[3];
+  __IO uint16_t ALDOY;
+  uint16_t RESERVED19;
+  __IO uint8_t ALMON;
+  uint8_t RESERVED20[3];
+  __IO uint16_t ALYEAR;
+  uint16_t RESERVED21;
+} LPC_RTC_TypeDef;
+
+/*------------- Watchdog Timer (WDT) -----------------------------------------*/
+/** @brief  Watchdog Timer (WDT) register structure definition */
+typedef struct {
+  __IO uint8_t WDMOD;
+  uint8_t RESERVED0[3];
+  __IO uint32_t WDTC;
+  __O uint8_t WDFEED;
+  uint8_t RESERVED1[3];
+  __I uint32_t WDTV;
+  __IO uint32_t WDCLKSEL;
+} LPC_WDT_TypeDef;
+
+/*------------- Analog-to-Digital Converter (ADC) ----------------------------*/
+/** @brief  Analog-to-Digital Converter (ADC) register structure definition */
+typedef struct {
+  __IO uint32_t ADCR;
+  __IO uint32_t ADGDR;
+  uint32_t RESERVED0;
+  __IO uint32_t ADINTEN;
+  __I uint32_t ADDR0;
+  __I uint32_t ADDR1;
+  __I uint32_t ADDR2;
+  __I uint32_t ADDR3;
+  __I uint32_t ADDR4;
+  __I uint32_t ADDR5;
+  __I uint32_t ADDR6;
+  __I uint32_t ADDR7;
+  __I uint32_t ADSTAT;
+  __IO uint32_t ADTRM;
+} LPC_ADC_TypeDef;
+
+/*------------- Digital-to-Analog Converter (DAC) ----------------------------*/
+/** @brief  Digital-to-Analog Converter (DAC) register structure definition */
+typedef struct {
+  __IO uint32_t DACR;
+  __IO uint32_t DACCTRL;
+  __IO uint16_t DACCNTVAL;
+} LPC_DAC_TypeDef;
+
+/*------------- Motor Control Pulse-Width Modulation (MCPWM) -----------------*/
+/** @brief  Motor Control Pulse-Width Modulation (MCPWM) register structure definition */
+typedef struct {
+  __I uint32_t MCCON;
+  __O uint32_t MCCON_SET;
+  __O uint32_t MCCON_CLR;
+  __I uint32_t MCCAPCON;
+  __O uint32_t MCCAPCON_SET;
+  __O uint32_t MCCAPCON_CLR;
+  __IO uint32_t MCTIM0;
+  __IO uint32_t MCTIM1;
+  __IO uint32_t MCTIM2;
+  __IO uint32_t MCPER0;
+  __IO uint32_t MCPER1;
+  __IO uint32_t MCPER2;
+  __IO uint32_t MCPW0;
+  __IO uint32_t MCPW1;
+  __IO uint32_t MCPW2;
+  __IO uint32_t MCDEADTIME;
+  __IO uint32_t MCCCP;
+  __IO uint32_t MCCR0;
+  __IO uint32_t MCCR1;
+  __IO uint32_t MCCR2;
+  __I uint32_t MCINTEN;
+  __O uint32_t MCINTEN_SET;
+  __O uint32_t MCINTEN_CLR;
+  __I uint32_t MCCNTCON;
+  __O uint32_t MCCNTCON_SET;
+  __O uint32_t MCCNTCON_CLR;
+  __I uint32_t MCINTFLAG;
+  __O uint32_t MCINTFLAG_SET;
+  __O uint32_t MCINTFLAG_CLR;
+  __O uint32_t MCCAP_CLR;
+} LPC_MCPWM_TypeDef;
+
+/*------------- Quadrature Encoder Interface (QEI) ---------------------------*/
+/** @brief  Quadrature Encoder Interface (QEI) register structure definition */
+typedef struct {
+  __O uint32_t QEICON;
+  __I uint32_t QEISTAT;
+  __IO uint32_t QEICONF;
+  __I uint32_t QEIPOS;
+  __IO uint32_t QEIMAXPOS;
+  __IO uint32_t CMPOS0;
+  __IO uint32_t CMPOS1;
+  __IO uint32_t CMPOS2;
+  __I uint32_t INXCNT;
+  __IO uint32_t INXCMP;
+  __IO uint32_t QEILOAD;
+  __I uint32_t QEITIME;
+  __I uint32_t QEIVEL;
+  __I uint32_t QEICAP;
+  __IO uint32_t VELCOMP;
+  __IO uint32_t FILTER;
+  uint32_t RESERVED0[998];
+  __O uint32_t QEIIEC;
+  __O uint32_t QEIIES;
+  __I uint32_t QEIINTSTAT;
+  __I uint32_t QEIIE;
+  __O uint32_t QEICLR;
+  __O uint32_t QEISET;
+} LPC_QEI_TypeDef;
+
+/*------------- Controller Area Network (CAN) --------------------------------*/
+/** @brief  Controller Area Network Acceptance Filter RAM (CANAF_RAM)structure definition */
+typedef struct {
+  __IO uint32_t mask[512];              /* ID Masks                           */
+} LPC_CANAF_RAM_TypeDef;
+
+/** @brief  Controller Area Network Acceptance Filter(CANAF) register structure definition */
+typedef struct                          /* Acceptance Filter Registers        */
+{
+  __IO uint32_t AFMR;
+  __IO uint32_t SFF_sa;
+  __IO uint32_t SFF_GRP_sa;
+  __IO uint32_t EFF_sa;
+  __IO uint32_t EFF_GRP_sa;
+  __IO uint32_t ENDofTable;
+  __I uint32_t LUTerrAd;
+  __I uint32_t LUTerr;
+  __IO uint32_t FCANIE;
+  __IO uint32_t FCANIC0;
+  __IO uint32_t FCANIC1;
+} LPC_CANAF_TypeDef;
+
+/** @brief  Controller Area Network Central (CANCR) register structure definition */
+typedef struct                          /* Central Registers                  */
+{
+  __I uint32_t CANTxSR;
+  __I uint32_t CANRxSR;
+  __I uint32_t CANMSR;
+} LPC_CANCR_TypeDef;
+
+/** @brief  Controller Area Network Controller (CAN) register structure definition */
+typedef struct                          /* Controller Registers               */
+{
+  __IO uint32_t MOD;
+  __O uint32_t CMR;
+  __IO uint32_t GSR;
+  __I uint32_t ICR;
+  __IO uint32_t IER;
+  __IO uint32_t BTR;
+  __IO uint32_t EWL;
+  __I uint32_t SR;
+  __IO uint32_t RFS;
+  __IO uint32_t RID;
+  __IO uint32_t RDA;
+  __IO uint32_t RDB;
+  __IO uint32_t TFI1;
+  __IO uint32_t TID1;
+  __IO uint32_t TDA1;
+  __IO uint32_t TDB1;
+  __IO uint32_t TFI2;
+  __IO uint32_t TID2;
+  __IO uint32_t TDA2;
+  __IO uint32_t TDB2;
+  __IO uint32_t TFI3;
+  __IO uint32_t TID3;
+  __IO uint32_t TDA3;
+  __IO uint32_t TDB3;
+} LPC_CAN_TypeDef;
+
+/*------------- General Purpose Direct Memory Access (GPDMA) -----------------*/
+/** @brief  General Purpose Direct Memory Access (GPDMA) register structure definition */
+typedef struct                          /* Common Registers                   */
+{
+  __I uint32_t DMACIntStat;
+  __I uint32_t DMACIntTCStat;
+  __O uint32_t DMACIntTCClear;
+  __I uint32_t DMACIntErrStat;
+  __O uint32_t DMACIntErrClr;
+  __I uint32_t DMACRawIntTCStat;
+  __I uint32_t DMACRawIntErrStat;
+  __I uint32_t DMACEnbldChns;
+  __IO uint32_t DMACSoftBReq;
+  __IO uint32_t DMACSoftSReq;
+  __IO uint32_t DMACSoftLBReq;
+  __IO uint32_t DMACSoftLSReq;
+  __IO uint32_t DMACConfig;
+  __IO uint32_t DMACSync;
+} LPC_GPDMA_TypeDef;
+
+/** @brief  General Purpose Direct Memory Access Channel (GPDMACH) register structure definition */
+typedef struct                          /* Channel Registers                  */
+{
+  __IO uint32_t DMACCSrcAddr;
+  __IO uint32_t DMACCDestAddr;
+  __IO uint32_t DMACCLLI;
+  __IO uint32_t DMACCControl;
+  __IO uint32_t DMACCConfig;
+} LPC_GPDMACH_TypeDef;
+
+/*------------- Universal Serial Bus (USB) -----------------------------------*/
+/** @brief  Universal Serial Bus (USB) register structure definition */
+typedef struct {
+  __I uint32_t HcRevision;              /* USB Host Registers                 */
+  __IO uint32_t HcControl;
+  __IO uint32_t HcCommandStatus;
+  __IO uint32_t HcInterruptStatus;
+  __IO uint32_t HcInterruptEnable;
+  __IO uint32_t HcInterruptDisable;
+  __IO uint32_t HcHCCA;
+  __I uint32_t HcPeriodCurrentED;
+  __IO uint32_t HcControlHeadED;
+  __IO uint32_t HcControlCurrentED;
+  __IO uint32_t HcBulkHeadED;
+  __IO uint32_t HcBulkCurrentED;
+  __I uint32_t HcDoneHead;
+  __IO uint32_t HcFmInterval;
+  __I uint32_t HcFmRemaining;
+  __I uint32_t HcFmNumber;
+  __IO uint32_t HcPeriodicStart;
+  __IO uint32_t HcLSTreshold;
+  __IO uint32_t HcRhDescriptorA;
+  __IO uint32_t HcRhDescriptorB;
+  __IO uint32_t HcRhStatus;
+  __IO uint32_t HcRhPortStatus1;
+  __IO uint32_t HcRhPortStatus2;
+  uint32_t RESERVED0[40];
+  __I uint32_t Module_ID;
+
+  __I uint32_t OTGIntSt;                /* USB On-The-Go Registers            */
+  __IO uint32_t OTGIntEn;
+  __O uint32_t OTGIntSet;
+  __O uint32_t OTGIntClr;
+  __IO uint32_t OTGStCtrl;
+  __IO uint32_t OTGTmr;
+  uint32_t RESERVED1[58];
+
+  __I uint32_t USBDevIntSt;             /* USB Device Interrupt Registers     */
+  __IO uint32_t USBDevIntEn;
+  __O uint32_t USBDevIntClr;
+  __O uint32_t USBDevIntSet;
+
+  __O uint32_t USBCmdCode;              /* USB Device SIE Command Registers   */
+  __I uint32_t USBCmdData;
+
+  __I uint32_t USBRxData;               /* USB Device Transfer Registers      */
+  __O uint32_t USBTxData;
+  __I uint32_t USBRxPLen;
+  __O uint32_t USBTxPLen;
+  __IO uint32_t USBCtrl;
+  __O uint32_t USBDevIntPri;
+
+  __I uint32_t USBEpIntSt;              /* USB Device Endpoint Interrupt Regs */
+  __IO uint32_t USBEpIntEn;
+  __O uint32_t USBEpIntClr;
+  __O uint32_t USBEpIntSet;
+  __O uint32_t USBEpIntPri;
+
+  __IO uint32_t USBReEp;                /* USB Device Endpoint Realization Reg*/
+  __O uint32_t USBEpInd;
+  __IO uint32_t USBMaxPSize;
+
+  __I uint32_t USBDMARSt;               /* USB Device DMA Registers           */
+  __O uint32_t USBDMARClr;
+  __O uint32_t USBDMARSet;
+  uint32_t RESERVED2[9];
+  __IO uint32_t USBUDCAH;
+  __I uint32_t USBEpDMASt;
+  __O uint32_t USBEpDMAEn;
+  __O uint32_t USBEpDMADis;
+  __I uint32_t USBDMAIntSt;
+  __IO uint32_t USBDMAIntEn;
+  uint32_t RESERVED3[2];
+  __I uint32_t USBEoTIntSt;
+  __O uint32_t USBEoTIntClr;
+  __O uint32_t USBEoTIntSet;
+  __I uint32_t USBNDDRIntSt;
+  __O uint32_t USBNDDRIntClr;
+  __O uint32_t USBNDDRIntSet;
+  __I uint32_t USBSysErrIntSt;
+  __O uint32_t USBSysErrIntClr;
+  __O uint32_t USBSysErrIntSet;
+  uint32_t RESERVED4[15];
+
+  union {
+    __I uint32_t I2C_RX;                /* USB OTG I2C Registers              */
+    __O uint32_t I2C_TX;
+  };
+  __I uint32_t I2C_STS;
+  __IO uint32_t I2C_CTL;
+  __IO uint32_t I2C_CLKHI;
+  __O uint32_t I2C_CLKLO;
+  uint32_t RESERVED5[824];
+
+  union {
+    __IO uint32_t USBClkCtrl;           /* USB Clock Control Registers        */
+    __IO uint32_t OTGClkCtrl;
+  };
+  union {
+    __I uint32_t USBClkSt;
+    __I uint32_t OTGClkSt;
+  };
+} LPC_USB_TypeDef;
+
+/*------------- Ethernet Media Access Controller (EMAC) ----------------------*/
+/** @brief  Ethernet Media Access Controller (EMAC) register structure definition */
+typedef struct {
+  __IO uint32_t MAC1;                   /* MAC Registers                      */
+  __IO uint32_t MAC2;
+  __IO uint32_t IPGT;
+  __IO uint32_t IPGR;
+  __IO uint32_t CLRT;
+  __IO uint32_t MAXF;
+  __IO uint32_t SUPP;
+  __IO uint32_t TEST;
+  __IO uint32_t MCFG;
+  __IO uint32_t MCMD;
+  __IO uint32_t MADR;
+  __O uint32_t MWTD;
+  __I uint32_t MRDD;
+  __I uint32_t MIND;
+  uint32_t RESERVED0[2];
+  __IO uint32_t SA0;
+  __IO uint32_t SA1;
+  __IO uint32_t SA2;
+  uint32_t RESERVED1[45];
+  __IO uint32_t Command;                /* Control Registers                  */
+  __I uint32_t Status;
+  __IO uint32_t RxDescriptor;
+  __IO uint32_t RxStatus;
+  __IO uint32_t RxDescriptorNumber;
+  __I uint32_t RxProduceIndex;
+  __IO uint32_t RxConsumeIndex;
+  __IO uint32_t TxDescriptor;
+  __IO uint32_t TxStatus;
+  __IO uint32_t TxDescriptorNumber;
+  __IO uint32_t TxProduceIndex;
+  __I uint32_t TxConsumeIndex;
+  uint32_t RESERVED2[10];
+  __I uint32_t TSV0;
+  __I uint32_t TSV1;
+  __I uint32_t RSV;
+  uint32_t RESERVED3[3];
+  __IO uint32_t FlowControlCounter;
+  __I uint32_t FlowControlStatus;
+  uint32_t RESERVED4[34];
+  __IO uint32_t RxFilterCtrl;           /* Rx Filter Registers                */
+  __IO uint32_t RxFilterWoLStatus;
+  __IO uint32_t RxFilterWoLClear;
+  uint32_t RESERVED5;
+  __IO uint32_t HashFilterL;
+  __IO uint32_t HashFilterH;
+  uint32_t RESERVED6[882];
+  __I uint32_t IntStatus;               /* Module Control Registers           */
+  __IO uint32_t IntEnable;
+  __O uint32_t IntClear;
+  __O uint32_t IntSet;
+  uint32_t RESERVED7;
+  __IO uint32_t PowerDown;
+  uint32_t RESERVED8;
+  __IO uint32_t Module_ID;
+} LPC_EMAC_TypeDef;
+
+#if defined(__CC_ARM)
+#pragma no_anon_unions
+#endif
+
+/******************************************************************************/
+/*                         Peripheral memory map                              */
+/******************************************************************************/
+/* Base addresses                                                             */
+#define LPC_FLASH_BASE        (0x00000000UL)
+#define LPC_RAM_BASE          (0x10000000UL)
+#ifdef __LPC17XX_REV00
+#define LPC_AHBRAM0_BASE      (0x20000000UL)
+#define LPC_AHBRAM1_BASE      (0x20004000UL)
+#else
+#define LPC_AHBRAM0_BASE      (0x2007C000UL)
+#define LPC_AHBRAM1_BASE      (0x20080000UL)
+#endif
+#define LPC_GPIO_BASE         (0x2009C000UL)
+#define LPC_APB0_BASE         (0x40000000UL)
+#define LPC_APB1_BASE         (0x40080000UL)
+#define LPC_AHB_BASE          (0x50000000UL)
+#define LPC_CM3_BASE          (0xE0000000UL)
+
+/* APB0 peripherals                                                           */
+#define LPC_WDT_BASE          (LPC_APB0_BASE + 0x00000)
+#define LPC_TIM0_BASE         (LPC_APB0_BASE + 0x04000)
+#define LPC_TIM1_BASE         (LPC_APB0_BASE + 0x08000)
+#define LPC_UART0_BASE        (LPC_APB0_BASE + 0x0C000)
+#define LPC_UART1_BASE        (LPC_APB0_BASE + 0x10000)
+#define LPC_PWM1_BASE         (LPC_APB0_BASE + 0x18000)
+#define LPC_I2C0_BASE         (LPC_APB0_BASE + 0x1C000)
+#define LPC_SPI_BASE          (LPC_APB0_BASE + 0x20000)
+#define LPC_RTC_BASE          (LPC_APB0_BASE + 0x24000)
+#define LPC_GPIOINT_BASE      (LPC_APB0_BASE + 0x28080)
+#define LPC_PINCON_BASE       (LPC_APB0_BASE + 0x2C000)
+#define LPC_SSP1_BASE         (LPC_APB0_BASE + 0x30000)
+#define LPC_ADC_BASE          (LPC_APB0_BASE + 0x34000)
+#define LPC_CANAF_RAM_BASE    (LPC_APB0_BASE + 0x38000)
+#define LPC_CANAF_BASE        (LPC_APB0_BASE + 0x3C000)
+#define LPC_CANCR_BASE        (LPC_APB0_BASE + 0x40000)
+#define LPC_CAN1_BASE         (LPC_APB0_BASE + 0x44000)
+#define LPC_CAN2_BASE         (LPC_APB0_BASE + 0x48000)
+#define LPC_I2C1_BASE         (LPC_APB0_BASE + 0x5C000)
+
+/* APB1 peripherals                                                           */
+#define LPC_SSP0_BASE         (LPC_APB1_BASE + 0x08000)
+#define LPC_DAC_BASE          (LPC_APB1_BASE + 0x0C000)
+#define LPC_TIM2_BASE         (LPC_APB1_BASE + 0x10000)
+#define LPC_TIM3_BASE         (LPC_APB1_BASE + 0x14000)
+#define LPC_UART2_BASE        (LPC_APB1_BASE + 0x18000)
+#define LPC_UART3_BASE        (LPC_APB1_BASE + 0x1C000)
+#define LPC_I2C2_BASE         (LPC_APB1_BASE + 0x20000)
+#define LPC_I2S_BASE          (LPC_APB1_BASE + 0x28000)
+#define LPC_RIT_BASE          (LPC_APB1_BASE + 0x30000)
+#define LPC_MCPWM_BASE        (LPC_APB1_BASE + 0x38000)
+#define LPC_QEI_BASE          (LPC_APB1_BASE + 0x3C000)
+#define LPC_SC_BASE           (LPC_APB1_BASE + 0x7C000)
+
+/* AHB peripherals                                                            */
+#define LPC_EMAC_BASE         (LPC_AHB_BASE + 0x00000)
+#define LPC_GPDMA_BASE        (LPC_AHB_BASE + 0x04000)
+#define LPC_GPDMACH0_BASE     (LPC_AHB_BASE + 0x04100)
+#define LPC_GPDMACH1_BASE     (LPC_AHB_BASE + 0x04120)
+#define LPC_GPDMACH2_BASE     (LPC_AHB_BASE + 0x04140)
+#define LPC_GPDMACH3_BASE     (LPC_AHB_BASE + 0x04160)
+#define LPC_GPDMACH4_BASE     (LPC_AHB_BASE + 0x04180)
+#define LPC_GPDMACH5_BASE     (LPC_AHB_BASE + 0x041A0)
+#define LPC_GPDMACH6_BASE     (LPC_AHB_BASE + 0x041C0)
+#define LPC_GPDMACH7_BASE     (LPC_AHB_BASE + 0x041E0)
+#define LPC_USB_BASE          (LPC_AHB_BASE + 0x0C000)
+
+/* GPIOs                                                                      */
+#define LPC_GPIO0_BASE        (LPC_GPIO_BASE + 0x00000)
+#define LPC_GPIO1_BASE        (LPC_GPIO_BASE + 0x00020)
+#define LPC_GPIO2_BASE        (LPC_GPIO_BASE + 0x00040)
+#define LPC_GPIO3_BASE        (LPC_GPIO_BASE + 0x00060)
+#define LPC_GPIO4_BASE        (LPC_GPIO_BASE + 0x00080)
+
+/******************************************************************************/
+/*                         Peripheral declaration                             */
+/******************************************************************************/
+#define LPC_SC                ((LPC_SC_TypeDef *)LPC_SC_BASE)
+#define LPC_GPIO0             ((LPC_GPIO_TypeDef *)LPC_GPIO0_BASE)
+#define LPC_GPIO1             ((LPC_GPIO_TypeDef *)LPC_GPIO1_BASE)
+#define LPC_GPIO2             ((LPC_GPIO_TypeDef *)LPC_GPIO2_BASE)
+#define LPC_GPIO3             ((LPC_GPIO_TypeDef *)LPC_GPIO3_BASE)
+#define LPC_GPIO4             ((LPC_GPIO_TypeDef *)LPC_GPIO4_BASE)
+#define LPC_WDT               ((LPC_WDT_TypeDef *)LPC_WDT_BASE)
+#define LPC_TIM0              ((LPC_TIM_TypeDef *)LPC_TIM0_BASE)
+#define LPC_TIM1              ((LPC_TIM_TypeDef *)LPC_TIM1_BASE)
+#define LPC_TIM2              ((LPC_TIM_TypeDef *)LPC_TIM2_BASE)
+#define LPC_TIM3              ((LPC_TIM_TypeDef *)LPC_TIM3_BASE)
+#define LPC_RIT               ((LPC_RIT_TypeDef *)LPC_RIT_BASE)
+#define LPC_UART0             ((LPC_UART_TypeDef *)LPC_UART0_BASE)
+#define LPC_UART1             ((LPC_UART1_TypeDef *)LPC_UART1_BASE)
+#define LPC_UART2             ((LPC_UART_TypeDef *)LPC_UART2_BASE)
+#define LPC_UART3             ((LPC_UART_TypeDef *)LPC_UART3_BASE)
+#define LPC_PWM1              ((LPC_PWM_TypeDef *)LPC_PWM1_BASE)
+#define LPC_I2C0              ((LPC_I2C_TypeDef *)LPC_I2C0_BASE)
+#define LPC_I2C1              ((LPC_I2C_TypeDef *)LPC_I2C1_BASE)
+#define LPC_I2C2              ((LPC_I2C_TypeDef *)LPC_I2C2_BASE)
+#define LPC_I2S               ((LPC_I2S_TypeDef *)LPC_I2S_BASE)
+#define LPC_SPI               ((LPC_SPI_TypeDef *)LPC_SPI_BASE)
+#define LPC_RTC               ((LPC_RTC_TypeDef *)LPC_RTC_BASE)
+#define LPC_GPIOINT           ((LPC_GPIOINT_TypeDef *)LPC_GPIOINT_BASE)
+#define LPC_PINCON            ((LPC_PINCON_TypeDef *)LPC_PINCON_BASE)
+#define LPC_SSP0              ((LPC_SSP_TypeDef *)LPC_SSP0_BASE)
+#define LPC_SSP1              ((LPC_SSP_TypeDef *)LPC_SSP1_BASE)
+#define LPC_ADC               ((LPC_ADC_TypeDef *)LPC_ADC_BASE)
+#define LPC_DAC               ((LPC_DAC_TypeDef *)LPC_DAC_BASE)
+#define LPC_CANAF_RAM         ((LPC_CANAF_RAM_TypeDef *)LPC_CANAF_RAM_BASE)
+#define LPC_CANAF             ((LPC_CANAF_TypeDef *)LPC_CANAF_BASE)
+#define LPC_CANCR             ((LPC_CANCR_TypeDef *)LPC_CANCR_BASE)
+#define LPC_CAN1              ((LPC_CAN_TypeDef *)LPC_CAN1_BASE)
+#define LPC_CAN2              ((LPC_CAN_TypeDef *)LPC_CAN2_BASE)
+#define LPC_MCPWM             ((LPC_MCPWM_TypeDef *)LPC_MCPWM_BASE)
+#define LPC_QEI               ((LPC_QEI_TypeDef *)LPC_QEI_BASE)
+#define LPC_EMAC              ((LPC_EMAC_TypeDef *)LPC_EMAC_BASE)
+#define LPC_GPDMA             ((LPC_GPDMA_TypeDef *)LPC_GPDMA_BASE)
+#define LPC_GPDMACH0          ((LPC_GPDMACH_TypeDef *)LPC_GPDMACH0_BASE)
+#define LPC_GPDMACH1          ((LPC_GPDMACH_TypeDef *)LPC_GPDMACH1_BASE)
+#define LPC_GPDMACH2          ((LPC_GPDMACH_TypeDef *)LPC_GPDMACH2_BASE)
+#define LPC_GPDMACH3          ((LPC_GPDMACH_TypeDef *)LPC_GPDMACH3_BASE)
+#define LPC_GPDMACH4          ((LPC_GPDMACH_TypeDef *)LPC_GPDMACH4_BASE)
+#define LPC_GPDMACH5          ((LPC_GPDMACH_TypeDef *)LPC_GPDMACH5_BASE)
+#define LPC_GPDMACH6          ((LPC_GPDMACH_TypeDef *)LPC_GPDMACH6_BASE)
+#define LPC_GPDMACH7          ((LPC_GPDMACH_TypeDef *)LPC_GPDMACH7_BASE)
+#define LPC_USB               ((LPC_USB_TypeDef *)LPC_USB_BASE)
+
+/**
+ * @}
+ */
+
+#endif  /* __LPC17xx_H__ */

--- a/cpu/arm/lpc1768/lpc17xx_clkpwr.c
+++ b/cpu/arm/lpc1768/lpc17xx_clkpwr.c
@@ -1,0 +1,325 @@
+/**********************************************************************
+ * $Id$		lpc17xx_clkpwr.c				2010-06-18
+ *//**
+ * @file		lpc17xx_clkpwr.c
+ * @brief	Contains all functions support for Clock and Power Control
+ *      firmware library on LPC17xx
+ * @version	3.0
+ * @date		18. June. 2010
+ * @author	NXP MCU SW Application Team
+ *
+ * Copyright(C) 2010, NXP Semiconductor
+ * All rights reserved.
+ *
+ ***********************************************************************
+ * Software that is described herein is for illustrative purposes only
+ * which provides customers with programming information regarding the
+ * products. This software is supplied "AS IS" without any warranties.
+ * NXP Semiconductors assumes no responsibility or liability for the
+ * use of the software, conveys no license or title under any patent,
+ * copyright, or mask work right to the product. NXP Semiconductors
+ * reserves the right to make changes in the software without
+ * notification. NXP Semiconductors also make no representation or
+ * warranty that such application will be suitable for the specified
+ * use without further testing or modification.
+ **********************************************************************/
+
+/* Peripheral group ----------------------------------------------------------- */
+/** @addtogroup CLKPWR
+ * @{
+ */
+
+/* Includes ------------------------------------------------------------------- */
+#include "lpc17xx_clkpwr.h"
+
+/* Public Functions ----------------------------------------------------------- */
+/** @addtogroup CLKPWR_Public_Functions
+ * @{
+ */
+
+/*********************************************************************//**
+ * @brief     Set value of each Peripheral Clock Selection
+ * @param[in]	ClkType	Peripheral Clock Selection of each type,
+ *        should be one of the following:
+ *				- CLKPWR_PCLKSEL_WDT      : WDT
+        - CLKPWR_PCLKSEL_TIMER0     : Timer 0
+        - CLKPWR_PCLKSEL_TIMER1     : Timer 1
+        - CLKPWR_PCLKSEL_UART0    : UART 0
+        - CLKPWR_PCLKSEL_UART1    : UART 1
+        - CLKPWR_PCLKSEL_PWM1     : PWM 1
+        - CLKPWR_PCLKSEL_I2C0     : I2C 0
+        - CLKPWR_PCLKSEL_SPI      : SPI
+        - CLKPWR_PCLKSEL_SSP1     : SSP 1
+        - CLKPWR_PCLKSEL_DAC      : DAC
+        - CLKPWR_PCLKSEL_ADC      : ADC
+        - CLKPWR_PCLKSEL_CAN1     : CAN 1
+        - CLKPWR_PCLKSEL_CAN2     : CAN 2
+        - CLKPWR_PCLKSEL_ACF      : ACF
+        - CLKPWR_PCLKSEL_QEI    : QEI
+        - CLKPWR_PCLKSEL_PCB      : PCB
+        - CLKPWR_PCLKSEL_I2C1     : I2C 1
+        - CLKPWR_PCLKSEL_SSP0     : SSP 0
+        - CLKPWR_PCLKSEL_TIMER2     : Timer 2
+        - CLKPWR_PCLKSEL_TIMER3     : Timer 3
+        - CLKPWR_PCLKSEL_UART2    : UART 2
+        - CLKPWR_PCLKSEL_UART3    : UART 3
+        - CLKPWR_PCLKSEL_I2C2     : I2C 2
+        - CLKPWR_PCLKSEL_I2S      : I2S
+        - CLKPWR_PCLKSEL_RIT      : RIT
+        - CLKPWR_PCLKSEL_SYSCON     : SYSCON
+        - CLKPWR_PCLKSEL_MC     : MC
+
+ * @param[in]	DivVal	Value of divider, should be:
+ *        - CLKPWR_PCLKSEL_CCLK_DIV_4 : PCLK_peripheral = CCLK/4
+ *        - CLKPWR_PCLKSEL_CCLK_DIV_1 : PCLK_peripheral = CCLK/1
+ *				- CLKPWR_PCLKSEL_CCLK_DIV_2 : PCLK_peripheral = CCLK/2
+ *
+ * @return none
+ **********************************************************************/
+void
+CLKPWR_SetPCLKDiv(uint32_t ClkType, uint32_t DivVal)
+{
+  uint32_t bitpos;
+
+  bitpos = (ClkType < 32) ? (ClkType) : (ClkType - 32);
+
+  /* PCLKSEL0 selected */
+  if(ClkType < 32) {
+    /* Clear two bit at bit position */
+    LPC_SC->PCLKSEL0 &= (~(CLKPWR_PCLKSEL_BITMASK(bitpos)));
+
+    /* Set two selected bit */
+    LPC_SC->PCLKSEL0 |= (CLKPWR_PCLKSEL_SET(bitpos, DivVal));
+  }
+  /* PCLKSEL1 selected */
+  else {
+    /* Clear two bit at bit position */
+    LPC_SC->PCLKSEL1 &= ~(CLKPWR_PCLKSEL_BITMASK(bitpos));
+
+    /* Set two selected bit */
+    LPC_SC->PCLKSEL1 |= (CLKPWR_PCLKSEL_SET(bitpos, DivVal));
+  }
+}
+/*********************************************************************//**
+ * @brief		Get current value of each Peripheral Clock Selection
+ * @param[in]	ClkType	Peripheral Clock Selection of each type,
+ *        should be one of the following:
+ *				- CLKPWR_PCLKSEL_WDT      : WDT
+        - CLKPWR_PCLKSEL_TIMER0     : Timer 0
+        - CLKPWR_PCLKSEL_TIMER1     : Timer 1
+        - CLKPWR_PCLKSEL_UART0    : UART 0
+        - CLKPWR_PCLKSEL_UART1    : UART 1
+        - CLKPWR_PCLKSEL_PWM1     : PWM 1
+        - CLKPWR_PCLKSEL_I2C0     : I2C 0
+        - CLKPWR_PCLKSEL_SPI      : SPI
+        - CLKPWR_PCLKSEL_SSP1     : SSP 1
+        - CLKPWR_PCLKSEL_DAC      : DAC
+        - CLKPWR_PCLKSEL_ADC      : ADC
+        - CLKPWR_PCLKSEL_CAN1     : CAN 1
+        - CLKPWR_PCLKSEL_CAN2     : CAN 2
+        - CLKPWR_PCLKSEL_ACF      : ACF
+        - CLKPWR_PCLKSEL_QEI    : QEI
+        - CLKPWR_PCLKSEL_PCB      : PCB
+        - CLKPWR_PCLKSEL_I2C1     : I2C 1
+        - CLKPWR_PCLKSEL_SSP0     : SSP 0
+        - CLKPWR_PCLKSEL_TIMER2     : Timer 2
+        - CLKPWR_PCLKSEL_TIMER3     : Timer 3
+        - CLKPWR_PCLKSEL_UART2    : UART 2
+        - CLKPWR_PCLKSEL_UART3    : UART 3
+        - CLKPWR_PCLKSEL_I2C2     : I2C 2
+        - CLKPWR_PCLKSEL_I2S      : I2S
+        - CLKPWR_PCLKSEL_RIT      : RIT
+        - CLKPWR_PCLKSEL_SYSCON     : SYSCON
+        - CLKPWR_PCLKSEL_MC     : MC
+
+ * @return		Value of Selected Peripheral Clock Selection
+ **********************************************************************/
+uint32_t
+CLKPWR_GetPCLKSEL(uint32_t ClkType)
+{
+  uint32_t bitpos, retval;
+
+  if(ClkType < 32) {
+    bitpos = ClkType;
+    retval = LPC_SC->PCLKSEL0;
+  } else {
+    bitpos = ClkType - 32;
+    retval = LPC_SC->PCLKSEL1;
+  }
+
+  retval = CLKPWR_PCLKSEL_GET(bitpos, retval);
+  return retval;
+}
+/*********************************************************************//**
+ * @brief     Get current value of each Peripheral Clock
+ * @param[in]	ClkType	Peripheral Clock Selection of each type,
+ *        should be one of the following:
+ *				- CLKPWR_PCLKSEL_WDT      : WDT
+        - CLKPWR_PCLKSEL_TIMER0     : Timer 0
+        - CLKPWR_PCLKSEL_TIMER1     : Timer 1
+        - CLKPWR_PCLKSEL_UART0    : UART 0
+        - CLKPWR_PCLKSEL_UART1    : UART 1
+        - CLKPWR_PCLKSEL_PWM1     : PWM 1
+        - CLKPWR_PCLKSEL_I2C0     : I2C 0
+        - CLKPWR_PCLKSEL_SPI      : SPI
+        - CLKPWR_PCLKSEL_SSP1     : SSP 1
+        - CLKPWR_PCLKSEL_DAC      : DAC
+        - CLKPWR_PCLKSEL_ADC      : ADC
+        - CLKPWR_PCLKSEL_CAN1     : CAN 1
+        - CLKPWR_PCLKSEL_CAN2     : CAN 2
+        - CLKPWR_PCLKSEL_ACF      : ACF
+        - CLKPWR_PCLKSEL_QEI    : QEI
+        - CLKPWR_PCLKSEL_PCB      : PCB
+        - CLKPWR_PCLKSEL_I2C1     : I2C 1
+        - CLKPWR_PCLKSEL_SSP0     : SSP 0
+        - CLKPWR_PCLKSEL_TIMER2     : Timer 2
+        - CLKPWR_PCLKSEL_TIMER3     : Timer 3
+        - CLKPWR_PCLKSEL_UART2    : UART 2
+        - CLKPWR_PCLKSEL_UART3    : UART 3
+        - CLKPWR_PCLKSEL_I2C2     : I2C 2
+        - CLKPWR_PCLKSEL_I2S      : I2S
+        - CLKPWR_PCLKSEL_RIT      : RIT
+        - CLKPWR_PCLKSEL_SYSCON     : SYSCON
+        - CLKPWR_PCLKSEL_MC     : MC
+
+ * @return		Value of Selected Peripheral Clock
+ **********************************************************************/
+uint32_t
+CLKPWR_GetPCLK(uint32_t ClkType)
+{
+  uint32_t retval, div;
+
+  retval = SystemCoreClock;
+  div = CLKPWR_GetPCLKSEL(ClkType);
+
+  switch(div) {
+  case 0:
+    div = 4;
+    break;
+
+  case 1:
+    div = 1;
+    break;
+
+  case 2:
+    div = 2;
+    break;
+
+  case 3:
+    div = 8;
+    break;
+  }
+  retval /= div;
+
+  return retval;
+}
+/*********************************************************************//**
+ * @brief     Configure power supply for each peripheral according to NewState
+ * @param[in]	PPType	Type of peripheral used to enable power,
+ *              should be one of the following:
+ *          -  CLKPWR_PCONP_PCTIM0    : Timer 0
+        -  CLKPWR_PCONP_PCTIM1    : Timer 1
+        -  CLKPWR_PCONP_PCUART0   : UART 0
+        -  CLKPWR_PCONP_PCUART1     : UART 1
+        -  CLKPWR_PCONP_PCPWM1    : PWM 1
+        -  CLKPWR_PCONP_PCI2C0    : I2C 0
+        -  CLKPWR_PCONP_PCSPI     : SPI
+        -  CLKPWR_PCONP_PCRTC     : RTC
+        -  CLKPWR_PCONP_PCSSP1    : SSP 1
+        -  CLKPWR_PCONP_PCAD      : ADC
+        -  CLKPWR_PCONP_PCAN1     : CAN 1
+        -  CLKPWR_PCONP_PCAN2     : CAN 2
+        -  CLKPWR_PCONP_PCGPIO    : GPIO
+        -  CLKPWR_PCONP_PCRIT     : RIT
+        -  CLKPWR_PCONP_PCMC    : MC
+        -  CLKPWR_PCONP_PCQEI     : QEI
+        -  CLKPWR_PCONP_PCI2C1    : I2C 1
+        -  CLKPWR_PCONP_PCSSP0    : SSP 0
+        -  CLKPWR_PCONP_PCTIM2    : Timer 2
+        -  CLKPWR_PCONP_PCTIM3    : Timer 3
+        -  CLKPWR_PCONP_PCUART2   : UART 2
+        -  CLKPWR_PCONP_PCUART3     : UART 3
+        -  CLKPWR_PCONP_PCI2C2    : I2C 2
+        -  CLKPWR_PCONP_PCI2S     : I2S
+        -  CLKPWR_PCONP_PCGPDMA     : GPDMA
+        -  CLKPWR_PCONP_PCENET    : Ethernet
+        -  CLKPWR_PCONP_PCUSB     : USB
+ *
+ * @param[in]	NewState	New state of Peripheral Power, should be:
+ *        - ENABLE	: Enable power for this peripheral
+ *        - DISABLE	: Disable power for this peripheral
+ *
+ * @return none
+ **********************************************************************/
+void
+CLKPWR_ConfigPPWR(uint32_t PPType, FunctionalState NewState)
+{
+  if(NewState == ENABLE) {
+    LPC_SC->PCONP |= PPType & CLKPWR_PCONP_BITMASK;
+  } else if(NewState == DISABLE) {
+    LPC_SC->PCONP &= (~PPType) & CLKPWR_PCONP_BITMASK;
+  }
+}
+/*********************************************************************//**
+ * @brief     Enter Sleep mode with co-operated instruction by the Cortex-M3.
+ * @param[in]	None
+ * @return		None
+ **********************************************************************/
+void
+CLKPWR_Sleep(void)
+{
+  LPC_SC->PCON = 0x00;
+  /* Sleep Mode*/
+  __WFI();
+}
+/*********************************************************************//**
+ * @brief     Enter Deep Sleep mode with co-operated instruction by the Cortex-M3.
+ * @param[in]	None
+ * @return		None
+ **********************************************************************/
+void
+CLKPWR_DeepSleep(void)
+{
+  /* Deep-Sleep Mode, set SLEEPDEEP bit */
+  SCB->SCR = 0x4;
+  LPC_SC->PCON = 0x8;
+  /* Deep Sleep Mode*/
+  __WFI();
+}
+/*********************************************************************//**
+ * @brief     Enter Power Down mode with co-operated instruction by the Cortex-M3.
+ * @param[in]	None
+ * @return		None
+ **********************************************************************/
+void
+CLKPWR_PowerDown(void)
+{
+  /* Deep-Sleep Mode, set SLEEPDEEP bit */
+  SCB->SCR = 0x4;
+  LPC_SC->PCON = 0x09;
+  /* Power Down Mode*/
+  __WFI();
+}
+/*********************************************************************//**
+ * @brief     Enter Deep Power Down mode with co-operated instruction by the Cortex-M3.
+ * @param[in]	None
+ * @return		None
+ **********************************************************************/
+void
+CLKPWR_DeepPowerDown(void)
+{
+  /* Deep-Sleep Mode, set SLEEPDEEP bit */
+  SCB->SCR = 0x4;
+  LPC_SC->PCON = 0x03;
+  /* Deep Power Down Mode*/
+  __WFI();
+}
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/* --------------------------------- End Of File ------------------------------ */

--- a/cpu/arm/lpc1768/lpc17xx_clkpwr.h
+++ b/cpu/arm/lpc1768/lpc17xx_clkpwr.h
@@ -1,0 +1,395 @@
+/**********************************************************************
+ * $Id$		lpc17xx_clkpwr.h			2010-05-21
+ *//**
+ * @file		lpc17xx_clkpwr.h
+ * @brief	Contains all macro definitions and function prototypes
+ *      support for Clock and Power Control firmware library on LPC17xx
+ * @version	2.0
+ * @date		21. May. 2010
+ * @author	NXP MCU SW Application Team
+ *
+ * Copyright(C) 2010, NXP Semiconductor
+ * All rights reserved.
+ *
+ ***********************************************************************
+ * Software that is described herein is for illustrative purposes only
+ * which provides customers with programming information regarding the
+ * products. This software is supplied "AS IS" without any warranties.
+ * NXP Semiconductors assumes no responsibility or liability for the
+ * use of the software, conveys no license or title under any patent,
+ * copyright, or mask work right to the product. NXP Semiconductors
+ * reserves the right to make changes in the software without
+ * notification. NXP Semiconductors also make no representation or
+ * warranty that such application will be suitable for the specified
+ * use without further testing or modification.
+ **********************************************************************/
+
+/* Peripheral group ----------------------------------------------------------- */
+/** @defgroup CLKPWR CLKPWR (Clock Power)
+ * @ingroup LPC1700CMSIS_FwLib_Drivers
+ * @{
+ */
+
+#ifndef LPC17XX_CLKPWR_H_
+#define LPC17XX_CLKPWR_H_
+
+/* Includes ------------------------------------------------------------------- */
+#include "lpc17xx.h"
+#include "lpc_types.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/* Public Macros -------------------------------------------------------------- */
+/** @defgroup CLKPWR_Public_Macros CLKPWR Public Macros
+ * @{
+ */
+
+/**********************************************************************
+ * Peripheral Clock Selection Definitions
+ **********************************************************************/
+/** Peripheral clock divider bit position for WDT */
+#define CLKPWR_PCLKSEL_WDT      ((uint32_t)(0))
+/** Peripheral clock divider bit position for TIMER0 */
+#define CLKPWR_PCLKSEL_TIMER0     ((uint32_t)(2))
+/** Peripheral clock divider bit position for TIMER1 */
+#define CLKPWR_PCLKSEL_TIMER1     ((uint32_t)(4))
+/** Peripheral clock divider bit position for UART0 */
+#define CLKPWR_PCLKSEL_UART0      ((uint32_t)(6))
+/** Peripheral clock divider bit position for UART1 */
+#define CLKPWR_PCLKSEL_UART1      ((uint32_t)(8))
+/** Peripheral clock divider bit position for PWM1 */
+#define CLKPWR_PCLKSEL_PWM1     ((uint32_t)(12))
+/** Peripheral clock divider bit position for I2C0 */
+#define CLKPWR_PCLKSEL_I2C0     ((uint32_t)(14))
+/** Peripheral clock divider bit position for SPI */
+#define CLKPWR_PCLKSEL_SPI      ((uint32_t)(16))
+/** Peripheral clock divider bit position for SSP1 */
+#define CLKPWR_PCLKSEL_SSP1     ((uint32_t)(20))
+/** Peripheral clock divider bit position for DAC */
+#define CLKPWR_PCLKSEL_DAC      ((uint32_t)(22))
+/** Peripheral clock divider bit position for ADC */
+#define CLKPWR_PCLKSEL_ADC      ((uint32_t)(24))
+/** Peripheral clock divider bit position for CAN1 */
+#define CLKPWR_PCLKSEL_CAN1     ((uint32_t)(26))
+/** Peripheral clock divider bit position for CAN2 */
+#define CLKPWR_PCLKSEL_CAN2     ((uint32_t)(28))
+/** Peripheral clock divider bit position for ACF */
+#define CLKPWR_PCLKSEL_ACF      ((uint32_t)(30))
+/** Peripheral clock divider bit position for QEI */
+#define CLKPWR_PCLKSEL_QEI      ((uint32_t)(32))
+/** Peripheral clock divider bit position for PCB */
+#define CLKPWR_PCLKSEL_PCB      ((uint32_t)(36))
+/** Peripheral clock divider bit position for  I2C1 */
+#define CLKPWR_PCLKSEL_I2C1     ((uint32_t)(38))
+/** Peripheral clock divider bit position for SSP0 */
+#define CLKPWR_PCLKSEL_SSP0     ((uint32_t)(42))
+/** Peripheral clock divider bit position for TIMER2 */
+#define CLKPWR_PCLKSEL_TIMER2     ((uint32_t)(44))
+/** Peripheral clock divider bit position for  TIMER3 */
+#define CLKPWR_PCLKSEL_TIMER3     ((uint32_t)(46))
+/** Peripheral clock divider bit position for UART2 */
+#define CLKPWR_PCLKSEL_UART2      ((uint32_t)(48))
+/** Peripheral clock divider bit position for UART3 */
+#define CLKPWR_PCLKSEL_UART3      ((uint32_t)(50))
+/** Peripheral clock divider bit position for I2C2 */
+#define CLKPWR_PCLKSEL_I2C2     ((uint32_t)(52))
+/** Peripheral clock divider bit position for I2S */
+#define CLKPWR_PCLKSEL_I2S      ((uint32_t)(54))
+/** Peripheral clock divider bit position for RIT */
+#define CLKPWR_PCLKSEL_RIT      ((uint32_t)(58))
+/** Peripheral clock divider bit position for SYSCON */
+#define CLKPWR_PCLKSEL_SYSCON     ((uint32_t)(60))
+/** Peripheral clock divider bit position for MC */
+#define CLKPWR_PCLKSEL_MC       ((uint32_t)(62))
+
+/** Macro for Peripheral Clock Selection register bit values
+ * Note: When CCLK_DIV_8, Peripheral’s clock is selected to
+ * PCLK_xyz = CCLK/8 except for CAN1, CAN2, and CAN filtering
+ * when ’11’selects PCLK_xyz = CCLK/6 */
+/* Peripheral clock divider is set to 4 from CCLK */
+#define CLKPWR_PCLKSEL_CCLK_DIV_4  ((uint32_t)(0))
+/** Peripheral clock divider is the same with CCLK */
+#define CLKPWR_PCLKSEL_CCLK_DIV_1  ((uint32_t)(1))
+/** Peripheral clock divider is set to 2 from CCLK */
+#define CLKPWR_PCLKSEL_CCLK_DIV_2  ((uint32_t)(2))
+
+/********************************************************************
+ * Power Control for Peripherals Definitions
+ **********************************************************************/
+/** Timer/Counter 0 power/clock control bit */
+#define  CLKPWR_PCONP_PCTIM0  ((uint32_t)(1 << 1))
+/* Timer/Counter 1 power/clock control bit */
+#define  CLKPWR_PCONP_PCTIM1  ((uint32_t)(1 << 2))
+/** UART0 power/clock control bit */
+#define  CLKPWR_PCONP_PCUART0   ((uint32_t)(1 << 3))
+/** UART1 power/clock control bit */
+#define  CLKPWR_PCONP_PCUART1   ((uint32_t)(1 << 4))
+/** PWM1 power/clock control bit */
+#define  CLKPWR_PCONP_PCPWM1  ((uint32_t)(1 << 6))
+/** The I2C0 interface power/clock control bit */
+#define  CLKPWR_PCONP_PCI2C0  ((uint32_t)(1 << 7))
+/** The SPI interface power/clock control bit */
+#define  CLKPWR_PCONP_PCSPI   ((uint32_t)(1 << 8))
+/** The RTC power/clock control bit */
+#define  CLKPWR_PCONP_PCRTC   ((uint32_t)(1 << 9))
+/** The SSP1 interface power/clock control bit */
+#define  CLKPWR_PCONP_PCSSP1  ((uint32_t)(1 << 10))
+/** A/D converter 0 (ADC0) power/clock control bit */
+#define  CLKPWR_PCONP_PCAD    ((uint32_t)(1 << 12))
+/** CAN Controller 1 power/clock control bit */
+#define  CLKPWR_PCONP_PCAN1   ((uint32_t)(1 << 13))
+/** CAN Controller 2 power/clock control bit */
+#define  CLKPWR_PCONP_PCAN2   ((uint32_t)(1 << 14))
+/** GPIO power/clock control bit */
+#define CLKPWR_PCONP_PCGPIO   ((uint32_t)(1 << 15))
+/** Repetitive Interrupt Timer power/clock control bit */
+#define CLKPWR_PCONP_PCRIT    ((uint32_t)(1 << 16))
+/** Motor Control PWM */
+#define CLKPWR_PCONP_PCMC     ((uint32_t)(1 << 17))
+/** Quadrature Encoder Interface power/clock control bit */
+#define CLKPWR_PCONP_PCQEI    ((uint32_t)(1 << 18))
+/** The I2C1 interface power/clock control bit */
+#define  CLKPWR_PCONP_PCI2C1    ((uint32_t)(1 << 19))
+/** The SSP0 interface power/clock control bit */
+#define  CLKPWR_PCONP_PCSSP0  ((uint32_t)(1 << 21))
+/** Timer 2 power/clock control bit */
+#define  CLKPWR_PCONP_PCTIM2  ((uint32_t)(1 << 22))
+/** Timer 3 power/clock control bit */
+#define  CLKPWR_PCONP_PCTIM3  ((uint32_t)(1 << 23))
+/** UART 2 power/clock control bit */
+#define  CLKPWR_PCONP_PCUART2   ((uint32_t)(1 << 24))
+/** UART 3 power/clock control bit */
+#define  CLKPWR_PCONP_PCUART3   ((uint32_t)(1 << 25))
+/** I2C interface 2 power/clock control bit */
+#define  CLKPWR_PCONP_PCI2C2  ((uint32_t)(1 << 26))
+/** I2S interface power/clock control bit*/
+#define  CLKPWR_PCONP_PCI2S   ((uint32_t)(1 << 27))
+/** GP DMA function power/clock control bit*/
+#define  CLKPWR_PCONP_PCGPDMA   ((uint32_t)(1 << 29))
+/** Ethernet block power/clock control bit*/
+#define  CLKPWR_PCONP_PCENET  ((uint32_t)(1 << 30))
+/** USB interface power/clock control bit*/
+#define  CLKPWR_PCONP_PCUSB   ((uint32_t)(1 << 31))
+
+/**
+ * @}
+ */
+/* Private Macros ------------------------------------------------------------- */
+/** @defgroup CLKPWR_Private_Macros CLKPWR Private Macros
+ * @{
+ */
+
+/* --------------------- BIT DEFINITIONS -------------------------------------- */
+/*********************************************************************//**
+ * Macro defines for Clock Source Select Register
+ **********************************************************************/
+/** Internal RC oscillator */
+#define CLKPWR_CLKSRCSEL_CLKSRC_IRC     ((uint32_t)(0x00))
+/** Main oscillator */
+#define CLKPWR_CLKSRCSEL_CLKSRC_MAINOSC   ((uint32_t)(0x01))
+/** RTC oscillator */
+#define CLKPWR_CLKSRCSEL_CLKSRC_RTC     ((uint32_t)(0x02))
+/** Clock source selection bit mask */
+#define CLKPWR_CLKSRCSEL_BITMASK      ((uint32_t)(0x03))
+
+/*********************************************************************//**
+ * Macro defines for Clock Output Configuration Register
+ **********************************************************************/
+/* Clock Output Configuration register definition */
+/** Selects the CPU clock as the CLKOUT source */
+#define CLKPWR_CLKOUTCFG_CLKOUTSEL_CPU    ((uint32_t)(0x00))
+/** Selects the main oscillator as the CLKOUT source */
+#define CLKPWR_CLKOUTCFG_CLKOUTSEL_MAINOSC  ((uint32_t)(0x01))
+/** Selects the Internal RC oscillator as the CLKOUT source */
+#define CLKPWR_CLKOUTCFG_CLKOUTSEL_RC   ((uint32_t)(0x02))
+/** Selects the USB clock as the CLKOUT source */
+#define CLKPWR_CLKOUTCFG_CLKOUTSEL_USB    ((uint32_t)(0x03))
+/** Selects the RTC oscillator as the CLKOUT source */
+#define CLKPWR_CLKOUTCFG_CLKOUTSEL_RTC    ((uint32_t)(0x04))
+/** Integer value to divide the output clock by, minus one */
+#define CLKPWR_CLKOUTCFG_CLKOUTDIV(n)   ((uint32_t)((n & 0x0F) << 4))
+/** CLKOUT enable control */
+#define CLKPWR_CLKOUTCFG_CLKOUT_EN      ((uint32_t)(1 << 8))
+/** CLKOUT activity indication */
+#define CLKPWR_CLKOUTCFG_CLKOUT_ACT     ((uint32_t)(1 << 9))
+/** Clock source selection bit mask */
+#define CLKPWR_CLKOUTCFG_BITMASK      ((uint32_t)(0x3FF))
+
+/*********************************************************************//**
+ * Macro defines for PPL0 Control Register
+ **********************************************************************/
+/** PLL 0 control enable */
+#define CLKPWR_PLL0CON_ENABLE   ((uint32_t)(0x01))
+/** PLL 0 control connect */
+#define CLKPWR_PLL0CON_CONNECT    ((uint32_t)(0x02))
+/** PLL 0 control bit mask */
+#define CLKPWR_PLL0CON_BITMASK    ((uint32_t)(0x03))
+
+/*********************************************************************//**
+ * Macro defines for PPL0 Configuration Register
+ **********************************************************************/
+/** PLL 0 Configuration MSEL field */
+#define CLKPWR_PLL0CFG_MSEL(n)    ((uint32_t)(n & 0x7FFF))
+/** PLL 0 Configuration NSEL field */
+#define CLKPWR_PLL0CFG_NSEL(n)    ((uint32_t)((n << 16) & 0xFF0000))
+/** PLL 0 Configuration bit mask */
+#define CLKPWR_PLL0CFG_BITMASK    ((uint32_t)(0xFF7FFF))
+
+/*********************************************************************//**
+ * Macro defines for PPL0 Status Register
+ **********************************************************************/
+/** PLL 0 MSEL value */
+#define CLKPWR_PLL0STAT_MSEL(n)   ((uint32_t)(n & 0x7FFF))
+/** PLL NSEL get value  */
+#define CLKPWR_PLL0STAT_NSEL(n)   ((uint32_t)((n >> 16) & 0xFF))
+/** PLL status enable bit */
+#define CLKPWR_PLL0STAT_PLLE    ((uint32_t)(1 << 24))
+/** PLL status Connect bit */
+#define CLKPWR_PLL0STAT_PLLC    ((uint32_t)(1 << 25))
+/** PLL status lock */
+#define CLKPWR_PLL0STAT_PLOCK   ((uint32_t)(1 << 26))
+
+/*********************************************************************//**
+ * Macro defines for PPL0 Feed Register
+ **********************************************************************/
+/** PLL0 Feed bit mask */
+#define CLKPWR_PLL0FEED_BITMASK     ((uint32_t)0xFF)
+
+/*********************************************************************//**
+ * Macro defines for PLL1 Control Register
+ **********************************************************************/
+/** USB PLL control enable */
+#define CLKPWR_PLL1CON_ENABLE   ((uint32_t)(0x01))
+/** USB PLL control connect */
+#define CLKPWR_PLL1CON_CONNECT    ((uint32_t)(0x02))
+/** USB PLL control bit mask */
+#define CLKPWR_PLL1CON_BITMASK    ((uint32_t)(0x03))
+
+/*********************************************************************//**
+ * Macro defines for PLL1 Configuration Register
+ **********************************************************************/
+/** USB PLL MSEL set value */
+#define CLKPWR_PLL1CFG_MSEL(n)    ((uint32_t)(n & 0x1F))
+/** USB PLL PSEL set value */
+#define CLKPWR_PLL1CFG_PSEL(n)    ((uint32_t)((n & 0x03) << 5))
+/** USB PLL configuration bit mask */
+#define CLKPWR_PLL1CFG_BITMASK    ((uint32_t)(0x7F))
+
+/*********************************************************************//**
+ * Macro defines for PLL1 Status Register
+ **********************************************************************/
+/** USB PLL MSEL get value  */
+#define CLKPWR_PLL1STAT_MSEL(n)   ((uint32_t)(n & 0x1F))
+/** USB PLL PSEL get value  */
+#define CLKPWR_PLL1STAT_PSEL(n)   ((uint32_t)((n >> 5) & 0x03))
+/** USB PLL status enable bit */
+#define CLKPWR_PLL1STAT_PLLE    ((uint32_t)(1 << 8))
+/** USB PLL status Connect bit */
+#define CLKPWR_PLL1STAT_PLLC    ((uint32_t)(1 << 9))
+/** USB PLL status lock */
+#define CLKPWR_PLL1STAT_PLOCK   ((uint32_t)(1 << 10))
+
+/*********************************************************************//**
+ * Macro defines for PLL1 Feed Register
+ **********************************************************************/
+/** PLL1 Feed bit mask */
+#define CLKPWR_PLL1FEED_BITMASK   ((uint32_t)0xFF)
+
+/*********************************************************************//**
+ * Macro defines for CPU Clock Configuration Register
+ **********************************************************************/
+/** CPU Clock configuration bit mask */
+#define CLKPWR_CCLKCFG_BITMASK    ((uint32_t)(0xFF))
+
+/*********************************************************************//**
+ * Macro defines for USB Clock Configuration Register
+ **********************************************************************/
+/** USB Clock Configuration bit mask */
+#define CLKPWR_USBCLKCFG_BITMASK  ((uint32_t)(0x0F))
+
+/*********************************************************************//**
+ * Macro defines for IRC Trim Register
+ **********************************************************************/
+/** IRC Trim bit mask */
+#define CLKPWR_IRCTRIM_BITMASK    ((uint32_t)(0x0F))
+
+/*********************************************************************//**
+ * Macro defines for Peripheral Clock Selection Register 0 and 1
+ **********************************************************************/
+/** Peripheral Clock Selection 0 mask bit */
+#define CLKPWR_PCLKSEL0_BITMASK   ((uint32_t)(0xFFF3F3FF))
+/** Peripheral Clock Selection 1 mask bit */
+#define CLKPWR_PCLKSEL1_BITMASK   ((uint32_t)(0xFCF3F0F3))
+/** Macro to set peripheral clock of each type
+ * p: position of two bits that hold divider of peripheral clock
+ * n: value of divider of peripheral clock  to be set */
+#define CLKPWR_PCLKSEL_SET(p, n)   _SBF(p, n)
+/** Macro to mask peripheral clock of each type */
+#define CLKPWR_PCLKSEL_BITMASK(p) _SBF(p, 0x03)
+/** Macro to get peripheral clock of each type */
+#define CLKPWR_PCLKSEL_GET(p, n)  ((uint32_t)((n >> p) & 0x03))
+
+/*********************************************************************//**
+ * Macro defines for Power Mode Control Register
+ **********************************************************************/
+/** Power mode control bit 0 */
+#define CLKPWR_PCON_PM0     ((uint32_t)(1 << 0))
+/** Power mode control bit 1 */
+#define CLKPWR_PCON_PM1     ((uint32_t)(1 << 1))
+/** Brown-Out Reduced Power Mode */
+#define CLKPWR_PCON_BODPDM    ((uint32_t)(1 << 2))
+/** Brown-Out Global Disable */
+#define CLKPWR_PCON_BOGD    ((uint32_t)(1 << 3))
+/** Brown Out Reset Disable */
+#define CLKPWR_PCON_BORD    ((uint32_t)(1 << 4))
+/** Sleep Mode entry flag */
+#define CLKPWR_PCON_SMFLAG    ((uint32_t)(1 << 8))
+/** Deep Sleep entry flag */
+#define CLKPWR_PCON_DSFLAG    ((uint32_t)(1 << 9))
+/** Power-down entry flag */
+#define CLKPWR_PCON_PDFLAG    ((uint32_t)(1 << 10))
+/** Deep Power-down entry flag */
+#define CLKPWR_PCON_DPDFLAG   ((uint32_t)(1 << 11))
+
+/*********************************************************************//**
+ * Macro defines for Power Control for Peripheral Register
+ **********************************************************************/
+/** Power Control for Peripherals bit mask */
+#define CLKPWR_PCONP_BITMASK  0xEFEFF7DE
+
+/**
+ * @}
+ */
+
+/* Public Functions ----------------------------------------------------------- */
+/** @defgroup CLKPWR_Public_Functions CLKPWR Public Functions
+ * @{
+ */
+
+void CLKPWR_SetPCLKDiv(uint32_t ClkType, uint32_t DivVal);
+uint32_t CLKPWR_GetPCLKSEL(uint32_t ClkType);
+uint32_t CLKPWR_GetPCLK(uint32_t ClkType);
+void CLKPWR_ConfigPPWR(uint32_t PPType, FunctionalState NewState);
+void CLKPWR_Sleep(void);
+void CLKPWR_DeepSleep(void);
+void CLKPWR_PowerDown(void);
+void CLKPWR_DeepPowerDown(void);
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* LPC17XX_CLKPWR_H_ */
+
+/**
+ * @}
+ */
+
+/* --------------------------------- End Of File ------------------------------ */

--- a/cpu/arm/lpc1768/lpc17xx_emac.c
+++ b/cpu/arm/lpc1768/lpc17xx_emac.c
@@ -1,0 +1,939 @@
+/**********************************************************************
+ * $Id$		lpc17xx_dac.c				2010-05-21
+ *//**
+ * @file		lpc17xx_dac.c
+ * @brief	Contains all functions support for Ethernet MAC firmware
+ *      library on LPC17xx
+ * @version	2.0
+ * @date		21. May. 2010
+ * @author	NXP MCU SW Application Team
+ *
+ * Copyright(C) 2010, NXP Semiconductor
+ * All rights reserved.
+ *
+ ***********************************************************************
+ * Software that is described herein is for illustrative purposes only
+ * which provides customers with programming information regarding the
+ * products. This software is supplied "AS IS" without any warranties.
+ * NXP Semiconductors assumes no responsibility or liability for the
+ * use of the software, conveys no license or title under any patent,
+ * copyright, or mask work right to the product. NXP Semiconductors
+ * reserves the right to make changes in the software without
+ * notification. NXP Semiconductors also make no representation or
+ * warranty that such application will be suitable for the specified
+ * use without further testing or modification.
+ **********************************************************************/
+
+/* Peripheral group ----------------------------------------------------------- */
+/** @addtogroup EMAC
+ * @{
+ */
+
+/* Includes ------------------------------------------------------------------- */
+#include "lpc17xx_emac.h"
+#include "lpc17xx_clkpwr.h"
+
+/* If this source file built with example, the LPC17xx FW library configuration
+ * file in each example directory ("lpc17xx_libcfg.h") must be included,
+ * otherwise the default FW library configuration file must be included instead
+ */
+#ifdef __BUILD_WITH_EXAMPLE__
+#include "lpc17xx_libcfg.h"
+#else
+#include "lpc17xx_libcfg_default.h"
+#endif /* __BUILD_WITH_EXAMPLE__ */
+
+#ifdef _EMAC
+
+/* Private Variables ---------------------------------------------------------- */
+/** @defgroup EMAC_Private_Variables EMAC Private Variables
+ * @{
+ */
+
+/* MII Mgmt Configuration register - Clock divider setting */
+const uint8_t EMAC_clkdiv[] = { 4, 6, 8, 10, 14, 20, 28 };
+
+/* EMAC local DMA Descriptors */
+
+/** Rx Descriptor data array */
+static RX_Desc Rx_Desc[EMAC_NUM_RX_FRAG];
+
+/** Rx Status data array - Must be 8-Byte aligned */
+#if defined(__CC_ARM)
+static __align(8) RX_Stat Rx_Stat[EMAC_NUM_RX_FRAG];
+#elif defined(__ICCARM__)
+#pragma data_alignment=8
+static RX_Stat Rx_Stat[EMAC_NUM_RX_FRAG];
+#elif defined(__GNUC__)
+static __attribute__ ((aligned(8))) RX_Stat Rx_Stat[EMAC_NUM_RX_FRAG];
+#endif
+
+/** Tx Descriptor data array */
+static TX_Desc Tx_Desc[EMAC_NUM_TX_FRAG];
+/** Tx Status data array */
+static TX_Stat Tx_Stat[EMAC_NUM_TX_FRAG];
+
+/* EMAC local DMA buffers */
+/** Rx buffer data */
+static uint32_t rx_buf[EMAC_NUM_RX_FRAG][EMAC_ETH_MAX_FLEN >> 2];
+/** Tx buffer data */
+static uint32_t tx_buf[EMAC_NUM_TX_FRAG][EMAC_ETH_MAX_FLEN >> 2];
+
+/**
+ * @}
+ */
+
+/* Private Functions ---------------------------------------------------------- */
+static void rx_descr_init(void);
+static void tx_descr_init(void);
+static int32_t write_PHY(uint32_t PhyReg, uint16_t Value);
+static int32_t  read_PHY(uint32_t PhyReg);
+
+static void setEmacAddr(uint8_t abStationAddr[]);
+static int32_t emac_CRCCalc(uint8_t frame_no_fcs[], int32_t frame_len);
+
+/*--------------------------- rx_descr_init ---------------------------------*/
+/*********************************************************************//**
+ * @brief     Initializes RX Descriptor
+ * @param[in]   None
+ * @return    None
+ ***********************************************************************/
+static void
+rx_descr_init(void)
+{
+  /* Initialize Receive Descriptor and Status array. */
+  uint32_t i;
+
+  for(i = 0; i < EMAC_NUM_RX_FRAG; i++) {
+    Rx_Desc[i].Packet = (uint32_t)&rx_buf[i];
+    Rx_Desc[i].Ctrl = EMAC_RCTRL_INT | (EMAC_ETH_MAX_FLEN - 1);
+    Rx_Stat[i].Info = 0;
+    Rx_Stat[i].HashCRC = 0;
+  }
+
+  /* Set EMAC Receive Descriptor Registers. */
+  LPC_EMAC->RxDescriptor = (uint32_t)&Rx_Desc[0];
+  LPC_EMAC->RxStatus = (uint32_t)&Rx_Stat[0];
+  LPC_EMAC->RxDescriptorNumber = EMAC_NUM_RX_FRAG - 1;
+
+  /* Rx Descriptors Point to 0 */
+  LPC_EMAC->RxConsumeIndex = 0;
+}
+/*--------------------------- tx_descr_init ---- ----------------------------*/
+/*********************************************************************//**
+ * @brief     Initializes TX Descriptor
+ * @param[in]   None
+ * @return    None
+ ***********************************************************************/
+static void
+tx_descr_init(void)
+{
+  /* Initialize Transmit Descriptor and Status array. */
+  uint32_t i;
+
+  for(i = 0; i < EMAC_NUM_TX_FRAG; i++) {
+    Tx_Desc[i].Packet = (uint32_t)&tx_buf[i];
+    Tx_Desc[i].Ctrl = 0;
+    Tx_Stat[i].Info = 0;
+  }
+
+  /* Set EMAC Transmit Descriptor Registers. */
+  LPC_EMAC->TxDescriptor = (uint32_t)&Tx_Desc[0];
+  LPC_EMAC->TxStatus = (uint32_t)&Tx_Stat[0];
+  LPC_EMAC->TxDescriptorNumber = EMAC_NUM_TX_FRAG - 1;
+
+  /* Tx Descriptors Point to 0 */
+  LPC_EMAC->TxProduceIndex = 0;
+}
+/*--------------------------- write_PHY -------------------------------------*/
+/*********************************************************************//**
+ * @brief     Write value to PHY device
+ * @param[in]   PhyReg: PHY Register address
+ * @param[in]   Value:  Value to write
+ * @return    0 - if success
+ *        1 - if fail
+ ***********************************************************************/
+static int32_t
+write_PHY(uint32_t PhyReg, uint16_t Value)
+{
+  /* Write a data 'Value' to PHY register 'PhyReg'. */
+  uint32_t tout;
+
+  LPC_EMAC->MADR = EMAC_DEF_ADR | PhyReg;
+  LPC_EMAC->MWTD = Value;
+
+  /* Wait until operation completed */
+  tout = 0;
+  for(tout = 0; tout < EMAC_MII_WR_TOUT; tout++) {
+    if((LPC_EMAC->MIND & EMAC_MIND_BUSY) == 0) {
+      return 0;
+      /* Time out! */
+    }
+  }
+  return -1;
+}
+/*--------------------------- read_PHY --------------------------------------*/
+/*********************************************************************//**
+ * @brief     Read value from PHY device
+ * @param[in]   PhyReg: PHY Register address
+ * @return    0 - if success
+ *        1 - if fail
+ ***********************************************************************/
+static int32_t
+read_PHY(uint32_t PhyReg)
+{
+  /* Read a PHY register 'PhyReg'. */
+  uint32_t tout;
+
+  LPC_EMAC->MADR = EMAC_DEF_ADR | PhyReg;
+  LPC_EMAC->MCMD = EMAC_MCMD_READ;
+
+  /* Wait until operation completed */
+  tout = 0;
+  for(tout = 0; tout < EMAC_MII_RD_TOUT; tout++) {
+    if((LPC_EMAC->MIND & EMAC_MIND_BUSY) == 0) {
+      LPC_EMAC->MCMD = 0;
+      return LPC_EMAC->MRDD;
+    }
+    /* Time out! */
+  }
+  return -1;
+}
+/*********************************************************************//**
+ * @brief		Set Station MAC address for EMAC module
+ * @param[in]	abStationAddr Pointer to Station address that contains 6-bytes
+ *        of MAC address (should be in order from MAC Address 1 to MAC Address 6)
+ * @return		None
+ **********************************************************************/
+static void
+setEmacAddr(uint8_t abStationAddr[])
+{
+  /* Set the Ethernet MAC Address registers */
+  LPC_EMAC->SA0 = ((uint32_t)abStationAddr[5] << 8) | (uint32_t)abStationAddr[4];
+  LPC_EMAC->SA1 = ((uint32_t)abStationAddr[3] << 8) | (uint32_t)abStationAddr[2];
+  LPC_EMAC->SA2 = ((uint32_t)abStationAddr[1] << 8) | (uint32_t)abStationAddr[0];
+}
+/*********************************************************************//**
+ * @brief		Calculates CRC code for number of bytes in the frame
+ * @param[in]	frame_no_fcs	Pointer to the first byte of the frame
+ * @param[in]	frame_len		length of the frame without the FCS
+ * @return		the CRC as a 32 bit integer
+ **********************************************************************/
+static int32_t
+emac_CRCCalc(uint8_t frame_no_fcs[], int32_t frame_len)
+{
+  int i;    /* iterator */
+  int j;    /* another iterator */
+  char byte;  /* current byte */
+  int crc;  /* CRC result */
+  int q0, q1, q2, q3; /* temporary variables */
+  crc = 0xFFFFFFFF;
+  for(i = 0; i < frame_len; i++) {
+    byte = *frame_no_fcs++;
+    for(j = 0; j < 2; j++) {
+      if(((crc >> 28) ^ (byte >> 3)) & 0x00000001) {
+        q3 = 0x04C11DB7;
+      } else {
+        q3 = 0x00000000;
+      } if(((crc >> 29) ^ (byte >> 2)) & 0x00000001) {
+        q2 = 0x09823B6E;
+      } else {
+        q2 = 0x00000000;
+      } if(((crc >> 30) ^ (byte >> 1)) & 0x00000001) {
+        q1 = 0x130476DC;
+      } else {
+        q1 = 0x00000000;
+      } if(((crc >> 31) ^ (byte >> 0)) & 0x00000001) {
+        q0 = 0x2608EDB8;
+      } else {
+        q0 = 0x00000000;
+      } crc = (crc << 4) ^ q3 ^ q2 ^ q1 ^ q0;
+      byte >>= 4;
+    }
+  }
+  return crc;
+}
+/* End of Private Functions --------------------------------------------------- */
+
+/* Public Functions ----------------------------------------------------------- */
+/** @addtogroup EMAC_Public_Functions
+ * @{
+ */
+
+/*********************************************************************//**
+ * @brief		Initializes the EMAC peripheral according to the specified
+ *               parameters in the EMAC_ConfigStruct.
+ * @param[in]	EMAC_ConfigStruct Pointer to a EMAC_CFG_Type structure
+ *                    that contains the configuration information for the
+ *                    specified EMAC peripheral.
+ * @return		None
+ *
+ * Note: This function will initialize EMAC module according to procedure below:
+ *  - Remove the soft reset condition from the MAC
+ *  - Configure the PHY via the MIIM interface of the MAC
+ *  - Select RMII mode
+ *  - Configure the transmit and receive DMA engines, including the descriptor arrays
+ *  - Configure the host registers (MAC1,MAC2 etc.) in the MAC
+ *  - Enable the receive and transmit data paths
+ *  In default state after initializing, only Rx Done and Tx Done interrupt are enabled,
+ *  all remain interrupts are disabled
+ *  (Ref. from LPC17xx UM)
+ **********************************************************************/
+Status
+EMAC_Init(EMAC_CFG_Type *EMAC_ConfigStruct)
+{
+  /* Initialize the EMAC Ethernet controller. */
+  int32_t regv, tout, tmp;
+
+  /* Set up clock and power for Ethernet module */
+  CLKPWR_ConfigPPWR(CLKPWR_PCONP_PCENET, ENABLE);
+
+  /* Reset all EMAC internal modules */
+  LPC_EMAC->MAC1 = EMAC_MAC1_RES_TX | EMAC_MAC1_RES_MCS_TX | EMAC_MAC1_RES_RX |
+    EMAC_MAC1_RES_MCS_RX | EMAC_MAC1_SIM_RES | EMAC_MAC1_SOFT_RES;
+
+  LPC_EMAC->Command = EMAC_CR_REG_RES | EMAC_CR_TX_RES | EMAC_CR_RX_RES | EMAC_CR_PASS_RUNT_FRM;
+
+  /* A short delay after reset. */
+  for(tout = 100; tout; tout--) {
+  }
+
+  /* Initialize MAC control registers. */
+  LPC_EMAC->MAC1 = EMAC_MAC1_PASS_ALL;
+  LPC_EMAC->MAC2 = EMAC_MAC2_CRC_EN | EMAC_MAC2_PAD_EN;
+  LPC_EMAC->MAXF = EMAC_ETH_MAX_FLEN;
+  /*
+   * Find the clock that close to desired target clock
+   */
+  tmp = SystemCoreClock / EMAC_MCFG_MII_MAXCLK;
+  for(tout = 0; tout < sizeof(EMAC_clkdiv); tout++) {
+    if(EMAC_clkdiv[tout] >= tmp) {
+      break;
+    }
+  }
+  tout++;
+  /* Write to MAC configuration register and reset */
+  LPC_EMAC->MCFG = EMAC_MCFG_CLK_SEL(tout) | EMAC_MCFG_RES_MII;
+  /* release reset */
+  LPC_EMAC->MCFG &= ~(EMAC_MCFG_RES_MII);
+  LPC_EMAC->CLRT = EMAC_CLRT_DEF;
+  LPC_EMAC->IPGR = EMAC_IPGR_P2_DEF;
+
+  /* Enable Reduced MII interface. */
+  LPC_EMAC->Command = EMAC_CR_RMII | EMAC_CR_PASS_RUNT_FRM;
+
+  /* Reset Reduced MII Logic. */
+  LPC_EMAC->SUPP = EMAC_SUPP_RES_RMII;
+
+  for(tout = 100; tout; tout--) {
+  }
+  LPC_EMAC->SUPP = 0;
+
+  /* Put the DP83848C in reset mode */
+  write_PHY(EMAC_PHY_REG_BMCR, EMAC_PHY_BMCR_RESET);
+
+  /* Wait for hardware reset to end. */
+  for(tout = EMAC_PHY_RESP_TOUT; tout; tout--) {
+    regv = read_PHY(EMAC_PHY_REG_BMCR);
+    if(!(regv & (EMAC_PHY_BMCR_RESET | EMAC_PHY_BMCR_POWERDOWN))) {
+      /* Reset complete, device not Power Down. */
+      break;
+    }
+    if(tout == 0) {
+      /* Time out, return ERROR */
+      return ERROR;
+    }
+  }
+
+  /* Set PHY mode */
+  if(EMAC_SetPHYMode(EMAC_ConfigStruct->Mode) < 0) {
+    return ERROR;
+  }
+  /* Set EMAC address */
+  setEmacAddr(EMAC_ConfigStruct->pbEMAC_Addr);
+
+  /* Initialize Tx and Rx DMA Descriptors */
+  rx_descr_init();
+  tx_descr_init();
+
+  /* Set Receive Filter register: enable broadcast and multicast */
+  LPC_EMAC->RxFilterCtrl = EMAC_RFC_MCAST_EN | EMAC_RFC_BCAST_EN | EMAC_RFC_PERFECT_EN;
+
+  /* Enable Rx Done and Tx Done interrupt for EMAC */
+  LPC_EMAC->IntEnable = EMAC_INT_RX_DONE | EMAC_INT_TX_DONE;
+
+  /* Reset all interrupts */
+  LPC_EMAC->IntClear = 0xFFFF;
+
+  /* Enable receive and transmit mode of MAC Ethernet core */
+  LPC_EMAC->Command |= (EMAC_CR_RX_EN | EMAC_CR_TX_EN);
+  LPC_EMAC->MAC1 |= EMAC_MAC1_REC_EN;
+
+  return SUCCESS;
+}
+/*********************************************************************//**
+ * @brief		De-initializes the EMAC peripheral registers to their
+ *                  default reset values.
+ * @param[in]	None
+ * @return    None
+ **********************************************************************/
+void
+EMAC_DeInit(void)
+{
+  /* Disable all interrupt */
+  LPC_EMAC->IntEnable = 0x00;
+  /* Clear all pending interrupt */
+  LPC_EMAC->IntClear = (0xFF) | (EMAC_INT_SOFT_INT | EMAC_INT_WAKEUP);
+
+  /* TurnOff clock and power for Ethernet module */
+  CLKPWR_ConfigPPWR(CLKPWR_PCONP_PCENET, DISABLE);
+}
+/*********************************************************************//**
+ * @brief		Check specified PHY status in EMAC peripheral
+ * @param[in]	ulPHYState	Specified PHY Status Type, should be:
+ *              - EMAC_PHY_STAT_LINK: Link Status
+ *              - EMAC_PHY_STAT_SPEED: Speed Status
+ *              - EMAC_PHY_STAT_DUP: Duplex Status
+ * @return		Status of specified PHY status (0 or 1).
+ *        (-1) if error.
+ *
+ * Note:
+ * For EMAC_PHY_STAT_LINK, return value:
+ * - 0: Link Down
+ * - 1: Link Up
+ * For EMAC_PHY_STAT_SPEED, return value:
+ * - 0: 10Mbps
+ * - 1: 100Mbps
+ * For EMAC_PHY_STAT_DUP, return value:
+ * - 0: Half-Duplex
+ * - 1: Full-Duplex
+ **********************************************************************/
+int32_t
+EMAC_CheckPHYStatus(uint32_t ulPHYState)
+{
+  int32_t regv, tmp;
+#ifdef MCB_LPC_1768
+  regv = read_PHY(EMAC_PHY_REG_STS);
+  switch(ulPHYState) {
+  case EMAC_PHY_STAT_LINK:
+    tmp = (regv & EMAC_PHY_SR_LINK) ? 1 : 0;
+    break;
+  case EMAC_PHY_STAT_SPEED:
+    tmp = (regv & EMAC_PHY_SR_SPEED) ? 0 : 1;
+    break;
+  case EMAC_PHY_STAT_DUP:
+    tmp = (regv & EMAC_PHY_SR_FULL_DUP) ? 1 : 0;
+    break;
+#elif defined(IAR_LPC_1768)
+  /* Use IAR_LPC_1768 board:
+   * FSZ8721BL doesn't have Status Register
+   * so we read Basic Mode Status Register (0x01h) instead
+   */
+  regv = read_PHY(EMAC_PHY_REG_BMSR);
+  switch(ulPHYState) {
+  case EMAC_PHY_STAT_LINK:
+    tmp = (regv & EMAC_PHY_BMSR_LINK_STATUS) ? 1 : 0;
+    break;
+  case EMAC_PHY_STAT_SPEED:
+    tmp = (regv & EMAC_PHY_SR_100_SPEED) ? 1 : 0;
+    break;
+  case EMAC_PHY_STAT_DUP:
+    tmp = (regv & EMAC_PHY_SR_FULL_DUP) ? 1 : 0;
+    break;
+#endif
+  default:
+    tmp = -1;
+    break;
+  }
+  return tmp;
+}
+/*********************************************************************//**
+ * @brief		Set specified PHY mode in EMAC peripheral
+ * @param[in]	ulPHYMode	Specified PHY mode, should be:
+ *              - EMAC_MODE_AUTO
+ *              - EMAC_MODE_10M_FULL
+ *              - EMAC_MODE_10M_HALF
+ *              - EMAC_MODE_100M_FULL
+ *              - EMAC_MODE_100M_HALF
+ * @return		Return (0) if no error, otherwise return (-1)
+ **********************************************************************/
+int32_t
+EMAC_SetPHYMode(uint32_t ulPHYMode)
+{
+  int32_t id1, id2, tout, regv;
+
+  /* Check if this is a DP83848C PHY. */
+  id1 = read_PHY(EMAC_PHY_REG_IDR1);
+  id2 = read_PHY(EMAC_PHY_REG_IDR2);
+
+#ifdef MCB_LPC_1768
+  if(((id1 << 16) | (id2 & 0xFFF0)) == EMAC_DP83848C_ID) {
+    switch(ulPHYMode) {
+    case EMAC_MODE_AUTO:
+      write_PHY(EMAC_PHY_REG_BMCR, EMAC_PHY_AUTO_NEG);
+#elif defined(IAR_LPC_1768) /* Use IAR LPC1768 KickStart board */
+  if(((id1 << 16) | id2) == EMAC_KSZ8721BL_ID) {
+    /* Configure the PHY device */
+    switch(ulPHYMode) {
+    case EMAC_MODE_AUTO:
+      /* Use auto-negotiation about the link speed. */
+      write_PHY(EMAC_PHY_REG_BMCR, EMAC_PHY_AUTO_NEG);
+/*			write_PHY (EMAC_PHY_REG_BMCR, EMAC_PHY_BMCR_AN); */
+#endif
+      /* Wait to complete Auto_Negotiation */
+      for(tout = EMAC_PHY_RESP_TOUT; tout; tout--) {
+        regv = read_PHY(EMAC_PHY_REG_BMSR);
+        if(regv & EMAC_PHY_BMSR_AUTO_DONE) {
+          /* Auto-negotiation Complete. */
+          break;
+        }
+        if(tout == 0) {
+          /* Time out, return error */
+          return -1;
+        }
+      }
+      break;
+    case EMAC_MODE_10M_FULL:
+      /* Connect at 10MBit full-duplex */
+      write_PHY(EMAC_PHY_REG_BMCR, EMAC_PHY_FULLD_10M);
+      break;
+    case EMAC_MODE_10M_HALF:
+      /* Connect at 10MBit half-duplex */
+      write_PHY(EMAC_PHY_REG_BMCR, EMAC_PHY_HALFD_10M);
+      break;
+    case EMAC_MODE_100M_FULL:
+      /* Connect at 100MBit full-duplex */
+      write_PHY(EMAC_PHY_REG_BMCR, EMAC_PHY_FULLD_100M);
+      break;
+    case EMAC_MODE_100M_HALF:
+      /* Connect at 100MBit half-duplex */
+      write_PHY(EMAC_PHY_REG_BMCR, EMAC_PHY_HALFD_100M);
+      break;
+    default:
+      /* un-supported */
+      return -1;
+    }
+  }
+  /* It's not correct module ID */
+  else {
+    return -1;
+  }
+  /* Update EMAC configuration with current PHY status */
+  if(EMAC_UpdatePHYStatus() < 0) {
+    return -1;
+  }
+  /* Complete */
+  return 0;
+}
+/*********************************************************************//**
+ * @brief		Auto-Configures value for the EMAC configuration register to
+ *        match with current PHY mode
+ * @param[in]	None
+ * @return		Return (0) if no error, otherwise return (-1)
+ *
+ * Note: The EMAC configuration will be auto-configured:
+ *    - Speed mode.
+ *    - Half/Full duplex mode
+ **********************************************************************/
+int32_t
+EMAC_UpdatePHYStatus(void)
+{
+  int32_t regv, tout;
+
+  /* Check the link status. */
+#ifdef MCB_LPC_1768
+  for(tout = EMAC_PHY_RESP_TOUT; tout; tout--) {
+    regv = read_PHY(EMAC_PHY_REG_STS);
+    if(regv & EMAC_PHY_SR_LINK) {
+      /* Link is on. */
+      break;
+    }
+    if(tout == 0) {
+      /* time out */
+      return -1;
+    }
+  }
+  /* Configure Full/Half Duplex mode. */
+  if(regv & EMAC_PHY_SR_DUP) {
+    /* Full duplex is enabled. */
+    LPC_EMAC->MAC2 |= EMAC_MAC2_FULL_DUP;
+    LPC_EMAC->Command |= EMAC_CR_FULL_DUP;
+    LPC_EMAC->IPGT = EMAC_IPGT_FULL_DUP;
+  } else {
+    /* Half duplex mode. */
+    LPC_EMAC->IPGT = EMAC_IPGT_HALF_DUP;
+  } if(regv & EMAC_PHY_SR_SPEED) {
+    /* 10MBit mode. */
+    LPC_EMAC->SUPP = 0;
+  } else {
+    /* 100MBit mode. */
+    LPC_EMAC->SUPP = EMAC_SUPP_SPEED;
+  }
+#elif defined(IAR_LPC_1768)
+  for(tout = EMAC_PHY_RESP_TOUT; tout; tout--) {
+    regv = read_PHY(EMAC_PHY_REG_BMSR);
+    if(regv & EMAC_PHY_BMSR_LINK_STATUS) {
+      /* Link is on. */
+      break;
+    }
+    if(tout == 0) {
+      /* time out */
+      return -1;
+    }
+  }
+
+  /* Configure Full/Half Duplex mode. */
+  if(regv & EMAC_PHY_SR_FULL_DUP) {
+    /* Full duplex is enabled. */
+    LPC_EMAC->MAC2 |= EMAC_MAC2_FULL_DUP;
+    LPC_EMAC->Command |= EMAC_CR_FULL_DUP;
+    LPC_EMAC->IPGT = EMAC_IPGT_FULL_DUP;
+  } else {
+    /* Half duplex mode. */
+    LPC_EMAC->IPGT = EMAC_IPGT_HALF_DUP;
+  }
+  /* Configure 100MBit/10MBit mode. */
+  if(!(regv & EMAC_PHY_SR_100_SPEED)) {
+    /* 10MBit mode. */
+    LPC_EMAC->SUPP = 0;
+  } else {
+    /* 100MBit mode. */
+    LPC_EMAC->SUPP = EMAC_SUPP_SPEED;
+  }
+#endif
+  /* Complete */
+  return 0;
+}
+/*********************************************************************//**
+ * @brief		Enable/Disable hash filter functionality for specified destination
+ *        MAC address in EMAC module
+ * @param[in]	dstMAC_addr		Pointer to the first MAC destination address, should
+ *                be 6-bytes length, in order LSB to the MSB
+ * @param[in]	NewState		New State of this command, should be:
+ *									- ENABLE.
+ *									- DISABLE.
+ * @return		None
+ *
+ * Note:
+ * The standard Ethernet cyclic redundancy check (CRC) function is calculated from
+ * the 6 byte destination address in the Ethernet frame (this CRC is calculated
+ * anyway as part of calculating the CRC of the whole frame), then bits [28:23] out of
+ * the 32 bits CRC result are taken to form the hash. The 6 bit hash is used to access
+ * the hash table: it is used as an index in the 64 bit HashFilter register that has been
+ * programmed with accept values. If the selected accept value is 1, the frame is
+ * accepted.
+ **********************************************************************/
+void
+EMAC_SetHashFilter(uint8_t dstMAC_addr[], FunctionalState NewState)
+{
+  uint32_t *pReg;
+  uint32_t tmp;
+  int32_t crc;
+
+  /* Calculate the CRC from the destination MAC address */
+  crc = emac_CRCCalc(dstMAC_addr, 6);
+  /* Extract the value from CRC to get index value for hash filter table */
+  crc = (crc >> 23) & 0x3F;
+
+  pReg = (crc > 31) ? ((uint32_t *)&LPC_EMAC->HashFilterH) \
+    : ((uint32_t *)&LPC_EMAC->HashFilterL);
+  tmp = (crc > 31) ? (crc - 32) : crc;
+  if(NewState == ENABLE) {
+    (*pReg) |= (1UL << tmp);
+  } else {
+    (*pReg) &= ~(1UL << tmp);
+    /* Enable Rx Filter */
+  }
+  LPC_EMAC->Command &= ~EMAC_CR_PASS_RX_FILT;
+}
+/*********************************************************************//**
+ * @brief		Enable/Disable Filter mode for each specified type EMAC peripheral
+ * @param[in]	ulFilterMode	Filter mode, should be:
+ *                - EMAC_RFC_UCAST_EN: all frames of unicast types
+ *                will be accepted
+ *                - EMAC_RFC_BCAST_EN: broadcast frame will be
+ *                accepted
+ *                - EMAC_RFC_MCAST_EN: all frames of multicast
+ *                types will be accepted
+ *                - EMAC_RFC_UCAST_HASH_EN: The imperfect hash
+ *                filter will be applied to unicast addresses
+ *                - EMAC_RFC_MCAST_HASH_EN: The imperfect hash
+ *                filter will be applied to multicast addresses
+ *                - EMAC_RFC_PERFECT_EN: the destination address
+ *                will be compared with the 6 byte station address
+ *                programmed in the station address by the filter
+ *                - EMAC_RFC_MAGP_WOL_EN: the result of the magic
+ *                packet filter will generate a WoL interrupt when
+ *                there is a match
+ *                - EMAC_RFC_PFILT_WOL_EN: the result of the perfect address
+ *                matching filter and the imperfect hash filter will
+ *                generate a WoL interrupt when there is a match
+ * @param[in]	NewState	New State of this command, should be:
+ *                - ENABLE
+ *                - DISABLE
+ * @return		None
+ **********************************************************************/
+void
+EMAC_SetFilterMode(uint32_t ulFilterMode, FunctionalState NewState)
+{
+  if(NewState == ENABLE) {
+    LPC_EMAC->RxFilterCtrl |= ulFilterMode;
+  } else {
+    LPC_EMAC->RxFilterCtrl &= ~ulFilterMode;
+  }
+}
+/*********************************************************************//**
+ * @brief		Get status of Wake On LAN Filter for each specified
+ *        type in EMAC peripheral, clear this status if it is set
+ * @param[in]	ulWoLMode	WoL Filter mode, should be:
+ *                - EMAC_WOL_UCAST: unicast frames caused WoL
+ *                - EMAC_WOL_UCAST: broadcast frame caused WoL
+ *                - EMAC_WOL_MCAST: multicast frame caused WoL
+ *                - EMAC_WOL_UCAST_HASH: unicast frame that passes the
+ *                imperfect hash filter caused WoL
+ *                - EMAC_WOL_MCAST_HASH: multicast frame that passes the
+ *                imperfect hash filter caused WoL
+ *                - EMAC_WOL_PERFECT:perfect address matching filter
+ *                caused WoL
+ *                - EMAC_WOL_RX_FILTER: the receive filter caused WoL
+ *                - EMAC_WOL_MAG_PACKET: the magic packet filter caused WoL
+ * @return		SET/RESET
+ **********************************************************************/
+FlagStatus
+EMAC_GetWoLStatus(uint32_t ulWoLMode)
+{
+  if(LPC_EMAC->RxFilterWoLStatus & ulWoLMode) {
+    LPC_EMAC->RxFilterWoLClear = ulWoLMode;
+    return SET;
+  } else {
+    return RESET;
+  }
+}
+/*********************************************************************//**
+ * @brief		Write data to Tx packet data buffer at current index due to
+ *        TxProduceIndex
+ * @param[in]	pDataStruct		Pointer to a EMAC_PACKETBUF_Type structure
+ *              data that contain specified information about
+ *              Packet data buffer.
+ * @return		None
+ **********************************************************************/
+void
+EMAC_WritePacketBuffer(EMAC_PACKETBUF_Type *pDataStruct)
+{
+  uint32_t idx, len;
+  uint32_t *sp, *dp;
+
+  idx = LPC_EMAC->TxProduceIndex;
+  sp = (uint32_t *)pDataStruct->pbDataBuf;
+  dp = (uint32_t *)Tx_Desc[idx].Packet;
+  /* Copy frame data to EMAC packet buffers. */
+  for(len = (pDataStruct->ulDataLen + 3) >> 2; len; len--) {
+    *dp++ = *sp++;
+  }
+  Tx_Desc[idx].Ctrl = (pDataStruct->ulDataLen - 1) | (EMAC_TCTRL_INT | EMAC_TCTRL_LAST);
+}
+/*********************************************************************//**
+ * @brief		Read data from Rx packet data buffer at current index due
+ *        to RxConsumeIndex
+ * @param[in]	pDataStruct		Pointer to a EMAC_PACKETBUF_Type structure
+ *              data that contain specified information about
+ *              Packet data buffer.
+ * @return		None
+ **********************************************************************/
+void
+EMAC_ReadPacketBuffer(EMAC_PACKETBUF_Type *pDataStruct)
+{
+  uint32_t idx, len;
+  uint32_t *dp, *sp;
+
+  idx = LPC_EMAC->RxConsumeIndex;
+  dp = (uint32_t *)pDataStruct->pbDataBuf;
+  sp = (uint32_t *)Rx_Desc[idx].Packet;
+
+  if(pDataStruct->pbDataBuf != NULL) {
+    for(len = (pDataStruct->ulDataLen + 3) >> 2; len; len--) {
+      *dp++ = *sp++;
+    }
+  }
+}
+/*********************************************************************//**
+ * @brief     Enable/Disable interrupt for each type in EMAC
+ * @param[in]	ulIntType	Interrupt Type, should be:
+ *              - EMAC_INT_RX_OVERRUN: Receive Overrun
+ *              - EMAC_INT_RX_ERR: Receive Error
+ *              - EMAC_INT_RX_FIN: Receive Descriptor Finish
+ *              - EMAC_INT_RX_DONE: Receive Done
+ *              - EMAC_INT_TX_UNDERRUN: Transmit Under-run
+ *              - EMAC_INT_TX_ERR: Transmit Error
+ *              - EMAC_INT_TX_FIN: Transmit descriptor finish
+ *              - EMAC_INT_TX_DONE: Transmit Done
+ *              - EMAC_INT_SOFT_INT: Software interrupt
+ *              - EMAC_INT_WAKEUP: Wakeup interrupt
+ * @param[in]	NewState	New State of this function, should be:
+ *              - ENABLE.
+ *              - DISABLE.
+ * @return		None
+ **********************************************************************/
+void
+EMAC_IntCmd(uint32_t ulIntType, FunctionalState NewState)
+{
+  if(NewState == ENABLE) {
+    LPC_EMAC->IntEnable |= ulIntType;
+  } else {
+    LPC_EMAC->IntEnable &= ~(ulIntType);
+  }
+}
+/*********************************************************************//**
+ * @brief     Check whether if specified interrupt flag is set or not
+ *        for each interrupt type in EMAC and clear interrupt pending
+ *        if it is set.
+ * @param[in]	ulIntType	Interrupt Type, should be:
+ *              - EMAC_INT_RX_OVERRUN: Receive Overrun
+ *              - EMAC_INT_RX_ERR: Receive Error
+ *              - EMAC_INT_RX_FIN: Receive Descriptor Finish
+ *              - EMAC_INT_RX_DONE: Receive Done
+ *              - EMAC_INT_TX_UNDERRUN: Transmit Under-run
+ *              - EMAC_INT_TX_ERR: Transmit Error
+ *              - EMAC_INT_TX_FIN: Transmit descriptor finish
+ *              - EMAC_INT_TX_DONE: Transmit Done
+ *              - EMAC_INT_SOFT_INT: Software interrupt
+ *              - EMAC_INT_WAKEUP: Wakeup interrupt
+ * @return		New state of specified interrupt (SET or RESET)
+ **********************************************************************/
+IntStatus
+EMAC_IntGetStatus(uint32_t ulIntType)
+{
+  if(LPC_EMAC->IntStatus & ulIntType) {
+    LPC_EMAC->IntClear = ulIntType;
+    return SET;
+  } else {
+    return RESET;
+  }
+}
+/*********************************************************************//**
+ * @brief		Check whether if the current RxConsumeIndex is not equal to the
+ *        current RxProduceIndex.
+ * @param[in]	None
+ * @return		TRUE if they're not equal, otherwise return FALSE
+ *
+ * Note: In case the RxConsumeIndex is not equal to the RxProduceIndex,
+ * it means there're available data has been received. They should be read
+ * out and released the Receive Data Buffer by updating the RxConsumeIndex value.
+ **********************************************************************/
+Bool
+EMAC_CheckReceiveIndex(void)
+{
+  if(LPC_EMAC->RxConsumeIndex != LPC_EMAC->RxProduceIndex) {
+    return TRUE;
+  } else {
+    return FALSE;
+  }
+}
+/*********************************************************************//**
+ * @brief		Check whether if the current TxProduceIndex is not equal to the
+ *        current RxProduceIndex - 1.
+ * @param[in]	None
+ * @return		TRUE if they're not equal, otherwise return FALSE
+ *
+ * Note: In case the RxConsumeIndex is equal to the RxProduceIndex - 1,
+ * it means the transmit buffer is available and data can be written to transmit
+ * buffer to be sent.
+ **********************************************************************/
+Bool
+EMAC_CheckTransmitIndex(void)
+{
+  uint32_t tmp = LPC_EMAC->TxConsumeIndex - 1;
+  if(LPC_EMAC->TxProduceIndex == tmp) {
+    return FALSE;
+  } else {
+    return TRUE;
+  }
+}
+/*********************************************************************//**
+ * @brief		Get current status value of receive data (due to RxConsumeIndex)
+ * @param[in]	ulRxStatType	Received Status type, should be one of following:
+ *              - EMAC_RINFO_CTRL_FRAME: Control Frame
+ *              - EMAC_RINFO_VLAN: VLAN Frame
+ *              - EMAC_RINFO_FAIL_FILT: RX Filter Failed
+ *              - EMAC_RINFO_MCAST: Multicast Frame
+ *              - EMAC_RINFO_BCAST: Broadcast Frame
+ *              - EMAC_RINFO_CRC_ERR: CRC Error in Frame
+ *              - EMAC_RINFO_SYM_ERR: Symbol Error from PHY
+ *              - EMAC_RINFO_LEN_ERR: Length Error
+ *              - EMAC_RINFO_RANGE_ERR: Range error(exceeded max size)
+ *              - EMAC_RINFO_ALIGN_ERR: Alignment error
+ *              - EMAC_RINFO_OVERRUN: Receive overrun
+ *              - EMAC_RINFO_NO_DESCR: No new Descriptor available
+ *              - EMAC_RINFO_LAST_FLAG: last Fragment in Frame
+ *              - EMAC_RINFO_ERR: Error Occurred (OR of all error)
+ * @return		Current value of receive data (due to RxConsumeIndex)
+ **********************************************************************/
+FlagStatus
+EMAC_CheckReceiveDataStatus(uint32_t ulRxStatType)
+{
+  uint32_t idx;
+  idx = LPC_EMAC->RxConsumeIndex;
+  return ((Rx_Stat[idx].Info) & ulRxStatType) ? SET : RESET;
+}
+/*********************************************************************//**
+ * @brief		Get size of current Received data in received buffer (due to
+ *        RxConsumeIndex)
+ * @param[in]	None
+ * @return		Size of received data
+ **********************************************************************/
+uint32_t
+EMAC_GetReceiveDataSize(void)
+{
+  uint32_t idx;
+  idx = LPC_EMAC->RxConsumeIndex;
+  return (Rx_Stat[idx].Info) & EMAC_RINFO_SIZE;
+}
+/*********************************************************************//**
+ * @brief		Increase the RxConsumeIndex (after reading the Receive buffer
+ *        to release the Receive buffer) and wrap-around the index if
+ *        it reaches the maximum Receive Number
+ * @param[in]	None
+ * @return		None
+ **********************************************************************/
+void
+EMAC_UpdateRxConsumeIndex(void)
+{
+  /* Get current Rx consume index */
+  uint32_t idx = LPC_EMAC->RxConsumeIndex;
+
+  /* Release frame from EMAC buffer */
+  if(++idx == EMAC_NUM_RX_FRAG) {
+    idx = 0;
+  }
+  LPC_EMAC->RxConsumeIndex = idx;
+}
+/*********************************************************************//**
+ * @brief		Increase the TxProduceIndex (after writting to the Transmit buffer
+ *        to enable the Transmit buffer) and wrap-around the index if
+ *        it reaches the maximum Transmit Number
+ * @param[in]	None
+ * @return		None
+ **********************************************************************/
+void
+EMAC_UpdateTxProduceIndex(void)
+{
+  /* Get current Tx produce index */
+  uint32_t idx = LPC_EMAC->TxProduceIndex;
+
+  /* Start frame transmission */
+  if(++idx == EMAC_NUM_TX_FRAG) {
+    idx = 0;
+  }
+  LPC_EMAC->TxProduceIndex = idx;
+}
+/**
+ * @}
+ */
+
+#endif /* _EMAC */
+
+/**
+ * @}
+ */
+
+/* --------------------------------- End Of File ------------------------------ */

--- a/cpu/arm/lpc1768/lpc17xx_emac.h
+++ b/cpu/arm/lpc1768/lpc17xx_emac.h
@@ -1,0 +1,695 @@
+/**********************************************************************
+ * $Id$		lpc17xx_emac.h				2010-05-21
+ *//**
+ * @file		lpc17xx_emac.h
+ * @brief	Contains all macro definitions and function prototypes
+ *      support for Ethernet MAC firmware library on LPC17xx
+ * @version	2.0
+ * @date		21. May. 2010
+ * @author	NXP MCU SW Application Team
+ *
+ * Copyright(C) 2010, NXP Semiconductor
+ * All rights reserved.
+ *
+ ***********************************************************************
+ * Software that is described herein is for illustrative purposes only
+ * which provides customers with programming information regarding the
+ * products. This software is supplied "AS IS" without any warranties.
+ * NXP Semiconductors assumes no responsibility or liability for the
+ * use of the software, conveys no license or title under any patent,
+ * copyright, or mask work right to the product. NXP Semiconductors
+ * reserves the right to make changes in the software without
+ * notification. NXP Semiconductors also make no representation or
+ * warranty that such application will be suitable for the specified
+ * use without further testing or modification.
+ **********************************************************************/
+
+/* Peripheral group ----------------------------------------------------------- */
+/** @defgroup EMAC EMAC (Ethernet Media Access Controller)
+ * @ingroup LPC1700CMSIS_FwLib_Drivers
+ * @{
+ */
+
+#ifndef LPC17XX_EMAC_H_
+#define LPC17XX_EMAC_H_
+
+/* Includes ------------------------------------------------------------------- */
+#include "lpc17xx.h"
+#include "lpc_types.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#define MCB_LPC_1768
+/* #define IAR_LPC_1768 */
+
+/* Public Macros -------------------------------------------------------------- */
+/** @defgroup EMAC_Public_Macros EMAC Public Macros
+ * @{
+ */
+
+/* EMAC PHY status type definitions */
+#define EMAC_PHY_STAT_LINK      (0)   /**< Link Status */
+#define EMAC_PHY_STAT_SPEED     (1)   /**< Speed Status */
+#define EMAC_PHY_STAT_DUP     (2)   /**< Duplex Status */
+
+/* EMAC PHY device Speed definitions */
+#define EMAC_MODE_AUTO        (0)   /**< Auto-negotiation mode */
+#define EMAC_MODE_10M_FULL      (1)   /**< 10Mbps FullDuplex mode */
+#define EMAC_MODE_10M_HALF      (2)   /**< 10Mbps HalfDuplex mode */
+#define EMAC_MODE_100M_FULL     (3)   /**< 100Mbps FullDuplex mode */
+#define EMAC_MODE_100M_HALF     (4)   /**< 100Mbps HalfDuplex mode */
+
+/**
+ * @}
+ */
+/* Private Macros ------------------------------------------------------------- */
+/** @defgroup EMAC_Private_Macros EMAC Private Macros
+ * @{
+ */
+
+/* EMAC Memory Buffer configuration for 16K Ethernet RAM */
+#define EMAC_NUM_RX_FRAG         4           /**< Num.of RX Fragments 4*1536= 6.0kB */
+#define EMAC_NUM_TX_FRAG         3           /**< Num.of TX Fragments 3*1536= 4.6kB */
+#define EMAC_ETH_MAX_FLEN        1536        /**< Max. Ethernet Frame Size          */
+#define EMAC_TX_FRAME_TOUT       0x00100000  /**< Frame Transmit timeout count      */
+
+/* --------------------- BIT DEFINITIONS -------------------------------------- */
+/*********************************************************************//**
+ * Macro defines for MAC Configuration Register 1
+ **********************************************************************/
+#define EMAC_MAC1_REC_EN         0x00000001  /**< Receive Enable                    */
+#define EMAC_MAC1_PASS_ALL       0x00000002  /**< Pass All Receive Frames           */
+#define EMAC_MAC1_RX_FLOWC       0x00000004  /**< RX Flow Control                   */
+#define EMAC_MAC1_TX_FLOWC       0x00000008  /**< TX Flow Control                   */
+#define EMAC_MAC1_LOOPB          0x00000010  /**< Loop Back Mode                    */
+#define EMAC_MAC1_RES_TX         0x00000100  /**< Reset TX Logic                    */
+#define EMAC_MAC1_RES_MCS_TX     0x00000200  /**< Reset MAC TX Control Sublayer     */
+#define EMAC_MAC1_RES_RX         0x00000400  /**< Reset RX Logic                    */
+#define EMAC_MAC1_RES_MCS_RX     0x00000800  /**< Reset MAC RX Control Sublayer     */
+#define EMAC_MAC1_SIM_RES        0x00004000  /**< Simulation Reset                  */
+#define EMAC_MAC1_SOFT_RES       0x00008000  /**< Soft Reset MAC                    */
+
+/*********************************************************************//**
+ * Macro defines for MAC Configuration Register 2
+ **********************************************************************/
+#define EMAC_MAC2_FULL_DUP       0x00000001  /**< Full-Duplex Mode                  */
+#define EMAC_MAC2_FRM_LEN_CHK    0x00000002  /**< Frame Length Checking             */
+#define EMAC_MAC2_HUGE_FRM_EN    0x00000004  /**< Huge Frame Enable                 */
+#define EMAC_MAC2_DLY_CRC        0x00000008  /**< Delayed CRC Mode                  */
+#define EMAC_MAC2_CRC_EN         0x00000010  /**< Append CRC to every Frame         */
+#define EMAC_MAC2_PAD_EN         0x00000020  /**< Pad all Short Frames              */
+#define EMAC_MAC2_VLAN_PAD_EN    0x00000040  /**< VLAN Pad Enable                   */
+#define EMAC_MAC2_ADET_PAD_EN    0x00000080  /**< Auto Detect Pad Enable            */
+#define EMAC_MAC2_PPREAM_ENF     0x00000100  /**< Pure Preamble Enforcement         */
+#define EMAC_MAC2_LPREAM_ENF     0x00000200  /**< Long Preamble Enforcement         */
+#define EMAC_MAC2_NO_BACKOFF     0x00001000  /**< No Backoff Algorithm              */
+#define EMAC_MAC2_BACK_PRESSURE  0x00002000  /**< Backoff Presurre / No Backoff     */
+#define EMAC_MAC2_EXCESS_DEF     0x00004000  /**< Excess Defer                      */
+
+/*********************************************************************//**
+ * Macro defines for Back-to-Back Inter-Packet-Gap Register
+ **********************************************************************/
+/** Programmable field representing the nibble time offset of the minimum possible period
+ * between the end of any transmitted packet to the beginning of the next */
+#define EMAC_IPGT_BBIPG(n)    (n & 0x7F)
+/** Recommended value for Full Duplex of Programmable field representing the nibble time
+ * offset of the minimum possible period between the end of any transmitted packet to the
+ * beginning of the next */
+#define EMAC_IPGT_FULL_DUP    (EMAC_IPGT_BBIPG(0x15))
+/** Recommended value for Half Duplex of Programmable field representing the nibble time
+ * offset of the minimum possible period between the end of any transmitted packet to the
+ * beginning of the next */
+#define EMAC_IPGT_HALF_DUP      (EMAC_IPGT_BBIPG(0x12))
+
+/*********************************************************************//**
+ * Macro defines for Non Back-to-Back Inter-Packet-Gap Register
+ **********************************************************************/
+/** Programmable field representing the Non-Back-to-Back Inter-Packet-Gap */
+#define EMAC_IPGR_NBBIPG_P2(n)  (n & 0x7F)
+/** Recommended value for Programmable field representing the Non-Back-to-Back Inter-Packet-Gap Part 1 */
+#define EMAC_IPGR_P2_DEF    (EMAC_IPGR_NBBIPG_P2(0x12))
+/** Programmable field representing the optional carrierSense window referenced in
+ * IEEE 802.3/4.2.3.2.1 'Carrier Deference' */
+#define EMAC_IPGR_NBBIPG_P1(n)  ((n & 0x7F) << 8)
+/** Recommended value for Programmable field representing the Non-Back-to-Back Inter-Packet-Gap Part 2 */
+#define EMAC_IPGR_P1_DEF        EMAC_IPGR_NBBIPG_P1(0x0C)
+
+/*********************************************************************//**
+ * Macro defines for Collision Window/Retry Register
+ **********************************************************************/
+/** Programmable field specifying the number of retransmission attempts following a collision before
+ * aborting the packet due to excessive collisions */
+#define EMAC_CLRT_MAX_RETX(n) (n & 0x0F)
+/** Programmable field representing the slot time or collision window during which collisions occur
+ * in properly configured networks */
+#define EMAC_CLRT_COLL(n)   ((n & 0x3F) << 8)
+/** Default value for Collision Window / Retry register */
+#define EMAC_CLRT_DEF           ((EMAC_CLRT_MAX_RETX(0x0F)) | (EMAC_CLRT_COLL(0x37)))
+
+/*********************************************************************//**
+ * Macro defines for Maximum Frame Register
+ **********************************************************************/
+/** Represents a maximum receive frame of 1536 octets */
+#define EMAC_MAXF_MAXFRMLEN(n)  (n & 0xFFFF)
+
+/*********************************************************************//**
+ * Macro defines for PHY Support Register
+ **********************************************************************/
+#define EMAC_SUPP_SPEED     0x00000100    /**< Reduced MII Logic Current Speed   */
+#define EMAC_SUPP_RES_RMII      0x00000800    /**< Reset Reduced MII Logic           */
+
+/*********************************************************************//**
+ * Macro defines for Test Register
+ **********************************************************************/
+#define EMAC_TEST_SHCUT_PQUANTA  0x00000001   /**< Shortcut Pause Quanta             */
+#define EMAC_TEST_TST_PAUSE      0x00000002   /**< Test Pause                        */
+#define EMAC_TEST_TST_BACKP      0x00000004   /**< Test Back Pressure                */
+
+/*********************************************************************//**
+ * Macro defines for MII Management Configuration Register
+ **********************************************************************/
+#define EMAC_MCFG_SCAN_INC       0x00000001   /**< Scan Increment PHY Address        */
+#define EMAC_MCFG_SUPP_PREAM     0x00000002   /**< Suppress Preamble                 */
+#define EMAC_MCFG_CLK_SEL(n)     ((n & 0x0F) << 2)  /**< Clock Select Field                 */
+#define EMAC_MCFG_RES_MII        0x00008000   /**< Reset MII Management Hardware     */
+#define EMAC_MCFG_MII_MAXCLK   2500000UL    /**< MII Clock max */
+
+/*********************************************************************//**
+ * Macro defines for MII Management Command Register
+ **********************************************************************/
+#define EMAC_MCMD_READ           0x00000001   /**< MII Read                          */
+#define EMAC_MCMD_SCAN           0x00000002   /**< MII Scan continuously             */
+
+#define EMAC_MII_WR_TOUT         0x00050000   /**< MII Write timeout count           */
+#define EMAC_MII_RD_TOUT         0x00050000   /**< MII Read timeout count            */
+
+/*********************************************************************//**
+ * Macro defines for MII Management Address Register
+ **********************************************************************/
+#define EMAC_MADR_REG_ADR(n)     (n & 0x1F)     /**< MII Register Address field         */
+#define EMAC_MADR_PHY_ADR(n)     ((n & 0x1F) << 8)  /**< PHY Address Field                  */
+
+/*********************************************************************//**
+ * Macro defines for MII Management Write Data Register
+ **********************************************************************/
+#define EMAC_MWTD_DATA(n)   (n & 0xFFFF)    /**< Data field for MMI Management Write Data register */
+
+/*********************************************************************//**
+ * Macro defines for MII Management Read Data Register
+ **********************************************************************/
+#define EMAC_MRDD_DATA(n)   (n & 0xFFFF)    /**< Data field for MMI Management Read Data register */
+
+/*********************************************************************//**
+ * Macro defines for MII Management Indicators Register
+ **********************************************************************/
+#define EMAC_MIND_BUSY           0x00000001   /**< MII is Busy                       */
+#define EMAC_MIND_SCAN           0x00000002   /**< MII Scanning in Progress          */
+#define EMAC_MIND_NOT_VAL        0x00000004   /**< MII Read Data not valid           */
+#define EMAC_MIND_MII_LINK_FAIL  0x00000008   /**< MII Link Failed                   */
+
+/* Station Address 0 Register */
+/* Station Address 1 Register */
+/* Station Address 2 Register */
+
+/* Control register definitions --------------------------------------------------------------------------- */
+/*********************************************************************//**
+ * Macro defines for Command Register
+ **********************************************************************/
+#define EMAC_CR_RX_EN            0x00000001   /**< Enable Receive                    */
+#define EMAC_CR_TX_EN            0x00000002   /**< Enable Transmit                   */
+#define EMAC_CR_REG_RES          0x00000008   /**< Reset Host Registers              */
+#define EMAC_CR_TX_RES           0x00000010   /**< Reset Transmit Datapath           */
+#define EMAC_CR_RX_RES           0x00000020   /**< Reset Receive Datapath            */
+#define EMAC_CR_PASS_RUNT_FRM    0x00000040   /**< Pass Runt Frames                  */
+#define EMAC_CR_PASS_RX_FILT     0x00000080   /**< Pass RX Filter                    */
+#define EMAC_CR_TX_FLOW_CTRL     0x00000100   /**< TX Flow Control                   */
+#define EMAC_CR_RMII             0x00000200   /**< Reduced MII Interface             */
+#define EMAC_CR_FULL_DUP         0x00000400   /**< Full Duplex                       */
+
+/*********************************************************************//**
+ * Macro defines for Status Register
+ **********************************************************************/
+#define EMAC_SR_RX_EN            0x00000001   /**< Enable Receive                    */
+#define EMAC_SR_TX_EN            0x00000002   /**< Enable Transmit                   */
+
+/*********************************************************************//**
+ * Macro defines for Transmit Status Vector 0 Register
+ **********************************************************************/
+#define EMAC_TSV0_CRC_ERR        0x00000001  /**< CRC error                         */
+#define EMAC_TSV0_LEN_CHKERR     0x00000002  /**< Length Check Error                */
+#define EMAC_TSV0_LEN_OUTRNG     0x00000004  /**< Length Out of Range               */
+#define EMAC_TSV0_DONE           0x00000008  /**< Tramsmission Completed            */
+#define EMAC_TSV0_MCAST          0x00000010  /**< Multicast Destination             */
+#define EMAC_TSV0_BCAST          0x00000020  /**< Broadcast Destination             */
+#define EMAC_TSV0_PKT_DEFER      0x00000040  /**< Packet Deferred                   */
+#define EMAC_TSV0_EXC_DEFER      0x00000080  /**< Excessive Packet Deferral         */
+#define EMAC_TSV0_EXC_COLL       0x00000100  /**< Excessive Collision               */
+#define EMAC_TSV0_LATE_COLL      0x00000200  /**< Late Collision Occured            */
+#define EMAC_TSV0_GIANT          0x00000400  /**< Giant Frame                       */
+#define EMAC_TSV0_UNDERRUN       0x00000800  /**< Buffer Underrun                   */
+#define EMAC_TSV0_BYTES          0x0FFFF000  /**< Total Bytes Transferred           */
+#define EMAC_TSV0_CTRL_FRAME     0x10000000  /**< Control Frame                     */
+#define EMAC_TSV0_PAUSE          0x20000000  /**< Pause Frame                       */
+#define EMAC_TSV0_BACK_PRESS     0x40000000  /**< Backpressure Method Applied       */
+#define EMAC_TSV0_VLAN           0x80000000  /**< VLAN Frame                        */
+
+/*********************************************************************//**
+ * Macro defines for Transmit Status Vector 1 Register
+ **********************************************************************/
+#define EMAC_TSV1_BYTE_CNT       0x0000FFFF  /**< Transmit Byte Count               */
+#define EMAC_TSV1_COLL_CNT       0x000F0000  /**< Transmit Collision Count          */
+
+/*********************************************************************//**
+ * Macro defines for Receive Status Vector Register
+ **********************************************************************/
+#define EMAC_RSV_BYTE_CNT        0x0000FFFF  /**< Receive Byte Count                */
+#define EMAC_RSV_PKT_IGNORED     0x00010000  /**< Packet Previously Ignored         */
+#define EMAC_RSV_RXDV_SEEN       0x00020000  /**< RXDV Event Previously Seen        */
+#define EMAC_RSV_CARR_SEEN       0x00040000  /**< Carrier Event Previously Seen     */
+#define EMAC_RSV_REC_CODEV       0x00080000  /**< Receive Code Violation            */
+#define EMAC_RSV_CRC_ERR         0x00100000  /**< CRC Error                         */
+#define EMAC_RSV_LEN_CHKERR      0x00200000  /**< Length Check Error                */
+#define EMAC_RSV_LEN_OUTRNG      0x00400000  /**< Length Out of Range               */
+#define EMAC_RSV_REC_OK          0x00800000  /**< Frame Received OK                 */
+#define EMAC_RSV_MCAST           0x01000000  /**< Multicast Frame                   */
+#define EMAC_RSV_BCAST           0x02000000  /**< Broadcast Frame                   */
+#define EMAC_RSV_DRIB_NIBB       0x04000000  /**< Dribble Nibble                    */
+#define EMAC_RSV_CTRL_FRAME      0x08000000  /**< Control Frame                     */
+#define EMAC_RSV_PAUSE           0x10000000  /**< Pause Frame                       */
+#define EMAC_RSV_UNSUPP_OPC      0x20000000  /**< Unsupported Opcode                */
+#define EMAC_RSV_VLAN            0x40000000  /**< VLAN Frame                        */
+
+/*********************************************************************//**
+ * Macro defines for Flow Control Counter Register
+ **********************************************************************/
+#define EMAC_FCC_MIRR_CNT(n)          (n & 0xFFFF)      /**< Mirror Counter                    */
+#define EMAC_FCC_PAUSE_TIM(n)         ((n & 0xFFFF) << 16)    /**< Pause Timer                       */
+
+/*********************************************************************//**
+ * Macro defines for Flow Control Status Register
+ **********************************************************************/
+#define EMAC_FCS_MIRR_CNT(n)          (n & 0xFFFF)      /**< Mirror Counter Current            */
+
+/* Receive filter register definitions -------------------------------------------------------- */
+/*********************************************************************//**
+ * Macro defines for Receive Filter Control Register
+ **********************************************************************/
+#define EMAC_RFC_UCAST_EN        0x00000001  /**< Accept Unicast Frames Enable      */
+#define EMAC_RFC_BCAST_EN        0x00000002  /**< Accept Broadcast Frames Enable    */
+#define EMAC_RFC_MCAST_EN        0x00000004  /**< Accept Multicast Frames Enable    */
+#define EMAC_RFC_UCAST_HASH_EN   0x00000008  /**< Accept Unicast Hash Filter Frames */
+#define EMAC_RFC_MCAST_HASH_EN   0x00000010  /**< Accept Multicast Hash Filter Fram.*/
+#define EMAC_RFC_PERFECT_EN      0x00000020  /**< Accept Perfect Match Enable       */
+#define EMAC_RFC_MAGP_WOL_EN     0x00001000  /**< Magic Packet Filter WoL Enable    */
+#define EMAC_RFC_PFILT_WOL_EN    0x00002000  /**< Perfect Filter WoL Enable         */
+
+/*********************************************************************//**
+ * Macro defines for Receive Filter WoL Status/Clear Registers
+ **********************************************************************/
+#define EMAC_WOL_UCAST           0x00000001  /**< Unicast Frame caused WoL          */
+#define EMAC_WOL_BCAST           0x00000002  /**< Broadcast Frame caused WoL        */
+#define EMAC_WOL_MCAST           0x00000004  /**< Multicast Frame caused WoL        */
+#define EMAC_WOL_UCAST_HASH      0x00000008  /**< Unicast Hash Filter Frame WoL     */
+#define EMAC_WOL_MCAST_HASH      0x00000010  /**< Multicast Hash Filter Frame WoL   */
+#define EMAC_WOL_PERFECT         0x00000020  /**< Perfect Filter WoL                */
+#define EMAC_WOL_RX_FILTER       0x00000080  /**< RX Filter caused WoL              */
+#define EMAC_WOL_MAG_PACKET      0x00000100  /**< Magic Packet Filter caused WoL    */
+#define EMAC_WOL_BITMASK     0x01BF   /**< Receive Filter WoL Status/Clear bitmasl value */
+
+/* Module control register definitions ---------------------------------------------------- */
+/*********************************************************************//**
+ * Macro defines for Interrupt Status/Enable/Clear/Set Registers
+ **********************************************************************/
+#define EMAC_INT_RX_OVERRUN      0x00000001  /**< Overrun Error in RX Queue         */
+#define EMAC_INT_RX_ERR          0x00000002  /**< Receive Error                     */
+#define EMAC_INT_RX_FIN          0x00000004  /**< RX Finished Process Descriptors   */
+#define EMAC_INT_RX_DONE         0x00000008  /**< Receive Done                      */
+#define EMAC_INT_TX_UNDERRUN     0x00000010  /**< Transmit Underrun                 */
+#define EMAC_INT_TX_ERR          0x00000020  /**< Transmit Error                    */
+#define EMAC_INT_TX_FIN          0x00000040  /**< TX Finished Process Descriptors   */
+#define EMAC_INT_TX_DONE         0x00000080  /**< Transmit Done                     */
+#define EMAC_INT_SOFT_INT        0x00001000  /**< Software Triggered Interrupt      */
+#define EMAC_INT_WAKEUP          0x00002000  /**< Wakeup Event Interrupt            */
+
+/*********************************************************************//**
+ * Macro defines for Power Down Register
+ **********************************************************************/
+#define EMAC_PD_POWER_DOWN       0x80000000  /**< Power Down MAC                    */
+
+/* Descriptor and status formats ---------------------------------------------------- */
+/*********************************************************************//**
+ * Macro defines for RX Descriptor Control Word
+ **********************************************************************/
+#define EMAC_RCTRL_SIZE(n)       (n & 0x7FF)    /**< Buffer size field                  */
+#define EMAC_RCTRL_INT           0x80000000   /**< Generate RxDone Interrupt         */
+
+/*********************************************************************//**
+ * Macro defines for RX Status Hash CRC Word
+ **********************************************************************/
+#define EMAC_RHASH_SA            0x000001FF   /**< Hash CRC for Source Address       */
+#define EMAC_RHASH_DA            0x001FF000   /**< Hash CRC for Destination Address  */
+
+/*********************************************************************//**
+ * Macro defines for RX Status Information Word
+ **********************************************************************/
+#define EMAC_RINFO_SIZE          0x000007FF  /**< Data size in bytes                */
+#define EMAC_RINFO_CTRL_FRAME    0x00040000  /**< Control Frame                     */
+#define EMAC_RINFO_VLAN          0x00080000  /**< VLAN Frame                        */
+#define EMAC_RINFO_FAIL_FILT     0x00100000  /**< RX Filter Failed                  */
+#define EMAC_RINFO_MCAST         0x00200000  /**< Multicast Frame                   */
+#define EMAC_RINFO_BCAST         0x00400000  /**< Broadcast Frame                   */
+#define EMAC_RINFO_CRC_ERR       0x00800000  /**< CRC Error in Frame                */
+#define EMAC_RINFO_SYM_ERR       0x01000000  /**< Symbol Error from PHY             */
+#define EMAC_RINFO_LEN_ERR       0x02000000  /**< Length Error                      */
+#define EMAC_RINFO_RANGE_ERR     0x04000000  /**< Range Error (exceeded max. size)  */
+#define EMAC_RINFO_ALIGN_ERR     0x08000000  /**< Alignment Error                   */
+#define EMAC_RINFO_OVERRUN       0x10000000  /**< Receive overrun                   */
+#define EMAC_RINFO_NO_DESCR      0x20000000  /**< No new Descriptor available       */
+#define EMAC_RINFO_LAST_FLAG     0x40000000  /**< Last Fragment in Frame            */
+#define EMAC_RINFO_ERR           0x80000000  /**< Error Occured (OR of all errors)  */
+#define EMAC_RINFO_ERR_MASK     (EMAC_RINFO_FAIL_FILT | EMAC_RINFO_CRC_ERR | EMAC_RINFO_SYM_ERR | \
+                                 EMAC_RINFO_LEN_ERR | EMAC_RINFO_ALIGN_ERR | EMAC_RINFO_OVERRUN)
+
+/*********************************************************************//**
+ * Macro defines for TX Descriptor Control Word
+ **********************************************************************/
+#define EMAC_TCTRL_SIZE          0x000007FF  /**< Size of data buffer in bytes      */
+#define EMAC_TCTRL_OVERRIDE      0x04000000  /**< Override Default MAC Registers    */
+#define EMAC_TCTRL_HUGE          0x08000000  /**< Enable Huge Frame                 */
+#define EMAC_TCTRL_PAD           0x10000000  /**< Pad short Frames to 64 bytes      */
+#define EMAC_TCTRL_CRC           0x20000000  /**< Append a hardware CRC to Frame    */
+#define EMAC_TCTRL_LAST          0x40000000  /**< Last Descriptor for TX Frame      */
+#define EMAC_TCTRL_INT           0x80000000  /**< Generate TxDone Interrupt         */
+
+/*********************************************************************//**
+ * Macro defines for TX Status Information Word
+ **********************************************************************/
+#define EMAC_TINFO_COL_CNT       0x01E00000  /**< Collision Count                   */
+#define EMAC_TINFO_DEFER         0x02000000  /**< Packet Deferred (not an error)    */
+#define EMAC_TINFO_EXCESS_DEF    0x04000000  /**< Excessive Deferral                */
+#define EMAC_TINFO_EXCESS_COL    0x08000000  /**< Excessive Collision               */
+#define EMAC_TINFO_LATE_COL      0x10000000  /**< Late Collision Occured            */
+#define EMAC_TINFO_UNDERRUN      0x20000000  /**< Transmit Underrun                 */
+#define EMAC_TINFO_NO_DESCR      0x40000000  /**< No new Descriptor available       */
+#define EMAC_TINFO_ERR           0x80000000  /**< Error Occured (OR of all errors)  */
+
+#ifdef MCB_LPC_1768
+/* DP83848C PHY definition ------------------------------------------------------------ */
+
+/** PHY device reset time out definition */
+#define EMAC_PHY_RESP_TOUT    0x100000UL
+
+/* ENET Device Revision ID */
+#define EMAC_OLD_EMAC_MODULE_ID  0x39022000  /**< Rev. ID for first rev '-'         */
+
+/*********************************************************************//**
+ * Macro defines for DP83848C PHY Registers
+ **********************************************************************/
+#define EMAC_PHY_REG_BMCR        0x00        /**< Basic Mode Control Register       */
+#define EMAC_PHY_REG_BMSR        0x01        /**< Basic Mode Status Register        */
+#define EMAC_PHY_REG_IDR1        0x02        /**< PHY Identifier 1                  */
+#define EMAC_PHY_REG_IDR2        0x03        /**< PHY Identifier 2                  */
+#define EMAC_PHY_REG_ANAR        0x04        /**< Auto-Negotiation Advertisement    */
+#define EMAC_PHY_REG_ANLPAR      0x05        /**< Auto-Neg. Link Partner Abitily    */
+#define EMAC_PHY_REG_ANER        0x06        /**< Auto-Neg. Expansion Register      */
+#define EMAC_PHY_REG_ANNPTR      0x07        /**< Auto-Neg. Next Page TX            */
+#define EMAC_PHY_REG_LPNPA     0x08
+
+/*********************************************************************//**
+ * Macro defines for PHY Extended Registers
+ **********************************************************************/
+#define EMAC_PHY_REG_STS         0x10        /**< Status Register                   */
+#define EMAC_PHY_REG_MICR        0x11        /**< MII Interrupt Control Register    */
+#define EMAC_PHY_REG_MISR        0x12        /**< MII Interrupt Status Register     */
+#define EMAC_PHY_REG_FCSCR       0x14        /**< False Carrier Sense Counter       */
+#define EMAC_PHY_REG_RECR        0x15        /**< Receive Error Counter             */
+#define EMAC_PHY_REG_PCSR        0x16        /**< PCS Sublayer Config. and Status   */
+#define EMAC_PHY_REG_RBR         0x17        /**< RMII and Bypass Register          */
+#define EMAC_PHY_REG_LEDCR       0x18        /**< LED Direct Control Register       */
+#define EMAC_PHY_REG_PHYCR       0x19        /**< PHY Control Register              */
+#define EMAC_PHY_REG_10BTSCR     0x1A        /**< 10Base-T Status/Control Register  */
+#define EMAC_PHY_REG_CDCTRL1     0x1B        /**< CD Test Control and BIST Extens.  */
+#define EMAC_PHY_REG_EDCR        0x1D        /**< Energy Detect Control Register    */
+
+/*********************************************************************//**
+ * Macro defines for PHY Basic Mode Control Register
+ **********************************************************************/
+#define EMAC_PHY_BMCR_RESET           (1 << 15)   /**< Reset bit */
+#define EMAC_PHY_BMCR_LOOPBACK          (1 << 14)   /**< Loop back */
+#define EMAC_PHY_BMCR_SPEED_SEL         (1 << 13)   /**< Speed selection */
+#define EMAC_PHY_BMCR_AN          (1 << 12)   /**< Auto Negotiation */
+#define EMAC_PHY_BMCR_POWERDOWN       (1 << 11)   /**< Power down mode */
+#define EMAC_PHY_BMCR_ISOLATE       (1 << 10)   /**< Isolate */
+#define EMAC_PHY_BMCR_RE_AN         (1 << 9)    /**< Restart auto negotiation */
+#define EMAC_PHY_BMCR_DUPLEX        (1 << 8)    /**< Duplex mode */
+
+/*********************************************************************//**
+ * Macro defines for PHY Basic Mode Status Status Register
+ **********************************************************************/
+#define EMAC_PHY_BMSR_100BE_T4              (1 << 15)   /**< 100 base T4 */
+#define EMAC_PHY_BMSR_100TX_FULL      (1 << 14)   /**< 100 base full duplex */
+#define EMAC_PHY_BMSR_100TX_HALF      (1 << 13)   /**< 100 base half duplex */
+#define EMAC_PHY_BMSR_10BE_FULL       (1 << 12)   /**< 10 base T full duplex */
+#define EMAC_PHY_BMSR_10BE_HALF       (1 << 11)   /**< 10 base T half duplex */
+#define EMAC_PHY_BMSR_NOPREAM       (1 << 6)    /**< MF Preamable Supress */
+#define EMAC_PHY_BMSR_AUTO_DONE       (1 << 5)    /**< Auto negotiation complete */
+#define EMAC_PHY_BMSR_REMOTE_FAULT      (1 << 4)    /**< Remote fault */
+#define EMAC_PHY_BMSR_NO_AUTO       (1 << 3)    /**< Auto Negotiation ability */
+#define EMAC_PHY_BMSR_LINK_ESTABLISHED    (1 << 2)    /**< Link status */
+
+/*********************************************************************//**
+ * Macro defines for PHY Status Register
+ **********************************************************************/
+#define EMAC_PHY_SR_REMOTE_FAULT        (1 << 6)    /**< Remote Fault */
+#define EMAC_PHY_SR_JABBER          (1 << 5)    /**< Jabber detect */
+#define EMAC_PHY_SR_AUTO_DONE       (1 << 4)    /**< Auto Negotiation complete */
+#define EMAC_PHY_SR_LOOPBACK        (1 << 3)    /**< Loop back status */
+#define EMAC_PHY_SR_DUP           (1 << 2)    /**< Duplex status */
+#define EMAC_PHY_SR_SPEED         (1 << 1)    /**< Speed status */
+#define EMAC_PHY_SR_LINK          (1 << 0)    /**< Link Status */
+
+#define EMAC_PHY_FULLD_100M      0x2100      /**< Full Duplex 100Mbit               */
+#define EMAC_PHY_HALFD_100M      0x2000      /**< Half Duplex 100Mbit               */
+#define EMAC_PHY_FULLD_10M       0x0100      /**< Full Duplex 10Mbit                */
+#define EMAC_PHY_HALFD_10M       0x0000      /**< Half Duplex 10MBit                */
+#define EMAC_PHY_AUTO_NEG        0x3000      /**< Select Auto Negotiation           */
+
+#define EMAC_DEF_ADR    0x0100      /**< Default PHY device address        */
+#define EMAC_DP83848C_ID         0x20005C90  /**< PHY Identifier                    */
+
+#define EMAC_PHY_SR_100_SPEED   ((1 << 14) | (1 << 13))
+#define EMAC_PHY_SR_FULL_DUP    ((1 << 14) | (1 << 12))
+#define EMAC_PHY_BMSR_LINK_STATUS     (1 << 2)    /**< Link status */
+
+#elif defined(IAR_LPC_1768)
+/* KSZ8721BL PHY definition ------------------------------------------------------------ */
+/** PHY device reset time out definition */
+#define EMAC_PHY_RESP_TOUT    0x100000UL
+
+/* ENET Device Revision ID */
+#define EMAC_OLD_EMAC_MODULE_ID  0x39022000  /**< Rev. ID for first rev '-'         */
+
+/*********************************************************************//**
+ * Macro defines for KSZ8721BL PHY Registers
+ **********************************************************************/
+#define EMAC_PHY_REG_BMCR        0x00        /**< Basic Mode Control Register       */
+#define EMAC_PHY_REG_BMSR        0x01        /**< Basic Mode Status Register        */
+#define EMAC_PHY_REG_IDR1        0x02        /**< PHY Identifier 1                  */
+#define EMAC_PHY_REG_IDR2        0x03        /**< PHY Identifier 2                  */
+#define EMAC_PHY_REG_ANAR        0x04        /**< Auto-Negotiation Advertisement    */
+#define EMAC_PHY_REG_ANLPAR      0x05        /**< Auto-Neg. Link Partner Abitily    */
+#define EMAC_PHY_REG_ANER        0x06        /**< Auto-Neg. Expansion Register      */
+#define EMAC_PHY_REG_ANNPTR      0x07        /**< Auto-Neg. Next Page TX            */
+#define EMAC_PHY_REG_LPNPA     0x08    /**< Link Partner Next Page Ability    */
+#define EMAC_PHY_REG_REC     0x15    /**< RXError Counter Register			*/
+#define EMAC_PHY_REG_ISC     0x1b    /**< Interrupt Control/Status Register */
+#define EMAC_PHY_REG_100BASE   0x1f    /**< 100BASE-TX PHY Control Register   */
+
+/*********************************************************************//**
+ * Macro defines for PHY Basic Mode Control Register
+ **********************************************************************/
+#define EMAC_PHY_BMCR_RESET           (1 << 15)   /**< Reset bit */
+#define EMAC_PHY_BMCR_LOOPBACK          (1 << 14)   /**< Loop back */
+#define EMAC_PHY_BMCR_SPEED_SEL         (1 << 13)   /**< Speed selection */
+#define EMAC_PHY_BMCR_AN          (1 << 12)   /**< Auto Negotiation */
+#define EMAC_PHY_BMCR_POWERDOWN       (1 << 11)   /**< Power down mode */
+#define EMAC_PHY_BMCR_ISOLATE       (1 << 10)   /**< Isolate */
+#define EMAC_PHY_BMCR_RE_AN         (1 << 9)    /**< Restart auto negotiation */
+#define EMAC_PHY_BMCR_DUPLEX        (1 << 8)    /**< Duplex mode */
+#define EMAC_PHY_BMCR_COLLISION       (1 << 7)    /**< Collision test */
+#define EMAC_PHY_BMCR_TXDIS         (1 << 0)    /**< Disable transmit */
+
+/*********************************************************************//**
+ * Macro defines for PHY Basic Mode Status Register
+ **********************************************************************/
+#define EMAC_PHY_BMSR_100BE_T4              (1 << 15)   /**< 100 base T4 */
+#define EMAC_PHY_BMSR_100TX_FULL      (1 << 14)   /**< 100 base full duplex */
+#define EMAC_PHY_BMSR_100TX_HALF      (1 << 13)   /**< 100 base half duplex */
+#define EMAC_PHY_BMSR_10BE_FULL       (1 << 12)   /**< 10 base T full duplex */
+#define EMAC_PHY_BMSR_10BE_HALF       (1 << 11)   /**< 10 base T half duplex */
+#define EMAC_PHY_BMSR_NOPREAM       (1 << 6)    /**< MF Preamable Supress */
+#define EMAC_PHY_BMSR_AUTO_DONE       (1 << 5)    /**< Auto negotiation complete */
+#define EMAC_PHY_BMSR_REMOTE_FAULT      (1 << 4)    /**< Remote fault */
+#define EMAC_PHY_BMSR_NO_AUTO       (1 << 3)    /**< Auto Negotiation ability */
+#define EMAC_PHY_BMSR_LINK_STATUS     (1 << 2)    /**< Link status */
+#define EMAC_PHY_BMSR_JABBER_DETECT     (1 << 1)    /**< Jabber detect */
+#define EMAC_PHY_BMSR_EXTEND        (1 << 0)    /**< Extended support */
+
+/*********************************************************************//**
+ * Macro defines for PHY Identifier
+ **********************************************************************/
+/* PHY Identifier 1 bitmap definitions */
+#define EMAC_PHY_IDR1(n)    (n & 0xFFFF)    /**< PHY ID1 Number */
+
+/* PHY Identifier 2 bitmap definitions */
+#define EMAC_PHY_IDR2(n)    (n & 0xFFFF)    /**< PHY ID2 Number */
+
+/*********************************************************************//**
+ * Macro defines for Auto-Negotiation Advertisement
+ **********************************************************************/
+#define EMAC_PHY_AN_NEXTPAGE          (1 << 15)   /**<  Next page capable */
+#define EMAC_PHY_AN_REMOTE_FAULT        (1 << 13)   /**< Remote Fault support */
+#define EMAC_PHY_AN_PAUSE           (1 << 10)   /**< Pause support */
+#define EMAC_PHY_AN_100BASE_T4          (1 << 9)    /**< T4 capable */
+#define EMAC_PHY_AN_100BASE_TX_FD       (1 << 8)    /**< TX with Full-duplex capable */
+#define EMAC_PHY_AN_100BASE_TX          (1 << 7)    /**< TX capable */
+#define EMAC_PHY_AN_10BASE_T_FD         (1 << 6)    /**< 10Mbps with full-duplex capable */
+#define EMAC_PHY_AN_10BASE_T          (1 << 5)    /**< 10Mbps capable */
+#define EMAC_PHY_AN_FIELD(n)          (n & 0x1F)  /**< Selector Field */
+
+#define EMAC_PHY_FULLD_100M      0x2100      /**< Full Duplex 100Mbit               */
+#define EMAC_PHY_HALFD_100M      0x2000      /**< Half Duplex 100Mbit               */
+#define EMAC_PHY_FULLD_10M       0x0100      /**< Full Duplex 10Mbit                */
+#define EMAC_PHY_HALFD_10M       0x0000      /**< Half Duplex 10MBit                */
+#define EMAC_PHY_AUTO_NEG        0x3000      /**< Select Auto Negotiation           */
+
+#define EMAC_PHY_SR_100_SPEED   ((1 << 14) | (1 << 13))
+#define EMAC_PHY_SR_FULL_DUP    ((1 << 14) | (1 << 12))
+
+#define EMAC_DEF_ADR    (0x01 << 8)   /**< Default PHY device address        */
+#define EMAC_KSZ8721BL_ID   ((0x22 << 16) | 0x1619)  /**< PHY Identifier */
+#endif
+
+/**
+ * @}
+ */
+
+/* Public Types --------------------------------------------------------------- */
+/** @defgroup EMAC_Public_Types EMAC Public Types
+ * @{
+ */
+
+/* Descriptor and status formats ---------------------------------------------- */
+
+/**
+ * @brief RX Descriptor structure type definition
+ */
+typedef struct {
+  uint32_t Packet;  /**< Receive Packet Descriptor */
+  uint32_t Ctrl;    /**< Receive Control Descriptor */
+} RX_Desc;
+
+/**
+ * @brief RX Status structure type definition
+ */
+typedef struct {
+  uint32_t Info;    /**< Receive Information Status */
+  uint32_t HashCRC; /**< Receive Hash CRC Status */
+} RX_Stat;
+
+/**
+ * @brief TX Descriptor structure type definition
+ */
+typedef struct {
+  uint32_t Packet;  /**< Transmit Packet Descriptor */
+  uint32_t Ctrl;    /**< Transmit Control Descriptor */
+} TX_Desc;
+
+/**
+ * @brief TX Status structure type definition
+ */
+typedef struct {
+  uint32_t Info;    /**< Transmit Information Status */
+} TX_Stat;
+
+/**
+ * @brief TX Data Buffer structure definition
+ */
+typedef struct {
+  uint32_t ulDataLen;     /**< Data length */
+  uint32_t *pbDataBuf;    /**< A word-align data pointer to data buffer */
+} EMAC_PACKETBUF_Type;
+
+/**
+ * @brief EMAC configuration structure definition
+ */
+typedef struct {
+  uint32_t Mode;            /**< Supported EMAC PHY device speed, should be one of the following:
+                               - EMAC_MODE_AUTO
+                               - EMAC_MODE_10M_FULL
+                               - EMAC_MODE_10M_HALF
+                               - EMAC_MODE_100M_FULL
+                               - EMAC_MODE_100M_HALF
+                             */
+  uint8_t *pbEMAC_Addr;         /**< Pointer to EMAC Station address that contains 6-bytes
+                                   of MAC address, it must be sorted in order (bEMAC_Addr[0]..[5])
+                                 */
+} EMAC_CFG_Type;
+
+/**
+ * @}
+ */
+
+/* Public Functions ----------------------------------------------------------- */
+/** @defgroup EMAC_Public_Functions EMAC Public Functions
+ * @{
+ */
+/* Init/DeInit EMAC peripheral */
+Status EMAC_Init(EMAC_CFG_Type *EMAC_ConfigStruct);
+void EMAC_DeInit(void);
+
+/* PHY functions --------------*/
+int32_t EMAC_CheckPHYStatus(uint32_t ulPHYState);
+int32_t EMAC_SetPHYMode(uint32_t ulPHYMode);
+int32_t EMAC_UpdatePHYStatus(void);
+
+/* Filter functions ----------*/
+void EMAC_SetHashFilter(uint8_t dstMAC_addr[], FunctionalState NewState);
+void EMAC_SetFilterMode(uint32_t ulFilterMode, FunctionalState NewState);
+
+/* EMAC Packet Buffer functions */
+void EMAC_WritePacketBuffer(EMAC_PACKETBUF_Type *pDataStruct);
+void EMAC_ReadPacketBuffer(EMAC_PACKETBUF_Type *pDataStruct);
+
+/* EMAC Interrupt functions -------*/
+void EMAC_IntCmd(uint32_t ulIntType, FunctionalState NewState);
+IntStatus EMAC_IntGetStatus(uint32_t ulIntType);
+
+/* EMAC Index functions -----------*/
+Bool EMAC_CheckReceiveIndex(void);
+Bool EMAC_CheckTransmitIndex(void);
+void EMAC_UpdateRxConsumeIndex(void);
+void EMAC_UpdateTxProduceIndex(void);
+
+FlagStatus EMAC_CheckReceiveDataStatus(uint32_t ulRxStatType);
+uint32_t EMAC_GetReceiveDataSize(void);
+FlagStatus EMAC_GetWoLStatus(uint32_t ulWoLMode);
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* LPC17XX_EMAC_H_ */
+
+/**
+ * @}
+ */
+
+/* --------------------------------- End Of File ------------------------------ */

--- a/cpu/arm/lpc1768/lpc17xx_gpio.c
+++ b/cpu/arm/lpc1768/lpc17xx_gpio.c
@@ -1,0 +1,734 @@
+/**********************************************************************
+ * $Id$		lpc17xx_gpio.c				2010-05-21
+ *//**
+ * @file		lpc17xx_gpio.c
+ * @brief	Contains all functions support for GPIO firmware
+ *      library on LPC17xx
+ * @version	2.0
+ * @date		21. May. 2010
+ * @author	NXP MCU SW Application Team
+ *
+ * Copyright(C) 2010, NXP Semiconductor
+ * All rights reserved.
+ *
+ ***********************************************************************
+ * Software that is described herein is for illustrative purposes only
+ * which provides customers with programming information regarding the
+ * products. This software is supplied "AS IS" without any warranties.
+ * NXP Semiconductors assumes no responsibility or liability for the
+ * use of the software, conveys no license or title under any patent,
+ * copyright, or mask work right to the product. NXP Semiconductors
+ * reserves the right to make changes in the software without
+ * notification. NXP Semiconductors also make no representation or
+ * warranty that such application will be suitable for the specified
+ * use without further testing or modification.
+ **********************************************************************/
+
+/* Peripheral group ----------------------------------------------------------- */
+/** @addtogroup GPIO
+ * @{
+ */
+
+/* Includes ------------------------------------------------------------------- */
+#include "lpc17xx_gpio.h"
+
+/* If this source file built with example, the LPC17xx FW library configuration
+ * file in each example directory ("lpc17xx_libcfg.h") must be included,
+ * otherwise the default FW library configuration file must be included instead
+ */
+#ifdef __BUILD_WITH_EXAMPLE__
+#include "lpc17xx_libcfg.h"
+#else
+#include "lpc17xx_libcfg_default.h"
+#endif /* __BUILD_WITH_EXAMPLE__ */
+
+#ifdef _GPIO
+
+/* Private Functions ---------------------------------------------------------- */
+
+static LPC_GPIO_TypeDef *GPIO_GetPointer(uint8_t portNum);
+static GPIO_HalfWord_TypeDef *FIO_HalfWordGetPointer(uint8_t portNum);
+static GPIO_Byte_TypeDef *FIO_ByteGetPointer(uint8_t portNum);
+
+/*********************************************************************//**
+ * @brief		Get pointer to GPIO peripheral due to GPIO port
+ * @param[in]	portNum		Port Number value, should be in range from 0 to 4.
+ * @return		Pointer to GPIO peripheral
+ **********************************************************************/
+static LPC_GPIO_TypeDef *
+GPIO_GetPointer(uint8_t portNum)
+{
+  LPC_GPIO_TypeDef *pGPIO = NULL;
+
+  switch(portNum) {
+  case 0:
+    pGPIO = LPC_GPIO0;
+    break;
+  case 1:
+    pGPIO = LPC_GPIO1;
+    break;
+  case 2:
+    pGPIO = LPC_GPIO2;
+    break;
+  case 3:
+    pGPIO = LPC_GPIO3;
+    break;
+  case 4:
+    pGPIO = LPC_GPIO4;
+    break;
+  default:
+    break;
+  }
+
+  return pGPIO;
+}
+/*********************************************************************//**
+ * @brief		Get pointer to FIO peripheral in halfword accessible style
+ *        due to FIO port
+ * @param[in]	portNum		Port Number value, should be in range from 0 to 4.
+ * @return		Pointer to FIO peripheral
+ **********************************************************************/
+static GPIO_HalfWord_TypeDef *
+FIO_HalfWordGetPointer(uint8_t portNum)
+{
+  GPIO_HalfWord_TypeDef *pFIO = NULL;
+
+  switch(portNum) {
+  case 0:
+    pFIO = GPIO0_HalfWord;
+    break;
+  case 1:
+    pFIO = GPIO1_HalfWord;
+    break;
+  case 2:
+    pFIO = GPIO2_HalfWord;
+    break;
+  case 3:
+    pFIO = GPIO3_HalfWord;
+    break;
+  case 4:
+    pFIO = GPIO4_HalfWord;
+    break;
+  default:
+    break;
+  }
+
+  return pFIO;
+}
+/*********************************************************************//**
+ * @brief		Get pointer to FIO peripheral in byte accessible style
+ *        due to FIO port
+ * @param[in]	portNum		Port Number value, should be in range from 0 to 4.
+ * @return		Pointer to FIO peripheral
+ **********************************************************************/
+static GPIO_Byte_TypeDef *
+FIO_ByteGetPointer(uint8_t portNum)
+{
+  GPIO_Byte_TypeDef *pFIO = NULL;
+
+  switch(portNum) {
+  case 0:
+    pFIO = GPIO0_Byte;
+    break;
+  case 1:
+    pFIO = GPIO1_Byte;
+    break;
+  case 2:
+    pFIO = GPIO2_Byte;
+    break;
+  case 3:
+    pFIO = GPIO3_Byte;
+    break;
+  case 4:
+    pFIO = GPIO4_Byte;
+    break;
+  default:
+    break;
+  }
+
+  return pFIO;
+}
+/* End of Private Functions --------------------------------------------------- */
+
+/* Public Functions ----------------------------------------------------------- */
+/** @addtogroup GPIO_Public_Functions
+ * @{
+ */
+
+/* GPIO ------------------------------------------------------------------------------ */
+
+/*********************************************************************//**
+ * @brief		Set Direction for GPIO port.
+ * @param[in]	portNum		Port Number value, should be in range from 0 to 4
+ * @param[in]	bitValue	Value that contains all bits to set direction,
+ *              in range from 0 to 0xFFFFFFFF.
+ *              example: value 0x5 to set direction for bit 0 and bit 1.
+ * @param[in]	dir			Direction value, should be:
+ *              - 0: Input.
+ *              - 1: Output.
+ * @return		None
+ *
+ * Note: All remaining bits that are not activated in bitValue (value '0')
+ * will not be effected by this function.
+ **********************************************************************/
+void
+GPIO_SetDir(uint8_t portNum, uint32_t bitValue, uint8_t dir)
+{
+  LPC_GPIO_TypeDef *pGPIO = GPIO_GetPointer(portNum);
+
+  if(pGPIO != NULL) {
+    /* Enable Output */
+    if(dir) {
+      pGPIO->FIODIR |= bitValue;
+      /* Enable Input */
+    } else {
+      pGPIO->FIODIR &= ~bitValue;
+    }
+  }
+}
+/*********************************************************************//**
+ * @brief		Set Value for bits that have output direction on GPIO port.
+ * @param[in]	portNum		Port number value, should be in range from 0 to 4
+ * @param[in]	bitValue	Value that contains all bits on GPIO to set,
+ *              in range from 0 to 0xFFFFFFFF.
+ *              example: value 0x5 to set bit 0 and bit 1.
+ * @return		None
+ *
+ * Note:
+ * - For all bits that has been set as input direction, this function will
+ * not effect.
+ * - For all remaining bits that are not activated in bitValue (value '0')
+ * will not be effected by this function.
+ **********************************************************************/
+void
+GPIO_SetValue(uint8_t portNum, uint32_t bitValue)
+{
+  LPC_GPIO_TypeDef *pGPIO = GPIO_GetPointer(portNum);
+
+  if(pGPIO != NULL) {
+    pGPIO->FIOSET = bitValue;
+  }
+}
+/*********************************************************************//**
+ * @brief		Clear Value for bits that have output direction on GPIO port.
+ * @param[in]	portNum		Port number value, should be in range from 0 to 4
+ * @param[in]	bitValue	Value that contains all bits on GPIO to clear,
+ *              in range from 0 to 0xFFFFFFFF.
+ *              example: value 0x5 to clear bit 0 and bit 1.
+ * @return		None
+ *
+ * Note:
+ * - For all bits that has been set as input direction, this function will
+ * not effect.
+ * - For all remaining bits that are not activated in bitValue (value '0')
+ * will not be effected by this function.
+ **********************************************************************/
+void
+GPIO_ClearValue(uint8_t portNum, uint32_t bitValue)
+{
+  LPC_GPIO_TypeDef *pGPIO = GPIO_GetPointer(portNum);
+
+  if(pGPIO != NULL) {
+    pGPIO->FIOCLR = bitValue;
+  }
+}
+/*********************************************************************//**
+ * @brief		Read Current state on port pin that have input direction of GPIO
+ * @param[in]	portNum		Port number to read value, in range from 0 to 4
+ * @return		Current value of GPIO port.
+ *
+ * Note: Return value contain state of each port pin (bit) on that GPIO regardless
+ * its direction is input or output.
+ **********************************************************************/
+uint32_t
+GPIO_ReadValue(uint8_t portNum)
+{
+  LPC_GPIO_TypeDef *pGPIO = GPIO_GetPointer(portNum);
+
+  if(pGPIO != NULL) {
+    return pGPIO->FIOPIN;
+  }
+  return 0;
+}
+/*********************************************************************//**
+ * @brief		Enable GPIO interrupt (just used for P0.0-P0.30, P2.0-P2.13)
+ * @param[in]	portNum		Port number to read value, should be: 0 or 2
+ * @param[in]	bitValue	Value that contains all bits on GPIO to enable,
+ *              in range from 0 to 0xFFFFFFFF.
+ * @param[in]	edgeState	state of edge, should be:
+ *              - 0: Rising edge
+ *              - 1: Falling edge
+ * @return		None
+ **********************************************************************/
+void
+GPIO_IntCmd(uint8_t portNum, uint32_t bitValue, uint8_t edgeState)
+{
+  if((portNum == 0) && (edgeState == 0)) {
+    LPC_GPIOINT->IO0IntEnR = bitValue;
+  } else if((portNum == 2) && (edgeState == 0)) {
+    LPC_GPIOINT->IO2IntEnR = bitValue;
+  } else if((portNum == 0) && (edgeState == 1)) {
+    LPC_GPIOINT->IO0IntEnF = bitValue;
+  } else if((portNum == 2) && (edgeState == 1)) {
+    LPC_GPIOINT->IO2IntEnF = bitValue;
+  } else {
+    /* Error */
+    while(1) ;
+  }
+}
+/*********************************************************************//**
+ * @brief		Get GPIO Interrupt Status (just used for P0.0-P0.30, P2.0-P2.13)
+ * @param[in]	portNum		Port number to read value, should be: 0 or 2
+ * @param[in]	pinNum		Pin number, should be: 0..30(with port 0) and 0..13
+ *              (with port 2)
+ * @param[in]	edgeState	state of edge, should be:
+ *              - 0: Rising edge
+ *              - 1: Falling edge
+ * @return		Bool	could be:
+ *            - ENABLE: Interrupt has been generated due to a rising
+ *                edge on P0.0
+ *            - DISABLE: A rising edge has not been detected on P0.0
+ **********************************************************************/
+FunctionalState
+GPIO_GetIntStatus(uint8_t portNum, uint32_t pinNum, uint8_t edgeState)
+{
+  if((portNum == 0) && (edgeState == 0)) { /* Rising Edge */
+    return (FunctionalState)(((LPC_GPIOINT->IO0IntStatR) >> pinNum) & 0x1);
+  } else if((portNum == 2) && (edgeState == 0)) {
+    return (FunctionalState)(((LPC_GPIOINT->IO2IntStatR) >> pinNum) & 0x1);
+  } else if((portNum == 0) && (edgeState == 1)) { /* Falling Edge */
+    return (FunctionalState)(((LPC_GPIOINT->IO0IntStatF) >> pinNum) & 0x1);
+  } else if((portNum == 2) && (edgeState == 1)) {
+    return (FunctionalState)(((LPC_GPIOINT->IO2IntStatF) >> pinNum) & 0x1);
+  } else {
+    /* Error */
+    while(1) ;
+  }
+}
+/*********************************************************************//**
+ * @brief		Clear GPIO interrupt (just used for P0.0-P0.30, P2.0-P2.13)
+ * @param[in]	portNum		Port number to read value, should be: 0 or 2
+ * @param[in]	bitValue	Value that contains all bits on GPIO to enable,
+ *              in range from 0 to 0xFFFFFFFF.
+ * @return		None
+ **********************************************************************/
+void
+GPIO_ClearInt(uint8_t portNum, uint32_t bitValue)
+{
+  if(portNum == 0) {
+    LPC_GPIOINT->IO0IntClr = bitValue;
+  } else if(portNum == 2) {
+    LPC_GPIOINT->IO2IntClr = bitValue;
+  } else {
+    /* Invalid portNum */
+    while(1) ;
+  }
+}
+/* FIO word accessible ----------------------------------------------------------------- */
+/* Stub function for FIO (word-accessible) style */
+
+/**
+ * @brief The same with GPIO_SetDir()
+ */
+void
+FIO_SetDir(uint8_t portNum, uint32_t bitValue, uint8_t dir)
+{
+  GPIO_SetDir(portNum, bitValue, dir);
+}
+/**
+ * @brief The same with GPIO_SetValue()
+ */
+void
+FIO_SetValue(uint8_t portNum, uint32_t bitValue)
+{
+  GPIO_SetValue(portNum, bitValue);
+}
+/**
+ * @brief The same with GPIO_ClearValue()
+ */
+void
+FIO_ClearValue(uint8_t portNum, uint32_t bitValue)
+{
+  GPIO_ClearValue(portNum, bitValue);
+}
+/**
+ * @brief The same with GPIO_ReadValue()
+ */
+uint32_t
+FIO_ReadValue(uint8_t portNum)
+{
+  return GPIO_ReadValue(portNum);
+}
+/**
+ * @brief The same with GPIO_IntCmd()
+ */
+void
+FIO_IntCmd(uint8_t portNum, uint32_t bitValue, uint8_t edgeState)
+{
+  GPIO_IntCmd(portNum, bitValue, edgeState);
+}
+/**
+ * @brief The same with GPIO_GetIntStatus()
+ */
+FunctionalState
+FIO_GetIntStatus(uint8_t portNum, uint32_t pinNum, uint8_t edgeState)
+{
+  return GPIO_GetIntStatus(portNum, pinNum, edgeState);
+}
+/**
+ * @brief The same with GPIO_ClearInt()
+ */
+void
+FIO_ClearInt(uint8_t portNum, uint32_t bitValue)
+{
+  GPIO_ClearInt(portNum, bitValue);
+}
+/*********************************************************************//**
+ * @brief		Set mask value for bits in FIO port
+ * @param[in]	portNum		Port number, in range from 0 to 4
+ * @param[in]	bitValue	Value that contains all bits in to set,
+ *              in range from 0 to 0xFFFFFFFF.
+ * @param[in]	maskValue	Mask value contains state value for each bit:
+ *              - 0: not mask.
+ *              - 1: mask.
+ * @return		None
+ *
+ * Note:
+ * - All remaining bits that are not activated in bitValue (value '0')
+ * will not be effected by this function.
+ * - After executing this function, in mask register, value '0' on each bit
+ * enables an access to the corresponding physical pin via a read or write access,
+ * while value '1' on bit (masked) that corresponding pin will not be changed
+ * with write access and if read, will not be reflected in the updated pin.
+ **********************************************************************/
+void
+FIO_SetMask(uint8_t portNum, uint32_t bitValue, uint8_t maskValue)
+{
+  LPC_GPIO_TypeDef *pFIO = GPIO_GetPointer(portNum);
+  if(pFIO != NULL) {
+    /* Mask */
+    if(maskValue) {
+      pFIO->FIOMASK |= bitValue;
+      /* Un-mask */
+    } else {
+      pFIO->FIOMASK &= ~bitValue;
+    }
+  }
+}
+/* FIO halfword accessible ------------------------------------------------------------- */
+
+/*********************************************************************//**
+ * @brief		Set direction for FIO port in halfword accessible style
+ * @param[in]	portNum		Port number, in range from 0 to 4
+ * @param[in]	halfwordNum	HalfWord part number, should be 0 (lower) or 1(upper)
+ * @param[in]	bitValue	Value that contains all bits in to set direction,
+ *              in range from 0 to 0xFFFF.
+ * @param[in]	dir			Direction value, should be:
+ *              - 0: Input.
+ *              - 1: Output.
+ * @return		None
+ *
+ * Note: All remaining bits that are not activated in bitValue (value '0')
+ * will not be effected by this function.
+ **********************************************************************/
+void
+FIO_HalfWordSetDir(uint8_t portNum, uint8_t halfwordNum, uint16_t bitValue, uint8_t dir)
+{
+  GPIO_HalfWord_TypeDef *pFIO = FIO_HalfWordGetPointer(portNum);
+  if(pFIO != NULL) {
+    /* Output direction */
+    if(dir) {
+      /* Upper */
+      if(halfwordNum) {
+        pFIO->FIODIRU |= bitValue;
+        /* lower */
+      } else {
+        pFIO->FIODIRL |= bitValue;
+      }
+    }
+    /* Input direction */
+    else {
+      /* Upper */
+      if(halfwordNum) {
+        pFIO->FIODIRU &= ~bitValue;
+        /* lower */
+      } else {
+        pFIO->FIODIRL &= ~bitValue;
+      }
+    }
+  }
+}
+/*********************************************************************//**
+ * @brief		Set mask value for bits in FIO port in halfword accessible style
+ * @param[in]	portNum		Port number, in range from 0 to 4
+ * @param[in]	halfwordNum	HalfWord part number, should be 0 (lower) or 1(upper)
+ * @param[in]	bitValue	Value that contains all bits in to set,
+ *              in range from 0 to 0xFFFF.
+ * @param[in]	maskValue	Mask value contains state value for each bit:
+ *          - 0: not mask.
+ *          - 1: mask.
+ * @return		None
+ *
+ * Note:
+ * - All remaining bits that are not activated in bitValue (value '0')
+ * will not be effected by this function.
+ * - After executing this function, in mask register, value '0' on each bit
+ * enables an access to the corresponding physical pin via a read or write access,
+ * while value '1' on bit (masked) that corresponding pin will not be changed
+ * with write access and if read, will not be reflected in the updated pin.
+ **********************************************************************/
+void
+FIO_HalfWordSetMask(uint8_t portNum, uint8_t halfwordNum, uint16_t bitValue, uint8_t maskValue)
+{
+  GPIO_HalfWord_TypeDef *pFIO = FIO_HalfWordGetPointer(portNum);
+  if(pFIO != NULL) {
+    /* Mask */
+    if(maskValue) {
+      /* Upper */
+      if(halfwordNum) {
+        pFIO->FIOMASKU |= bitValue;
+        /* lower */
+      } else {
+        pFIO->FIOMASKL |= bitValue;
+      }
+    }
+    /* Un-mask */
+    else {
+      /* Upper */
+      if(halfwordNum) {
+        pFIO->FIOMASKU &= ~bitValue;
+        /* lower */
+      } else {
+        pFIO->FIOMASKL &= ~bitValue;
+      }
+    }
+  }
+}
+/*********************************************************************//**
+ * @brief		Set bits for FIO port in halfword accessible style
+ * @param[in]	portNum		Port number, in range from 0 to 4
+ * @param[in]	halfwordNum	HalfWord part number, should be 0 (lower) or 1(upper)
+ * @param[in]	bitValue	Value that contains all bits in to set,
+ *              in range from 0 to 0xFFFF.
+ * @return		None
+ *
+ * Note:
+ * - For all bits that has been set as input direction, this function will
+ * not effect.
+ * - For all remaining bits that are not activated in bitValue (value '0')
+ * will not be effected by this function.
+ **********************************************************************/
+void
+FIO_HalfWordSetValue(uint8_t portNum, uint8_t halfwordNum, uint16_t bitValue)
+{
+  GPIO_HalfWord_TypeDef *pFIO = FIO_HalfWordGetPointer(portNum);
+  if(pFIO != NULL) {
+    /* Upper */
+    if(halfwordNum) {
+      pFIO->FIOSETU = bitValue;
+      /* lower */
+    } else {
+      pFIO->FIOSETL = bitValue;
+    }
+  }
+}
+/*********************************************************************//**
+ * @brief		Clear bits for FIO port in halfword accessible style
+ * @param[in]	portNum		Port number, in range from 0 to 4
+ * @param[in]	halfwordNum	HalfWord part number, should be 0 (lower) or 1(upper)
+ * @param[in]	bitValue	Value that contains all bits in to clear,
+ *              in range from 0 to 0xFFFF.
+ * @return		None
+ *
+ * Note:
+ * - For all bits that has been set as input direction, this function will
+ * not effect.
+ * - For all remaining bits that are not activated in bitValue (value '0')
+ * will not be effected by this function.
+ **********************************************************************/
+void
+FIO_HalfWordClearValue(uint8_t portNum, uint8_t halfwordNum, uint16_t bitValue)
+{
+  GPIO_HalfWord_TypeDef *pFIO = FIO_HalfWordGetPointer(portNum);
+  if(pFIO != NULL) {
+    /* Upper */
+    if(halfwordNum) {
+      pFIO->FIOCLRU = bitValue;
+      /* lower */
+    } else {
+      pFIO->FIOCLRL = bitValue;
+    }
+  }
+}
+/*********************************************************************//**
+ * @brief		Read Current state on port pin that have input direction of GPIO
+ *        in halfword accessible style.
+ * @param[in]	portNum		Port number, in range from 0 to 4
+ * @param[in]	halfwordNum	HalfWord part number, should be 0 (lower) or 1(upper)
+ * @return		Current value of FIO port pin of specified halfword.
+ * Note: Return value contain state of each port pin (bit) on that FIO regardless
+ * its direction is input or output.
+ **********************************************************************/
+uint16_t
+FIO_HalfWordReadValue(uint8_t portNum, uint8_t halfwordNum)
+{
+  GPIO_HalfWord_TypeDef *pFIO = FIO_HalfWordGetPointer(portNum);
+  if(pFIO != NULL) {
+    /* Upper */
+    if(halfwordNum) {
+      return pFIO->FIOPINU;
+      /* lower */
+    } else {
+      return pFIO->FIOPINL;
+    }
+  }
+  return 0;
+}
+/* FIO Byte accessible ------------------------------------------------------------ */
+
+/*********************************************************************//**
+ * @brief		Set direction for FIO port in byte accessible style
+ * @param[in]	portNum		Port number, in range from 0 to 4
+ * @param[in]	byteNum		Byte part number, should be in range from 0 to 3
+ * @param[in]	bitValue	Value that contains all bits in to set direction,
+ *              in range from 0 to 0xFF.
+ * @param[in]	dir			Direction value, should be:
+ *              - 0: Input.
+ *              - 1: Output.
+ * @return		None
+ *
+ * Note: All remaining bits that are not activated in bitValue (value '0')
+ * will not be effected by this function.
+ **********************************************************************/
+void
+FIO_ByteSetDir(uint8_t portNum, uint8_t byteNum, uint8_t bitValue, uint8_t dir)
+{
+  GPIO_Byte_TypeDef *pFIO = FIO_ByteGetPointer(portNum);
+  if(pFIO != NULL) {
+    /* Output direction */
+    if(dir) {
+      if(byteNum <= 3) {
+        pFIO->FIODIR[byteNum] |= bitValue;
+      }
+    }
+    /* Input direction */
+    else if(byteNum <= 3) {
+      pFIO->FIODIR[byteNum] &= ~bitValue;
+    }
+  }
+}
+/*********************************************************************//**
+ * @brief		Set mask value for bits in FIO port in byte accessible style
+ * @param[in]	portNum		Port number, in range from 0 to 4
+ * @param[in]	byteNum		Byte part number, should be in range from 0 to 3
+ * @param[in]	bitValue	Value that contains all bits in to set mask,
+ *              in range from 0 to 0xFF.
+ * @param[in]	maskValue	Mask value contains state value for each bit:
+ *              - 0: not mask.
+ *              - 1: mask.
+ * @return		None
+ *
+ * Note:
+ * - All remaining bits that are not activated in bitValue (value '0')
+ * will not be effected by this function.
+ * - After executing this function, in mask register, value '0' on each bit
+ * enables an access to the corresponding physical pin via a read or write access,
+ * while value '1' on bit (masked) that corresponding pin will not be changed
+ * with write access and if read, will not be reflected in the updated pin.
+ **********************************************************************/
+void
+FIO_ByteSetMask(uint8_t portNum, uint8_t byteNum, uint8_t bitValue, uint8_t maskValue)
+{
+  GPIO_Byte_TypeDef *pFIO = FIO_ByteGetPointer(portNum);
+  if(pFIO != NULL) {
+    /* Mask */
+    if(maskValue) {
+      if(byteNum <= 3) {
+        pFIO->FIOMASK[byteNum] |= bitValue;
+      }
+    }
+    /* Un-mask */
+    else if(byteNum <= 3) {
+      pFIO->FIOMASK[byteNum] &= ~bitValue;
+    }
+  }
+}
+/*********************************************************************//**
+ * @brief		Set bits for FIO port in byte accessible style
+ * @param[in]	portNum		Port number, in range from 0 to 4
+ * @param[in]	byteNum		Byte part number, should be in range from 0 to 3
+ * @param[in]	bitValue	Value that contains all bits in to set,
+ *              in range from 0 to 0xFF.
+ * @return		None
+ *
+ * Note:
+ * - For all bits that has been set as input direction, this function will
+ * not effect.
+ * - For all remaining bits that are not activated in bitValue (value '0')
+ * will not be effected by this function.
+ **********************************************************************/
+void
+FIO_ByteSetValue(uint8_t portNum, uint8_t byteNum, uint8_t bitValue)
+{
+  GPIO_Byte_TypeDef *pFIO = FIO_ByteGetPointer(portNum);
+  if(pFIO != NULL) {
+    if(byteNum <= 3) {
+      pFIO->FIOSET[byteNum] = bitValue;
+    }
+  }
+}
+/*********************************************************************//**
+ * @brief		Clear bits for FIO port in byte accessible style
+ * @param[in]	portNum		Port number, in range from 0 to 4
+ * @param[in]	byteNum		Byte part number, should be in range from 0 to 3
+ * @param[in]	bitValue	Value that contains all bits in to clear,
+ *              in range from 0 to 0xFF.
+ * @return		None
+ *
+ * Note:
+ * - For all bits that has been set as input direction, this function will
+ * not effect.
+ * - For all remaining bits that are not activated in bitValue (value '0')
+ * will not be effected by this function.
+ **********************************************************************/
+void
+FIO_ByteClearValue(uint8_t portNum, uint8_t byteNum, uint8_t bitValue)
+{
+  GPIO_Byte_TypeDef *pFIO = FIO_ByteGetPointer(portNum);
+  if(pFIO != NULL) {
+    if(byteNum <= 3) {
+      pFIO->FIOCLR[byteNum] = bitValue;
+    }
+  }
+}
+/*********************************************************************//**
+ * @brief		Read Current state on port pin that have input direction of GPIO
+ *        in byte accessible style.
+ * @param[in]	portNum		Port number, in range from 0 to 4
+ * @param[in]	byteNum		Byte part number, should be in range from 0 to 3
+ * @return		Current value of FIO port pin of specified byte part.
+ * Note: Return value contain state of each port pin (bit) on that FIO regardless
+ * its direction is input or output.
+ **********************************************************************/
+uint8_t
+FIO_ByteReadValue(uint8_t portNum, uint8_t byteNum)
+{
+  GPIO_Byte_TypeDef *pFIO = FIO_ByteGetPointer(portNum);
+  if(pFIO != NULL) {
+    if(byteNum <= 3) {
+      return pFIO->FIOPIN[byteNum];
+    }
+  }
+  return 0;
+}
+/**
+ * @}
+ */
+
+#endif /* _GPIO */
+
+/**
+ * @}
+ */
+
+/* --------------------------------- End Of File ------------------------------ */

--- a/cpu/arm/lpc1768/lpc17xx_gpio.h
+++ b/cpu/arm/lpc1768/lpc17xx_gpio.h
@@ -1,0 +1,166 @@
+/**********************************************************************
+ * $Id$		lpc17xx_gpio.h				2010-06-18
+ *//**
+ * @file		lpc17xx_gpio.h
+ * @brief	Contains all macro definitions and function prototypes
+ *      support for GPDMA firmware library on LPC17xx
+ * @version	3.0
+ * @date		18. June. 2010
+ * @author	NXP MCU SW Application Team
+ *
+ * Copyright(C) 2010, NXP Semiconductor
+ * All rights reserved.
+ *
+ ***********************************************************************
+ * Software that is described herein is for illustrative purposes only
+ * which provides customers with programming information regarding the
+ * products. This software is supplied "AS IS" without any warranties.
+ * NXP Semiconductors assumes no responsibility or liability for the
+ * use of the software, conveys no license or title under any patent,
+ * copyright, or mask work right to the product. NXP Semiconductors
+ * reserves the right to make changes in the software without
+ * notification. NXP Semiconductors also make no representation or
+ * warranty that such application will be suitable for the specified
+ * use without further testing or modification.
+ **********************************************************************/
+
+/* Peripheral group ----------------------------------------------------------- */
+/** @defgroup GPIO GPIO (General Purpose Input/Output)
+ * @ingroup LPC1700CMSIS_FwLib_Drivers
+ * @{
+ */
+
+#ifndef LPC17XX_GPIO_H_
+#define LPC17XX_GPIO_H_
+
+/* Includes ------------------------------------------------------------------- */
+#include "lpc17xx.h"
+#include "lpc_types.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/* Public Macros -------------------------------------------------------------- */
+/** @defgroup GPIO_Public_Macros GPIO Public Macros
+ * @{
+ */
+
+/** Fast GPIO port 0 byte accessible definition */
+#define GPIO0_Byte  ((GPIO_Byte_TypeDef *)(LPC_GPIO0_BASE))
+/** Fast GPIO port 1 byte accessible definition */
+#define GPIO1_Byte  ((GPIO_Byte_TypeDef *)(LPC_GPIO1_BASE))
+/** Fast GPIO port 2 byte accessible definition */
+#define GPIO2_Byte  ((GPIO_Byte_TypeDef *)(LPC_GPIO2_BASE))
+/** Fast GPIO port 3 byte accessible definition */
+#define GPIO3_Byte  ((GPIO_Byte_TypeDef *)(LPC_GPIO3_BASE))
+/** Fast GPIO port 4 byte accessible definition */
+#define GPIO4_Byte  ((GPIO_Byte_TypeDef *)(LPC_GPIO4_BASE))
+
+/** Fast GPIO port 0 half-word accessible definition */
+#define GPIO0_HalfWord  ((GPIO_HalfWord_TypeDef *)(LPC_GPIO0_BASE))
+/** Fast GPIO port 1 half-word accessible definition */
+#define GPIO1_HalfWord  ((GPIO_HalfWord_TypeDef *)(LPC_GPIO1_BASE))
+/** Fast GPIO port 2 half-word accessible definition */
+#define GPIO2_HalfWord  ((GPIO_HalfWord_TypeDef *)(LPC_GPIO2_BASE))
+/** Fast GPIO port 3 half-word accessible definition */
+#define GPIO3_HalfWord  ((GPIO_HalfWord_TypeDef *)(LPC_GPIO3_BASE))
+/** Fast GPIO port 4 half-word accessible definition */
+#define GPIO4_HalfWord  ((GPIO_HalfWord_TypeDef *)(LPC_GPIO4_BASE))
+
+/**
+ * @}
+ */
+
+/* Public Types --------------------------------------------------------------- */
+/** @defgroup GPIO_Public_Types GPIO Public Types
+ * @{
+ */
+
+/**
+ * @brief Fast GPIO port byte type definition
+ */
+typedef struct {
+  __IO uint8_t FIODIR[4];   /**< FIO direction register in byte-align */
+  uint32_t RESERVED0[3];    /**< Reserved */
+  __IO uint8_t FIOMASK[4];  /**< FIO mask register in byte-align */
+  __IO uint8_t FIOPIN[4];   /**< FIO pin register in byte align */
+  __IO uint8_t FIOSET[4];   /**< FIO set register in byte-align */
+  __O uint8_t FIOCLR[4];    /**< FIO clear register in byte-align */
+} GPIO_Byte_TypeDef;
+
+/**
+ * @brief Fast GPIO port half-word type definition
+ */
+typedef struct {
+  __IO uint16_t FIODIRL;    /**< FIO direction register lower halfword part */
+  __IO uint16_t FIODIRU;    /**< FIO direction register upper halfword part */
+  uint32_t RESERVED0[3];    /**< Reserved */
+  __IO uint16_t FIOMASKL;   /**< FIO mask register lower halfword part */
+  __IO uint16_t FIOMASKU;   /**< FIO mask register upper halfword part */
+  __IO uint16_t FIOPINL;    /**< FIO pin register lower halfword part */
+  __IO uint16_t FIOPINU;    /**< FIO pin register upper halfword part */
+  __IO uint16_t FIOSETL;    /**< FIO set register lower halfword part */
+  __IO uint16_t FIOSETU;    /**< FIO set register upper halfword part */
+  __O uint16_t FIOCLRL;     /**< FIO clear register lower halfword part */
+  __O uint16_t FIOCLRU;     /**< FIO clear register upper halfword part */
+} GPIO_HalfWord_TypeDef;
+
+/**
+ * @}
+ */
+
+/* Public Functions ----------------------------------------------------------- */
+/** @defgroup GPIO_Public_Functions GPIO Public Functions
+ * @{
+ */
+
+/* GPIO style ------------------------------- */
+void GPIO_SetDir(uint8_t portNum, uint32_t bitValue, uint8_t dir);
+void GPIO_SetValue(uint8_t portNum, uint32_t bitValue);
+void GPIO_ClearValue(uint8_t portNum, uint32_t bitValue);
+uint32_t GPIO_ReadValue(uint8_t portNum);
+void GPIO_IntCmd(uint8_t portNum, uint32_t bitValue, uint8_t edgeState);
+FunctionalState GPIO_GetIntStatus(uint8_t portNum, uint32_t pinNum, uint8_t edgeState);
+void GPIO_ClearInt(uint8_t portNum, uint32_t bitValue);
+
+/* FIO (word-accessible) style ------------------------------- */
+void FIO_SetDir(uint8_t portNum, uint32_t bitValue, uint8_t dir);
+void FIO_SetValue(uint8_t portNum, uint32_t bitValue);
+void FIO_ClearValue(uint8_t portNum, uint32_t bitValue);
+uint32_t FIO_ReadValue(uint8_t portNum);
+void FIO_SetMask(uint8_t portNum, uint32_t bitValue, uint8_t maskValue);
+void FIO_IntCmd(uint8_t portNum, uint32_t bitValue, uint8_t edgeState);
+FunctionalState FIO_GetIntStatus(uint8_t portNum, uint32_t pinNum, uint8_t edgeState);
+void FIO_ClearInt(uint8_t portNum, uint32_t pinNum);
+
+/* FIO (halfword-accessible) style ------------------------------- */
+void FIO_HalfWordSetDir(uint8_t portNum, uint8_t halfwordNum, uint16_t bitValue, uint8_t dir);
+void FIO_HalfWordSetMask(uint8_t portNum, uint8_t halfwordNum, uint16_t bitValue, uint8_t maskValue);
+void FIO_HalfWordSetValue(uint8_t portNum, uint8_t halfwordNum, uint16_t bitValue);
+void FIO_HalfWordClearValue(uint8_t portNum, uint8_t halfwordNum, uint16_t bitValue);
+uint16_t FIO_HalfWordReadValue(uint8_t portNum, uint8_t halfwordNum);
+
+/* FIO (byte-accessible) style ------------------------------- */
+void FIO_ByteSetDir(uint8_t portNum, uint8_t byteNum, uint8_t bitValue, uint8_t dir);
+void FIO_ByteSetMask(uint8_t portNum, uint8_t byteNum, uint8_t bitValue, uint8_t maskValue);
+void FIO_ByteSetValue(uint8_t portNum, uint8_t byteNum, uint8_t bitValue);
+void FIO_ByteClearValue(uint8_t portNum, uint8_t byteNum, uint8_t bitValue);
+uint8_t FIO_ByteReadValue(uint8_t portNum, uint8_t byteNum);
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* LPC17XX_GPIO_H_ */
+
+/**
+ * @}
+ */
+
+/* --------------------------------- End Of File ------------------------------ */

--- a/cpu/arm/lpc1768/lpc17xx_libcfg_default.c
+++ b/cpu/arm/lpc1768/lpc17xx_libcfg_default.c
@@ -1,0 +1,71 @@
+/**********************************************************************
+ * $Id$		lpc17xx_libcfg_default.c				2010-05-21
+ *//**
+ * @file		lpc17xx_libcfg_default.c
+ * @brief	Library configuration source file (default), used to build
+ *      library without examples
+ * @version	2.0
+ * @date		21. May. 2010
+ * @author	NXP MCU SW Application Team
+ *
+ * Copyright(C) 2010, NXP Semiconductor
+ * All rights reserved.
+ *
+ ***********************************************************************
+ * Software that is described herein is for illustrative purposes only
+ * which provides customers with programming information regarding the
+ * products. This software is supplied "AS IS" without any warranties.
+ * NXP Semiconductors assumes no responsibility or liability for the
+ * use of the software, conveys no license or title under any patent,
+ * copyright, or mask work right to the product. NXP Semiconductors
+ * reserves the right to make changes in the software without
+ * notification. NXP Semiconductors also make no representation or
+ * warranty that such application will be suitable for the specified
+ * use without further testing or modification.
+ **********************************************************************/
+
+/* Library group ----------------------------------------------------------- */
+/** @addtogroup LIBCFG_DEFAULT
+ * @{
+ */
+
+/* Includes ------------------------------------------------------------------- */
+#include "lpc17xx_libcfg_default.h"
+
+/* Public Functions ----------------------------------------------------------- */
+/** @addtogroup LIBCFG_DEFAULT_Public_Functions
+ * @{
+ */
+
+#ifndef __BUILD_WITH_EXAMPLE__
+
+#ifdef  DEBUG
+/*******************************************************************************
+ * @brief		Reports the name of the source file and the source line number
+ *        where the CHECK_PARAM error has occurred.
+ * @param[in]	file Pointer to the source file name
+ * @param[in]    line assert_param error line source number
+ * @return		None
+ *******************************************************************************/
+void
+check_failed(uint8_t *file, uint32_t line)
+{
+  /* User can add his own implementation to report the file name and line number,
+     ex: printf("Wrong parameters value: file %s on line %d\r\n", file, line) */
+
+  /* Infinite loop */
+  while(1) ;
+}
+#endif /* DEBUG */
+
+#endif /* __BUILD_WITH_EXAMPLE__ */
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/* --------------------------------- End Of File ------------------------------ */

--- a/cpu/arm/lpc1768/lpc17xx_libcfg_default.h
+++ b/cpu/arm/lpc1768/lpc17xx_libcfg_default.h
@@ -1,0 +1,169 @@
+/**********************************************************************
+ * $Id$		lpc17xx_libcfg_default.h				2010-05-21
+ *//**
+ * @file		lpc17xx_libcfg_default.h
+ * @brief	Default Library configuration header file
+ * @version	2.0
+ * @date		21. May. 2010
+ * @author	NXP MCU SW Application Team
+ *
+ * Copyright(C) 2010, NXP Semiconductor
+ * All rights reserved.
+ *
+ ***********************************************************************
+ * Software that is described herein is for illustrative purposes only
+ * which provides customers with programming information regarding the
+ * products. This software is supplied "AS IS" without any warranties.
+ * NXP Semiconductors assumes no responsibility or liability for the
+ * use of the software, conveys no license or title under any patent,
+ * copyright, or mask work right to the product. NXP Semiconductors
+ * reserves the right to make changes in the software without
+ * notification. NXP Semiconductors also make no representation or
+ * warranty that such application will be suitable for the specified
+ * use without further testing or modification.
+ **********************************************************************/
+
+/* Library Configuration group ----------------------------------------------------------- */
+/** @defgroup LIBCFG_DEFAULT LIBCFG_DEFAULT (Default Library Configuration)
+ * @ingroup LPC1700CMSIS_FwLib_Drivers
+ * @{
+ */
+
+#ifndef LPC17XX_LIBCFG_DEFAULT_H_
+#define LPC17XX_LIBCFG_DEFAULT_H_
+
+/* Includes ------------------------------------------------------------------- */
+#include "lpc_types.h"
+
+/* Public Macros -------------------------------------------------------------- */
+/** @defgroup LIBCFG_DEFAULT_Public_Macros LIBCFG_DEFAULT Public Macros
+ * @{
+ */
+
+/************************** DEBUG MODE DEFINITIONS *********************************/
+/* Un-comment the line below to compile the library in DEBUG mode, this will expanse
+   the "CHECK_PARAM" macro in the FW library code */
+
+#define DEBUG
+
+/******************* PERIPHERAL FW LIBRARY CONFIGURATION DEFINITIONS ***********************/
+/* Comment the line below to disable the specific peripheral inclusion */
+
+/* DEBUG_FRAMWORK ------------------------------ */
+#define _DBGFWK
+
+/* GPIO ------------------------------- */
+#define _GPIO
+
+/* EXTI ------------------------------- */
+#define _EXTI
+
+/* UART ------------------------------- */
+#define _UART
+#define _UART0
+#define _UART1
+#define _UART2
+#define _UART3
+
+/* SPI ------------------------------- */
+#define _SPI
+
+/* SYSTICK --------------------------- */
+#define _SYSTICK
+
+/* SSP ------------------------------- */
+#define _SSP
+#define _SSP0
+#define _SSP1
+
+/* I2C ------------------------------- */
+#define _I2C
+#define _I2C0
+#define _I2C1
+#define _I2C2
+
+/* TIMER ------------------------------- */
+#define _TIM
+
+/* WDT ------------------------------- */
+#define _WDT
+
+/* GPDMA ------------------------------- */
+#define _GPDMA
+
+/* DAC ------------------------------- */
+#define _DAC
+
+/* DAC ------------------------------- */
+#define _ADC
+
+/* PWM ------------------------------- */
+#define _PWM
+#define _PWM1
+
+/* RTC ------------------------------- */
+#define _RTC
+
+/* I2S ------------------------------- */
+#define _I2S
+
+/* USB device ------------------------------- */
+#define _USBDEV
+#define _USB_DMA
+
+/* QEI ------------------------------- */
+#define _QEI
+
+/* MCPWM ------------------------------- */
+#define _MCPWM
+
+/* CAN--------------------------------*/
+#define _CAN
+
+/* RIT ------------------------------- */
+#define _RIT
+
+/* EMAC ------------------------------ */
+#define _EMAC
+
+/************************** GLOBAL/PUBLIC MACRO DEFINITIONS *********************************/
+
+#ifdef  DEBUG
+/*******************************************************************************
+ * @brief		The CHECK_PARAM macro is used for function's parameters check.
+ *        It is used only if the library is compiled in DEBUG mode.
+ * @param[in]	expr - If expr is false, it calls check_failed() function
+ *                      which reports the name of the source file and the source
+ *                      line number of the call that failed.
+ *                    - If expr is true, it returns no value.
+ * @return		None
+ *******************************************************************************/
+#define CHECK_PARAM(expr) ((expr) ? (void)0 : check_failed((uint8_t *)__FILE__, __LINE__))
+#else
+#define CHECK_PARAM(expr)
+#endif /* DEBUG */
+
+/**
+ * @}
+ */
+
+/* Public Functions ----------------------------------------------------------- */
+/** @defgroup LIBCFG_DEFAULT_Public_Functions LIBCFG_DEFAULT Public Functions
+ * @{
+ */
+
+#ifdef  DEBUG
+void check_failed(uint8_t *file, uint32_t line);
+#endif
+
+/**
+ * @}
+ */
+
+#endif /* LPC17XX_LIBCFG_DEFAULT_H_ */
+
+/**
+ * @}
+ */
+
+/* --------------------------------- End Of File ------------------------------ */

--- a/cpu/arm/lpc1768/lpc17xx_pinsel.c
+++ b/cpu/arm/lpc1768/lpc17xx_pinsel.c
@@ -1,0 +1,309 @@
+/**********************************************************************
+ * $Id$		lpc17xx_pinsel.c				2010-05-21
+ *//**
+ * @file		lpc17xx_pinsel.c
+ * @brief	Contains all functions support for Pin connect block firmware
+ *      library on LPC17xx
+ * @version	2.0
+ * @date		21. May. 2010
+ * @author	NXP MCU SW Application Team
+ *
+ * Copyright(C) 2010, NXP Semiconductor
+ * All rights reserved.
+ *
+ ***********************************************************************
+ * Software that is described herein is for illustrative purposes only
+ * which provides customers with programming information regarding the
+ * products. This software is supplied "AS IS" without any warranties.
+ * NXP Semiconductors assumes no responsibility or liability for the
+ * use of the software, conveys no license or title under any patent,
+ * copyright, or mask work right to the product. NXP Semiconductors
+ * reserves the right to make changes in the software without
+ * notification. NXP Semiconductors also make no representation or
+ * warranty that such application will be suitable for the specified
+ * use without further testing or modification.
+ **********************************************************************/
+
+/* Peripheral group ----------------------------------------------------------- */
+/** @addtogroup PINSEL
+ * @{
+ */
+
+/* Includes ------------------------------------------------------------------- */
+#include "lpc17xx_pinsel.h"
+
+/* Public Functions ----------------------------------------------------------- */
+
+static void set_PinFunc(uint8_t portnum, uint8_t pinnum, uint8_t funcnum);
+static void set_ResistorMode(uint8_t portnum, uint8_t pinnum, uint8_t modenum);
+static void set_OpenDrainMode(uint8_t portnum, uint8_t pinnum, uint8_t modenum);
+
+/*********************************************************************//**
+ * @brief     Setup the pin selection function
+ * @param[in]	portnum PORT number,
+ *        should be one of the following:
+ *        - PINSEL_PORT_0	: Port 0
+ *        - PINSEL_PORT_1	: Port 1
+ *        - PINSEL_PORT_2	: Port 2
+ *        - PINSEL_PORT_3	: Port 3
+ *
+ * @param[in]	pinnum	Pin number,
+ *        should be one of the following:
+        - PINSEL_PIN_0 : Pin 0
+        - PINSEL_PIN_1 : Pin 1
+        - PINSEL_PIN_2 : Pin 2
+        - PINSEL_PIN_3 : Pin 3
+        - PINSEL_PIN_4 : Pin 4
+        - PINSEL_PIN_5 : Pin 5
+        - PINSEL_PIN_6 : Pin 6
+        - PINSEL_PIN_7 : Pin 7
+        - PINSEL_PIN_8 : Pin 8
+        - PINSEL_PIN_9 : Pin 9
+        - PINSEL_PIN_10 : Pin 10
+        - PINSEL_PIN_11 : Pin 11
+        - PINSEL_PIN_12 : Pin 12
+        - PINSEL_PIN_13 : Pin 13
+        - PINSEL_PIN_14 : Pin 14
+        - PINSEL_PIN_15 : Pin 15
+        - PINSEL_PIN_16 : Pin 16
+        - PINSEL_PIN_17 : Pin 17
+        - PINSEL_PIN_18 : Pin 18
+        - PINSEL_PIN_19 : Pin 19
+        - PINSEL_PIN_20 : Pin 20
+        - PINSEL_PIN_21 : Pin 21
+        - PINSEL_PIN_22 : Pin 22
+        - PINSEL_PIN_23 : Pin 23
+        - PINSEL_PIN_24 : Pin 24
+        - PINSEL_PIN_25 : Pin 25
+        - PINSEL_PIN_26 : Pin 26
+        - PINSEL_PIN_27 : Pin 27
+        - PINSEL_PIN_28 : Pin 28
+        - PINSEL_PIN_29 : Pin 29
+        - PINSEL_PIN_30 : Pin 30
+        - PINSEL_PIN_31 : Pin 31
+
+ * @param[in]   funcnum Function number,
+ *        should be one of the following:
+ *				- PINSEL_FUNC_0 : default function
+ *				- PINSEL_FUNC_1 : first alternate function
+ *				- PINSEL_FUNC_2 : second alternate function
+ *				- PINSEL_FUNC_3 : third alternate function
+ *
+ * @return    None
+ **********************************************************************/
+static void
+set_PinFunc(uint8_t portnum, uint8_t pinnum, uint8_t funcnum)
+{
+  uint32_t pinnum_t = pinnum;
+  uint32_t pinselreg_idx = 2 * portnum;
+  uint32_t *pPinCon = (uint32_t *)&LPC_PINCON->PINSEL0;
+
+  if(pinnum_t >= 16) {
+    pinnum_t -= 16;
+    pinselreg_idx++;
+  }
+  *(uint32_t *)(pPinCon + pinselreg_idx) &= ~(0x03UL << (pinnum_t * 2));
+  *(uint32_t *)(pPinCon + pinselreg_idx) |= ((uint32_t)funcnum) << (pinnum_t * 2);
+}
+/*********************************************************************//**
+ * @brief     Setup resistor mode for each pin
+ * @param[in]	portnum PORT number,
+ *        should be one of the following:
+ *        - PINSEL_PORT_0	: Port 0
+ *        - PINSEL_PORT_1	: Port 1
+ *        - PINSEL_PORT_2	: Port 2
+ *        - PINSEL_PORT_3	: Port 3
+ * @param[in]	pinnum	Pin number,
+ *        should be one of the following:
+        - PINSEL_PIN_0 : Pin 0
+        - PINSEL_PIN_1 : Pin 1
+        - PINSEL_PIN_2 : Pin 2
+        - PINSEL_PIN_3 : Pin 3
+        - PINSEL_PIN_4 : Pin 4
+        - PINSEL_PIN_5 : Pin 5
+        - PINSEL_PIN_6 : Pin 6
+        - PINSEL_PIN_7 : Pin 7
+        - PINSEL_PIN_8 : Pin 8
+        - PINSEL_PIN_9 : Pin 9
+        - PINSEL_PIN_10 : Pin 10
+        - PINSEL_PIN_11 : Pin 11
+        - PINSEL_PIN_12 : Pin 12
+        - PINSEL_PIN_13 : Pin 13
+        - PINSEL_PIN_14 : Pin 14
+        - PINSEL_PIN_15 : Pin 15
+        - PINSEL_PIN_16 : Pin 16
+        - PINSEL_PIN_17 : Pin 17
+        - PINSEL_PIN_18 : Pin 18
+        - PINSEL_PIN_19 : Pin 19
+        - PINSEL_PIN_20 : Pin 20
+        - PINSEL_PIN_21 : Pin 21
+        - PINSEL_PIN_22 : Pin 22
+        - PINSEL_PIN_23 : Pin 23
+        - PINSEL_PIN_24 : Pin 24
+        - PINSEL_PIN_25 : Pin 25
+        - PINSEL_PIN_26 : Pin 26
+        - PINSEL_PIN_27 : Pin 27
+        - PINSEL_PIN_28 : Pin 28
+        - PINSEL_PIN_29 : Pin 29
+        - PINSEL_PIN_30 : Pin 30
+        - PINSEL_PIN_31 : Pin 31
+
+ * @param[in]   modenum: Mode number,
+ *        should be one of the following:
+        - PINSEL_PINMODE_PULLUP	: Internal pull-up resistor
+        - PINSEL_PINMODE_TRISTATE : Tri-state
+        - PINSEL_PINMODE_PULLDOWN : Internal pull-down resistor
+
+ * @return    None
+ **********************************************************************/
+void
+set_ResistorMode(uint8_t portnum, uint8_t pinnum, uint8_t modenum)
+{
+  uint32_t pinnum_t = pinnum;
+  uint32_t pinmodereg_idx = 2 * portnum;
+  uint32_t *pPinCon = (uint32_t *)&LPC_PINCON->PINMODE0;
+
+  if(pinnum_t >= 16) {
+    pinnum_t -= 16;
+    pinmodereg_idx++;
+  }
+
+  *(uint32_t *)(pPinCon + pinmodereg_idx) &= ~(0x03UL << (pinnum_t * 2));
+  *(uint32_t *)(pPinCon + pinmodereg_idx) |= ((uint32_t)modenum) << (pinnum_t * 2);
+}
+/*********************************************************************//**
+ * @brief     Setup Open drain mode for each pin
+ * @param[in]	portnum PORT number,
+ *        should be one of the following:
+ *        - PINSEL_PORT_0	: Port 0
+ *        - PINSEL_PORT_1	: Port 1
+ *        - PINSEL_PORT_2	: Port 2
+ *        - PINSEL_PORT_3	: Port 3
+ *
+ * @param[in]	pinnum	Pin number,
+ *        should be one of the following:
+        - PINSEL_PIN_0 : Pin 0
+        - PINSEL_PIN_1 : Pin 1
+        - PINSEL_PIN_2 : Pin 2
+        - PINSEL_PIN_3 : Pin 3
+        - PINSEL_PIN_4 : Pin 4
+        - PINSEL_PIN_5 : Pin 5
+        - PINSEL_PIN_6 : Pin 6
+        - PINSEL_PIN_7 : Pin 7
+        - PINSEL_PIN_8 : Pin 8
+        - PINSEL_PIN_9 : Pin 9
+        - PINSEL_PIN_10 : Pin 10
+        - PINSEL_PIN_11 : Pin 11
+        - PINSEL_PIN_12 : Pin 12
+        - PINSEL_PIN_13 : Pin 13
+        - PINSEL_PIN_14 : Pin 14
+        - PINSEL_PIN_15 : Pin 15
+        - PINSEL_PIN_16 : Pin 16
+        - PINSEL_PIN_17 : Pin 17
+        - PINSEL_PIN_18 : Pin 18
+        - PINSEL_PIN_19 : Pin 19
+        - PINSEL_PIN_20 : Pin 20
+        - PINSEL_PIN_21 : Pin 21
+        - PINSEL_PIN_22 : Pin 22
+        - PINSEL_PIN_23 : Pin 23
+        - PINSEL_PIN_24 : Pin 24
+        - PINSEL_PIN_25 : Pin 25
+        - PINSEL_PIN_26 : Pin 26
+        - PINSEL_PIN_27 : Pin 27
+        - PINSEL_PIN_28 : Pin 28
+        - PINSEL_PIN_29 : Pin 29
+        - PINSEL_PIN_30 : Pin 30
+        - PINSEL_PIN_31 : Pin 31
+
+ * @param[in]	modenum  Open drain mode number,
+ *        should be one of the following:
+ *        - PINSEL_PINMODE_NORMAL : Pin is in the normal (not open drain) mode
+ *        - PINSEL_PINMODE_OPENDRAIN : Pin is in the open drain mode
+ *
+ * @return    None
+ **********************************************************************/
+void
+set_OpenDrainMode(uint8_t portnum, uint8_t pinnum, uint8_t modenum)
+{
+  uint32_t *pPinCon = (uint32_t *)&LPC_PINCON->PINMODE_OD0;
+
+  if(modenum == PINSEL_PINMODE_OPENDRAIN) {
+    *(uint32_t *)(pPinCon + portnum) |= (0x01UL << pinnum);
+  } else {
+    *(uint32_t *)(pPinCon + portnum) &= ~(0x01UL << pinnum);
+  }
+}
+/* End of Public Functions ---------------------------------------------------- */
+
+/* Public Functions ----------------------------------------------------------- */
+/** @addtogroup PINSEL_Public_Functions
+ * @{
+ */
+/*********************************************************************//**
+ * @brief     Configure trace function
+ * @param[in]   NewState State of the Trace function configuration,
+ *        should be one of the following:
+ *        - ENABLE : Enable Trace Function
+ *        - DISABLE : Disable Trace Function
+ *
+ * @return    None
+ **********************************************************************/
+void
+PINSEL_ConfigTraceFunc(FunctionalState NewState)
+{
+  if(NewState == ENABLE) {
+    LPC_PINCON->PINSEL10 |= (0x01UL << 3);
+  } else if(NewState == DISABLE) {
+    LPC_PINCON->PINSEL10 &= ~(0x01UL << 3);
+  }
+}
+/*********************************************************************//**
+ * @brief     Setup I2C0 pins
+ * @param[in]	i2cPinMode I2C pin mode,
+ *        should be one of the following:
+ *        - PINSEL_I2C_Normal_Mode : The standard drive mode
+ *        - PINSEL_I2C_Fast_Mode : Fast Mode Plus drive mode
+ *
+ * @param[in]	filterSlewRateEnable  should be:
+ *        - ENABLE: Enable filter and slew rate.
+ *        - DISABLE: Disable filter and slew rate.
+ *
+ * @return    None
+ **********************************************************************/
+void
+PINSEL_SetI2C0Pins(uint8_t i2cPinMode, FunctionalState filterSlewRateEnable)
+{
+  uint32_t regVal;
+
+  if(i2cPinMode == PINSEL_I2C_Fast_Mode) {
+    regVal = PINSEL_I2CPADCFG_SCLDRV0 | PINSEL_I2CPADCFG_SDADRV0;
+  }
+  if(filterSlewRateEnable == DISABLE) {
+    regVal = PINSEL_I2CPADCFG_SCLI2C0 | PINSEL_I2CPADCFG_SDAI2C0;
+  }
+  LPC_PINCON->I2CPADCFG = regVal;
+}
+/*********************************************************************//**
+ * @brief     Configure Pin corresponding to specified parameters passed
+ *        in the PinCfg
+ * @param[in]	PinCfg	Pointer to a PINSEL_CFG_Type structure
+ *                    that contains the configuration information for the
+ *                    specified pin.
+ * @return    None
+ **********************************************************************/
+void
+PINSEL_ConfigPin(PINSEL_CFG_Type *PinCfg)
+{
+  set_PinFunc(PinCfg->Portnum, PinCfg->Pinnum, PinCfg->Funcnum);
+  set_ResistorMode(PinCfg->Portnum, PinCfg->Pinnum, PinCfg->Pinmode);
+  set_OpenDrainMode(PinCfg->Portnum, PinCfg->Pinnum, PinCfg->OpenDrain);
+}
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+
+/* --------------------------------- End Of File ------------------------------ */

--- a/cpu/arm/lpc1768/lpc17xx_pinsel.h
+++ b/cpu/arm/lpc1768/lpc17xx_pinsel.h
@@ -1,0 +1,192 @@
+/**********************************************************************
+ * $Id$		lpc17xx_pinsel.h				2010-05-21
+ *//**
+ * @file		lpc17xx_pinsel.h
+ * @brief	Contains all macro definitions and function prototypes
+ *      support for Pin connect block firmware library on LPC17xx
+ * @version	2.0
+ * @date		21. May. 2010
+ * @author	NXP MCU SW Application Team
+ *
+ * Copyright(C) 2010, NXP Semiconductor
+ * All rights reserved.
+ *
+ ***********************************************************************
+ * Software that is described herein is for illustrative purposes only
+ * which provides customers with programming information regarding the
+ * products. This software is supplied "AS IS" without any warranties.
+ * NXP Semiconductors assumes no responsibility or liability for the
+ * use of the software, conveys no license or title under any patent,
+ * copyright, or mask work right to the product. NXP Semiconductors
+ * reserves the right to make changes in the software without
+ * notification. NXP Semiconductors also make no representation or
+ * warranty that such application will be suitable for the specified
+ * use without further testing or modification.
+ **********************************************************************/
+
+/* Peripheral group ----------------------------------------------------------- */
+/** @defgroup PINSEL PINSEL (Pin Selection)
+ * @ingroup LPC1700CMSIS_FwLib_Drivers
+ * @{
+ */
+
+#ifndef LPC17XX_PINSEL_H_
+#define LPC17XX_PINSEL_H_
+
+/* Includes ------------------------------------------------------------------- */
+#include "lpc17xx.h"
+#include "lpc_types.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/* Public Macros -------------------------------------------------------------- */
+/** @defgroup PINSEL_Public_Macros PINSEL Public Macros
+ * @{
+ */
+
+/*********************************************************************//**
+   *!< Macros define for PORT Selection
+ ***********************************************************************/
+#define PINSEL_PORT_0   ((0)) /**< PORT 0*/
+#define PINSEL_PORT_1   ((1)) /**< PORT 1*/
+#define PINSEL_PORT_2   ((2)) /**< PORT 2*/
+#define PINSEL_PORT_3   ((3)) /**< PORT 3*/
+#define PINSEL_PORT_4   ((4)) /**< PORT 4*/
+
+/***********************************************************************
+ * Macros define for Pin Function selection
+ **********************************************************************/
+#define PINSEL_FUNC_0 ((0)) /**< default function*/
+#define PINSEL_FUNC_1 ((1)) /**< first alternate function*/
+#define PINSEL_FUNC_2 ((2)) /**< second alternate function*/
+#define PINSEL_FUNC_3 ((3)) /**< third or reserved alternate function*/
+
+/***********************************************************************
+ * Macros define for Pin Number of Port
+ **********************************************************************/
+#define PINSEL_PIN_0  ((0))   /**< Pin 0 */
+#define PINSEL_PIN_1  ((1))   /**< Pin 1 */
+#define PINSEL_PIN_2  ((2))   /**< Pin 2 */
+#define PINSEL_PIN_3  ((3))   /**< Pin 3 */
+#define PINSEL_PIN_4  ((4))   /**< Pin 4 */
+#define PINSEL_PIN_5  ((5))   /**< Pin 5 */
+#define PINSEL_PIN_6  ((6))   /**< Pin 6 */
+#define PINSEL_PIN_7  ((7))   /**< Pin 7 */
+#define PINSEL_PIN_8  ((8))   /**< Pin 8 */
+#define PINSEL_PIN_9  ((9))   /**< Pin 9 */
+#define PINSEL_PIN_10   ((10))  /**< Pin 10 */
+#define PINSEL_PIN_11   ((11))  /**< Pin 11 */
+#define PINSEL_PIN_12   ((12))  /**< Pin 12 */
+#define PINSEL_PIN_13   ((13))  /**< Pin 13 */
+#define PINSEL_PIN_14   ((14))  /**< Pin 14 */
+#define PINSEL_PIN_15   ((15))  /**< Pin 15 */
+#define PINSEL_PIN_16   ((16))  /**< Pin 16 */
+#define PINSEL_PIN_17   ((17))  /**< Pin 17 */
+#define PINSEL_PIN_18   ((18))  /**< Pin 18 */
+#define PINSEL_PIN_19   ((19))  /**< Pin 19 */
+#define PINSEL_PIN_20   ((20))  /**< Pin 20 */
+#define PINSEL_PIN_21   ((21))  /**< Pin 21 */
+#define PINSEL_PIN_22   ((22))  /**< Pin 22 */
+#define PINSEL_PIN_23   ((23))  /**< Pin 23 */
+#define PINSEL_PIN_24   ((24))  /**< Pin 24 */
+#define PINSEL_PIN_25   ((25))  /**< Pin 25 */
+#define PINSEL_PIN_26   ((26))  /**< Pin 26 */
+#define PINSEL_PIN_27   ((27))  /**< Pin 27 */
+#define PINSEL_PIN_28   ((28))  /**< Pin 28 */
+#define PINSEL_PIN_29   ((29))  /**< Pin 29 */
+#define PINSEL_PIN_30   ((30))  /**< Pin 30 */
+#define PINSEL_PIN_31   ((31))  /**< Pin 31 */
+
+/***********************************************************************
+ * Macros define for Pin mode
+ **********************************************************************/
+#define PINSEL_PINMODE_PULLUP   ((0)) /**< Internal pull-up resistor*/
+#define PINSEL_PINMODE_TRISTATE   ((2)) /**< Tri-state */
+#define PINSEL_PINMODE_PULLDOWN   ((3))   /**< Internal pull-down resistor */
+
+/***********************************************************************
+ * Macros define for Pin mode (normal/open drain)
+ **********************************************************************/
+#define PINSEL_PINMODE_NORMAL   ((0)) /**< Pin is in the normal (not open drain) mode.*/
+#define PINSEL_PINMODE_OPENDRAIN  ((1))   /**< Pin is in the open drain mode */
+
+/***********************************************************************
+ * Macros define for I2C mode
+ ***********************************************************************/
+#define PINSEL_I2C_Normal_Mode    ((0)) /**< The standard drive mode */
+#define PINSEL_I2C_Fast_Mode    ((1))   /**<  Fast Mode Plus drive mode */
+
+/**
+ * @}
+ */
+
+/* Private Macros ------------------------------------------------------------- */
+/** @defgroup PINSEL_Private_Macros PINSEL Private Macros
+ * @{
+ */
+
+/* Pin selection define */
+/* I2C Pin Configuration register bit description */
+#define PINSEL_I2CPADCFG_SDADRV0  _BIT(0) /**< Drive mode control for the SDA0 pin, P0.27 */
+#define PINSEL_I2CPADCFG_SDAI2C0  _BIT(1) /**< I2C mode control for the SDA0 pin, P0.27 */
+#define PINSEL_I2CPADCFG_SCLDRV0  _BIT(2) /**< Drive mode control for the SCL0 pin, P0.28 */
+#define PINSEL_I2CPADCFG_SCLI2C0  _BIT(3) /**< I2C mode control for the SCL0 pin, P0.28 */
+
+/**
+ * @}
+ */
+
+/* Public Types --------------------------------------------------------------- */
+/** @defgroup PINSEL_Public_Types PINSEL Public Types
+ * @{
+ */
+
+/** @brief Pin configuration structure */
+typedef struct {
+  uint8_t Portnum;  /**< Port Number, should be PINSEL_PORT_x,
+                       where x should be in range from 0 to 4 */
+  uint8_t Pinnum;   /**< Pin Number, should be PINSEL_PIN_x,
+                       where x should be in range from 0 to 31 */
+  uint8_t Funcnum;  /**< Function Number, should be PINSEL_FUNC_x,
+                       where x should be in range from 0 to 3 */
+  uint8_t Pinmode;  /**< Pin Mode, should be:
+                       - PINSEL_PINMODE_PULLUP: Internal pull-up resistor
+                       - PINSEL_PINMODE_TRISTATE: Tri-state
+                       - PINSEL_PINMODE_PULLDOWN: Internal pull-down resistor */
+  uint8_t OpenDrain;  /**< OpenDrain mode, should be:
+                         - PINSEL_PINMODE_NORMAL: Pin is in the normal (not open drain) mode
+                         - PINSEL_PINMODE_OPENDRAIN: Pin is in the open drain mode */
+} PINSEL_CFG_Type;
+
+/**
+ * @}
+ */
+
+/* Public Functions ----------------------------------------------------------- */
+/** @defgroup PINSEL_Public_Functions PINSEL Public Functions
+ * @{
+ */
+
+void PINSEL_ConfigPin(PINSEL_CFG_Type *PinCfg);
+void PINSEL_ConfigTraceFunc(FunctionalState NewState);
+void PINSEL_SetI2C0Pins(uint8_t i2cPinMode, FunctionalState filterSlewRateEnable);
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* LPC17XX_PINSEL_H_ */
+
+/**
+ * @}
+ */
+
+/* --------------------------------- End Of File ------------------------------ */
+

--- a/cpu/arm/lpc1768/lpc17xx_systick.c
+++ b/cpu/arm/lpc1768/lpc17xx_systick.c
@@ -1,0 +1,187 @@
+/**********************************************************************
+ * $Id$		lpc17xx_systick.c				2010-05-21
+ *//**
+ * @file		lpc17xx_systick.c
+ * @brief	Contains all functions support for SYSTICK firmware library
+ *      on LPC17xx
+ * @version	2.0
+ * @date		21. May. 2010
+ * @author	NXP MCU SW Application Team
+ *
+ * Copyright(C) 2010, NXP Semiconductor
+ * All rights reserved.
+ *
+ ***********************************************************************
+ * Software that is described herein is for illustrative purposes only
+ * which provides customers with programming information regarding the
+ * products. This software is supplied "AS IS" without any warranties.
+ * NXP Semiconductors assumes no responsibility or liability for the
+ * use of the software, conveys no license or title under any patent,
+ * copyright, or mask work right to the product. NXP Semiconductors
+ * reserves the right to make changes in the software without
+ * notification. NXP Semiconductors also make no representation or
+ * warranty that such application will be suitable for the specified
+ * use without further testing or modification.
+ **********************************************************************/
+
+/* Peripheral group ----------------------------------------------------------- */
+/** @addtogroup SYSTICK
+ * @{
+ */
+
+/* Includes ------------------------------------------------------------------- */
+#include "lpc17xx_systick.h"
+#include "lpc17xx_clkpwr.h"
+
+/* If this source file built with example, the LPC17xx FW library configuration
+ * file in each example directory ("lpc17xx_libcfg.h") must be included,
+ * otherwise the default FW library configuration file must be included instead
+ */
+#ifdef __BUILD_WITH_EXAMPLE__
+#include "lpc17xx_libcfg.h"
+#else
+#include "lpc17xx_libcfg_default.h"
+#endif /* __BUILD_WITH_EXAMPLE__ */
+
+#ifdef _SYSTICK
+
+/* Public Functions ----------------------------------------------------------- */
+/** @addtogroup SYSTICK_Public_Functions
+ * @{
+ */
+/*********************************************************************//**
+ * @brief     Initial System Tick with using internal CPU clock source
+ * @param[in]	time	time interval(ms)
+ * @return    None
+ **********************************************************************/
+void
+SYSTICK_InternalInit(uint32_t time)
+{
+  uint32_t cclk;
+  float maxtime;
+
+  cclk = SystemCoreClock;
+  /* With internal CPU clock frequency for LPC17xx is 'SystemCoreClock'
+   * And limit 24 bit for RELOAD value
+   * So the maximum time can be set:
+   * 1/SystemCoreClock * (2^24) * 1000 (ms)
+   */
+  /* check time value is available or not */
+  maxtime = (1 << 24) / (SystemCoreClock / 1000);
+  if(time > maxtime) {
+    /* Error loop */
+    while(1) ;
+  } else {
+    /* Select CPU clock is System Tick clock source */
+    SysTick->CTRL |= ST_CTRL_CLKSOURCE;
+    /* Set RELOAD value
+     * RELOAD = (SystemCoreClock/1000) * time - 1
+     * with time base is millisecond
+     */
+    SysTick->LOAD = (cclk / 1000) * time - 1;
+  }
+}
+/*********************************************************************//**
+ * @brief     Initial System Tick with using external clock source
+ * @param[in]	freq	external clock frequency(Hz)
+ * @param[in]	time	time interval(ms)
+ * @return    None
+ **********************************************************************/
+void
+SYSTICK_ExternalInit(uint32_t freq, uint32_t time)
+{
+  float maxtime;
+
+  /* With external clock frequency for LPC17xx is 'freq'
+   * And limit 24 bit for RELOAD value
+   * So the maximum time can be set:
+   * 1/freq * (2^24) * 1000 (ms)
+   */
+  /* check time value is available or not */
+  maxtime = (1 << 24) / (freq / 1000);
+  if(time > maxtime) {
+    /* Error Loop */
+    while(1) ;
+  } else {
+    /* Select external clock is System Tick clock source */
+    SysTick->CTRL &= ~ST_CTRL_CLKSOURCE;
+    /* Set RELOAD value
+     * RELOAD = (freq/1000) * time - 1
+     * with time base is millisecond
+     */
+    maxtime = (freq / 1000) * time - 1;
+    SysTick->LOAD = (freq / 1000) * time - 1;
+  }
+}
+/*********************************************************************//**
+ * @brief     Enable/disable System Tick counter
+ * @param[in]	NewState	System Tick counter status, should be:
+ *          - ENABLE
+ *          - DISABLE
+ * @return    None
+ **********************************************************************/
+void
+SYSTICK_Cmd(FunctionalState NewState)
+{
+  CHECK_PARAM(PARAM_FUNCTIONALSTATE(NewState));
+
+  if(NewState == ENABLE) {
+    /* Enable System Tick counter */
+    SysTick->CTRL |= ST_CTRL_ENABLE;
+  } else {
+    /* Disable System Tick counter */
+    SysTick->CTRL &= ~ST_CTRL_ENABLE;
+  }
+}
+/*********************************************************************//**
+ * @brief     Enable/disable System Tick interrupt
+ * @param[in]	NewState	System Tick interrupt status, should be:
+ *          - ENABLE
+ *          - DISABLE
+ * @return    None
+ **********************************************************************/
+void
+SYSTICK_IntCmd(FunctionalState NewState)
+{
+  CHECK_PARAM(PARAM_FUNCTIONALSTATE(NewState));
+
+  if(NewState == ENABLE) {
+    /* Enable System Tick counter */
+    SysTick->CTRL |= ST_CTRL_TICKINT;
+  } else {
+    /* Disable System Tick counter */
+    SysTick->CTRL &= ~ST_CTRL_TICKINT;
+  }
+}
+/*********************************************************************//**
+ * @brief     Get current value of System Tick counter
+ * @param[in]	None
+ * @return    current value of System Tick counter
+ **********************************************************************/
+uint32_t
+SYSTICK_GetCurrentValue(void)
+{
+  return SysTick->VAL;
+}
+/*********************************************************************//**
+ * @brief     Clear Counter flag
+ * @param[in]	None
+ * @return    None
+ **********************************************************************/
+void
+SYSTICK_ClearCounterFlag(void)
+{
+  SysTick->CTRL &= ~ST_CTRL_COUNTFLAG;
+}
+/**
+ * @}
+ */
+
+#endif /* _SYSTICK */
+
+/**
+ * @}
+ */
+
+/* --------------------------------- End Of File ------------------------------ */
+

--- a/cpu/arm/lpc1768/lpc17xx_systick.h
+++ b/cpu/arm/lpc1768/lpc17xx_systick.h
@@ -1,0 +1,108 @@
+/**********************************************************************
+ * $Id$		lpc17xx_systick.h				2010-05-21
+ *//**
+ * @file		lpc17xx_systick.h
+ * @brief	Contains all macro definitions and function prototypes
+ *      support for SYSTICK firmware library on LPC17xx
+ * @version	2.0
+ * @date		21. May. 2010
+ * @author	NXP MCU SW Application Team
+ *
+ * Copyright(C) 2010, NXP Semiconductor
+ * All rights reserved.
+ *
+ ***********************************************************************
+ * Software that is described herein is for illustrative purposes only
+ * which provides customers with programming information regarding the
+ * products. This software is supplied "AS IS" without any warranties.
+ * NXP Semiconductors assumes no responsibility or liability for the
+ * use of the software, conveys no license or title under any patent,
+ * copyright, or mask work right to the product. NXP Semiconductors
+ * reserves the right to make changes in the software without
+ * notification. NXP Semiconductors also make no representation or
+ * warranty that such application will be suitable for the specified
+ * use without further testing or modification.
+ **********************************************************************/
+
+/* Peripheral group ----------------------------------------------------------- */
+/** @defgroup SYSTICK SYSTICK (System Tick)
+ * @ingroup LPC1700CMSIS_FwLib_Drivers
+ * @{
+ */
+
+#ifndef LPC17XX_SYSTICK_H_
+#define LPC17XX_SYSTICK_H_
+
+/* Includes ------------------------------------------------------------------- */
+#include "lpc17xx.h"
+#include "lpc_types.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/* Private Macros ------------------------------------------------------------- */
+/** @defgroup SYSTICK_Private_Macros SYSTICK Private Macros
+ * @{
+ */
+/*********************************************************************//**
+ * Macro defines for System Timer Control and status (STCTRL) register
+ **********************************************************************/
+#define ST_CTRL_ENABLE    ((uint32_t)(1 << 0))
+#define ST_CTRL_TICKINT   ((uint32_t)(1 << 1))
+#define ST_CTRL_CLKSOURCE ((uint32_t)(1 << 2))
+#define ST_CTRL_COUNTFLAG ((uint32_t)(1 << 16))
+
+/*********************************************************************//**
+ * Macro defines for System Timer Reload value (STRELOAD) register
+ **********************************************************************/
+#define ST_RELOAD_RELOAD(n)   ((uint32_t)(n & 0x00FFFFFF))
+
+/*********************************************************************//**
+ * Macro defines for System Timer Current value (STCURRENT) register
+ **********************************************************************/
+#define ST_RELOAD_CURRENT(n)  ((uint32_t)(n & 0x00FFFFFF))
+
+/*********************************************************************//**
+ * Macro defines for System Timer Calibration value (STCALIB) register
+ **********************************************************************/
+#define ST_CALIB_TENMS(n)   ((uint32_t)(n & 0x00FFFFFF))
+#define ST_CALIB_SKEW     ((uint32_t)(1 << 30))
+#define ST_CALIB_NOREF      ((uint32_t)(1 << 31))
+
+#define CLKSOURCE_EXT     ((uint32_t)(0))
+#define CLKSOURCE_CPU     ((uint32_t)(1))
+
+/**
+ * @}
+ */
+
+/* Public Functions ----------------------------------------------------------- */
+/** @defgroup SYSTICK_Public_Functions SYSTICK Public Functions
+ * @{
+ */
+
+void SYSTICK_InternalInit(uint32_t time);
+void SYSTICK_ExternalInit(uint32_t freq, uint32_t time);
+
+void SYSTICK_Cmd(FunctionalState NewState);
+void SYSTICK_IntCmd(FunctionalState NewState);
+uint32_t SYSTICK_GetCurrentValue(void);
+void SYSTICK_ClearCounterFlag(void);
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* LPC17XX_SYSTICK_H_ */
+
+/**
+ * @}
+ */
+
+/* --------------------------------- End Of File ------------------------------ */

--- a/cpu/arm/lpc1768/lpc17xx_uart.c
+++ b/cpu/arm/lpc1768/lpc17xx_uart.c
@@ -1,0 +1,1264 @@
+/**********************************************************************
+ * $Id$		lpc17xx_uart.c			2011-06-06
+ *//**
+ * @file		lpc17xx_uart.c
+ * @brief	Contains all functions support for UART firmware library
+ *      on LPC17xx
+ * @version	3.2
+ * @date		25. July. 2011
+ * @author	NXP MCU SW Application Team
+ *
+ * Copyright(C) 2011, NXP Semiconductor
+ * All rights reserved.
+ *
+ ***********************************************************************
+ * Software that is described herein is for illustrative purposes only
+ * which provides customers with programming information regarding the
+ * products. This software is supplied "AS IS" without any warranties.
+ * NXP Semiconductors assumes no responsibility or liability for the
+ * use of the software, conveys no license or title under any patent,
+ * copyright, or mask work right to the product. NXP Semiconductors
+ * reserves the right to make changes in the software without
+ * notification. NXP Semiconductors also make no representation or
+ * warranty that such application will be suitable for the specified
+ * use without further testing or modification.
+ **********************************************************************/
+
+/* Peripheral group ----------------------------------------------------------- */
+/** @addtogroup UART
+ * @{
+ */
+
+/* Includes ------------------------------------------------------------------- */
+#include "lpc17xx_uart.h"
+#include "lpc17xx_clkpwr.h"
+
+/* If this source file built with example, the LPC17xx FW library configuration
+ * file in each example directory ("lpc17xx_libcfg.h") must be included,
+ * otherwise the default FW library configuration file must be included instead
+ */
+#ifdef __BUILD_WITH_EXAMPLE__
+#include "lpc17xx_libcfg.h"
+#else
+#include "lpc17xx_libcfg_default.h"
+#endif /* __BUILD_WITH_EXAMPLE__ */
+
+#ifdef _UART
+
+/* Private Functions ---------------------------------------------------------- */
+
+static Status uart_set_divisors(LPC_UART_TypeDef *UARTx, uint32_t baudrate);
+
+/*********************************************************************//**
+ * @brief		Determines best dividers to get a target clock rate
+ * @param[in]	UARTx	Pointer to selected UART peripheral, should be:
+ *        - LPC_UART0: UART0 peripheral
+ *        - LPC_UART1: UART1 peripheral
+ *        - LPC_UART2: UART2 peripheral
+ *        - LPC_UART3: UART3 peripheral
+ * @param[in]	baudrate Desired UART baud rate.
+ * @return    Error status, could be:
+ *        - SUCCESS
+ *        - ERROR
+ **********************************************************************/
+static Status
+uart_set_divisors(LPC_UART_TypeDef *UARTx, uint32_t baudrate)
+{
+  Status errorStatus = ERROR;
+
+  uint32_t uClk;
+  uint32_t d, m, bestd, bestm, tmp;
+  uint64_t best_divisor, divisor;
+  uint32_t current_error, best_error;
+  uint32_t recalcbaud;
+
+  /* get UART block clock */
+  if(UARTx == LPC_UART0) {
+    uClk = CLKPWR_GetPCLK(CLKPWR_PCLKSEL_UART0);
+  } else if(UARTx == (LPC_UART_TypeDef *)LPC_UART1) {
+    uClk = CLKPWR_GetPCLK(CLKPWR_PCLKSEL_UART1);
+  } else if(UARTx == LPC_UART2) {
+    uClk = CLKPWR_GetPCLK(CLKPWR_PCLKSEL_UART2);
+  } else if(UARTx == LPC_UART3) {
+    uClk = CLKPWR_GetPCLK(CLKPWR_PCLKSEL_UART3);
+  }
+
+  /* In the Uart IP block, baud rate is calculated using FDR and DLL-DLM registers
+   * The formula is :
+   * BaudRate= uClk * (mulFracDiv/(mulFracDiv+dividerAddFracDiv) / (16 * (DLL)
+   * It involves floating point calculations. That's the reason the formulae are adjusted with
+   * Multiply and divide method.*/
+  /* The value of mulFracDiv and dividerAddFracDiv should comply to the following expressions:
+   * 0 < mulFracDiv <= 15, 0 <= dividerAddFracDiv <= 15 */
+  best_error = 0xFFFFFFFF; /* Worst case */
+  bestd = 0;
+  bestm = 0;
+  best_divisor = 0;
+  for(m = 1; m <= 15; m++) {
+    for(d = 0; d < m; d++) {
+      divisor = ((uint64_t)uClk << 28) * m / (baudrate * (m + d));
+      current_error = divisor & 0xFFFFFFFF;
+
+      tmp = divisor >> 32;
+
+      /* Adjust error */
+      if(current_error > ((uint32_t)1 << 31)) {
+        current_error = -current_error;
+        tmp++;
+      }
+
+      if(tmp < 1 || tmp > 65536) { /* Out of range */
+        continue;
+      }
+
+      if(current_error < best_error) {
+        best_error = current_error;
+        best_divisor = tmp;
+        bestd = d;
+        bestm = m;
+        if(best_error == 0) {
+          break;
+        }
+      }
+    } /* end of inner for loop */
+
+    if(best_error == 0) {
+      break;
+    }
+  } /* end of outer for loop  */
+
+  if(best_divisor == 0) {
+    return ERROR;                     /* can not find best match */
+  }
+  recalcbaud = (uClk >> 4) * bestm / (best_divisor * (bestm + bestd));
+
+  /* reuse best_error to evaluate baud error*/
+  if(baudrate > recalcbaud) {
+    best_error = baudrate - recalcbaud;
+  } else { best_error = recalcbaud - baudrate;
+  }
+
+  best_error = best_error * 100 / baudrate;
+
+  if(best_error < UART_ACCEPTED_BAUDRATE_ERROR) {
+    if(((LPC_UART1_TypeDef *)UARTx) == LPC_UART1) {
+      ((LPC_UART1_TypeDef *)UARTx)->LCR |= UART_LCR_DLAB_EN;
+      ((LPC_UART1_TypeDef *)UARTx)->/*DLIER.*/ DLM = UART_LOAD_DLM(best_divisor);
+      ((LPC_UART1_TypeDef *)UARTx)->/*RBTHDLR.*/ DLL = UART_LOAD_DLL(best_divisor);
+      /* Then reset DLAB bit */
+      ((LPC_UART1_TypeDef *)UARTx)->LCR &= (~UART_LCR_DLAB_EN) & UART_LCR_BITMASK;
+      ((LPC_UART1_TypeDef *)UARTx)->FDR = (UART_FDR_MULVAL(bestm) \
+                                           | UART_FDR_DIVADDVAL(bestd)) & UART_FDR_BITMASK;
+    } else {
+      UARTx->LCR |= UART_LCR_DLAB_EN;
+      UARTx->/*DLIER.*/ DLM = UART_LOAD_DLM(best_divisor);
+      UARTx->/*RBTHDLR.*/ DLL = UART_LOAD_DLL(best_divisor);
+      /* Then reset DLAB bit */
+      UARTx->LCR &= (~UART_LCR_DLAB_EN) & UART_LCR_BITMASK;
+      UARTx->FDR = (UART_FDR_MULVAL(bestm) \
+                    | UART_FDR_DIVADDVAL(bestd)) & UART_FDR_BITMASK;
+    }
+    errorStatus = SUCCESS;
+  }
+
+  return errorStatus;
+}
+/* End of Private Functions ---------------------------------------------------- */
+
+/* Public Functions ----------------------------------------------------------- */
+/** @addtogroup UART_Public_Functions
+ * @{
+ */
+/* UART Init/DeInit functions -------------------------------------------------*/
+/********************************************************************//**
+ * @brief		Initializes the UARTx peripheral according to the specified
+ *               parameters in the UART_ConfigStruct.
+ * @param[in]	UARTx	UART peripheral selected, should be:
+ *        - LPC_UART0: UART0 peripheral
+ *        - LPC_UART1: UART1 peripheral
+ *        - LPC_UART2: UART2 peripheral
+ *        - LPC_UART3: UART3 peripheral
+ * @param[in]	UART_ConfigStruct Pointer to a UART_CFG_Type structure
+ *                    that contains the configuration information for the
+ *                    specified UART peripheral.
+ * @return    None
+ *********************************************************************/
+void
+UART_Init(LPC_UART_TypeDef *UARTx, UART_CFG_Type *UART_ConfigStruct)
+{
+  uint32_t tmp;
+
+  /* For debug mode */
+  CHECK_PARAM(PARAM_UARTx(UARTx));
+  CHECK_PARAM(PARAM_UART_DATABIT(UART_ConfigStruct->Databits));
+  CHECK_PARAM(PARAM_UART_STOPBIT(UART_ConfigStruct->Stopbits));
+  CHECK_PARAM(PARAM_UART_PARITY(UART_ConfigStruct->Parity));
+
+#ifdef _UART0
+  if(UARTx == LPC_UART0) {
+    /* Set up clock and power for UART module */
+    CLKPWR_ConfigPPWR(CLKPWR_PCONP_PCUART0, ENABLE);
+  }
+#endif
+
+#ifdef _UART1
+  if(((LPC_UART1_TypeDef *)UARTx) == LPC_UART1) {
+    /* Set up clock and power for UART module */
+    CLKPWR_ConfigPPWR(CLKPWR_PCONP_PCUART1, ENABLE);
+  }
+#endif
+
+#ifdef _UART2
+  if(UARTx == LPC_UART2) {
+    /* Set up clock and power for UART module */
+    CLKPWR_ConfigPPWR(CLKPWR_PCONP_PCUART2, ENABLE);
+  }
+#endif
+
+#ifdef _UART3
+  if(UARTx == LPC_UART3) {
+    /* Set up clock and power for UART module */
+    CLKPWR_ConfigPPWR(CLKPWR_PCONP_PCUART3, ENABLE);
+  }
+#endif
+
+  if(((LPC_UART1_TypeDef *)UARTx) == LPC_UART1) {
+    /* FIFOs are empty */
+    ((LPC_UART1_TypeDef *)UARTx)->/*IIFCR.*/ FCR = (UART_FCR_FIFO_EN \
+                                                    | UART_FCR_RX_RS | UART_FCR_TX_RS);
+    /* Disable FIFO */
+    ((LPC_UART1_TypeDef *)UARTx)->/*IIFCR.*/ FCR = 0;
+
+    /* Dummy reading */
+    while(((LPC_UART1_TypeDef *)UARTx)->LSR & UART_LSR_RDR) {
+      tmp = ((LPC_UART1_TypeDef *)UARTx)->/*RBTHDLR.*/ RBR;
+    }
+
+    ((LPC_UART1_TypeDef *)UARTx)->TER = UART_TER_TXEN;
+    /* Wait for current transmit complete */
+    while(!(((LPC_UART1_TypeDef *)UARTx)->LSR & UART_LSR_THRE)) ;
+    /* Disable Tx */
+    ((LPC_UART1_TypeDef *)UARTx)->TER = 0;
+
+    /* Disable interrupt */
+    ((LPC_UART1_TypeDef *)UARTx)->/*DLIER.*/ IER = 0;
+    /* Set LCR to default state */
+    ((LPC_UART1_TypeDef *)UARTx)->LCR = 0;
+    /* Set ACR to default state */
+    ((LPC_UART1_TypeDef *)UARTx)->ACR = 0;
+    /* Set Modem Control to default state */
+    ((LPC_UART1_TypeDef *)UARTx)->MCR = 0;
+    /* Set RS485 control to default state */
+    ((LPC_UART1_TypeDef *)UARTx)->RS485CTRL = 0;
+    /* Set RS485 delay timer to default state */
+    ((LPC_UART1_TypeDef *)UARTx)->RS485DLY = 0;
+    /* Set RS485 addr match to default state */
+    ((LPC_UART1_TypeDef *)UARTx)->ADRMATCH = 0;
+    /* Dummy Reading to Clear Status */
+    tmp = ((LPC_UART1_TypeDef *)UARTx)->MSR;
+    tmp = ((LPC_UART1_TypeDef *)UARTx)->LSR;
+  } else {
+    /* FIFOs are empty */
+    UARTx->/*IIFCR.*/ FCR = (UART_FCR_FIFO_EN | UART_FCR_RX_RS | UART_FCR_TX_RS);
+    /* Disable FIFO */
+    UARTx->/*IIFCR.*/ FCR = 0;
+
+    /* Dummy reading */
+    while(UARTx->LSR & UART_LSR_RDR) {
+      tmp = UARTx->/*RBTHDLR.*/ RBR;
+    }
+
+    UARTx->TER = UART_TER_TXEN;
+    /* Wait for current transmit complete */
+    while(!(UARTx->LSR & UART_LSR_THRE)) ;
+    /* Disable Tx */
+    UARTx->TER = 0;
+
+    /* Disable interrupt */
+    UARTx->/*DLIER.*/ IER = 0;
+    /* Set LCR to default state */
+    UARTx->LCR = 0;
+    /* Set ACR to default state */
+    UARTx->ACR = 0;
+    /* Dummy reading */
+    tmp = UARTx->LSR;
+  }
+
+  if(UARTx == LPC_UART3) {
+    /* Set IrDA to default state */
+    UARTx->ICR = 0;
+  }
+  /* Set Line Control register ---------------------------- */
+
+  uart_set_divisors(UARTx, (UART_ConfigStruct->Baud_rate));
+
+  if(((LPC_UART1_TypeDef *)UARTx) == LPC_UART1) {
+    tmp = (((LPC_UART1_TypeDef *)UARTx)->LCR & (UART_LCR_DLAB_EN | UART_LCR_BREAK_EN)) \
+      & UART_LCR_BITMASK;
+  } else {
+    tmp = (UARTx->LCR & (UART_LCR_DLAB_EN | UART_LCR_BREAK_EN)) & UART_LCR_BITMASK;
+  }
+  switch(UART_ConfigStruct->Databits) {
+  case UART_DATABIT_5:
+    tmp |= UART_LCR_WLEN5;
+    break;
+  case UART_DATABIT_6:
+    tmp |= UART_LCR_WLEN6;
+    break;
+  case UART_DATABIT_7:
+    tmp |= UART_LCR_WLEN7;
+    break;
+  case UART_DATABIT_8:
+  default:
+    tmp |= UART_LCR_WLEN8;
+    break;
+  }
+
+  if(UART_ConfigStruct->Parity == UART_PARITY_NONE) {
+    /* Do nothing... */
+  } else {
+    tmp |= UART_LCR_PARITY_EN;
+    switch(UART_ConfigStruct->Parity) {
+    case UART_PARITY_ODD:
+      tmp |= UART_LCR_PARITY_ODD;
+      break;
+
+    case UART_PARITY_EVEN:
+      tmp |= UART_LCR_PARITY_EVEN;
+      break;
+
+    case UART_PARITY_SP_1:
+      tmp |= UART_LCR_PARITY_F_1;
+      break;
+
+    case UART_PARITY_SP_0:
+      tmp |= UART_LCR_PARITY_F_0;
+      break;
+    default:
+      break;
+    }
+  }
+
+  switch(UART_ConfigStruct->Stopbits) {
+  case UART_STOPBIT_2:
+    tmp |= UART_LCR_STOPBIT_SEL;
+    break;
+  case UART_STOPBIT_1:
+  default:
+    /* Do no thing */
+    break;
+  }
+
+  /* Write back to LCR, configure FIFO and Disable Tx */
+  if(((LPC_UART1_TypeDef *)UARTx) == LPC_UART1) {
+    ((LPC_UART1_TypeDef *)UARTx)->LCR = (uint8_t)(tmp & UART_LCR_BITMASK);
+  } else {
+    UARTx->LCR = (uint8_t)(tmp & UART_LCR_BITMASK);
+  }
+}
+/*********************************************************************//**
+ * @brief		De-initializes the UARTx peripheral registers to their
+ *                  default reset values.
+ * @param[in]	UARTx	UART peripheral selected, should be:
+ *        - LPC_UART0: UART0 peripheral
+ *        - LPC_UART1: UART1 peripheral
+ *        - LPC_UART2: UART2 peripheral
+ *        - LPC_UART3: UART3 peripheral
+ * @return    None
+ **********************************************************************/
+void
+UART_DeInit(LPC_UART_TypeDef *UARTx)
+{
+  /* For debug mode */
+  CHECK_PARAM(PARAM_UARTx(UARTx));
+
+  UART_TxCmd(UARTx, DISABLE);
+
+#ifdef _UART0
+  if(UARTx == LPC_UART0) {
+    /* Set up clock and power for UART module */
+    CLKPWR_ConfigPPWR(CLKPWR_PCONP_PCUART0, DISABLE);
+  }
+#endif
+
+#ifdef _UART1
+  if(((LPC_UART1_TypeDef *)UARTx) == LPC_UART1) {
+    /* Set up clock and power for UART module */
+    CLKPWR_ConfigPPWR(CLKPWR_PCONP_PCUART1, DISABLE);
+  }
+#endif
+
+#ifdef _UART2
+  if(UARTx == LPC_UART2) {
+    /* Set up clock and power for UART module */
+    CLKPWR_ConfigPPWR(CLKPWR_PCONP_PCUART2, DISABLE);
+  }
+#endif
+
+#ifdef _UART3
+  if(UARTx == LPC_UART3) {
+    /* Set up clock and power for UART module */
+    CLKPWR_ConfigPPWR(CLKPWR_PCONP_PCUART3, DISABLE);
+  }
+#endif
+}
+/*****************************************************************************//**
+ * @brief		Fills each UART_InitStruct member with its default value:
+ *        - 9600 bps
+ *        - 8-bit data
+ *        - 1 Stopbit
+ *        - None Parity
+ * @param[in]	UART_InitStruct Pointer to a UART_CFG_Type structure
+ *                    which will be initialized.
+ * @return		None
+ *******************************************************************************/
+void
+UART_ConfigStructInit(UART_CFG_Type *UART_InitStruct)
+{
+  UART_InitStruct->Baud_rate = 9600;
+  UART_InitStruct->Databits = UART_DATABIT_8;
+  UART_InitStruct->Parity = UART_PARITY_NONE;
+  UART_InitStruct->Stopbits = UART_STOPBIT_1;
+}
+/* UART Send/Recieve functions -------------------------------------------------*/
+/*********************************************************************//**
+ * @brief		Transmit a single data through UART peripheral
+ * @param[in]	UARTx	UART peripheral selected, should be:
+ *        - LPC_UART0: UART0 peripheral
+ *        - LPC_UART1: UART1 peripheral
+ *        - LPC_UART2: UART2 peripheral
+ *        - LPC_UART3: UART3 peripheral
+ * @param[in]	Data	Data to transmit (must be 8-bit long)
+ * @return    None
+ **********************************************************************/
+void
+UART_SendByte(LPC_UART_TypeDef *UARTx, uint8_t Data)
+{
+  CHECK_PARAM(PARAM_UARTx(UARTx));
+
+  if(((LPC_UART1_TypeDef *)UARTx) == LPC_UART1) {
+    ((LPC_UART1_TypeDef *)UARTx)->/*RBTHDLR.*/ THR = Data & UART_THR_MASKBIT;
+  } else {
+    UARTx->/*RBTHDLR.*/ THR = Data & UART_THR_MASKBIT;
+  }
+}
+/*********************************************************************//**
+ * @brief		Receive a single data from UART peripheral
+ * @param[in]	UARTx	UART peripheral selected, should be:
+ *        - LPC_UART0: UART0 peripheral
+ *        - LPC_UART1: UART1 peripheral
+ *        - LPC_UART2: UART2 peripheral
+ *        - LPC_UART3: UART3 peripheral
+ * @return    Data received
+ **********************************************************************/
+uint8_t
+UART_ReceiveByte(LPC_UART_TypeDef *UARTx)
+{
+  CHECK_PARAM(PARAM_UARTx(UARTx));
+
+  if(((LPC_UART1_TypeDef *)UARTx) == LPC_UART1) {
+    return ((LPC_UART1_TypeDef *)UARTx)->/*RBTHDLR.*/ RBR & UART_RBR_MASKBIT;
+  } else {
+    return UARTx->/*RBTHDLR.*/ RBR & UART_RBR_MASKBIT;
+  }
+}
+/*********************************************************************//**
+ * @brief		Send a block of data via UART peripheral
+ * @param[in]	UARTx	Selected UART peripheral used to send data, should be:
+ *        - LPC_UART0: UART0 peripheral
+ *        - LPC_UART1: UART1 peripheral
+ *        - LPC_UART2: UART2 peripheral
+ *        - LPC_UART3: UART3 peripheral
+ * @param[in]	txbuf   Pointer to Transmit buffer
+ * @param[in]	buflen  Length of Transmit buffer
+ * @param[in]   flag  Flag used in  UART transfer, should be
+ *            NONE_BLOCKING or BLOCKING
+ * @return    Number of bytes sent.
+ *
+ * Note: when using UART in BLOCKING mode, a time-out condition is used
+ * via defined symbol UART_BLOCKING_TIMEOUT.
+ **********************************************************************/
+uint32_t
+UART_Send(LPC_UART_TypeDef *UARTx, uint8_t *txbuf,
+          uint32_t buflen, TRANSFER_BLOCK_Type flag)
+{
+  uint32_t bToSend, bSent, timeOut, fifo_cnt;
+  uint8_t *pChar = txbuf;
+
+  bToSend = buflen;
+
+  /* blocking mode */
+  if(flag == BLOCKING) {
+    bSent = 0;
+    while(bToSend) {
+      timeOut = UART_BLOCKING_TIMEOUT;
+      /* Wait for THR empty with timeout */
+      while(!(UARTx->LSR & UART_LSR_THRE)) {
+        if(timeOut == 0) {
+          break;
+        }
+        timeOut--;
+      }
+      /* Time out! */
+      if(timeOut == 0) {
+        break;
+      }
+      fifo_cnt = UART_TX_FIFO_SIZE;
+      while(fifo_cnt && bToSend) {
+        UART_SendByte(UARTx, (*pChar++));
+        fifo_cnt--;
+        bToSend--;
+        bSent++;
+      }
+    }
+  }
+  /* None blocking mode */
+  else {
+    bSent = 0;
+    while(bToSend) {
+      if(!(UARTx->LSR & UART_LSR_THRE)) {
+        break;
+      }
+      fifo_cnt = UART_TX_FIFO_SIZE;
+      while(fifo_cnt && bToSend) {
+        UART_SendByte(UARTx, (*pChar++));
+        bToSend--;
+        fifo_cnt--;
+        bSent++;
+      }
+    }
+  }
+  return bSent;
+}
+/*********************************************************************//**
+ * @brief		Receive a block of data via UART peripheral
+ * @param[in]	UARTx	Selected UART peripheral used to send data,
+ *        should be:
+ *        - LPC_UART0: UART0 peripheral
+ *        - LPC_UART1: UART1 peripheral
+ *        - LPC_UART2: UART2 peripheral
+ *        - LPC_UART3: UART3 peripheral
+ * @param[out]	rxbuf   Pointer to Received buffer
+ * @param[in]	buflen  Length of Received buffer
+ * @param[in]   flag  Flag mode, should be NONE_BLOCKING or BLOCKING
+
+ * @return    Number of bytes received
+ *
+ * Note: when using UART in BLOCKING mode, a time-out condition is used
+ * via defined symbol UART_BLOCKING_TIMEOUT.
+ **********************************************************************/
+uint32_t
+UART_Receive(LPC_UART_TypeDef *UARTx, uint8_t *rxbuf, \
+             uint32_t buflen, TRANSFER_BLOCK_Type flag)
+{
+  uint32_t bToRecv, bRecv, timeOut;
+  uint8_t *pChar = rxbuf;
+
+  bToRecv = buflen;
+
+  /* Blocking mode */
+  if(flag == BLOCKING) {
+    bRecv = 0;
+    while(bToRecv) {
+      timeOut = UART_BLOCKING_TIMEOUT;
+      while(!(UARTx->LSR & UART_LSR_RDR)) {
+        if(timeOut == 0) {
+          break;
+        }
+        timeOut--;
+      }
+      /* Time out! */
+      if(timeOut == 0) {
+        break;
+      }
+      /* Get data from the buffer */
+      (*pChar++) = UART_ReceiveByte(UARTx);
+      bToRecv--;
+      bRecv++;
+    }
+  }
+  /* None blocking mode */
+  else {
+    bRecv = 0;
+    while(bToRecv) {
+      if(!(UARTx->LSR & UART_LSR_RDR)) {
+        break;
+      } else {
+        (*pChar++) = UART_ReceiveByte(UARTx);
+        bRecv++;
+        bToRecv--;
+      }
+    }
+  }
+  return bRecv;
+}
+/*********************************************************************//**
+ * @brief		Force BREAK character on UART line, output pin UARTx TXD is
+        forced to logic 0.
+ * @param[in]	UARTx	UART peripheral selected, should be:
+ *        - LPC_UART0: UART0 peripheral
+ *        - LPC_UART1: UART1 peripheral
+ *        - LPC_UART2: UART2 peripheral
+ *        - LPC_UART3: UART3 peripheral
+ * @return    None
+ **********************************************************************/
+void
+UART_ForceBreak(LPC_UART_TypeDef *UARTx)
+{
+  CHECK_PARAM(PARAM_UARTx(UARTx));
+
+  if(((LPC_UART1_TypeDef *)UARTx) == LPC_UART1) {
+    ((LPC_UART1_TypeDef *)UARTx)->LCR |= UART_LCR_BREAK_EN;
+  } else {
+    UARTx->LCR |= UART_LCR_BREAK_EN;
+  }
+}
+/********************************************************************//**
+ * @brief     Enable or disable specified UART interrupt.
+ * @param[in]	UARTx	UART peripheral selected, should be
+ *        - LPC_UART0: UART0 peripheral
+ *        - LPC_UART1: UART1 peripheral
+ *        - LPC_UART2: UART2 peripheral
+ *        - LPC_UART3: UART3 peripheral
+ * @param[in]	UARTIntCfg	Specifies the interrupt flag,
+ *        should be one of the following:
+        - UART_INTCFG_RBR   :  RBR Interrupt enable
+        - UART_INTCFG_THRE  :  THR Interrupt enable
+        - UART_INTCFG_RLS   :  RX line status interrupt enable
+        - UART1_INTCFG_MS	:  Modem status interrupt enable (UART1 only)
+        - UART1_INTCFG_CTS	:  CTS1 signal transition interrupt enable (UART1 only)
+        - UART_INTCFG_ABEO  :  Enables the end of auto-baud interrupt
+        - UART_INTCFG_ABTO  :  Enables the auto-baud time-out interrupt
+ * @param[in]	NewState New state of specified UART interrupt type,
+ *        should be:
+ *        - ENALBE: Enable this UART interrupt type.
+ *        - DISALBE: Disable this UART interrupt type.
+ * @return    None
+ *********************************************************************/
+void
+UART_IntConfig(LPC_UART_TypeDef *UARTx, UART_INT_Type UARTIntCfg, FunctionalState NewState)
+{
+  uint32_t tmp;
+
+  CHECK_PARAM(PARAM_UARTx(UARTx));
+  CHECK_PARAM(PARAM_FUNCTIONALSTATE(NewState));
+
+  switch(UARTIntCfg) {
+  case UART_INTCFG_RBR:
+    tmp = UART_IER_RBRINT_EN;
+    break;
+  case UART_INTCFG_THRE:
+    tmp = UART_IER_THREINT_EN;
+    break;
+  case UART_INTCFG_RLS:
+    tmp = UART_IER_RLSINT_EN;
+    break;
+  case UART1_INTCFG_MS:
+    tmp = UART1_IER_MSINT_EN;
+    break;
+  case UART1_INTCFG_CTS:
+    tmp = UART1_IER_CTSINT_EN;
+    break;
+  case UART_INTCFG_ABEO:
+    tmp = UART_IER_ABEOINT_EN;
+    break;
+  case UART_INTCFG_ABTO:
+    tmp = UART_IER_ABTOINT_EN;
+    break;
+  }
+
+  if((LPC_UART1_TypeDef *)UARTx == LPC_UART1) {
+    CHECK_PARAM((PARAM_UART_INTCFG(UARTIntCfg)) || (PARAM_UART1_INTCFG(UARTIntCfg)));
+  } else {
+    CHECK_PARAM(PARAM_UART_INTCFG(UARTIntCfg));
+  }
+  if(NewState == ENABLE) {
+    if((LPC_UART1_TypeDef *)UARTx == LPC_UART1) {
+      ((LPC_UART1_TypeDef *)UARTx)->/*DLIER.*/ IER |= tmp;
+    } else {
+      UARTx->/*DLIER.*/ IER |= tmp;
+    }
+  } else {
+    if((LPC_UART1_TypeDef *)UARTx == LPC_UART1) {
+      ((LPC_UART1_TypeDef *)UARTx)->/*DLIER.*/ IER &= (~tmp) & UART1_IER_BITMASK;
+    } else {
+      UARTx->/*DLIER.*/ IER &= (~tmp) & UART_IER_BITMASK;
+    }
+  }
+}
+/********************************************************************//**
+ * @brief     Get current value of Line Status register in UART peripheral.
+ * @param[in]	UARTx	UART peripheral selected, should be:
+ *        - LPC_UART0: UART0 peripheral
+ *        - LPC_UART1: UART1 peripheral
+ *        - LPC_UART2: UART2 peripheral
+ *        - LPC_UART3: UART3 peripheral
+ * @return		Current value of Line Status register in UART peripheral.
+ * Note:	The return value of this function must be ANDed with each member in
+ *      UART_LS_Type enumeration to determine current flag status
+ *      corresponding to each Line status type. Because some flags in
+ *      Line Status register will be cleared after reading, the next reading
+ *      Line Status register could not be correct. So this function used to
+ *      read Line status register in one time only, then the return value
+ *      used to check all flags.
+ *********************************************************************/
+uint8_t
+UART_GetLineStatus(LPC_UART_TypeDef *UARTx)
+{
+  CHECK_PARAM(PARAM_UARTx(UARTx));
+
+  if(((LPC_UART1_TypeDef *)UARTx) == LPC_UART1) {
+    return (((LPC_UART1_TypeDef *)LPC_UART1)->LSR) & UART_LSR_BITMASK;
+  } else {
+    return (UARTx->LSR) & UART_LSR_BITMASK;
+  }
+}
+/********************************************************************//**
+ * @brief     Get Interrupt Identification value
+ * @param[in]	UARTx	UART peripheral selected, should be:
+ *        - LPC_UART0: UART0 peripheral
+ *        - LPC_UART1: UART1 peripheral
+ *        - LPC_UART2: UART2 peripheral
+ *        - LPC_UART3: UART3 peripheral
+ * @return		Current value of UART UIIR register in UART peripheral.
+ *********************************************************************/
+uint32_t
+UART_GetIntId(LPC_UART_TypeDef *UARTx)
+{
+  CHECK_PARAM(PARAM_UARTx(UARTx));
+  return UARTx->IIR & 0x03CF;
+}
+/*********************************************************************//**
+ * @brief		Check whether if UART is busy or not
+ * @param[in]	UARTx	UART peripheral selected, should be:
+ *        - LPC_UART0: UART0 peripheral
+ *        - LPC_UART1: UART1 peripheral
+ *        - LPC_UART2: UART2 peripheral
+ *        - LPC_UART3: UART3 peripheral
+ * @return		RESET if UART is not busy, otherwise return SET.
+ **********************************************************************/
+FlagStatus
+UART_CheckBusy(LPC_UART_TypeDef *UARTx)
+{
+  if(UARTx->LSR & UART_LSR_TEMT) {
+    return RESET;
+  } else {
+    return SET;
+  }
+}
+/*********************************************************************//**
+ * @brief		Configure FIFO function on selected UART peripheral
+ * @param[in]	UARTx	UART peripheral selected, should be:
+ *        - LPC_UART0: UART0 peripheral
+ *        - LPC_UART1: UART1 peripheral
+ *        - LPC_UART2: UART2 peripheral
+ *        - LPC_UART3: UART3 peripheral
+ * @param[in]	FIFOCfg	Pointer to a UART_FIFO_CFG_Type Structure that
+ *            contains specified information about FIFO configuration
+ * @return    none
+ **********************************************************************/
+void
+UART_FIFOConfig(LPC_UART_TypeDef *UARTx, UART_FIFO_CFG_Type *FIFOCfg)
+{
+  uint8_t tmp = 0;
+
+  CHECK_PARAM(PARAM_UARTx(UARTx));
+  CHECK_PARAM(PARAM_UART_FIFO_LEVEL(FIFOCfg->FIFO_Level));
+  CHECK_PARAM(PARAM_FUNCTIONALSTATE(FIFOCfg->FIFO_DMAMode));
+  CHECK_PARAM(PARAM_FUNCTIONALSTATE(FIFOCfg->FIFO_ResetRxBuf));
+  CHECK_PARAM(PARAM_FUNCTIONALSTATE(FIFOCfg->FIFO_ResetTxBuf));
+
+  tmp |= UART_FCR_FIFO_EN;
+  switch(FIFOCfg->FIFO_Level) {
+  case UART_FIFO_TRGLEV0:
+    tmp |= UART_FCR_TRG_LEV0;
+    break;
+  case UART_FIFO_TRGLEV1:
+    tmp |= UART_FCR_TRG_LEV1;
+    break;
+  case UART_FIFO_TRGLEV2:
+    tmp |= UART_FCR_TRG_LEV2;
+    break;
+  case UART_FIFO_TRGLEV3:
+  default:
+    tmp |= UART_FCR_TRG_LEV3;
+    break;
+  }
+
+  if(FIFOCfg->FIFO_ResetTxBuf == ENABLE) {
+    tmp |= UART_FCR_TX_RS;
+  }
+  if(FIFOCfg->FIFO_ResetRxBuf == ENABLE) {
+    tmp |= UART_FCR_RX_RS;
+  }
+  if(FIFOCfg->FIFO_DMAMode == ENABLE) {
+    tmp |= UART_FCR_DMAMODE_SEL;
+  }
+
+  /* write to FIFO control register */
+  if(((LPC_UART1_TypeDef *)UARTx) == LPC_UART1) {
+    ((LPC_UART1_TypeDef *)UARTx)->/*IIFCR.*/ FCR = tmp & UART_FCR_BITMASK;
+  } else {
+    UARTx->/*IIFCR.*/ FCR = tmp & UART_FCR_BITMASK;
+  }
+}
+/*****************************************************************************//**
+ * @brief		Fills each UART_FIFOInitStruct member with its default value:
+ *        - FIFO_DMAMode = DISABLE
+ *        - FIFO_Level = UART_FIFO_TRGLEV0
+ *        - FIFO_ResetRxBuf = ENABLE
+ *        - FIFO_ResetTxBuf = ENABLE
+ *        - FIFO_State = ENABLE
+
+ * @param[in]	UART_FIFOInitStruct Pointer to a UART_FIFO_CFG_Type structure
+ *                    which will be initialized.
+ * @return		None
+ *******************************************************************************/
+void
+UART_FIFOConfigStructInit(UART_FIFO_CFG_Type *UART_FIFOInitStruct)
+{
+  UART_FIFOInitStruct->FIFO_DMAMode = DISABLE;
+  UART_FIFOInitStruct->FIFO_Level = UART_FIFO_TRGLEV0;
+  UART_FIFOInitStruct->FIFO_ResetRxBuf = ENABLE;
+  UART_FIFOInitStruct->FIFO_ResetTxBuf = ENABLE;
+}
+/*********************************************************************//**
+ * @brief		Start/Stop Auto Baudrate activity
+ * @param[in]	UARTx	UART peripheral selected, should be
+ *        - LPC_UART0: UART0 peripheral
+ *        - LPC_UART1: UART1 peripheral
+ *        - LPC_UART2: UART2 peripheral
+ *        - LPC_UART3: UART3 peripheral
+ * @param[in]	ABConfigStruct	A pointer to UART_AB_CFG_Type structure that
+ *                contains specified information about UART
+ *                auto baudrate configuration
+ * @param[in]	NewState New State of Auto baudrate activity, should be:
+ *        - ENABLE: Start this activity
+ *				- DISABLE: Stop this activity
+ * Note:		Auto-baudrate mode enable bit will be cleared once this mode
+ *        completed.
+ * @return    none
+ **********************************************************************/
+void
+UART_ABCmd(LPC_UART_TypeDef *UARTx, UART_AB_CFG_Type *ABConfigStruct, \
+           FunctionalState NewState)
+{
+  uint32_t tmp;
+
+  CHECK_PARAM(PARAM_UARTx(UARTx));
+  CHECK_PARAM(PARAM_FUNCTIONALSTATE(NewState));
+
+  tmp = 0;
+  if(NewState == ENABLE) {
+    if(ABConfigStruct->ABMode == UART_AUTOBAUD_MODE1) {
+      tmp |= UART_ACR_MODE;
+    }
+    if(ABConfigStruct->AutoRestart == ENABLE) {
+      tmp |= UART_ACR_AUTO_RESTART;
+    }
+  }
+
+  if(((LPC_UART1_TypeDef *)UARTx) == LPC_UART1) {
+    if(NewState == ENABLE) {
+      /* Clear DLL and DLM value */
+      ((LPC_UART1_TypeDef *)UARTx)->LCR |= UART_LCR_DLAB_EN;
+      ((LPC_UART1_TypeDef *)UARTx)->DLL = 0;
+      ((LPC_UART1_TypeDef *)UARTx)->DLM = 0;
+      ((LPC_UART1_TypeDef *)UARTx)->LCR &= ~UART_LCR_DLAB_EN;
+      /* FDR value must be reset to default value */
+      ((LPC_UART1_TypeDef *)UARTx)->FDR = 0x10;
+      ((LPC_UART1_TypeDef *)UARTx)->ACR = UART_ACR_START | tmp;
+    } else {
+      ((LPC_UART1_TypeDef *)UARTx)->ACR = 0;
+    }
+  } else {
+    if(NewState == ENABLE) {
+      /* Clear DLL and DLM value */
+      UARTx->LCR |= UART_LCR_DLAB_EN;
+      UARTx->DLL = 0;
+      UARTx->DLM = 0;
+      UARTx->LCR &= ~UART_LCR_DLAB_EN;
+      /* FDR value must be reset to default value */
+      UARTx->FDR = 0x10;
+      UARTx->ACR = UART_ACR_START | tmp;
+    } else {
+      UARTx->ACR = 0;
+    }
+  }
+}
+/*********************************************************************//**
+ * @brief		Clear Autobaud Interrupt Pending
+ * @param[in]	UARTx	UART peripheral selected, should be
+ *        - LPC_UART0: UART0 peripheral
+ *        - LPC_UART1: UART1 peripheral
+ *        - LPC_UART2: UART2 peripheral
+ *        - LPC_UART3: UART3 peripheral
+ * @param[in]	ABIntType	type of auto-baud interrupt, should be:
+ *        - UART_AUTOBAUD_INTSTAT_ABEO: End of Auto-baud interrupt
+ *        - UART_AUTOBAUD_INTSTAT_ABTO: Auto-baud time out interrupt
+ * @return    none
+ **********************************************************************/
+void
+UART_ABClearIntPending(LPC_UART_TypeDef *UARTx, UART_ABEO_Type ABIntType)
+{
+  CHECK_PARAM(PARAM_UARTx(UARTx));
+  if(((LPC_UART1_TypeDef *)UARTx) == LPC_UART1) {
+    UARTx->ACR |= ABIntType;
+  } else {
+    UARTx->ACR |= ABIntType;
+  }
+}
+/*********************************************************************//**
+ * @brief		Enable/Disable transmission on UART TxD pin
+ * @param[in]	UARTx	UART peripheral selected, should be:
+ *        - LPC_UART0: UART0 peripheral
+ *        - LPC_UART1: UART1 peripheral
+ *        - LPC_UART2: UART2 peripheral
+ *        - LPC_UART3: UART3 peripheral
+ * @param[in]	NewState New State of Tx transmission function, should be:
+ *        - ENABLE: Enable this function
+        - DISABLE: Disable this function
+ * @return none
+ **********************************************************************/
+void
+UART_TxCmd(LPC_UART_TypeDef *UARTx, FunctionalState NewState)
+{
+  CHECK_PARAM(PARAM_UARTx(UARTx));
+  CHECK_PARAM(PARAM_FUNCTIONALSTATE(NewState));
+
+  if(NewState == ENABLE) {
+    if(((LPC_UART1_TypeDef *)UARTx) == LPC_UART1) {
+      ((LPC_UART1_TypeDef *)UARTx)->TER |= UART_TER_TXEN;
+    } else {
+      UARTx->TER |= UART_TER_TXEN;
+    }
+  } else {
+    if(((LPC_UART1_TypeDef *)UARTx) == LPC_UART1) {
+      ((LPC_UART1_TypeDef *)UARTx)->TER &= (~UART_TER_TXEN) & UART_TER_BITMASK;
+    } else {
+      UARTx->TER &= (~UART_TER_TXEN) & UART_TER_BITMASK;
+    }
+  }
+}
+/* UART IrDA functions ---------------------------------------------------*/
+
+#ifdef _UART3
+
+/*********************************************************************//**
+ * @brief		Enable or disable inverting serial input function of IrDA
+ *        on UART peripheral.
+ * @param[in]	UARTx UART peripheral selected, should be LPC_UART3 (only)
+ * @param[in]	NewState New state of inverting serial input, should be:
+ *        - ENABLE: Enable this function.
+ *        - DISABLE: Disable this function.
+ * @return none
+ **********************************************************************/
+void
+UART_IrDAInvtInputCmd(LPC_UART_TypeDef *UARTx, FunctionalState NewState)
+{
+  CHECK_PARAM(PARAM_UART_IrDA(UARTx));
+  CHECK_PARAM(PARAM_FUNCTIONALSTATE(NewState));
+
+  if(NewState == ENABLE) {
+    UARTx->ICR |= UART_ICR_IRDAINV;
+  } else if(NewState == DISABLE) {
+    UARTx->ICR &= (~UART_ICR_IRDAINV) & UART_ICR_BITMASK;
+  }
+}
+/*********************************************************************//**
+ * @brief		Enable or disable IrDA function on UART peripheral.
+ * @param[in]	UARTx UART peripheral selected, should be LPC_UART3 (only)
+ * @param[in]	NewState New state of IrDA function, should be:
+ *        - ENABLE: Enable this function.
+ *        - DISABLE: Disable this function.
+ * @return none
+ **********************************************************************/
+void
+UART_IrDACmd(LPC_UART_TypeDef *UARTx, FunctionalState NewState)
+{
+  CHECK_PARAM(PARAM_UART_IrDA(UARTx));
+  CHECK_PARAM(PARAM_FUNCTIONALSTATE(NewState));
+
+  if(NewState == ENABLE) {
+    UARTx->ICR |= UART_ICR_IRDAEN;
+  } else {
+    UARTx->ICR &= (~UART_ICR_IRDAEN) & UART_ICR_BITMASK;
+  }
+}
+/*********************************************************************//**
+ * @brief		Configure Pulse divider for IrDA function on UART peripheral.
+ * @param[in]	UARTx UART peripheral selected, should be LPC_UART3 (only)
+ * @param[in]	PulseDiv Pulse Divider value from Peripheral clock,
+ *        should be one of the following:
+        - UART_IrDA_PULSEDIV2   : Pulse width = 2 * Tpclk
+        - UART_IrDA_PULSEDIV4   : Pulse width = 4 * Tpclk
+        - UART_IrDA_PULSEDIV8   : Pulse width = 8 * Tpclk
+        - UART_IrDA_PULSEDIV16  : Pulse width = 16 * Tpclk
+        - UART_IrDA_PULSEDIV32  : Pulse width = 32 * Tpclk
+        - UART_IrDA_PULSEDIV64  : Pulse width = 64 * Tpclk
+        - UART_IrDA_PULSEDIV128 : Pulse width = 128 * Tpclk
+        - UART_IrDA_PULSEDIV256 : Pulse width = 256 * Tpclk
+
+ * @return none
+ **********************************************************************/
+void
+UART_IrDAPulseDivConfig(LPC_UART_TypeDef *UARTx, UART_IrDA_PULSE_Type PulseDiv)
+{
+  uint32_t tmp, tmp1;
+  CHECK_PARAM(PARAM_UART_IrDA(UARTx));
+  CHECK_PARAM(PARAM_UART_IrDA_PULSEDIV(PulseDiv));
+
+  tmp1 = UART_ICR_PULSEDIV(PulseDiv);
+  tmp = UARTx->ICR & (~UART_ICR_PULSEDIV(7));
+  tmp |= tmp1 | UART_ICR_FIXPULSE_EN;
+  UARTx->ICR = tmp & UART_ICR_BITMASK;
+}
+#endif
+
+/* UART1 FullModem function ---------------------------------------------*/
+
+#ifdef _UART1
+
+/*********************************************************************//**
+ * @brief		Force pin DTR/RTS corresponding to given state (Full modem mode)
+ * @param[in]	UARTx	LPC_UART1 (only)
+ * @param[in]	Pin	Pin that NewState will be applied to, should be:
+ *        - UART1_MODEM_PIN_DTR: DTR pin.
+ *        - UART1_MODEM_PIN_RTS: RTS pin.
+ * @param[in]	NewState New State of DTR/RTS pin, should be:
+ *        - INACTIVE: Force the pin to inactive signal.
+        - ACTIVE: Force the pin to active signal.
+ * @return none
+ **********************************************************************/
+void
+UART_FullModemForcePinState(LPC_UART1_TypeDef *UARTx, UART_MODEM_PIN_Type Pin, \
+                            UART1_SignalState NewState)
+{
+  uint8_t tmp = 0;
+
+  CHECK_PARAM(PARAM_UART1_MODEM(UARTx));
+  CHECK_PARAM(PARAM_UART1_MODEM_PIN(Pin));
+  CHECK_PARAM(PARAM_UART1_SIGNALSTATE(NewState));
+
+  switch(Pin) {
+  case UART1_MODEM_PIN_DTR:
+    tmp = UART1_MCR_DTR_CTRL;
+    break;
+  case UART1_MODEM_PIN_RTS:
+    tmp = UART1_MCR_RTS_CTRL;
+    break;
+  default:
+    break;
+  }
+
+  if(NewState == ACTIVE) {
+    UARTx->MCR |= tmp;
+  } else {
+    UARTx->MCR &= (~tmp) & UART1_MCR_BITMASK;
+  }
+}
+/*********************************************************************//**
+ * @brief		Configure Full Modem mode for UART peripheral
+ * @param[in]	UARTx	LPC_UART1 (only)
+ * @param[in]	Mode Full Modem mode, should be:
+ *        - UART1_MODEM_MODE_LOOPBACK: Loop back mode.
+ *        - UART1_MODEM_MODE_AUTO_RTS: Auto-RTS mode.
+ *        - UART1_MODEM_MODE_AUTO_CTS: Auto-CTS mode.
+ * @param[in]	NewState New State of this mode, should be:
+ *        - ENABLE: Enable this mode.
+        - DISABLE: Disable this mode.
+ * @return none
+ **********************************************************************/
+void
+UART_FullModemConfigMode(LPC_UART1_TypeDef *UARTx, UART_MODEM_MODE_Type Mode, \
+                         FunctionalState NewState)
+{
+  uint8_t tmp;
+
+  CHECK_PARAM(PARAM_UART1_MODEM(UARTx));
+  CHECK_PARAM(PARAM_UART1_MODEM_MODE(Mode));
+  CHECK_PARAM(PARAM_FUNCTIONALSTATE(NewState));
+
+  switch(Mode) {
+  case UART1_MODEM_MODE_LOOPBACK:
+    tmp = UART1_MCR_LOOPB_EN;
+    break;
+  case UART1_MODEM_MODE_AUTO_RTS:
+    tmp = UART1_MCR_AUTO_RTS_EN;
+    break;
+  case UART1_MODEM_MODE_AUTO_CTS:
+    tmp = UART1_MCR_AUTO_CTS_EN;
+    break;
+  default:
+    break;
+  }
+
+  if(NewState == ENABLE) {
+    UARTx->MCR |= tmp;
+  } else {
+    UARTx->MCR &= (~tmp) & UART1_MCR_BITMASK;
+  }
+}
+/*********************************************************************//**
+ * @brief		Get current status of modem status register
+ * @param[in]	UARTx	LPC_UART1 (only)
+ * @return    Current value of modem status register
+ * Note:	The return value of this function must be ANDed with each member
+ *      UART_MODEM_STAT_type enumeration to determine current flag status
+ *      corresponding to each modem flag status. Because some flags in
+ *      modem status register will be cleared after reading, the next reading
+ *      modem register could not be correct. So this function used to
+ *      read modem status register in one time only, then the return value
+ *      used to check all flags.
+ **********************************************************************/
+uint8_t
+UART_FullModemGetStatus(LPC_UART1_TypeDef *UARTx)
+{
+  CHECK_PARAM(PARAM_UART1_MODEM(UARTx));
+  return (UARTx->MSR) & UART1_MSR_BITMASK;
+}
+/* UART RS485 functions --------------------------------------------------------------*/
+
+/*********************************************************************//**
+ * @brief		Configure UART peripheral in RS485 mode according to the specified
+ *               parameters in the RS485ConfigStruct.
+ * @param[in]	UARTx	LPC_UART1 (only)
+ * @param[in]	RS485ConfigStruct Pointer to a UART1_RS485_CTRLCFG_Type structure
+ *                    that contains the configuration information for specified UART
+ *                    in RS485 mode.
+ * @return		None
+ **********************************************************************/
+void
+UART_RS485Config(LPC_UART1_TypeDef *UARTx, UART1_RS485_CTRLCFG_Type *RS485ConfigStruct)
+{
+  uint32_t tmp;
+
+  CHECK_PARAM(PARAM_UART1_MODEM(UARTx));
+  CHECK_PARAM(PARAM_FUNCTIONALSTATE(RS485ConfigStruct->AutoAddrDetect_State));
+  CHECK_PARAM(PARAM_FUNCTIONALSTATE(RS485ConfigStruct->AutoDirCtrl_State));
+  CHECK_PARAM(PARAM_UART1_RS485_CFG_DELAYVALUE(RS485ConfigStruct->DelayValue));
+  CHECK_PARAM(PARAM_SETSTATE(RS485ConfigStruct->DirCtrlPol_Level));
+  CHECK_PARAM(PARAM_UART_RS485_DIRCTRL_PIN(RS485ConfigStruct->DirCtrlPin));
+  CHECK_PARAM(PARAM_UART1_RS485_CFG_MATCHADDRVALUE(RS485ConfigStruct->MatchAddrValue));
+  CHECK_PARAM(PARAM_FUNCTIONALSTATE(RS485ConfigStruct->NormalMultiDropMode_State));
+  CHECK_PARAM(PARAM_FUNCTIONALSTATE(RS485ConfigStruct->Rx_State));
+
+  tmp = 0;
+  /* If Auto Direction Control is enabled -  This function is used in Master mode */
+  if(RS485ConfigStruct->AutoDirCtrl_State == ENABLE) {
+    tmp |= UART1_RS485CTRL_DCTRL_EN;
+
+    /* Set polar */
+    if(RS485ConfigStruct->DirCtrlPol_Level == SET) {
+      tmp |= UART1_RS485CTRL_OINV_1;
+    }
+    /* Set pin according to */
+    if(RS485ConfigStruct->DirCtrlPin == UART1_RS485_DIRCTRL_DTR) {
+      tmp |= UART1_RS485CTRL_SEL_DTR;
+    }
+    /* Fill delay time */
+    UARTx->RS485DLY = RS485ConfigStruct->DelayValue & UART1_RS485DLY_BITMASK;
+  }
+
+  /* MultiDrop mode is enable */
+  if(RS485ConfigStruct->NormalMultiDropMode_State == ENABLE) {
+    tmp |= UART1_RS485CTRL_NMM_EN;
+  }
+  /* Auto Address Detect function */
+  if(RS485ConfigStruct->AutoAddrDetect_State == ENABLE) {
+    tmp |= UART1_RS485CTRL_AADEN;
+    /* Fill Match Address */
+    UARTx->ADRMATCH = RS485ConfigStruct->MatchAddrValue & UART1_RS485ADRMATCH_BITMASK;
+  }
+
+  /* Receiver is disable */
+  if(RS485ConfigStruct->Rx_State == DISABLE) {
+    tmp |= UART1_RS485CTRL_RX_DIS;
+  }
+  /* write back to RS485 control register */
+  UARTx->RS485CTRL = tmp & UART1_RS485CTRL_BITMASK;
+
+  /* Enable Parity function and leave parity in stick '0' parity as default */
+  UARTx->LCR |= (UART_LCR_PARITY_F_0 | UART_LCR_PARITY_EN);
+}
+/*********************************************************************//**
+ * @brief		Enable/Disable receiver in RS485 module in UART1
+ * @param[in]	UARTx	LPC_UART1 (only)
+ * @param[in]	NewState	New State of command, should be:
+ *              - ENABLE: Enable this function.
+ *              - DISABLE: Disable this function.
+ * @return		None
+ **********************************************************************/
+void
+UART_RS485ReceiverCmd(LPC_UART1_TypeDef *UARTx, FunctionalState NewState)
+{
+  if(NewState == ENABLE) {
+    UARTx->RS485CTRL &= ~UART1_RS485CTRL_RX_DIS;
+  } else {
+    UARTx->RS485CTRL |= UART1_RS485CTRL_RX_DIS;
+  }
+}
+/*********************************************************************//**
+ * @brief		Send data on RS485 bus with specified parity stick value (9-bit mode).
+ * @param[in]	UARTx	LPC_UART1 (only)
+ * @param[in]	pDatFrm   Pointer to data frame.
+ * @param[in]	size		Size of data.
+ * @param[in]	ParityStick	Parity Stick value, should be 0 or 1.
+ * @return		None
+ **********************************************************************/
+uint32_t
+UART_RS485Send(LPC_UART1_TypeDef *UARTx, uint8_t *pDatFrm, \
+               uint32_t size, uint8_t ParityStick)
+{
+  uint8_t tmp, save;
+  uint32_t cnt;
+
+  if(ParityStick) {
+    save = tmp = UARTx->LCR & UART_LCR_BITMASK;
+    tmp &= ~(UART_LCR_PARITY_EVEN);
+    UARTx->LCR = tmp;
+    cnt = UART_Send((LPC_UART_TypeDef *)UARTx, pDatFrm, size, BLOCKING);
+    while(!(UARTx->LSR & UART_LSR_TEMT)) ;
+    UARTx->LCR = save;
+  } else {
+    cnt = UART_Send((LPC_UART_TypeDef *)UARTx, pDatFrm, size, BLOCKING);
+    while(!(UARTx->LSR & UART_LSR_TEMT)) ;
+  }
+  return cnt;
+}
+/*********************************************************************//**
+ * @brief		Send Slave address frames on RS485 bus.
+ * @param[in]	UARTx	LPC_UART1 (only)
+ * @param[in]	SlvAddr Slave Address.
+ * @return		None
+ **********************************************************************/
+void
+UART_RS485SendSlvAddr(LPC_UART1_TypeDef *UARTx, uint8_t SlvAddr)
+{
+  UART_RS485Send(UARTx, &SlvAddr, 1, 1);
+}
+/*********************************************************************//**
+ * @brief		Send Data frames on RS485 bus.
+ * @param[in]	UARTx	LPC_UART1 (only)
+ * @param[in]	pData Pointer to data to be sent.
+ * @param[in]	size Size of data frame to be sent.
+ * @return		None
+ **********************************************************************/
+uint32_t
+UART_RS485SendData(LPC_UART1_TypeDef *UARTx, uint8_t *pData, uint32_t size)
+{
+  return UART_RS485Send(UARTx, pData, size, 0);
+}
+#endif /* _UART1 */
+
+#endif /* _UART */
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */
+/* --------------------------------- End Of File ------------------------------ */
+

--- a/cpu/arm/lpc1768/lpc17xx_uart.h
+++ b/cpu/arm/lpc1768/lpc17xx_uart.h
@@ -1,0 +1,643 @@
+/**********************************************************************
+ * $Id$		lpc17xx_uart.h				2010-06-18
+ *//**
+ * @file		lpc17xx_uart.h
+ * @brief	Contains all macro definitions and function prototypes
+ *      support for UART firmware library on LPC17xx
+ * @version	3.0
+ * @date		18. June. 2010
+ * @author	NXP MCU SW Application Team
+ *
+ * Copyright(C) 2010, NXP Semiconductor
+ * All rights reserved.
+ *
+ ***********************************************************************
+ * Software that is described herein is for illustrative purposes only
+ * which provides customers with programming information regarding the
+ * products. This software is supplied "AS IS" without any warranties.
+ * NXP Semiconductors assumes no responsibility or liability for the
+ * use of the software, conveys no license or title under any patent,
+ * copyright, or mask work right to the product. NXP Semiconductors
+ * reserves the right to make changes in the software without
+ * notification. NXP Semiconductors also make no representation or
+ * warranty that such application will be suitable for the specified
+ * use without further testing or modification.
+ **********************************************************************/
+
+/* Peripheral group ----------------------------------------------------------- */
+/** @defgroup UART UART (Universal Asynchronous Receiver/Transmitter)
+ * @ingroup LPC1700CMSIS_FwLib_Drivers
+ * @{
+ */
+
+#ifndef __LPC17XX_UART_H
+#define __LPC17XX_UART_H
+
+/* Includes ------------------------------------------------------------------- */
+#include "lpc17xx.h"
+#include "lpc_types.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/* Public Macros -------------------------------------------------------------- */
+/** @defgroup UART_Public_Macros  UART Public Macros
+ * @{
+ */
+
+/** UART time-out definitions in case of using Read() and Write function
+ * with Blocking Flag mode
+ */
+#define UART_BLOCKING_TIMEOUT     (0xFFFFFFFFUL)
+
+/**
+ * @}
+ */
+
+/* Private Macros ------------------------------------------------------------- */
+/** @defgroup UART_Private_Macros UART Private Macros
+ * @{
+ */
+
+/* Accepted Error baud rate value (in percent unit) */
+#define UART_ACCEPTED_BAUDRATE_ERROR  (3)     /*!< Acceptable UART baudrate error */
+
+/* --------------------- BIT DEFINITIONS -------------------------------------- */
+/*********************************************************************//**
+ * Macro defines for Macro defines for UARTn Receiver Buffer Register
+ **********************************************************************/
+#define UART_RBR_MASKBIT    ((uint8_t)0xFF)     /*!< UART Received Buffer mask bit (8 bits) */
+
+/*********************************************************************//**
+ * Macro defines for Macro defines for UARTn Transmit Holding Register
+ **********************************************************************/
+#define UART_THR_MASKBIT    ((uint8_t)0xFF)     /*!< UART Transmit Holding mask bit (8 bits) */
+
+/*********************************************************************//**
+ * Macro defines for Macro defines for UARTn Divisor Latch LSB register
+ **********************************************************************/
+#define UART_LOAD_DLL(div)  ((div) & 0xFF)  /**< Macro for loading least significant halfs of divisors */
+#define UART_DLL_MASKBIT  ((uint8_t)0xFF) /*!< Divisor latch LSB bit mask */
+
+/*********************************************************************//**
+ * Macro defines for Macro defines for UARTn Divisor Latch MSB register
+ **********************************************************************/
+#define UART_DLM_MASKBIT  ((uint8_t)0xFF)     /*!< Divisor latch MSB bit mask */
+#define UART_LOAD_DLM(div)  (((div) >> 8) & 0xFF) /**< Macro for loading most significant halfs of divisors */
+
+/*********************************************************************//**
+ * Macro defines for Macro defines for UART interrupt enable register
+ **********************************************************************/
+#define UART_IER_RBRINT_EN    ((uint32_t)(1 << 0))  /*!< RBR Interrupt enable*/
+#define UART_IER_THREINT_EN   ((uint32_t)(1 << 1))  /*!< THR Interrupt enable*/
+#define UART_IER_RLSINT_EN    ((uint32_t)(1 << 2))  /*!< RX line status interrupt enable*/
+#define UART1_IER_MSINT_EN    ((uint32_t)(1 << 3))  /*!< Modem status interrupt enable */
+#define UART1_IER_CTSINT_EN   ((uint32_t)(1 << 7))  /*!< CTS1 signal transition interrupt enable */
+#define UART_IER_ABEOINT_EN   ((uint32_t)(1 << 8))  /*!< Enables the end of auto-baud interrupt */
+#define UART_IER_ABTOINT_EN   ((uint32_t)(1 << 9))  /*!< Enables the auto-baud time-out interrupt */
+#define UART_IER_BITMASK    ((uint32_t)(0x307)) /*!< UART interrupt enable register bit mask */
+#define UART1_IER_BITMASK   ((uint32_t)(0x38F)) /*!< UART1 interrupt enable register bit mask */
+
+/*********************************************************************//**
+ * Macro defines for Macro defines for UART interrupt identification register
+ **********************************************************************/
+#define UART_IIR_INTSTAT_PEND ((uint32_t)(1 << 0))  /*!<Interrupt Status - Active low */
+#define UART_IIR_INTID_RLS    ((uint32_t)(3 << 1))  /*!<Interrupt identification: Receive line status*/
+#define UART_IIR_INTID_RDA    ((uint32_t)(2 << 1))  /*!<Interrupt identification: Receive data available*/
+#define UART_IIR_INTID_CTI    ((uint32_t)(6 << 1))  /*!<Interrupt identification: Character time-out indicator*/
+#define UART_IIR_INTID_THRE   ((uint32_t)(1 << 1))  /*!<Interrupt identification: THRE interrupt*/
+#define UART1_IIR_INTID_MODEM ((uint32_t)(0 << 1))  /*!<Interrupt identification: Modem interrupt*/
+#define UART_IIR_INTID_MASK   ((uint32_t)(7 << 1))  /*!<Interrupt identification: Interrupt ID mask */
+#define UART_IIR_FIFO_EN    ((uint32_t)(3 << 6))  /*!<These bits are equivalent to UnFCR[0] */
+#define UART_IIR_ABEO_INT   ((uint32_t)(1 << 8))  /*!< End of auto-baud interrupt */
+#define UART_IIR_ABTO_INT   ((uint32_t)(1 << 9))  /*!< Auto-baud time-out interrupt */
+#define UART_IIR_BITMASK    ((uint32_t)(0x3CF)) /*!< UART interrupt identification register bit mask */
+
+/*********************************************************************//**
+ * Macro defines for Macro defines for UART FIFO control register
+ **********************************************************************/
+#define UART_FCR_FIFO_EN    ((uint8_t)(1 << 0))   /*!< UART FIFO enable */
+#define UART_FCR_RX_RS      ((uint8_t)(1 << 1))   /*!< UART FIFO RX reset */
+#define UART_FCR_TX_RS      ((uint8_t)(1 << 2))   /*!< UART FIFO TX reset */
+#define UART_FCR_DMAMODE_SEL  ((uint8_t)(1 << 3))   /*!< UART DMA mode selection */
+#define UART_FCR_TRG_LEV0   ((uint8_t)(0))    /*!< UART FIFO trigger level 0: 1 character */
+#define UART_FCR_TRG_LEV1   ((uint8_t)(1 << 6))   /*!< UART FIFO trigger level 1: 4 character */
+#define UART_FCR_TRG_LEV2   ((uint8_t)(2 << 6))   /*!< UART FIFO trigger level 2: 8 character */
+#define UART_FCR_TRG_LEV3   ((uint8_t)(3 << 6))   /*!< UART FIFO trigger level 3: 14 character */
+#define UART_FCR_BITMASK    ((uint8_t)(0xCF)) /*!< UART FIFO control bit mask */
+#define UART_TX_FIFO_SIZE   (16)
+
+/*********************************************************************//**
+ * Macro defines for Macro defines for UART line control register
+ **********************************************************************/
+#define UART_LCR_WLEN5        ((uint8_t)(0))      /*!< UART 5 bit data mode */
+#define UART_LCR_WLEN6        ((uint8_t)(1 << 0))     /*!< UART 6 bit data mode */
+#define UART_LCR_WLEN7        ((uint8_t)(2 << 0))     /*!< UART 7 bit data mode */
+#define UART_LCR_WLEN8        ((uint8_t)(3 << 0))     /*!< UART 8 bit data mode */
+#define UART_LCR_STOPBIT_SEL  ((uint8_t)(1 << 2))     /*!< UART Two Stop Bits Select */
+#define UART_LCR_PARITY_EN    ((uint8_t)(1 << 3))   /*!< UART Parity Enable */
+#define UART_LCR_PARITY_ODD   ((uint8_t)(0))          /*!< UART Odd Parity Select */
+#define UART_LCR_PARITY_EVEN  ((uint8_t)(1 << 4))   /*!< UART Even Parity Select */
+#define UART_LCR_PARITY_F_1   ((uint8_t)(2 << 4))   /*!< UART force 1 stick parity */
+#define UART_LCR_PARITY_F_0   ((uint8_t)(3 << 4))   /*!< UART force 0 stick parity */
+#define UART_LCR_BREAK_EN   ((uint8_t)(1 << 6))   /*!< UART Transmission Break enable */
+#define UART_LCR_DLAB_EN    ((uint8_t)(1 << 7))     /*!< UART Divisor Latches Access bit enable */
+#define UART_LCR_BITMASK    ((uint8_t)(0xFF))   /*!< UART line control bit mask */
+
+/*********************************************************************//**
+ * Macro defines for Macro defines for UART1 Modem Control Register
+ **********************************************************************/
+#define UART1_MCR_DTR_CTRL    ((uint8_t)(1 << 0))   /*!< Source for modem output pin DTR */
+#define UART1_MCR_RTS_CTRL    ((uint8_t)(1 << 1))   /*!< Source for modem output pin RTS */
+#define UART1_MCR_LOOPB_EN    ((uint8_t)(1 << 4))   /*!< Loop back mode select */
+#define UART1_MCR_AUTO_RTS_EN ((uint8_t)(1 << 6))   /*!< Enable Auto RTS flow-control */
+#define UART1_MCR_AUTO_CTS_EN ((uint8_t)(1 << 7))   /*!< Enable Auto CTS flow-control */
+#define UART1_MCR_BITMASK   ((uint8_t)(0x0F3))    /*!< UART1 bit mask value */
+
+/*********************************************************************//**
+ * Macro defines for Macro defines for UART line status register
+ **********************************************************************/
+#define UART_LSR_RDR    ((uint8_t)(1 << 0))   /*!<Line status register: Receive data ready*/
+#define UART_LSR_OE     ((uint8_t)(1 << 1))   /*!<Line status register: Overrun error*/
+#define UART_LSR_PE     ((uint8_t)(1 << 2))   /*!<Line status register: Parity error*/
+#define UART_LSR_FE     ((uint8_t)(1 << 3))   /*!<Line status register: Framing error*/
+#define UART_LSR_BI     ((uint8_t)(1 << 4))   /*!<Line status register: Break interrupt*/
+#define UART_LSR_THRE   ((uint8_t)(1 << 5))   /*!<Line status register: Transmit holding register empty*/
+#define UART_LSR_TEMT   ((uint8_t)(1 << 6))   /*!<Line status register: Transmitter empty*/
+#define UART_LSR_RXFE   ((uint8_t)(1 << 7))   /*!<Error in RX FIFO*/
+#define UART_LSR_BITMASK  ((uint8_t)(0xFF))   /*!<UART Line status bit mask */
+
+/*********************************************************************//**
+ * Macro defines for Macro defines for UART Modem (UART1 only) status register
+ **********************************************************************/
+#define UART1_MSR_DELTA_CTS   ((uint8_t)(1 << 0)) /*!< Set upon state change of input CTS */
+#define UART1_MSR_DELTA_DSR   ((uint8_t)(1 << 1)) /*!< Set upon state change of input DSR */
+#define UART1_MSR_LO2HI_RI    ((uint8_t)(1 << 2)) /*!< Set upon low to high transition of input RI */
+#define UART1_MSR_DELTA_DCD   ((uint8_t)(1 << 3)) /*!< Set upon state change of input DCD */
+#define UART1_MSR_CTS     ((uint8_t)(1 << 4)) /*!< Clear To Send State */
+#define UART1_MSR_DSR     ((uint8_t)(1 << 5)) /*!< Data Set Ready State */
+#define UART1_MSR_RI      ((uint8_t)(1 << 6)) /*!< Ring Indicator State */
+#define UART1_MSR_DCD     ((uint8_t)(1 << 7)) /*!< Data Carrier Detect State */
+#define UART1_MSR_BITMASK   ((uint8_t)(0xFF)) /*!< MSR register bit-mask value */
+
+/*********************************************************************//**
+ * Macro defines for Macro defines for UART Scratch Pad Register
+ **********************************************************************/
+#define UART_SCR_BIMASK   ((uint8_t)(0xFF)) /*!< UART Scratch Pad bit mask */
+
+/*********************************************************************//**
+ * Macro defines for Macro defines for UART Auto baudrate control register
+ **********************************************************************/
+#define UART_ACR_START        ((uint32_t)(1 << 0))  /**< UART Auto-baud start */
+#define UART_ACR_MODE       ((uint32_t)(1 << 1))  /**< UART Auto baudrate Mode 1 */
+#define UART_ACR_AUTO_RESTART   ((uint32_t)(1 << 2))  /**< UART Auto baudrate restart */
+#define UART_ACR_ABEOINT_CLR    ((uint32_t)(1 << 8))  /**< UART End of auto-baud interrupt clear */
+#define UART_ACR_ABTOINT_CLR    ((uint32_t)(1 << 9))  /**< UART Auto-baud time-out interrupt clear */
+#define UART_ACR_BITMASK      ((uint32_t)(0x307)) /**< UART Auto Baudrate register bit mask */
+
+/*********************************************************************//**
+ * Macro defines for Macro defines for UART IrDA control register
+ **********************************************************************/
+#define UART_ICR_IRDAEN     ((uint32_t)(1 << 0))      /**< IrDA mode enable */
+#define UART_ICR_IRDAINV    ((uint32_t)(1 << 1))      /**< IrDA serial input inverted */
+#define UART_ICR_FIXPULSE_EN  ((uint32_t)(1 << 2))      /**< IrDA fixed pulse width mode */
+#define UART_ICR_PULSEDIV(n)  ((uint32_t)((n & 0x07) << 3)) /**< PulseDiv - Configures the pulse when FixPulseEn = 1 */
+#define UART_ICR_BITMASK    ((uint32_t)(0x3F))      /*!< UART IRDA bit mask */
+
+/*********************************************************************//**
+ * Macro defines for Macro defines for UART Fractional divider register
+ **********************************************************************/
+#define UART_FDR_DIVADDVAL(n) ((uint32_t)(n & 0x0F))    /**< Baud-rate generation pre-scaler divisor */
+#define UART_FDR_MULVAL(n)    ((uint32_t)((n << 4) & 0xF0)) /**< Baud-rate pre-scaler multiplier value */
+#define UART_FDR_BITMASK    ((uint32_t)(0xFF))      /**< UART Fractional Divider register bit mask */
+
+/*********************************************************************//**
+ * Macro defines for Macro defines for UART Tx Enable register
+ **********************************************************************/
+#define UART_TER_TXEN     ((uint8_t)(1 << 7))     /*!< Transmit enable bit */
+#define UART_TER_BITMASK    ((uint8_t)(0x80))   /**< UART Transmit Enable Register bit mask */
+
+/*********************************************************************//**
+ * Macro defines for Macro defines for UART1 RS485 Control register
+ **********************************************************************/
+#define UART1_RS485CTRL_NMM_EN    ((uint32_t)(1 << 0))  /*!< RS-485/EIA-485 Normal Multi-drop Mode (NMM)
+                                                           is disabled */
+#define UART1_RS485CTRL_RX_DIS    ((uint32_t)(1 << 1))  /*!< The receiver is disabled */
+#define UART1_RS485CTRL_AADEN   ((uint32_t)(1 << 2))  /*!< Auto Address Detect (AAD) is enabled */
+#define UART1_RS485CTRL_SEL_DTR   ((uint32_t)(1 << 3))  /*!< If direction control is enabled
+                                                           (bit DCTRL = 1), pin DTR is used for direction control */
+#define UART1_RS485CTRL_DCTRL_EN  ((uint32_t)(1 << 4))  /*!< Enable Auto Direction Control */
+#define UART1_RS485CTRL_OINV_1    ((uint32_t)(1 << 5))  /*!< This bit reverses the polarity of the direction
+                                                           control signal on the RTS (or DTR) pin. The direction control pin
+                                                           will be driven to logic "1" when the transmitter has data to be sent */
+#define UART1_RS485CTRL_BITMASK   ((uint32_t)(0x3F))  /**< RS485 control bit-mask value */
+
+/*********************************************************************//**
+ * Macro defines for Macro defines for UART1 RS-485 Address Match register
+ **********************************************************************/
+#define UART1_RS485ADRMATCH_BITMASK ((uint8_t)(0xFF))   /**< Bit mask value */
+
+/*********************************************************************//**
+ * Macro defines for Macro defines for UART1 RS-485 Delay value register
+ **********************************************************************/
+/* Macro defines for UART1 RS-485 Delay value register */
+#define UART1_RS485DLY_BITMASK    ((uint8_t)(0xFF))   /** Bit mask value */
+
+/*********************************************************************//**
+ * Macro defines for Macro defines for UART FIFO Level register
+ **********************************************************************/
+#define UART_FIFOLVL_RXFIFOLVL(n) ((uint32_t)(n & 0x0F))    /**< Reflects the current level of the UART receiver FIFO */
+#define UART_FIFOLVL_TXFIFOLVL(n) ((uint32_t)((n >> 8) & 0x0F)) /**< Reflects the current level of the UART transmitter FIFO */
+#define UART_FIFOLVL_BITMASK    ((uint32_t)(0x0F0F))    /**< UART FIFO Level Register bit mask */
+
+/* ---------------- CHECK PARAMETER DEFINITIONS ---------------------------- */
+
+/** Macro to check the input UART_DATABIT parameters */
+#define PARAM_UART_DATABIT(databit) ((databit == UART_DATABIT_5) || (databit == UART_DATABIT_6) \
+                                     || (databit == UART_DATABIT_7) || (databit == UART_DATABIT_8))
+
+/** Macro to check the input UART_STOPBIT parameters */
+#define PARAM_UART_STOPBIT(stopbit) ((stopbit == UART_STOPBIT_1) || (stopbit == UART_STOPBIT_2))
+
+/** Macro to check the input UART_PARITY parameters */
+#define PARAM_UART_PARITY(parity) ((parity == UART_PARITY_NONE) || (parity == UART_PARITY_ODD) \
+                                   || (parity == UART_PARITY_EVEN) || (parity == UART_PARITY_SP_1) \
+                                   || (parity == UART_PARITY_SP_0))
+
+/** Macro to check the input UART_FIFO parameters */
+#define PARAM_UART_FIFO_LEVEL(fifo) ((fifo == UART_FIFO_TRGLEV0) \
+                                     || (fifo == UART_FIFO_TRGLEV1) || (fifo == UART_FIFO_TRGLEV2) \
+                                     || (fifo == UART_FIFO_TRGLEV3))
+
+/** Macro to check the input UART_INTCFG parameters */
+#define PARAM_UART_INTCFG(IntCfg) ((IntCfg == UART_INTCFG_RBR) || (IntCfg == UART_INTCFG_THRE) \
+                                   || (IntCfg == UART_INTCFG_RLS) || (IntCfg == UART_INTCFG_ABEO) \
+                                   || (IntCfg == UART_INTCFG_ABTO))
+
+/** Macro to check the input UART1_INTCFG parameters - expansion input parameter for UART1 */
+#define PARAM_UART1_INTCFG(IntCfg)  ((IntCfg == UART1_INTCFG_MS) || (IntCfg == UART1_INTCFG_CTS))
+
+/** Macro to check the input UART_AUTOBAUD_MODE parameters */
+#define PARAM_UART_AUTOBAUD_MODE(ABmode)  ((ABmode == UART_AUTOBAUD_MODE0) || (ABmode == UART_AUTOBAUD_MODE1))
+
+/** Macro to check the input UART_AUTOBAUD_INTSTAT parameters */
+#define PARAM_UART_AUTOBAUD_INTSTAT(ABIntStat)  ((ABIntStat == UART_AUTOBAUD_INTSTAT_ABEO) || \
+                                                 (ABIntStat == UART_AUTOBAUD_INTSTAT_ABTO))
+
+/** Macro to check the input UART_IrDA_PULSEDIV parameters */
+#define PARAM_UART_IrDA_PULSEDIV(PulseDiv)  ((PulseDiv == UART_IrDA_PULSEDIV2) || (PulseDiv == UART_IrDA_PULSEDIV4) \
+                                             || (PulseDiv == UART_IrDA_PULSEDIV8) || (PulseDiv == UART_IrDA_PULSEDIV16) \
+                                             || (PulseDiv == UART_IrDA_PULSEDIV32) || (PulseDiv == UART_IrDA_PULSEDIV64) \
+                                             || (PulseDiv == UART_IrDA_PULSEDIV128) || (PulseDiv == UART_IrDA_PULSEDIV256))
+
+/* Macro to check the input UART1_SignalState parameters */
+#define PARAM_UART1_SIGNALSTATE(x) ((x == INACTIVE) || (x == ACTIVE))
+
+/** Macro to check the input PARAM_UART1_MODEM_PIN parameters */
+#define PARAM_UART1_MODEM_PIN(x) ((x == UART1_MODEM_PIN_DTR) || (x == UART1_MODEM_PIN_RTS))
+
+/** Macro to check the input PARAM_UART1_MODEM_MODE parameters */
+#define PARAM_UART1_MODEM_MODE(x) ((x == UART1_MODEM_MODE_LOOPBACK) || (x == UART1_MODEM_MODE_AUTO_RTS) \
+                                   || (x == UART1_MODEM_MODE_AUTO_CTS))
+
+/** Macro to check the direction control pin type */
+#define PARAM_UART_RS485_DIRCTRL_PIN(x) ((x == UART1_RS485_DIRCTRL_RTS) || (x == UART1_RS485_DIRCTRL_DTR))
+
+/* Macro to determine if it is valid UART port number */
+#define PARAM_UARTx(x)  ((((uint32_t *)x) == ((uint32_t *)LPC_UART0)) \
+                         || (((uint32_t *)x) == ((uint32_t *)LPC_UART1)) \
+                         || (((uint32_t *)x) == ((uint32_t *)LPC_UART2)) \
+                         || (((uint32_t *)x) == ((uint32_t *)LPC_UART3)))
+#define PARAM_UART_IrDA(x) (((uint32_t *)x) == ((uint32_t *)LPC_UART3))
+#define PARAM_UART1_MODEM(x) (((uint32_t *)x) == ((uint32_t *)LPC_UART1))
+
+/** Macro to check the input value for UART1_RS485_CFG_MATCHADDRVALUE parameter */
+#define PARAM_UART1_RS485_CFG_MATCHADDRVALUE(x) ((x < 0xFF))
+
+/** Macro to check the input value for UART1_RS485_CFG_DELAYVALUE parameter */
+#define PARAM_UART1_RS485_CFG_DELAYVALUE(x) ((x < 0xFF))
+
+/**
+ * @}
+ */
+
+/* Public Types --------------------------------------------------------------- */
+/** @defgroup UART_Public_Types UART Public Types
+ * @{
+ */
+
+/**
+ * @brief UART Databit type definitions
+ */
+typedef enum {
+  UART_DATABIT_5 = 0,           /*!< UART 5 bit data mode */
+  UART_DATABIT_6,             /*!< UART 6 bit data mode */
+  UART_DATABIT_7,             /*!< UART 7 bit data mode */
+  UART_DATABIT_8              /*!< UART 8 bit data mode */
+} UART_DATABIT_Type;
+
+/**
+ * @brief UART Stop bit type definitions
+ */
+typedef enum {
+  UART_STOPBIT_1 = (0),               /*!< UART 1 Stop Bits Select */
+  UART_STOPBIT_2                  /*!< UART Two Stop Bits Select */
+} UART_STOPBIT_Type;
+
+/**
+ * @brief UART Parity type definitions
+ */
+typedef enum {
+  UART_PARITY_NONE = 0,           /*!< No parity */
+  UART_PARITY_ODD,              /*!< Odd parity */
+  UART_PARITY_EVEN,               /*!< Even parity */
+  UART_PARITY_SP_1,               /*!< Forced "1" stick parity */
+  UART_PARITY_SP_0              /*!< Forced "0" stick parity */
+} UART_PARITY_Type;
+
+/**
+ * @brief FIFO Level type definitions
+ */
+typedef enum {
+  UART_FIFO_TRGLEV0 = 0,  /*!< UART FIFO trigger level 0: 1 character */
+  UART_FIFO_TRGLEV1,    /*!< UART FIFO trigger level 1: 4 character */
+  UART_FIFO_TRGLEV2,    /*!< UART FIFO trigger level 2: 8 character */
+  UART_FIFO_TRGLEV3   /*!< UART FIFO trigger level 3: 14 character */
+} UART_FITO_LEVEL_Type;
+
+/********************************************************************//**
+ * @brief UART Interrupt Type definitions
+ **********************************************************************/
+typedef enum {
+  UART_INTCFG_RBR = 0,  /*!< RBR Interrupt enable*/
+  UART_INTCFG_THRE,   /*!< THR Interrupt enable*/
+  UART_INTCFG_RLS,    /*!< RX line status interrupt enable*/
+  UART1_INTCFG_MS,    /*!< Modem status interrupt enable (UART1 only) */
+  UART1_INTCFG_CTS,   /*!< CTS1 signal transition interrupt enable (UART1 only) */
+  UART_INTCFG_ABEO,   /*!< Enables the end of auto-baud interrupt */
+  UART_INTCFG_ABTO    /*!< Enables the auto-baud time-out interrupt */
+} UART_INT_Type;
+
+/**
+ * @brief UART Line Status Type definition
+ */
+typedef enum {
+  UART_LINESTAT_RDR = UART_LSR_RDR,     /*!<Line status register: Receive data ready*/
+  UART_LINESTAT_OE = UART_LSR_OE,       /*!<Line status register: Overrun error*/
+  UART_LINESTAT_PE = UART_LSR_PE,       /*!<Line status register: Parity error*/
+  UART_LINESTAT_FE = UART_LSR_FE,       /*!<Line status register: Framing error*/
+  UART_LINESTAT_BI = UART_LSR_BI,       /*!<Line status register: Break interrupt*/
+  UART_LINESTAT_THRE = UART_LSR_THRE,     /*!<Line status register: Transmit holding register empty*/
+  UART_LINESTAT_TEMT = UART_LSR_TEMT,     /*!<Line status register: Transmitter empty*/
+  UART_LINESTAT_RXFE = UART_LSR_RXFE      /*!<Error in RX FIFO*/
+} UART_LS_Type;
+
+/**
+ * @brief UART Auto-baudrate mode type definition
+ */
+typedef enum {
+  UART_AUTOBAUD_MODE0 = 0,            /**< UART Auto baudrate Mode 0 */
+  UART_AUTOBAUD_MODE1             /**< UART Auto baudrate Mode 1 */
+} UART_AB_MODE_Type;
+
+/**
+ * @brief Auto Baudrate mode configuration type definition
+ */
+typedef struct {
+  UART_AB_MODE_Type ABMode;     /**< Autobaudrate mode */
+  FunctionalState AutoRestart;    /**< Auto Restart state */
+} UART_AB_CFG_Type;
+
+/**
+ * @brief UART End of Auto-baudrate type definition
+ */
+typedef enum {
+  UART_AUTOBAUD_INTSTAT_ABEO = UART_IIR_ABEO_INT,       /**< UART End of auto-baud interrupt  */
+  UART_AUTOBAUD_INTSTAT_ABTO = UART_IIR_ABTO_INT        /**< UART Auto-baud time-out interrupt  */
+}UART_ABEO_Type;
+
+/**
+ * UART IrDA Control type Definition
+ */
+typedef enum {
+  UART_IrDA_PULSEDIV2 = 0,      /**< Pulse width = 2 * Tpclk
+                                   - Configures the pulse when FixPulseEn = 1 */
+  UART_IrDA_PULSEDIV4,        /**< Pulse width = 4 * Tpclk
+                                 - Configures the pulse when FixPulseEn = 1 */
+  UART_IrDA_PULSEDIV8,        /**< Pulse width = 8 * Tpclk
+                                 - Configures the pulse when FixPulseEn = 1 */
+  UART_IrDA_PULSEDIV16,       /**< Pulse width = 16 * Tpclk
+                                 - Configures the pulse when FixPulseEn = 1 */
+  UART_IrDA_PULSEDIV32,       /**< Pulse width = 32 * Tpclk
+                                 - Configures the pulse when FixPulseEn = 1 */
+  UART_IrDA_PULSEDIV64,       /**< Pulse width = 64 * Tpclk
+                                 - Configures the pulse when FixPulseEn = 1 */
+  UART_IrDA_PULSEDIV128,        /**< Pulse width = 128 * Tpclk
+                                   - Configures the pulse when FixPulseEn = 1 */
+  UART_IrDA_PULSEDIV256       /**< Pulse width = 256 * Tpclk
+                                 - Configures the pulse when FixPulseEn = 1 */
+} UART_IrDA_PULSE_Type;
+
+/********************************************************************//**
+ * @brief UART1 Full modem -  Signal states definition
+ **********************************************************************/
+typedef enum {
+  INACTIVE = 0,     /* In-active state */
+  ACTIVE = !INACTIVE    /* Active state */
+}UART1_SignalState;
+
+/**
+ * @brief UART modem status type definition
+ */
+typedef enum {
+  UART1_MODEM_STAT_DELTA_CTS = UART1_MSR_DELTA_CTS,     /*!< Set upon state change of input CTS */
+  UART1_MODEM_STAT_DELTA_DSR = UART1_MSR_DELTA_DSR,     /*!< Set upon state change of input DSR */
+  UART1_MODEM_STAT_LO2HI_RI = UART1_MSR_LO2HI_RI,   /*!< Set upon low to high transition of input RI */
+  UART1_MODEM_STAT_DELTA_DCD = UART1_MSR_DELTA_DCD,     /*!< Set upon state change of input DCD */
+  UART1_MODEM_STAT_CTS = UART1_MSR_CTS,         /*!< Clear To Send State */
+  UART1_MODEM_STAT_DSR = UART1_MSR_DSR,         /*!< Data Set Ready State */
+  UART1_MODEM_STAT_RI = UART1_MSR_RI,           /*!< Ring Indicator State */
+  UART1_MODEM_STAT_DCD = UART1_MSR_DCD          /*!< Data Carrier Detect State */
+} UART_MODEM_STAT_type;
+
+/**
+ * @brief Modem output pin type definition
+ */
+typedef enum {
+  UART1_MODEM_PIN_DTR = 0,        /*!< Source for modem output pin DTR */
+  UART1_MODEM_PIN_RTS           /*!< Source for modem output pin RTS */
+} UART_MODEM_PIN_Type;
+
+/**
+ * @brief UART Modem mode type definition
+ */
+typedef enum {
+  UART1_MODEM_MODE_LOOPBACK = 0,    /*!< Loop back mode select */
+  UART1_MODEM_MODE_AUTO_RTS,        /*!< Enable Auto RTS flow-control */
+  UART1_MODEM_MODE_AUTO_CTS         /*!< Enable Auto CTS flow-control */
+} UART_MODEM_MODE_Type;
+
+/**
+ * @brief UART Direction Control Pin type definition
+ */
+typedef enum {
+  UART1_RS485_DIRCTRL_RTS = 0,  /**< Pin RTS is used for direction control */
+  UART1_RS485_DIRCTRL_DTR     /**< Pin DTR is used for direction control */
+} UART_RS485_DIRCTRL_PIN_Type;
+
+/********************************************************************//**
+ * @brief UART Configuration Structure definition
+ **********************************************************************/
+typedef struct {
+  uint32_t Baud_rate;       /**< UART baud rate */
+  UART_PARITY_Type Parity;      /**< Parity selection, should be:
+                                   - UART_PARITY_NONE: No parity
+                                   - UART_PARITY_ODD: Odd parity
+                                   - UART_PARITY_EVEN: Even parity
+                                   - UART_PARITY_SP_1: Forced "1" stick parity
+                                   - UART_PARITY_SP_0: Forced "0" stick parity
+                                 */
+  UART_DATABIT_Type Databits;   /**< Number of data bits, should be:
+                                   - UART_DATABIT_5: UART 5 bit data mode
+                                   - UART_DATABIT_6: UART 6 bit data mode
+                                   - UART_DATABIT_7: UART 7 bit data mode
+                                   - UART_DATABIT_8: UART 8 bit data mode
+                                 */
+  UART_STOPBIT_Type Stopbits;   /**< Number of stop bits, should be:
+                                   - UART_STOPBIT_1: UART 1 Stop Bits Select
+                                   - UART_STOPBIT_2: UART 2 Stop Bits Select
+                                 */
+} UART_CFG_Type;
+
+/********************************************************************//**
+ * @brief UART FIFO Configuration Structure definition
+ **********************************************************************/
+
+typedef struct {
+  FunctionalState FIFO_ResetRxBuf;  /**< Reset Rx FIFO command state , should be:
+                                       - ENABLE: Reset Rx FIFO in UART
+                                       - DISABLE: Do not reset Rx FIFO  in UART
+                                     */
+  FunctionalState FIFO_ResetTxBuf;  /**< Reset Tx FIFO command state , should be:
+                                       - ENABLE: Reset Tx FIFO in UART
+                                       - DISABLE: Do not reset Tx FIFO  in UART
+                                     */
+  FunctionalState FIFO_DMAMode;   /**< DMA mode, should be:
+                                     - ENABLE: Enable DMA mode in UART
+                                     - DISABLE: Disable DMA mode in UART
+                                   */
+  UART_FITO_LEVEL_Type FIFO_Level;  /**< Rx FIFO trigger level, should be:
+                                       - UART_FIFO_TRGLEV0: UART FIFO trigger level 0: 1 character
+                                       - UART_FIFO_TRGLEV1: UART FIFO trigger level 1: 4 character
+                                       - UART_FIFO_TRGLEV2: UART FIFO trigger level 2: 8 character
+                                       - UART_FIFO_TRGLEV3: UART FIFO trigger level 3: 14 character
+                                     */
+} UART_FIFO_CFG_Type;
+
+/********************************************************************//**
+ * @brief UART1 Full modem -  RS485 Control configuration type
+ **********************************************************************/
+typedef struct {
+  FunctionalState NormalMultiDropMode_State; /*!< Normal MultiDrop mode State:
+                                                - ENABLE: Enable this function.
+                                                - DISABLE: Disable this function. */
+  FunctionalState Rx_State;         /*!< Receiver State:
+                                       - ENABLE: Enable Receiver.
+                                       - DISABLE: Disable Receiver. */
+  FunctionalState AutoAddrDetect_State;   /*!< Auto Address Detect mode state:
+                                             - ENABLE: ENABLE this function.
+                                             - DISABLE: Disable this function. */
+  FunctionalState AutoDirCtrl_State;      /*!< Auto Direction Control State:
+                                             - ENABLE: Enable this function.
+                                             - DISABLE: Disable this function. */
+  UART_RS485_DIRCTRL_PIN_Type DirCtrlPin;   /*!< If direction control is enabled, state:
+                                               - UART1_RS485_DIRCTRL_RTS:
+                                               pin RTS is used for direction control.
+                                               - UART1_RS485_DIRCTRL_DTR:
+                                               pin DTR is used for direction control. */
+  SetState DirCtrlPol_Level;          /*!< Polarity of the direction control signal on
+                                         the RTS (or DTR) pin:
+                                         - RESET: The direction control pin will be driven
+                                         to logic "0" when the transmitter has data to be sent.
+                                         - SET: The direction control pin will be driven
+                                         to logic "1" when the transmitter has data to be sent. */
+  uint8_t MatchAddrValue;         /*!< address match value for RS-485/EIA-485 mode, 8-bit long */
+  uint8_t DelayValue;           /*!< delay time is in periods of the baud clock, 8-bit long */
+} UART1_RS485_CTRLCFG_Type;
+
+/**
+ * @}
+ */
+
+/* Public Functions ----------------------------------------------------------- */
+/** @defgroup UART_Public_Functions UART Public Functions
+ * @{
+ */
+/* UART Init/DeInit functions --------------------------------------------------*/
+void UART_Init(LPC_UART_TypeDef *UARTx, UART_CFG_Type *UART_ConfigStruct);
+void UART_DeInit(LPC_UART_TypeDef *UARTx);
+void UART_ConfigStructInit(UART_CFG_Type *UART_InitStruct);
+
+/* UART Send/Receive functions -------------------------------------------------*/
+void UART_SendByte(LPC_UART_TypeDef *UARTx, uint8_t Data);
+uint8_t UART_ReceiveByte(LPC_UART_TypeDef *UARTx);
+uint32_t UART_Send(LPC_UART_TypeDef *UARTx, uint8_t *txbuf,
+                   uint32_t buflen, TRANSFER_BLOCK_Type flag);
+uint32_t UART_Receive(LPC_UART_TypeDef *UARTx, uint8_t *rxbuf, \
+                      uint32_t buflen, TRANSFER_BLOCK_Type flag);
+
+/* UART FIFO functions ----------------------------------------------------------*/
+void UART_FIFOConfig(LPC_UART_TypeDef *UARTx, UART_FIFO_CFG_Type *FIFOCfg);
+void UART_FIFOConfigStructInit(UART_FIFO_CFG_Type *UART_FIFOInitStruct);
+
+/* UART get information functions -----------------------------------------------*/
+uint32_t UART_GetIntId(LPC_UART_TypeDef *UARTx);
+uint8_t UART_GetLineStatus(LPC_UART_TypeDef *UARTx);
+
+/* UART operate functions -------------------------------------------------------*/
+void UART_IntConfig(LPC_UART_TypeDef *UARTx, UART_INT_Type UARTIntCfg, \
+                    FunctionalState NewState);
+void UART_TxCmd(LPC_UART_TypeDef *UARTx, FunctionalState NewState);
+FlagStatus UART_CheckBusy(LPC_UART_TypeDef *UARTx);
+void UART_ForceBreak(LPC_UART_TypeDef *UARTx);
+
+/* UART Auto-baud functions -----------------------------------------------------*/
+void UART_ABClearIntPending(LPC_UART_TypeDef *UARTx, UART_ABEO_Type ABIntType);
+void UART_ABCmd(LPC_UART_TypeDef *UARTx, UART_AB_CFG_Type *ABConfigStruct, \
+                FunctionalState NewState);
+
+/* UART1 FullModem functions ----------------------------------------------------*/
+void UART_FullModemForcePinState(LPC_UART1_TypeDef *UARTx, UART_MODEM_PIN_Type Pin, \
+                                 UART1_SignalState NewState);
+void UART_FullModemConfigMode(LPC_UART1_TypeDef *UARTx, UART_MODEM_MODE_Type Mode, \
+                              FunctionalState NewState);
+uint8_t UART_FullModemGetStatus(LPC_UART1_TypeDef *UARTx);
+
+/* UART RS485 functions ----------------------------------------------------------*/
+void UART_RS485Config(LPC_UART1_TypeDef *UARTx, \
+                      UART1_RS485_CTRLCFG_Type *RS485ConfigStruct);
+void UART_RS485ReceiverCmd(LPC_UART1_TypeDef *UARTx, FunctionalState NewState);
+void UART_RS485SendSlvAddr(LPC_UART1_TypeDef *UARTx, uint8_t SlvAddr);
+uint32_t UART_RS485SendData(LPC_UART1_TypeDef *UARTx, uint8_t *pData, uint32_t size);
+
+/* UART IrDA functions-------------------------------------------------------------*/
+void UART_IrDAInvtInputCmd(LPC_UART_TypeDef *UARTx, FunctionalState NewState);
+void UART_IrDACmd(LPC_UART_TypeDef *UARTx, FunctionalState NewState);
+void UART_IrDAPulseDivConfig(LPC_UART_TypeDef *UARTx, UART_IrDA_PULSE_Type PulseDiv);
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __LPC17XX_UART_H */
+
+/**
+ * @}
+ */
+
+/* --------------------------------- End Of File ------------------------------ */

--- a/cpu/arm/lpc1768/lpc_types.h
+++ b/cpu/arm/lpc1768/lpc_types.h
@@ -1,0 +1,195 @@
+/**********************************************************************
+ * $Id$		lpc_types.h		2008-07-27
+ *//**
+ * @file		lpc_types.h
+ * @brief	Contains the NXP ABL typedefs for C standard types.
+ *        It is intended to be used in ISO C conforming development
+ *        environments and checks for this insofar as it is possible
+ *        to do so.
+ * @version	2.0
+ * @date		27 Jul. 2008
+ * @author	NXP MCU SW Application Team
+ *
+ * Copyright(C) 2008, NXP Semiconductor
+ * All rights reserved.
+ *
+ ***********************************************************************
+ * Software that is described herein is for illustrative purposes only
+ * which provides customers with programming information regarding the
+ * products. This software is supplied "AS IS" without any warranties.
+ * NXP Semiconductors assumes no responsibility or liability for the
+ * use of the software, conveys no license or title under any patent,
+ * copyright, or mask work right to the product. NXP Semiconductors
+ * reserves the right to make changes in the software without
+ * notification. NXP Semiconductors also make no representation or
+ * warranty that such application will be suitable for the specified
+ * use without further testing or modification.
+ **********************************************************************/
+
+/* Type group ----------------------------------------------------------- */
+/** @defgroup LPC_Types LPC_Types
+ * @ingroup LPC1700CMSIS_FwLib_Drivers
+ * @{
+ */
+
+#ifndef LPC_TYPES_H
+#define LPC_TYPES_H
+
+/* Includes ------------------------------------------------------------------- */
+#include <stdint.h>
+
+/* Public Types --------------------------------------------------------------- */
+/** @defgroup LPC_Types_Public_Types LPC_Types Public Types
+ * @{
+ */
+
+/**
+ * @brief Boolean Type definition
+ */
+typedef enum {FALSE = 0, TRUE = !FALSE} Bool;
+
+/**
+ * @brief Flag Status and Interrupt Flag Status type definition
+ */
+typedef enum {RESET = 0, SET = !RESET} FlagStatus, IntStatus, SetState;
+#define PARAM_SETSTATE(State) ((State == RESET) || (State == SET))
+
+/**
+ * @brief Functional State Definition
+ */
+typedef enum {DISABLE = 0, ENABLE = !DISABLE} FunctionalState;
+#define PARAM_FUNCTIONALSTATE(State) ((State == DISABLE) || (State == ENABLE))
+
+/**
+ * @ Status type definition
+ */
+typedef enum {ERROR = 0, SUCCESS = !ERROR} Status;
+
+/**
+ * Read/Write transfer type mode (Block or non-block)
+ */
+typedef enum {
+  NONE_BLOCKING = 0,    /**< None Blocking type */
+  BLOCKING        /**< Blocking type */
+} TRANSFER_BLOCK_Type;
+
+/** Pointer to Function returning Void (any number of parameters) */
+typedef void (*PFV)();
+
+/** Pointer to Function returning int32_t (any number of parameters) */
+typedef int32_t (*PFI)();
+
+/**
+ * @}
+ */
+
+/* Public Macros -------------------------------------------------------------- */
+/** @defgroup LPC_Types_Public_Macros  LPC_Types Public Macros
+ * @{
+ */
+
+/* _BIT(n) sets the bit at position "n"
+ * _BIT(n) is intended to be used in "OR" and "AND" expressions:
+ * e.g., "(_BIT(3) | _BIT(7))".
+ */
+#undef _BIT
+/* Set bit macro */
+#define _BIT(n) (1 << n)
+
+/* _SBF(f,v) sets the bit field starting at position "f" to value "v".
+ * _SBF(f,v) is intended to be used in "OR" and "AND" expressions:
+ * e.g., "((_SBF(5,7) | _SBF(12,0xF)) & 0xFFFF)"
+ */
+#undef _SBF
+/* Set bit field macro */
+#define _SBF(f, v) (v << f)
+
+/* _BITMASK constructs a symbol with 'field_width' least significant
+ * bits set.
+ * e.g., _BITMASK(5) constructs '0x1F', _BITMASK(16) == 0xFFFF
+ * The symbol is intended to be used to limit the bit field width
+ * thusly:
+ * <a_register> = (any_expression) & _BITMASK(x), where 0 < x <= 32.
+ * If "any_expression" results in a value that is larger than can be
+ * contained in 'x' bits, the bits above 'x - 1' are masked off.  When
+ * used with the _SBF example above, the example would be written:
+ * a_reg = ((_SBF(5,7) | _SBF(12,0xF)) & _BITMASK(16))
+ * This ensures that the value written to a_reg is no wider than
+ * 16 bits, and makes the code easier to read and understand.
+ */
+#undef _BITMASK
+/* Bitmask creation macro */
+#define _BITMASK(field_width) (_BIT(field_width) - 1)
+
+/* NULL pointer */
+#ifndef NULL
+#define NULL ((void *)0)
+#endif
+
+/* Number of elements in an array */
+#define NELEMENTS(array)  (sizeof(array) / sizeof(array[0]))
+
+/* Static data/function define */
+#define STATIC static
+/* External data/function define */
+#define EXTERN extern
+
+#define MAX(a, b) (((a) > (b)) ? (a) : (b))
+#define MIN(a, b) (((a) < (b)) ? (a) : (b))
+
+/**
+ * @}
+ */
+
+/* Old Type Definition compatibility ------------------------------------------ */
+/** @addtogroup LPC_Types_Public_Types LPC_Types Public Types
+ * @{
+ */
+
+/** SMA type for character type */
+typedef char CHAR;
+
+/** SMA type for 8 bit unsigned value */
+typedef uint8_t UNS_8;
+
+/** SMA type for 8 bit signed value */
+typedef int8_t INT_8;
+
+/** SMA type for 16 bit unsigned value */
+typedef uint16_t UNS_16;
+
+/** SMA type for 16 bit signed value */
+typedef int16_t INT_16;
+
+/** SMA type for 32 bit unsigned value */
+typedef uint32_t UNS_32;
+
+/** SMA type for 32 bit signed value */
+typedef int32_t INT_32;
+
+/** SMA type for 64 bit signed value */
+typedef int64_t INT_64;
+
+/** SMA type for 64 bit unsigned value */
+typedef uint64_t UNS_64;
+
+/** 32 bit boolean type */
+typedef Bool BOOL_32;
+
+/** 16 bit boolean type */
+typedef Bool BOOL_16;
+
+/** 8 bit boolean type */
+typedef Bool BOOL_8;
+
+/**
+ * @}
+ */
+
+#endif /* LPC_TYPES_H */
+
+/**
+ * @}
+ */
+
+/* --------------------------------- End Of File ------------------------------ */

--- a/cpu/arm/lpc1768/rtimer-arch.h
+++ b/cpu/arm/lpc1768/rtimer-arch.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2013, KTH, Royal Institute of Technology
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE UNIVERSITY AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ */
+
+#ifndef __RTIMER_ARCH_H__
+#define __RTIMER_ARCH_H__
+
+#include "sys/rtimer.h"
+
+#define RTIMER_ARCH_SECOND (MCK / 1024)
+
+void rtimer_arch_set(rtimer_clock_t t);
+
+rtimer_clock_t rtimer_arch_now(void);
+
+#endif /* __RTIMER_ARCH_H__ */

--- a/cpu/arm/lpc1768/startup-LPC1768.c
+++ b/cpu/arm/lpc1768/startup-LPC1768.c
@@ -1,0 +1,316 @@
+/*
+ * Copyright (c) 2013, KTH, Royal Institute of Technology
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE UNIVERSITY AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ */
+
+#include <stdint.h>
+#include "system_LPC17xx.h"
+#include "lpc17xx.h"
+
+extern int
+main(void);
+
+typedef void
+(*ISR_func)(void);
+
+#define SECTION(x) __attribute__ ((section(# x)))
+#define ISR_VECTOR_SECTION SECTION(.isr_vector)
+static void
+sys_reset(void) __attribute__((naked));
+void
+NMI_handler(void) __attribute__((interrupt));
+void
+HardFault_handler(void) __attribute__((interrupt));
+void
+MemManage_handler(void) __attribute__((interrupt));
+void
+BusFault_handler(void) __attribute__((interrupt));
+void
+UsageFault_handler(void) __attribute__((interrupt));
+
+static void
+unhandled_int(void) __attribute__((interrupt));
+
+#define UNHANDLED_ALIAS __attribute__((weak, alias("unhandled_int")));
+void
+Main_Stack_End(void);
+void
+HardFault_handler(void) __attribute__((weak, alias("dHardFault_handler")));
+void
+MemManage_handler(void) __attribute__((weak, alias("dMemManage_handler")));
+void
+BusFault_handler(void) __attribute__((weak, alias("dBusFault_handler")));
+void
+UsageFault_handler(void) __attribute__((weak, alias("dUsageFault_handler")));
+void
+Reserved_handler(void) UNHANDLED_ALIAS
+;
+void
+SVC_handler(void) UNHANDLED_ALIAS
+;
+void
+DebugMon_handler(void) UNHANDLED_ALIAS
+;
+void
+PendSV_handler(void) UNHANDLED_ALIAS
+;
+void
+SysTick_handler(void) UNHANDLED_ALIAS
+;
+void
+WDT_IRQHandler(void) UNHANDLED_ALIAS
+;
+void
+TIMER0_IRQHandler(void) UNHANDLED_ALIAS
+;
+void
+TIMER1_IRQHandler(void) UNHANDLED_ALIAS
+;
+void
+TIMER2_IRQHandler(void) UNHANDLED_ALIAS
+;
+void
+TIMER3_IRQHandler(void) UNHANDLED_ALIAS
+;
+void
+UART0_IRQHandler(void) UNHANDLED_ALIAS
+;
+void
+UART1_IRQHandler(void) UNHANDLED_ALIAS
+;
+void
+UART2_IRQHandler(void) UNHANDLED_ALIAS
+;
+void
+UART3_IRQHandler(void) UNHANDLED_ALIAS
+;
+void
+PWM1_IRQHandler(void) UNHANDLED_ALIAS
+;
+void
+I2C0_IRQHandler(void) UNHANDLED_ALIAS
+;
+void
+I2C1_IRQHandler(void) UNHANDLED_ALIAS
+;
+void
+I2C2_IRQHandler(void) UNHANDLED_ALIAS
+;
+void
+SPI_IRQHandler(void) UNHANDLED_ALIAS
+;
+void
+SSP0_IRQHandler(void) UNHANDLED_ALIAS
+;
+void
+SSP1_IRQHandler(void) UNHANDLED_ALIAS
+;
+void
+PLL0_IRQHandler(void) UNHANDLED_ALIAS
+;
+void
+RTC_IRQHandler(void) UNHANDLED_ALIAS
+;
+void
+EINT0_IRQHandler(void) UNHANDLED_ALIAS
+;
+void
+EINT1_IRQHandler(void) UNHANDLED_ALIAS
+;
+void
+EINT2_IRQHandler(void) UNHANDLED_ALIAS
+;
+void
+EINT3_IRQHandler(void) UNHANDLED_ALIAS
+;
+void
+ADC_IRQHandler(void) UNHANDLED_ALIAS
+;
+void
+BOD_IRQHandler(void) UNHANDLED_ALIAS
+;
+void
+USB_IRQHandler(void) UNHANDLED_ALIAS
+;
+void
+CAN_IRQHandler(void) UNHANDLED_ALIAS
+;
+void
+DMA_IRQHandler(void) UNHANDLED_ALIAS
+;
+void
+I2S_IRQHandler(void) UNHANDLED_ALIAS
+;
+void
+ENET_IRQHandler(void) UNHANDLED_ALIAS
+;
+void
+RIT_IRQHandler(void) UNHANDLED_ALIAS
+;
+void
+MCPWM_IRQHandler(void) UNHANDLED_ALIAS
+;
+void
+QEI_IRQHandler(void) UNHANDLED_ALIAS
+;
+void
+PLL1_IRQHandler(void) UNHANDLED_ALIAS
+;
+void
+USBActivity_IRQHandler(void) UNHANDLED_ALIAS
+;
+void
+CANActivity_IRQHandler(void) UNHANDLED_ALIAS
+;
+
+const ISR_func isr_vector[51] ISR_VECTOR_SECTION =
+{ Main_Stack_End,   /* Top of Stack                 */
+  sys_reset, /* Reset Handler                */
+  NMI_handler, /* NMI Handler                  */
+  HardFault_handler, /* Hard Fault Handler           */
+  MemManage_handler, /* MPU Fault Handler            */
+  BusFault_handler, /* Bus Fault Handler            */
+  UsageFault_handler, /* Usage Fault Handler          */
+  Reserved_handler, /* Reserved                     */
+  Reserved_handler, /* Reserved                     */
+  Reserved_handler, /* Reserved                     */
+  Reserved_handler, /* Reserved                     */
+  SVC_handler,  /* SVCall Handler    */
+  DebugMon_handler, /* Debug Monitor Handler */
+  Reserved_handler, /* Reserved */
+  PendSV_handler, /* PendSV Handler               */
+  SysTick_handler, /* SysTick Handler              */
+
+  /* External Interrupts */
+  WDT_IRQHandler, /* 16: Watchdog Timer               */
+  TIMER0_IRQHandler, /* 17: Timer0                       */
+  TIMER1_IRQHandler, /* 18: Timer1                       */
+  TIMER2_IRQHandler, /* 19: Timer2                       */
+  TIMER3_IRQHandler, /* 20: Timer3                       */
+  UART0_IRQHandler, /* 21: UART0                        */
+  UART1_IRQHandler, /* 22: UART1                        */
+  UART2_IRQHandler, /* 23: UART2                        */
+  UART3_IRQHandler, /* 24: UART3                        */
+  PWM1_IRQHandler, /* 25: PWM1                         */
+  I2C0_IRQHandler, /* 26: I2C0                         */
+  I2C1_IRQHandler, /* 27: I2C1                         */
+  I2C2_IRQHandler, /* 28: I2C2                         */
+  SPI_IRQHandler, /* 29: SPI                          */
+  SSP0_IRQHandler, /* 30: SSP0                         */
+  SSP1_IRQHandler, /* 31: SSP1                         */
+  PLL0_IRQHandler, /* 32: PLL0 Lock (Main PLL)         */
+  RTC_IRQHandler, /* 33: Real Time Clock              */
+  EINT0_IRQHandler, /* 34: External Interrupt 0         */
+  EINT1_IRQHandler, /* 35: External Interrupt 1         */
+  EINT2_IRQHandler, /* 36: External Interrupt 2         */
+  EINT3_IRQHandler, /* 37: External Interrupt 3         */
+  ADC_IRQHandler, /* 38: A/D Converter                */
+  BOD_IRQHandler, /* 39: Brown-Out Detect             */
+  USB_IRQHandler, /* 40: USB                          */
+  CAN_IRQHandler, /* 41: CAN                          */
+  DMA_IRQHandler, /* 42: General Purpose DMA          */
+  I2S_IRQHandler, /* 43: I2S                          */
+  ENET_IRQHandler, /* 44: Ethernet                     */
+  RIT_IRQHandler, /* 45: Repetitive Interrupt Timer   */
+  MCPWM_IRQHandler, /* 46: Motor Control PWM            */
+  QEI_IRQHandler, /* 47: Quadrature Encoder Interface */
+  PLL1_IRQHandler, /* 48: PLL1 Lock (USB PLL)          */
+  USBActivity_IRQHandler, /* 49: USB Activity                 */
+  CANActivity_IRQHandler /* 50: CAN Activity                 */
+};
+
+extern uint8_t _data[];
+extern uint8_t _etext[];
+extern uint8_t _edata[];
+
+static void
+copy_initialized(void)
+{
+  uint8_t *ram = _data;
+  uint8_t *rom = _etext;
+  while(ram < _edata) {
+    *ram++ = *rom++;
+  }
+}
+extern uint8_t __bss_start[];
+extern uint8_t __bss_end[];
+
+static void
+clear_bss(void)
+{
+  uint8_t *m = __bss_start;
+  while(m < __bss_end) {
+    *m++ = 0;
+  }
+}
+static void
+sys_reset(void)
+{
+  copy_initialized();
+  clear_bss();
+  SystemInit();
+  main();
+  while(1)
+    ;
+}
+void
+NMI_handler(void)
+{
+  while(1)
+    ;
+}
+static void
+unhandled_int(void)
+{
+  while(1)
+    ;
+}
+static void
+dHardFault_handler(void)
+{
+  while(1)
+    ;
+}
+static void
+dUsageFault_handler(void)
+{
+  while(1)
+    ;
+}
+static void
+dMemManage_handler(void)
+{
+  while(1)
+    ;
+}
+static void
+dBusFault_handler(void)
+{
+  while(1)
+    ;
+}

--- a/cpu/arm/lpc1768/syscalls.c
+++ b/cpu/arm/lpc1768/syscalls.c
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2013, KTH, Royal Institute of Technology
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE UNIVERSITY AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ */
+
+#include <sys/stat.h>
+#include "debug_frmwrk.h"
+
+#define CR     0x0D
+
+int
+_close(int file)
+{
+  return -1;
+}
+int
+_fstat(int file, struct stat *st)
+{
+  st->st_mode = S_IFCHR;
+  return 0;
+}
+int
+_isatty(int file)
+{
+  return 1;
+}
+int
+_lseek(int file, int ptr, int dir)
+{
+  return 0;
+}
+int
+_open(const char *name, int flags, int mode)
+{
+  return -1;
+}
+int
+_read(int file, char *ptr, int len)
+{
+  int todo;
+  if(len == 0) {
+    return 0;
+  }
+
+  for(todo = 0; todo < len; todo++) {
+    *ptr++ = _DG;
+  }
+  return todo;
+}
+/*
+ * sbrk -- changes heap size size. Get nbytes more
+ * RAM. We just increment a pointer in what’s
+ * left of memory on the board.
+ */
+char *heap_end = 0;
+caddr_t
+_sbrk(int incr)
+{
+  extern char __heap_start__; /* Defined by the linker */
+  extern char __heap_end__; /* Defined by the linker */
+  char *prev_heap_end;
+
+  if(heap_end == 0) {
+    heap_end = &__heap_start__;
+  }
+  prev_heap_end = heap_end;
+
+  if(heap_end + incr > &__heap_end__) {
+    /* Heap and stack collision */
+    return (caddr_t)0;
+  }
+  heap_end += incr;
+  return (caddr_t)prev_heap_end;
+}
+int
+_write(int file, char *ptr, int len)
+{
+  int todo;
+  char ch;
+
+  for(todo = 0; todo < len; todo++) {
+    ch = *ptr++;
+    _DBC(ch);
+    if(ch == '\n') {
+      _DBC(CR);
+    }
+  }
+  return len;
+}

--- a/cpu/arm/lpc1768/system_LPC17xx.c
+++ b/cpu/arm/lpc1768/system_LPC17xx.c
@@ -1,0 +1,560 @@
+/**************************************************************************//**
+ * @file     system_LPC17xx.c
+ * @brief    CMSIS Cortex-M3 Device Peripheral Access Layer Source File
+ *           for the NXP LPC17xx Device Series
+ * @version  V1.03
+ * @date     07. October 2009
+ *
+ * @note
+ * Copyright (C) 2009 ARM Limited. All rights reserved.
+ *
+ * @par
+ * ARM Limited (ARM) is supplying this software for use with Cortex-M
+ * processor based microcontrollers.  This file can be freely distributed
+ * within development tools that are supporting such ARM based processors.
+ *
+ * @par
+ * THIS SOFTWARE IS PROVIDED "AS IS".  NO WARRANTIES, WHETHER EXPRESS, IMPLIED
+ * OR STATUTORY, INCLUDING, BUT NOT LIMITED TO, IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE APPLY TO THIS SOFTWARE.
+ * ARM SHALL NOT, IN ANY CIRCUMSTANCES, BE LIABLE FOR SPECIAL, INCIDENTAL, OR
+ * CONSEQUENTIAL DAMAGES, FOR ANY REASON WHATSOEVER.
+ *
+ ******************************************************************************/
+
+#include <stdint.h>
+#include "lpc17xx.h"
+
+/** @addtogroup LPC17xx_System
+ * @{
+ */
+
+/*
+   //-------- <<< Use Configuration Wizard in Context Menu >>> ------------------
+ */
+
+/*--------------------- Clock Configuration ----------------------------------
+   //
+   // <e> Clock Configuration
+   //   <h> System Controls and Status Register (SCS)
+   //     <o1.4>    OSCRANGE: Main Oscillator Range Select
+   //                     <0=>  1 MHz to 20 MHz
+   //                     <1=> 15 MHz to 24 MHz
+   //     <e1.5>       OSCEN: Main Oscillator Enable
+   //     </e>
+   //   </h>
+   //
+   //   <h> Clock Source Select Register (CLKSRCSEL)
+   //     <o2.0..1>   CLKSRC: PLL Clock Source Selection
+   //                     <0=> Internal RC oscillator
+   //                     <1=> Main oscillator
+   //                     <2=> RTC oscillator
+   //   </h>
+   //
+   //   <e3> PLL0 Configuration (Main PLL)
+   //     <h> PLL0 Configuration Register (PLL0CFG)
+   //                     <i> F_cco0 = (2 * M * F_in) / N
+   //                     <i> F_in must be in the range of 32 kHz to 50 MHz
+   //                     <i> F_cco0 must be in the range of 275 MHz to 550 MHz
+   //       <o4.0..14>  MSEL: PLL Multiplier Selection
+   //                     <6-32768><#-1>
+   //                     <i> M Value
+   //       <o4.16..23> NSEL: PLL Divider Selection
+   //                     <1-256><#-1>
+   //                     <i> N Value
+   //     </h>
+   //   </e>
+   //
+   //   <e5> PLL1 Configuration (USB PLL)
+   //     <h> PLL1 Configuration Register (PLL1CFG)
+   //                     <i> F_usb = M * F_osc or F_usb = F_cco1 / (2 * P)
+   //                     <i> F_cco1 = F_osc * M * 2 * P
+   //                     <i> F_cco1 must be in the range of 156 MHz to 320 MHz
+   //       <o6.0..4>   MSEL: PLL Multiplier Selection
+   //                     <1-32><#-1>
+   //                     <i> M Value (for USB maximum value is 4)
+   //       <o6.5..6>   PSEL: PLL Divider Selection
+   //                     <0=> 1
+   //                     <1=> 2
+   //                     <2=> 4
+   //                     <3=> 8
+   //                     <i> P Value
+   //     </h>
+   //   </e>
+   //
+   //   <h> CPU Clock Configuration Register (CCLKCFG)
+   //     <o7.0..7>  CCLKSEL: Divide Value for CPU Clock from PLL0
+   //                     <3-256><#-1>
+   //   </h>
+   //
+   //   <h> USB Clock Configuration Register (USBCLKCFG)
+   //     <o8.0..3>   USBSEL: Divide Value for USB Clock from PLL0
+   //                     <0-15>
+   //                     <i> Divide is USBSEL + 1
+   //   </h>
+   //
+   //   <h> Peripheral Clock Selection Register 0 (PCLKSEL0)
+   //     <o9.0..1>    PCLK_WDT: Peripheral Clock Selection for WDT
+   //                     <0=> Pclk = Cclk / 4
+   //                     <1=> Pclk = Cclk
+   //                     <2=> Pclk = Cclk / 2
+   //                     <3=> Pclk = Hclk / 8
+   //     <o9.2..3>    PCLK_TIMER0: Peripheral Clock Selection for TIMER0
+   //                     <0=> Pclk = Cclk / 4
+   //                     <1=> Pclk = Cclk
+   //                     <2=> Pclk = Cclk / 2
+   //                     <3=> Pclk = Hclk / 8
+   //     <o9.4..5>    PCLK_TIMER1: Peripheral Clock Selection for TIMER1
+   //                     <0=> Pclk = Cclk / 4
+   //                     <1=> Pclk = Cclk
+   //                     <2=> Pclk = Cclk / 2
+   //                     <3=> Pclk = Hclk / 8
+   //     <o9.6..7>    PCLK_UART0: Peripheral Clock Selection for UART0
+   //                     <0=> Pclk = Cclk / 4
+   //                     <1=> Pclk = Cclk
+   //                     <2=> Pclk = Cclk / 2
+   //                     <3=> Pclk = Hclk / 8
+   //     <o9.8..9>    PCLK_UART1: Peripheral Clock Selection for UART1
+   //                     <0=> Pclk = Cclk / 4
+   //                     <1=> Pclk = Cclk
+   //                     <2=> Pclk = Cclk / 2
+   //                     <3=> Pclk = Hclk / 8
+   //     <o9.12..13>  PCLK_PWM1: Peripheral Clock Selection for PWM1
+   //                     <0=> Pclk = Cclk / 4
+   //                     <1=> Pclk = Cclk
+   //                     <2=> Pclk = Cclk / 2
+   //                     <3=> Pclk = Hclk / 8
+   //     <o9.14..15>  PCLK_I2C0: Peripheral Clock Selection for I2C0
+   //                     <0=> Pclk = Cclk / 4
+   //                     <1=> Pclk = Cclk
+   //                     <2=> Pclk = Cclk / 2
+   //                     <3=> Pclk = Hclk / 8
+   //     <o9.16..17>  PCLK_SPI: Peripheral Clock Selection for SPI
+   //                     <0=> Pclk = Cclk / 4
+   //                     <1=> Pclk = Cclk
+   //                     <2=> Pclk = Cclk / 2
+   //                     <3=> Pclk = Hclk / 8
+   //     <o9.20..21>  PCLK_SSP1: Peripheral Clock Selection for SSP1
+   //                     <0=> Pclk = Cclk / 4
+   //                     <1=> Pclk = Cclk
+   //                     <2=> Pclk = Cclk / 2
+   //                     <3=> Pclk = Hclk / 8
+   //     <o9.22..23>  PCLK_DAC: Peripheral Clock Selection for DAC
+   //                     <0=> Pclk = Cclk / 4
+   //                     <1=> Pclk = Cclk
+   //                     <2=> Pclk = Cclk / 2
+   //                     <3=> Pclk = Hclk / 8
+   //     <o9.24..25>  PCLK_ADC: Peripheral Clock Selection for ADC
+   //                     <0=> Pclk = Cclk / 4
+   //                     <1=> Pclk = Cclk
+   //                     <2=> Pclk = Cclk / 2
+   //                     <3=> Pclk = Hclk / 8
+   //     <o9.26..27>  PCLK_CAN1: Peripheral Clock Selection for CAN1
+   //                     <0=> Pclk = Cclk / 4
+   //                     <1=> Pclk = Cclk
+   //                     <2=> Pclk = Cclk / 2
+   //                     <3=> Pclk = Hclk / 6
+   //     <o9.28..29>  PCLK_CAN2: Peripheral Clock Selection for CAN2
+   //                     <0=> Pclk = Cclk / 4
+   //                     <1=> Pclk = Cclk
+   //                     <2=> Pclk = Cclk / 2
+   //                     <3=> Pclk = Hclk / 6
+   //     <o9.30..31>  PCLK_ACF: Peripheral Clock Selection for ACF
+   //                     <0=> Pclk = Cclk / 4
+   //                     <1=> Pclk = Cclk
+   //                     <2=> Pclk = Cclk / 2
+   //                     <3=> Pclk = Hclk / 6
+   //   </h>
+   //
+   //   <h> Peripheral Clock Selection Register 1 (PCLKSEL1)
+   //     <o10.0..1>   PCLK_QEI: Peripheral Clock Selection for the Quadrature Encoder Interface
+   //                     <0=> Pclk = Cclk / 4
+   //                     <1=> Pclk = Cclk
+   //                     <2=> Pclk = Cclk / 2
+   //                     <3=> Pclk = Hclk / 8
+   //     <o10.2..3>   PCLK_GPIO: Peripheral Clock Selection for GPIOs
+   //                     <0=> Pclk = Cclk / 4
+   //                     <1=> Pclk = Cclk
+   //                     <2=> Pclk = Cclk / 2
+   //                     <3=> Pclk = Hclk / 8
+   //     <o10.4..5>   PCLK_PCB: Peripheral Clock Selection for the Pin Connect Block
+   //                     <0=> Pclk = Cclk / 4
+   //                     <1=> Pclk = Cclk
+   //                     <2=> Pclk = Cclk / 2
+   //                     <3=> Pclk = Hclk / 8
+   //     <o10.6..7>   PCLK_I2C1: Peripheral Clock Selection for I2C1
+   //                     <0=> Pclk = Cclk / 4
+   //                     <1=> Pclk = Cclk
+   //                     <2=> Pclk = Cclk / 2
+   //                     <3=> Pclk = Hclk / 8
+   //     <o10.10..11> PCLK_SSP0: Peripheral Clock Selection for SSP0
+   //                     <0=> Pclk = Cclk / 4
+   //                     <1=> Pclk = Cclk
+   //                     <2=> Pclk = Cclk / 2
+   //                     <3=> Pclk = Hclk / 8
+   //     <o10.12..13> PCLK_TIMER2: Peripheral Clock Selection for TIMER2
+   //                     <0=> Pclk = Cclk / 4
+   //                     <1=> Pclk = Cclk
+   //                     <2=> Pclk = Cclk / 2
+   //                     <3=> Pclk = Hclk / 8
+   //     <o10.14..15> PCLK_TIMER3: Peripheral Clock Selection for TIMER3
+   //                     <0=> Pclk = Cclk / 4
+   //                     <1=> Pclk = Cclk
+   //                     <2=> Pclk = Cclk / 2
+   //                     <3=> Pclk = Hclk / 8
+   //     <o10.16..17> PCLK_UART2: Peripheral Clock Selection for UART2
+   //                     <0=> Pclk = Cclk / 4
+   //                     <1=> Pclk = Cclk
+   //                     <2=> Pclk = Cclk / 2
+   //                     <3=> Pclk = Hclk / 8
+   //     <o10.18..19> PCLK_UART3: Peripheral Clock Selection for UART3
+   //                     <0=> Pclk = Cclk / 4
+   //                     <1=> Pclk = Cclk
+   //                     <2=> Pclk = Cclk / 2
+   //                     <3=> Pclk = Hclk / 8
+   //     <o10.20..21> PCLK_I2C2: Peripheral Clock Selection for I2C2
+   //                     <0=> Pclk = Cclk / 4
+   //                     <1=> Pclk = Cclk
+   //                     <2=> Pclk = Cclk / 2
+   //                     <3=> Pclk = Hclk / 8
+   //     <o10.22..23> PCLK_I2S: Peripheral Clock Selection for I2S
+   //                     <0=> Pclk = Cclk / 4
+   //                     <1=> Pclk = Cclk
+   //                     <2=> Pclk = Cclk / 2
+   //                     <3=> Pclk = Hclk / 8
+   //     <o10.26..27> PCLK_RIT: Peripheral Clock Selection for the Repetitive Interrupt Timer
+   //                     <0=> Pclk = Cclk / 4
+   //                     <1=> Pclk = Cclk
+   //                     <2=> Pclk = Cclk / 2
+   //                     <3=> Pclk = Hclk / 8
+   //     <o10.28..29> PCLK_SYSCON: Peripheral Clock Selection for the System Control Block
+   //                     <0=> Pclk = Cclk / 4
+   //                     <1=> Pclk = Cclk
+   //                     <2=> Pclk = Cclk / 2
+   //                     <3=> Pclk = Hclk / 8
+   //     <o10.30..31> PCLK_MC: Peripheral Clock Selection for the Motor Control PWM
+   //                     <0=> Pclk = Cclk / 4
+   //                     <1=> Pclk = Cclk
+   //                     <2=> Pclk = Cclk / 2
+   //                     <3=> Pclk = Hclk / 8
+   //   </h>
+   //
+   //   <h> Power Control for Peripherals Register (PCONP)
+   //     <o11.1>      PCTIM0: Timer/Counter 0 power/clock enable
+   //     <o11.2>      PCTIM1: Timer/Counter 1 power/clock enable
+   //     <o11.3>      PCUART0: UART 0 power/clock enable
+   //     <o11.4>      PCUART1: UART 1 power/clock enable
+   //     <o11.6>      PCPWM1: PWM 1 power/clock enable
+   //     <o11.7>      PCI2C0: I2C interface 0 power/clock enable
+   //     <o11.8>      PCSPI: SPI interface power/clock enable
+   //     <o11.9>      PCRTC: RTC power/clock enable
+   //     <o11.10>     PCSSP1: SSP interface 1 power/clock enable
+   //     <o11.12>     PCAD: A/D converter power/clock enable
+   //     <o11.13>     PCCAN1: CAN controller 1 power/clock enable
+   //     <o11.14>     PCCAN2: CAN controller 2 power/clock enable
+   //     <o11.15>     PCGPIO: GPIOs power/clock enable
+   //     <o11.16>     PCRIT: Repetitive interrupt timer power/clock enable
+   //     <o11.17>     PCMC: Motor control PWM power/clock enable
+   //     <o11.18>     PCQEI: Quadrature encoder interface power/clock enable
+   //     <o11.19>     PCI2C1: I2C interface 1 power/clock enable
+   //     <o11.21>     PCSSP0: SSP interface 0 power/clock enable
+   //     <o11.22>     PCTIM2: Timer 2 power/clock enable
+   //     <o11.23>     PCTIM3: Timer 3 power/clock enable
+   //     <o11.24>     PCUART2: UART 2 power/clock enable
+   //     <o11.25>     PCUART3: UART 3 power/clock enable
+   //     <o11.26>     PCI2C2: I2C interface 2 power/clock enable
+   //     <o11.27>     PCI2S: I2S interface power/clock enable
+   //     <o11.29>     PCGPDMA: GP DMA function power/clock enable
+   //     <o11.30>     PCENET: Ethernet block power/clock enable
+   //     <o11.31>     PCUSB: USB interface power/clock enable
+   //   </h>
+   //
+   //   <h> Clock Output Configuration Register (CLKOUTCFG)
+   //     <o12.0..3>   CLKOUTSEL: Selects clock source for CLKOUT
+   //                     <0=> CPU clock
+   //                     <1=> Main oscillator
+   //                     <2=> Internal RC oscillator
+   //                     <3=> USB clock
+   //                     <4=> RTC oscillator
+   //     <o12.4..7>   CLKOUTDIV: Selects clock divider for CLKOUT
+   //                     <1-16><#-1>
+   //     <o12.8>      CLKOUT_EN: CLKOUT enable control
+   //   </h>
+   //
+   // </e>
+ */
+
+/** @addtogroup LPC17xx_System_Defines  LPC17xx System Defines
+   @{
+ */
+
+#define CLOCK_SETUP           1
+#define SCS_Val               0x00000020
+#define CLKSRCSEL_Val         0x00000001
+#define PLL0_SETUP            1
+#define PLL0CFG_Val           0x00050063
+#define PLL1_SETUP            1
+#define PLL1CFG_Val           0x00000023
+#define CCLKCFG_Val           0x00000003
+#define USBCLKCFG_Val         0x00000000
+#define PCLKSEL0_Val          0x00000000
+#define PCLKSEL1_Val          0x00000000
+#define PCONP_Val             0x042887DE
+#define CLKOUTCFG_Val         0x00000000
+
+/*--------------------- Flash Accelerator Configuration ----------------------
+   //
+   // <e> Flash Accelerator Configuration
+   //   <o1.0..11>  Reserved
+   //   <o1.12..15> FLASHTIM: Flash Access Time
+   //               <0=> 1 CPU clock (for CPU clock up to 20 MHz)
+   //               <1=> 2 CPU clocks (for CPU clock up to 40 MHz)
+   //               <2=> 3 CPU clocks (for CPU clock up to 60 MHz)
+   //               <3=> 4 CPU clocks (for CPU clock up to 80 MHz)
+   //               <4=> 5 CPU clocks (for CPU clock up to 100 MHz)
+   //               <5=> 6 CPU clocks (for any CPU clock)
+   // </e>
+ */
+#define FLASH_SETUP           1
+#define FLASHCFG_Val          0x0000303A
+
+/*
+   //-------- <<< end of configuration section >>> ------------------------------
+ */
+
+/*----------------------------------------------------------------------------
+   Check the register settings
+ *----------------------------------------------------------------------------*/
+#define CHECK_RANGE(val, min, max)                ((val < min) || (val > max))
+#define CHECK_RSVD(val, mask)                     (val & mask)
+
+/* Clock Configuration -------------------------------------------------------*/
+#if (CHECK_RSVD((SCS_Val), ~0x00000030))
+#error "SCS: Invalid values of reserved bits!"
+#endif
+
+#if (CHECK_RANGE((CLKSRCSEL_Val), 0, 2))
+#error "CLKSRCSEL: Value out of range!"
+#endif
+
+#if (CHECK_RSVD((PLL0CFG_Val), ~0x00FF7FFF))
+#error "PLL0CFG: Invalid values of reserved bits!"
+#endif
+
+#if (CHECK_RSVD((PLL1CFG_Val), ~0x0000007F))
+#error "PLL1CFG: Invalid values of reserved bits!"
+#endif
+
+#if (CHECK_RANGE(CCLKCFG_Val, 2, 255))
+#error "CCLKCFG: CCLKSEL field does not contain value in range from 2 to 255!"
+#endif
+
+#if (CHECK_RSVD((USBCLKCFG_Val), ~0x0000000F))
+#error "USBCLKCFG: Invalid values of reserved bits!"
+#endif
+
+#if (CHECK_RSVD((PCLKSEL0_Val), 0x000C0C00))
+#error "PCLKSEL0: Invalid values of reserved bits!"
+#endif
+
+#if (CHECK_RSVD((PCLKSEL1_Val), 0x03000300))
+#error "PCLKSEL1: Invalid values of reserved bits!"
+#endif
+
+#if (CHECK_RSVD((PCONP_Val), 0x10100821))
+#error "PCONP: Invalid values of reserved bits!"
+#endif
+
+#if (CHECK_RSVD((CLKOUTCFG_Val), ~0x000001FF))
+#error "CLKOUTCFG: Invalid values of reserved bits!"
+#endif
+
+/* Flash Accelerator Configuration -------------------------------------------*/
+#if (CHECK_RSVD((FLASHCFG_Val), ~0x0000F07F))
+#error "FLASHCFG: Invalid values of reserved bits!"
+#endif
+
+/*----------------------------------------------------------------------------
+   DEFINES
+ *----------------------------------------------------------------------------*/
+
+/*----------------------------------------------------------------------------
+   Define clocks
+ *----------------------------------------------------------------------------*/
+#define XTAL        (12000000UL)        /* Oscillator frequency               */
+#define OSC_CLK     (XTAL)              /* Main oscillator frequency          */
+#define RTC_CLK     (32768UL)           /* RTC oscillator frequency           */
+#define IRC_OSC     (4000000UL)         /* Internal RC oscillator frequency   */
+
+/* F_cco0 = (2 * M * F_in) / N  */
+#define __M               (((PLL0CFG_Val) & 0x7FFF) + 1)
+#define __N               (((PLL0CFG_Val >> 16) & 0x00FF) + 1)
+#define __FCCO(__F_IN)    ((2 * __M * __F_IN) / __N)
+#define __CCLK_DIV        (((CCLKCFG_Val) & 0x00FF) + 1)
+
+/* Determine core clock frequency according to settings */
+#if (PLL0_SETUP)
+#if   ((CLKSRCSEL_Val & 0x03) == 1)
+#define __CORE_CLK (__FCCO(OSC_CLK) / __CCLK_DIV)
+#elif ((CLKSRCSEL_Val & 0x03) == 2)
+#define __CORE_CLK (__FCCO(RTC_CLK) / __CCLK_DIV)
+#else
+#define __CORE_CLK (__FCCO(IRC_OSC) / __CCLK_DIV)
+#endif
+#else
+#if   ((CLKSRCSEL_Val & 0x03) == 1)
+#define __CORE_CLK (OSC_CLK / __CCLK_DIV)
+#elif ((CLKSRCSEL_Val & 0x03) == 2)
+#define __CORE_CLK (RTC_CLK / __CCLK_DIV)
+#else
+#define __CORE_CLK (IRC_OSC / __CCLK_DIV)
+#endif
+#endif
+
+/**
+ * @}
+ */
+
+/** @addtogroup LPC17xx_System_Public_Variables  LPC17xx System Public Variables
+   @{
+ */
+/*----------------------------------------------------------------------------
+   Clock Variable definitions
+ *----------------------------------------------------------------------------*/
+uint32_t SystemCoreClock = __CORE_CLK; /*!< System Clock Frequency (Core Clock)*/
+
+/**
+ * @}
+ */
+
+/** @addtogroup LPC17xx_System_Public_Functions  LPC17xx System Public Functions
+   @{
+ */
+
+/*----------------------------------------------------------------------------
+   Clock functions
+ *----------------------------------------------------------------------------*/
+
+void
+SystemCoreClockUpdate(void)                  /* Get Core Clock Frequency      */
+{
+  /* Determine clock frequency according to clock register values             */
+  if(((LPC_SC->PLL0STAT >> 24) & 3) == 3) {  /* If PLL0 enabled and connected */
+    switch(LPC_SC->CLKSRCSEL & 0x03) {
+    case 0:                                  /* Int. RC oscillator => PLL0    */
+    case 3:                                  /* Reserved, default to Int. RC  */
+      SystemCoreClock = (IRC_OSC *
+                         ((2 * ((LPC_SC->PLL0STAT & 0x7FFF) + 1))) /
+                         (((LPC_SC->PLL0STAT >> 16) & 0xFF) + 1) /
+                         ((LPC_SC->CCLKCFG & 0xFF) + 1));
+      break;
+    case 1:                                  /* Main oscillator => PLL0       */
+      SystemCoreClock = (OSC_CLK *
+                         ((2 * ((LPC_SC->PLL0STAT & 0x7FFF) + 1))) /
+                         (((LPC_SC->PLL0STAT >> 16) & 0xFF) + 1) /
+                         ((LPC_SC->CCLKCFG & 0xFF) + 1));
+      break;
+    case 2:                                  /* RTC oscillator => PLL0        */
+      SystemCoreClock = (RTC_CLK *
+                         ((2 * ((LPC_SC->PLL0STAT & 0x7FFF) + 1))) /
+                         (((LPC_SC->PLL0STAT >> 16) & 0xFF) + 1) /
+                         ((LPC_SC->CCLKCFG & 0xFF) + 1));
+      break;
+    }
+  } else {
+    switch(LPC_SC->CLKSRCSEL & 0x03) {
+    case 0:                                  /* Int. RC oscillator => PLL0    */
+    case 3:                                  /* Reserved, default to Int. RC  */
+      SystemCoreClock = IRC_OSC / ((LPC_SC->CCLKCFG & 0xFF) + 1);
+      break;
+    case 1:                                  /* Main oscillator => PLL0       */
+      SystemCoreClock = OSC_CLK / ((LPC_SC->CCLKCFG & 0xFF) + 1);
+      break;
+    case 2:                                  /* RTC oscillator => PLL0        */
+      SystemCoreClock = RTC_CLK / ((LPC_SC->CCLKCFG & 0xFF) + 1);
+      break;
+    }
+  }
+}
+/**
+ * Initialize the system
+ *
+ * @param  none
+ * @return none
+ *
+ * @brief  Setup the microcontroller system.
+ *         Initialize the System.
+ */
+void
+SystemInit(void)
+{
+#if (CLOCK_SETUP)                       /* Clock Setup                        */
+  LPC_SC->SCS = SCS_Val;
+  if(LPC_SC->SCS & (1 << 5)) {              /* If Main Oscillator is enabled  */
+    while((LPC_SC->SCS & (1 << 6)) == 0) ;  /* Wait for Oscillator to be ready    */
+  }
+  LPC_SC->CCLKCFG = CCLKCFG_Val;        /* Setup Clock Divider                */
+  /* Periphral clock must be selected before PLL0 enabling and connecting
+   * - according errata.lpc1768-16.March.2010 -
+   */
+  LPC_SC->PCLKSEL0 = PCLKSEL0_Val;      /* Peripheral Clock Selection         */
+  LPC_SC->PCLKSEL1 = PCLKSEL1_Val;
+
+#if (PLL0_SETUP)
+  LPC_SC->CLKSRCSEL = CLKSRCSEL_Val;    /* Select Clock Source for PLL0       */
+
+  LPC_SC->PLL0CFG = PLL0CFG_Val;        /* configure PLL0                     */
+  LPC_SC->PLL0FEED = 0xAA;
+  LPC_SC->PLL0FEED = 0x55;
+
+  LPC_SC->PLL0CON = 0x01;               /* PLL0 Enable                        */
+  LPC_SC->PLL0FEED = 0xAA;
+  LPC_SC->PLL0FEED = 0x55;
+  while(!(LPC_SC->PLL0STAT & (1 << 26))) ;  /* Wait for PLOCK0                    */
+
+  LPC_SC->PLL0CON = 0x03;               /* PLL0 Enable & Connect              */
+  LPC_SC->PLL0FEED = 0xAA;
+  LPC_SC->PLL0FEED = 0x55;
+  while(!(LPC_SC->PLL0STAT & ((1 << 25) | (1 << 24)))) ;  /* Wait for PLLC0_STAT & PLLE0_STAT */
+#endif
+
+#if (PLL1_SETUP)
+  LPC_SC->PLL1CFG = PLL1CFG_Val;
+  LPC_SC->PLL1FEED = 0xAA;
+  LPC_SC->PLL1FEED = 0x55;
+
+  LPC_SC->PLL1CON = 0x01;               /* PLL1 Enable                        */
+  LPC_SC->PLL1FEED = 0xAA;
+  LPC_SC->PLL1FEED = 0x55;
+  while(!(LPC_SC->PLL1STAT & (1 << 10))) ;  /* Wait for PLOCK1                    */
+
+  LPC_SC->PLL1CON = 0x03;               /* PLL1 Enable & Connect              */
+  LPC_SC->PLL1FEED = 0xAA;
+  LPC_SC->PLL1FEED = 0x55;
+  while(!(LPC_SC->PLL1STAT & ((1 << 9) | (1 << 8)))) ;  /* Wait for PLLC1_STAT & PLLE1_STAT */
+#else
+  LPC_SC->USBCLKCFG = USBCLKCFG_Val;    /* Setup USB Clock Divider            */
+#endif
+  LPC_SC->PCONP = PCONP_Val;            /* Power Control for Peripherals      */
+
+  LPC_SC->CLKOUTCFG = CLKOUTCFG_Val;    /* Clock Output Configuration         */
+#endif
+
+#if (FLASH_SETUP == 1)                  /* Flash Accelerator Setup            */
+  LPC_SC->FLASHCFG = FLASHCFG_Val;
+#endif
+
+/*  Set Vector table offset value */
+#if (__RAM_MODE__ == 1)
+  SCB->VTOR = 0x10000000 & 0x3FFFFF80;
+#else
+  SCB->VTOR = 0x00000000 & 0x3FFFFF80;
+#endif
+}
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */

--- a/cpu/arm/lpc1768/system_LPC17xx.h
+++ b/cpu/arm/lpc1768/system_LPC17xx.h
@@ -1,0 +1,69 @@
+/**************************************************************************//**
+ * @file     system_LPC17xx.h
+ * @brief    CMSIS Cortex-M3 Device Peripheral Access Layer Header File
+ *           for the NXP LPC17xx Device Series
+ * @version  V1.02
+ * @date     08. September 2009
+ *
+ * @note
+ * Copyright (C) 2009 ARM Limited. All rights reserved.
+ *
+ * @par
+ * ARM Limited (ARM) is supplying this software for use with Cortex-M
+ * processor based microcontrollers.  This file can be freely distributed
+ * within development tools that are supporting such ARM based processors.
+ *
+ * @par
+ * THIS SOFTWARE IS PROVIDED "AS IS".  NO WARRANTIES, WHETHER EXPRESS, IMPLIED
+ * OR STATUTORY, INCLUDING, BUT NOT LIMITED TO, IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE APPLY TO THIS SOFTWARE.
+ * ARM SHALL NOT, IN ANY CIRCUMSTANCES, BE LIABLE FOR SPECIAL, INCIDENTAL, OR
+ * CONSEQUENTIAL DAMAGES, FOR ANY REASON WHATSOEVER.
+ *
+ ******************************************************************************/
+
+#ifndef __SYSTEM_LPC17xx_H
+#define __SYSTEM_LPC17xx_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdint.h>
+
+/** @addtogroup LPC17xx_System
+ * @{
+ */
+
+extern uint32_t SystemCoreClock;     /*!< System Clock Frequency (Core Clock)  */
+
+/**
+ * Initialize the system
+ *
+ * @param  none
+ * @return none
+ *
+ * @brief  Setup the microcontroller system.
+ *         Initialize the System and update the SystemCoreClock variable.
+ */
+extern void SystemInit(void);
+
+/**
+ * Update SystemCoreClock variable
+ *
+ * @param  none
+ * @return none
+ *
+ * @brief  Updates the SystemCoreClock with current core Clock
+ *         retrieved from cpu registers.
+ */
+extern void SystemCoreClockUpdate(void);
+#ifdef __cplusplus
+}
+#endif
+
+/**
+ * @}
+ */
+
+#endif /* __SYSTEM_LPC17xx_H */

--- a/platform/bi-dcdc/Makefile.bi-dcdc
+++ b/platform/bi-dcdc/Makefile.bi-dcdc
@@ -1,0 +1,25 @@
+BI-DCDC =  
+
+#CODEPROP_SOURCES = codeprop-otf.c ram-segments.c
+
+CONTIKI_TARGET_DIRS = . dev net
+# Master clock frequency
+MCK=48000000
+CFLAGS+=-DAUTOSTART_ENABLE -DMCK=48000000
+
+ifndef CONTIKI_TARGET_MAIN
+CONTIKI_TARGET_MAIN = contiki-main.c
+endif
+
+CONTIKI_TARGET_SOURCEFILES += $(CODEPROP_SOURCES) $(CONTIKI_TARGET_MAIN)
+
+#include $(CONTIKI)/platform/$(TARGET)/apps/Makefile.apps
+
+include $(CONTIKI)/cpu/arm/lpc1768/Makefile.lpc1768
+
+#contiki-$(TARGET).a: ${addprefix $(OBJECTDIR)/,symbols.o}
+
+ifndef BASE_IP
+BASE_IP := 172.16.1.1
+endif
+

--- a/platform/bi-dcdc/README.md
+++ b/platform/bi-dcdc/README.md
@@ -1,0 +1,4 @@
+Bidirectional DC-DC Converter
+============================
+
+This bi-dcdc platform is a bidirectional DC to DC conversion board with ethernet interface. It is a LPC1768-based board with built-in Ethernet support and bidirectional DCDC conversion circuit.

--- a/platform/bi-dcdc/contiki-conf.h
+++ b/platform/bi-dcdc/contiki-conf.h
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2013, KTH, Royal Institute of Technology
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE UNIVERSITY AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ */
+
+#ifndef __CONTIKI_CONF_H_
+#define __CONTIKI_CONF_H_
+
+#include <stdint.h>
+#include "lpc1768.h"
+
+#define CCIF
+#define CLIF
+
+#define CLOCK_CONF_SECOND 100
+
+/* Defined as 0 for UART0 and 1 for UART1 */
+#define DEBUG_UART      0
+
+typedef unsigned int clock_time_t;
+typedef unsigned int uip_stats_t;
+
+#ifndef BV
+#define BV(x) (1<<(x))
+#endif
+
+/* Define the MAC address of the device */
+#define EMAC_ADDR0              0x10
+#define EMAC_ADDR1              0x1F
+#define EMAC_ADDR2              0xE0
+#define EMAC_ADDR3              0x12
+#define EMAC_ADDR4              0x1D
+#define EMAC_ADDR5              0x0C
+
+/* uIP configuration */
+/* Ethernet LLH(Link Level Header) size is 14 bytes */
+#define UIP_CONF_LLH_LEN	14
+#define UIP_CONF_BROADCAST	1
+#define UIP_CONF_LOGGING	1
+#define UIP_CONF_BUFFER_SIZE	1024
+#define UIP_CONF_TCP_FORWARD	1
+#define UIP_CONF_ICMP6		1
+#define UIP_CONF_LL_802154	1
+
+/* Prefix for relocation sections in ELF files */
+#define REL_SECT_PREFIX ".rel"
+
+#define CC_BYTE_ALIGNED __attribute__ ((packed, aligned(1)))
+
+#define USB_EP1_SIZE 64
+#define USB_EP2_SIZE 64
+
+#define RAND_MAX 0x7fff
+
+#endif /* __CONTIKI_CONF_H__CDBB4VIH3I__ */

--- a/platform/bi-dcdc/contiki-main.c
+++ b/platform/bi-dcdc/contiki-main.c
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2013, KTH, Royal Institute of Technology
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE UNIVERSITY AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ */
+
+#include <stdint.h>
+#include <stdio.h>
+#include <sys/process.h>
+#include <sys/procinit.h>
+#include <sys/etimer.h>
+#include <sys/autostart.h>
+#include <sys/clock.h>
+#include <contiki-net.h>
+#include <net/dhcpc.h>
+#include "debug-uart.h"
+#include "emac-driver.h"
+#include "contiki-conf.h"
+#include <net/uip-debug.h>
+#include "dev/leds.h"
+#include "system_LPC17xx.h"
+
+int main()
+{
+	debug_uart_setup();
+	clock_init();
+	process_init();
+
+	process_start(&etimer_process, NULL );
+	process_start(&emac_lpc1768, NULL );
+	process_start(&tcpip_process, NULL );
+
+#if UIP_CONF_IPV6
+  uip_lladdr.addr[0] = EMAC_ADDR0;
+  uip_lladdr.addr[1] = EMAC_ADDR1;
+  uip_lladdr.addr[2] = EMAC_ADDR2;
+  uip_lladdr.addr[3] = EMAC_ADDR3;
+  uip_lladdr.addr[4] = EMAC_ADDR4;
+  uip_lladdr.addr[5] = EMAC_ADDR5;
+
+  uip_ds6_addr_t *lladdr;
+  lladdr = uip_ds6_get_link_local(-1);
+#else
+  uip_ipaddr_t addr;
+  uip_ethaddr.addr[0] = EMAC_ADDR0;
+  uip_ethaddr.addr[1] = EMAC_ADDR1;
+  uip_ethaddr.addr[2] = EMAC_ADDR2;
+  uip_ethaddr.addr[3] = EMAC_ADDR3;
+  uip_ethaddr.addr[4] = EMAC_ADDR4;
+  uip_ethaddr.addr[5] = EMAC_ADDR5;
+  uip_setethaddr(uip_ethaddr);
+
+  uip_ipaddr(&addr, 192, 168, 1, 5);
+  uip_sethostaddr(&addr);
+
+  uip_ipaddr(&addr, 255, 255, 255, 0);
+  uip_setnetmask(&addr);
+
+  uip_ipaddr(&addr, 192, 168, 1, 1);
+  uip_setdraddr(&addr);
+#endif
+
+	autostart_start(autostart_processes);
+
+	do
+	{
+	} while (process_run() > 0);
+
+	return 0;
+}
+
+void
+uip_log(char *m)
+{
+  printf("uIP: '%s'\n", m);
+}
+
+void
+log_message(const char *part1, const char *part2)
+{
+  printf("log: %s: %s\n", part1, part2);
+}
+


### PR DESCRIPTION
This is a port of LPC1768 and a bi-directional DC to DC conversion platform with Ethernet interface. The LPC1768 is a Cortex-M3 based microcontroller for embedded applications. Features include 512 kB of flash memory, 64 kB of data memory, Ethernet MAC, 4 UARTs, 8-channel 12-bit ADC, 10-bit DAC and so on. For more information, please refer to NXP webpage: 
http://www.nxp.com/products/microcontrollers/cortex_m3/LPC1768FBD100.html

This port is the result of several development iterations by master students at KTH (Royal Institute of Technology) and it can be part of a Microgrid, a concept in which smart power management system is achieved by utilizing IoT technologies. This port at the minimum features system initialization and configuration, Ethernet communication (LPC1768 has a built-in ethernet module) as well as UART interface for flash/debug.

PCB design of this platform will be publicly available via http://ttaportal.org shortly as well as technical report and comprehensive guide for anyone who will be interested in this platform. Also LPC1786 has been around for some years and there are publicly available platforms based on this microcontroller.

Following Contiki applications have been tested successfully with this port:
helloworld:
    In /example/hello-world/, uncomment UIP_CONF_IPV6=1 and set TARGET=bi-dcdc
er-rest-example:
    In /example/er-rest-example/, set TARGET=bi-dcdc

KTH telecommunication lab will be in charge of maintaining this port and corresponding applications.
