### PR TITLE
Fixed some of the targets broken by changing the UIP_CONF_LLH_LEN default.

### DIFF
--- a/cpu/6502/6502def.h
+++ b/cpu/6502/6502def.h
@@ -69,6 +69,7 @@ typedef unsigned short uip_stats_t;
 #define UIP_ARCH_ADD32  1
 #define UIP_ARCH_CHKSUM 1
 
+#define UIP_CONF_LLH_LEN                      14
 #define RESOLV_CONF_SUPPORTS_MDNS              0
 #define RESOLV_CONF_SUPPORTS_RECORD_EXPIRATION 0
 #define NETSTACK_CONF_RDC_CHANNEL_CHECK_RATE   1

--- a/platform/minimal-net/contiki-conf.h
+++ b/platform/minimal-net/contiki-conf.h
@@ -140,6 +140,7 @@ typedef unsigned short uip_stats_t;
 
 #endif
 
+#define UIP_CONF_LLH_LEN              14
 #define UIP_CONF_MAX_LISTENPORTS      40
 #define UIP_CONF_MAX_CONNECTIONS      40
 #define UIP_CONF_BYTE_ORDER           UIP_LITTLE_ENDIAN

--- a/platform/win32/contiki-conf.h
+++ b/platform/win32/contiki-conf.h
@@ -56,25 +56,26 @@ typedef          long  s32_t;
 
 typedef unsigned short uip_stats_t;
 
-#define UIP_CONF_MAX_CONNECTIONS 40
-#define UIP_CONF_MAX_LISTENPORTS 40
-#define UIP_CONF_BUFFER_SIZE     1514
-#define UIP_CONF_BYTE_ORDER      UIP_LITTLE_ENDIAN
-#define UIP_CONF_TCP_SPLIT       1
+#define UIP_CONF_MAX_CONNECTIONS     40
+#define UIP_CONF_MAX_LISTENPORTS     40
+#define UIP_CONF_LLH_LEN             14
+#define UIP_CONF_BUFFER_SIZE         1514
+#define UIP_CONF_BYTE_ORDER          UIP_LITTLE_ENDIAN
+#define UIP_CONF_TCP_SPLIT           1
+#define UIP_CONF_LOGGING             1
+#define UIP_CONF_UDP_CHECKSUMS       1
 #if UIP_CONF_IPV6
-#define UIP_CONF_IP_FORWARD      0
-#define NBR_TABLE_CONF_MAX_NEIGHBORS     100
-#define UIP_CONF_DS6_DEFRT_NBU   2
-#define UIP_CONF_DS6_PREFIX_NBU  5
-#define UIP_CONF_MAX_ROUTES   100
-#define UIP_CONF_DS6_ADDR_NBU    10
-#define UIP_CONF_DS6_MADDR_NBU   0  //VC++ does not allow zero length arrays
-#define UIP_CONF_DS6_AADDR_NBU   0  //inside a struct
+#define UIP_CONF_IP_FORWARD          0
+#define NBR_TABLE_CONF_MAX_NEIGHBORS 100
+#define UIP_CONF_DS6_DEFRT_NBU       2
+#define UIP_CONF_DS6_PREFIX_NBU      5
+#define UIP_CONF_MAX_ROUTES          100
+#define UIP_CONF_DS6_ADDR_NBU        10
+#define UIP_CONF_DS6_MADDR_NBU       0  //VC++ does not allow zero length arrays
+#define UIP_CONF_DS6_AADDR_NBU       0  //inside a struct
 #else
-#define UIP_CONF_IP_FORWARD      1
+#define UIP_CONF_IP_FORWARD          1
 #endif
-#define UIP_CONF_LOGGING         1
-#define UIP_CONF_UDP_CHECKSUMS   1
 
 
 #include <ctype.h>


### PR DESCRIPTION
https://github.com/contiki-os/contiki/commit/c0b3c87ba757b949aadfe20c3fcbc701c3ce192b changed the default of `UIP_CONF_LLH_LEN` from `14` to `0`. This broke of course all targets relying on the default :-(

BTW: I can't see a pull request for the change in question. So I was only afterwards made aware of it because of my subscription of contiki-commits-request@lists.sourceforge.net :-((
