### PR TITLE
Fix Cooja PCAP packet header timestamps

### DIFF
--- a/tools/cooja/java/org/contikios/cooja/plugins/analyzers/PcapExporter.java
+++ b/tools/cooja/java/org/contikios/cooja/plugins/analyzers/PcapExporter.java
@@ -46,7 +46,7 @@ public class PcapExporter {
         }
         try {
             /* pcap packet header */
-            out.writeInt((int) System.currentTimeMillis() / 1000);
+            out.writeInt((int) (System.currentTimeMillis() / 1000));
             out.writeInt((int) ((System.currentTimeMillis() % 1000) * 1000));
             out.writeInt(data.length);
             out.writeInt(data.length);


### PR DESCRIPTION
Due to a bad cast, the PCAP exporter writes the wrong value to the packet header's 'secs' field. This results in packets with very wrong arrival times, such as year 1969 or year 2106.
