### PR TITLE
cc2538: lpm: Fix build for LPM_CONF_ENABLE == 0

### DIFF
--- a/cpu/cc2538/lpm.c
+++ b/cpu/cc2538/lpm.c
@@ -48,6 +48,8 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <string.h>
+
+#if LPM_CONF_ENABLE != 0
 /*---------------------------------------------------------------------------*/
 #if ENERGEST_CONF_ON
 static unsigned long irq_energest = 0;
@@ -378,4 +380,5 @@ lpm_init()
   LPM_STATS_INIT();
 }
 /*---------------------------------------------------------------------------*/
+#endif /* LPM_CONF_ENABLE != 0 */
 /** @} */

--- a/cpu/cc2538/lpm.h
+++ b/cpu/cc2538/lpm.h
@@ -212,6 +212,7 @@ void lpm_register_peripheral(lpm_periph_permit_pm1_func_t permit_pm1_func);
 #define lpm_enter()
 #define lpm_exit()
 #define lpm_set_max_pm(...)
+#define lpm_register_peripheral(...)
 #endif
 
 #endif /* LPM_H_ */


### PR DESCRIPTION
lpm.c needs to #include lpm.h in order to get the definition of
lpm_periph_permit_pm1_func_t, which made the replacement macros conflict with
the function definitions for the LPM_CONF_ENABLE == 0 case. This change fixes
this issue by #if-ing out the code in lpm.c in that case. Also, the replacement
macro for lpm_register_peripheral() was missing in that case, which is fixed
here.
