### PR TITLE
Stopped to load plugins depending on simulations if there is no simulation

### DIFF
--- a/tools/cooja/java/org/contikios/cooja/Cooja.java
+++ b/tools/cooja/java/org/contikios/cooja/Cooja.java
@@ -963,7 +963,7 @@ public class Cooja extends Observable {
         tooltip += description + " (" + newPluginClass.getName() + ")";
 
         /* Check if simulation plugin depends on any particular radio medium */
-        if (pluginType == PluginType.SIM_PLUGIN || pluginType == PluginType.SIM_STANDARD_PLUGIN) {
+        if ((pluginType == PluginType.SIM_PLUGIN || pluginType == PluginType.SIM_STANDARD_PLUGIN) && (getSimulation() != null)) {
           if (newPluginClass.getAnnotation(SupportedArguments.class) != null) {
             boolean active = false;
             Class<? extends RadioMedium>[] radioMediums = newPluginClass.getAnnotation(SupportedArguments.class).radioMediums();


### PR DESCRIPTION
Till now, there was no check if there is a simulation when starting SIM_PLUGIN and SIM_STANDARD_PLUGIN, so this could lead to an error.
So the check was added. 
