### PR TITLE
mmem: Prevent duplicate init of mmem

### DIFF
--- a/core/lib/mmem.c
+++ b/core/lib/mmem.c
@@ -151,8 +151,13 @@ mmem_free(struct mmem *m)
 void
 mmem_init(void)
 {
+  static int inited = 0;
+  if(inited) {
+    return;
+  }
   list_init(mmemlist);
   avail_memory = MMEM_SIZE;
+  inited = 1;
 }
 /*---------------------------------------------------------------------------*/
 


### PR DESCRIPTION
This could seriously corrupt data if mmem_init was called again after
someone called mmem_alloc.
