### PR TITLE
Copied 'contiki_arg[c|v]' from 'native' to the other desktop targets.

### DIFF
--- a/cpu/6502/README.md
+++ b/cpu/6502/README.md
@@ -69,6 +69,10 @@ high-level configuration macros may be set:
     - Default: 0
     - Purpose: Enable CTK mouse support and load a mouse driver.
 
+- WITH_ARGS
+    - Default: 0
+    - Purpose: Enable support for contiki_argc / contiki_argv.
+
 - WITH_PFS
     - Default: 0
     - Purpose: Implement the CFS interface with a Platform-specific File System

--- a/platform/apple2enh/contiki-main.c
+++ b/platform/apple2enh/contiki-main.c
@@ -55,13 +55,29 @@ PROCINIT(&etimer_process,
          &tcpip_process
          RESOLV_PROCESS);
 
+static struct ethernet_config *ethernet_config;
+
 void clock_update(void);
 
 /*-----------------------------------------------------------------------------------*/
+#if WITH_ARGS
+
+int contiki_argc;
+char **contiki_argv;
+
+void
+main(int argc, char **argv)
+{
+  contiki_argc = argc;
+  contiki_argv = argv;
+
+#else /* WITH_ARGS */
+
 void
 main(void)
 {
-  struct ethernet_config *ethernet_config;
+
+#endif /* WITH_ARGS */
 
 #if WITH_REBOOT
   rebootafterexit();

--- a/platform/atarixl/contiki-main.c
+++ b/platform/atarixl/contiki-main.c
@@ -55,11 +55,27 @@ PROCINIT(&etimer_process,
          &tcpip_process
          RESOLV_PROCESS);
 
+static  struct ethernet_config *ethernet_config;
+
 /*-----------------------------------------------------------------------------------*/
+#if WITH_ARGS
+
+int contiki_argc;
+char **contiki_argv;
+
+void
+main(int argc, char **argv)
+{
+  contiki_argc = argc;
+  contiki_argv = argv;
+
+#else /* WITH_ARGS */
+
 void
 main(void)
 {
-  struct ethernet_config *ethernet_config;
+
+#endif /* WITH_ARGS */
 
   clrscr();
   bordercolor(BORDERCOLOR);

--- a/platform/c128/contiki-main.c
+++ b/platform/c128/contiki-main.c
@@ -57,11 +57,27 @@ PROCINIT(&etimer_process,
          &tcpip_process
          RESOLV_PROCESS);
 
+static struct ethernet_config *ethernet_config;
+
 /*-----------------------------------------------------------------------------------*/
+#if WITH_ARGS
+
+int contiki_argc;
+char **contiki_argv;
+
+void
+main(int argc, char **argv)
+{
+  contiki_argc = argc;
+  contiki_argv = argv;
+
+#else /* WITH_ARGS */
+
 void
 main(void)
 {
-  struct ethernet_config *ethernet_config;
+
+#endif /* WITH_ARGS */
 
   videomode(VIDEOMODE_80COL);
 

--- a/platform/c64/contiki-main.c
+++ b/platform/c64/contiki-main.c
@@ -57,11 +57,27 @@ PROCINIT(&etimer_process,
          &tcpip_process
          RESOLV_PROCESS);
 
+static struct ethernet_config *ethernet_config;
+
 /*-----------------------------------------------------------------------------------*/
+#if WITH_ARGS
+
+int contiki_argc;
+char **contiki_argv;
+
+void
+main(int argc, char **argv)
+{
+  contiki_argc = argc;
+  contiki_argv = argv;
+
+#else /* WITH_ARGS */
+
 void
 main(void)
 {
-  struct ethernet_config *ethernet_config;
+
+#endif /* WITH_ARGS */
 
   process_init();
 

--- a/platform/minimal-net/contiki-main.c
+++ b/platform/minimal-net/contiki-main.c
@@ -176,9 +176,27 @@ sprint_ip6(uip_ip6addr_t addr)
 }
 #endif /* UIP_CONF_IPV6 */
 /*---------------------------------------------------------------------------*/
+int contiki_argc = 0;
+char **contiki_argv;
+
 int
-main(void)
+main(int argc, char **argv)
 {
+  /* crappy way of remembering and accessing argc/v */
+  contiki_argc = argc;
+  contiki_argv = argv;
+
+  /* minimal-net under windows is hardcoded to use the first one or two args */
+  /* for wpcap configuration so this needs to be "removed" from contiki_args */
+#ifdef __CYGWIN__
+  contiki_argc--;
+  contiki_argv++;
+#ifdef UIP_FALLBACK_INTERFACE
+  contiki_argc--;
+  contiki_argv++;
+#endif
+#endif
+
   clock_init();
 #if UIP_CONF_IPV6
 /* A hard coded address overrides the stack default MAC address to

--- a/platform/win32/contiki-main.c
+++ b/platform/win32/contiki-main.c
@@ -95,9 +95,24 @@ log_message(const char *part1, const char *part2)
   debug_printf("%s%s\n", part1, part2);
 }
 /*-----------------------------------------------------------------------------------*/
+int contiki_argc = 0;
+char **contiki_argv;
+
 int
-main(void)
+main(int argc, char **argv)
 {
+  contiki_argc = argc;
+  contiki_argv = argv;
+
+  /* The first one or two args are used for wpcap configuration */
+  /* so this needs to be "removed" from  contiki_args.          */
+  contiki_argc--;
+  contiki_argv++;
+#ifdef UIP_FALLBACK_INTERFACE
+  contiki_argc--;
+  contiki_argv++;
+#endif
+
   process_init();
 
   procinit_init();


### PR DESCRIPTION
- On the retro targets support for 'contiki_arg[c|v]' is optional as accessing 'arg[c|v]' is rather expensive.
