### PR TITLE
Fix compilation error when DEBUG enabled in core/net/mac/framer-nullmac....

### DIFF
--- a/core/net/mac/framer-nullmac.c
+++ b/core/net/mac/framer-nullmac.c
@@ -67,7 +67,7 @@ create(void)
     rimeaddr_copy(&(hdr->receiver), packetbuf_addr(PACKETBUF_ADDR_RECEIVER));
     return sizeof(struct nullmac_hdr);
   }
-  PRINTF("PNULLMAC-UT: too large header: %u\n", len);
+  PRINTF("PNULLMAC-UT: too large header: %u\n", sizeof(struct nullmac_hdr));
   return FRAMER_FAILED;
 }
 /*---------------------------------------------------------------------------*/
@@ -83,7 +83,7 @@ parse(void)
     PRINTF("PNULLMAC-IN: ");
     PRINTADDR(packetbuf_addr(PACKETBUF_ADDR_SENDER));
     PRINTADDR(packetbuf_addr(PACKETBUF_ADDR_RECEIVER));
-    PRINTF("%u (%u)\n", packetbuf_datalen(), len);
+    PRINTF("%u (%u)\n", packetbuf_datalen(), sizeof(struct nullmac_hdr));
 
     return sizeof(struct nullmac_hdr);
   }


### PR DESCRIPTION
This is necessary to get de framer-nullmac to compile with debugging messages.
