### PR TITLE
cc2538: Fix library linkage

### DIFF
--- a/cpu/cc2538/Makefile.cc2538
+++ b/cpu/cc2538/Makefile.cc2538
@@ -71,7 +71,7 @@ CUSTOM_RULE_LINK=1
 
 %.elf: $(TARGET_STARTFILES) %.co $(PROJECT_OBJECTFILES) $(PROJECT_LIBRARIES) contiki-$(TARGET).a $(LDSCRIPT)
 	$(TRACE_LD)
-	$(Q)$(LD) $(LDFLAGS) ${filter-out $(LDSCRIPT) %.a,$^} ${filter %.a,$^} -o $@
+	$(Q)$(LD) $(LDFLAGS) ${filter-out $(LDSCRIPT) %.a,$^} ${filter %.a,$^} $(TARGET_LIBFILES) -o $@
 
 %.hex: %.elf
 	$(OBJCOPY) -O ihex $< $@


### PR DESCRIPTION
If a project needs to use some libraries at link stage, then the corresponding
linker options (e.g. '-lm') have to be passed after any .o file depending on
these libraries. Hence, LDFLAGS cannot be used to add such options when invoking
$(LD) in Makefile.cc2538, or it should be moved to the correct location.
Instead, this change adds TARGET_LIBFILES to the correct location, like most
other Contiki targets.
