### PR TITLE
Adds -encoding utf-8 arg to cooja compile command

### DIFF
--- a/tools/cooja/build.xml
+++ b/tools/cooja/build.xml
@@ -72,6 +72,7 @@ The COOJA Simulator
     <mkdir dir="${build}"/>
     <javac srcdir="${java}" destdir="${build}" debug="on"
            includeantruntime="false">
+      <compilerarg line="-encoding utf-8"/>
       <classpath>
         <pathelement path="."/>
         <pathelement location="lib/jdom.jar"/>


### PR DESCRIPTION
Alows to compile cooja, at least on my mac with java build 1.7.0_45-b18
