### PR TITLE
Rename the rimeaddr module to linkaddr

### DIFF
--- a/apps/collect-view/collect-view.c
+++ b/apps/collect-view/collect-view.c
@@ -48,7 +48,7 @@
 /*---------------------------------------------------------------------------*/
 void
 collect_view_construct_message(struct collect_view_data_msg *msg,
-                               const rimeaddr_t *parent,
+                               const linkaddr_t *parent,
                                uint16_t parent_etx,
                                uint16_t current_rtmetric,
                                uint16_t num_neighbors,
@@ -93,7 +93,7 @@ collect_view_construct_message(struct collect_view_data_msg *msg,
   last_transmit = energest_type_time(ENERGEST_TYPE_TRANSMIT);
   last_listen = energest_type_time(ENERGEST_TYPE_LISTEN);
 
-  memcpy(&msg->parent, &parent->u8[RIMEADDR_SIZE - 2], 2);
+  memcpy(&msg->parent, &parent->u8[LINKADDR_SIZE - 2], 2);
   msg->parent_etx = parent_etx;
   msg->current_rtmetric = current_rtmetric;
   msg->num_neighbors = num_neighbors;

--- a/apps/collect-view/collect-view.h
+++ b/apps/collect-view/collect-view.h
@@ -2,7 +2,7 @@
 #define COLLECT_VIEW_H
 
 #include "contiki-conf.h"
-#include "net/rimeaddr.h"
+#include "net/linkaddr.h"
 #include "net/rime/collect.h"
 
 struct collect_view_data_msg {
@@ -23,7 +23,7 @@ struct collect_view_data_msg {
 };
 
 void collect_view_construct_message(struct collect_view_data_msg *msg,
-                                    const rimeaddr_t *parent,
+                                    const linkaddr_t *parent,
                                     uint16_t etx_to_parent,
                                     uint16_t current_rtmetric,
                                     uint16_t num_neighbors,

--- a/apps/deluge/deluge.c
+++ b/apps/deluge/deluge.c
@@ -91,8 +91,8 @@ static struct ctimer profile_timer;
 static deluge_object_id_t next_object_id;
 
 /* Rime callbacks. */
-static void broadcast_recv(struct broadcast_conn *, const rimeaddr_t *);
-static void unicast_recv(struct unicast_conn *, const rimeaddr_t *);
+static void broadcast_recv(struct broadcast_conn *, const linkaddr_t *);
+static void unicast_recv(struct unicast_conn *, const linkaddr_t *);
 
 static const struct broadcast_callbacks broadcast_call = {broadcast_recv, NULL};
 static const struct unicast_callbacks unicast_call = {unicast_recv, NULL};
@@ -288,7 +288,7 @@ advertise_summary(struct deluge_object *obj)
 }
 
 static void
-handle_summary(struct deluge_msg_summary *msg, const rimeaddr_t *sender)
+handle_summary(struct deluge_msg_summary *msg, const linkaddr_t *sender)
 {
   int highest_available, i;
   clock_time_t oldest_request, oldest_data, now;
@@ -332,7 +332,7 @@ handle_summary(struct deluge_msg_summary *msg, const rimeaddr_t *sender)
       return;
     }
 
-    rimeaddr_copy(&current_object.summary_from, sender);
+    linkaddr_copy(&current_object.summary_from, sender);
     transition(DELUGE_STATE_RX);
 
     if(ctimer_expired(&rx_timer)) {
@@ -579,7 +579,7 @@ handle_profile(struct deluge_msg_profile *msg)
 }
 
 static void
-command_dispatcher(const rimeaddr_t *sender)
+command_dispatcher(const linkaddr_t *sender)
 {
   char *msg;
   int len;
@@ -615,13 +615,13 @@ command_dispatcher(const rimeaddr_t *sender)
 }
 
 static void
-unicast_recv(struct unicast_conn *c, const rimeaddr_t *sender)
+unicast_recv(struct unicast_conn *c, const linkaddr_t *sender)
 {
   command_dispatcher(sender);
 }
 
 static void
-broadcast_recv(struct broadcast_conn *c, const rimeaddr_t *sender)
+broadcast_recv(struct broadcast_conn *c, const linkaddr_t *sender)
 {
   command_dispatcher(sender);
 }

--- a/apps/deluge/deluge.h
+++ b/apps/deluge/deluge.h
@@ -142,7 +142,7 @@ struct deluge_object {
   uint8_t current_page[S_PAGE];
   uint8_t tx_set;
   int cfs_fd;
-  rimeaddr_t summary_from;
+  linkaddr_t summary_from;
 };
 
 struct deluge_page {

--- a/apps/powertrace/powertrace.c
+++ b/apps/powertrace/powertrace.c
@@ -117,7 +117,7 @@ powertrace_print(char *str)
 
   printf("%s %lu P %d.%d %lu %lu %lu %lu %lu %lu %lu %lu %lu %lu %lu %lu %lu (radio %d.%02d%% / %d.%02d%% tx %d.%02d%% / %d.%02d%% listen %d.%02d%% / %d.%02d%%)\n",
          str,
-         clock_time(), rimeaddr_node_addr.u8[0], rimeaddr_node_addr.u8[1], seqno,
+         clock_time(), linkaddr_node_addr.u8[0], linkaddr_node_addr.u8[1], seqno,
          all_cpu, all_lpm, all_transmit, all_listen, all_idle_transmit, all_idle_listen,
          cpu, lpm, transmit, listen, idle_transmit, idle_listen,
          (int)((100L * (all_transmit + all_listen)) / all_time),
@@ -137,7 +137,7 @@ powertrace_print(char *str)
 
 #if ! UIP_CONF_IPV6
     printf("%s %lu SP %d.%d %lu %u %lu %lu %lu %lu %lu %lu %lu %lu %lu %lu (channel %d radio %d.%02d%% / %d.%02d%%)\n",
-           str, clock_time(), rimeaddr_node_addr.u8[0], rimeaddr_node_addr.u8[1], seqno,
+           str, clock_time(), linkaddr_node_addr.u8[0], linkaddr_node_addr.u8[1], seqno,
            s->channel,
            s->num_input, s->input_txtime, s->input_rxtime,
            s->input_txtime - s->last_input_txtime,
@@ -160,7 +160,7 @@ powertrace_print(char *str)
                  radio));
 #else
     printf("%s %lu SP %d.%d %lu %u %u %lu %lu %lu %lu %lu %lu %lu %lu %lu %lu (proto %u(%u) radio %d.%02d%% / %d.%02d%%)\n",
-           str, clock_time(), rimeaddr_node_addr.u8[0], rimeaddr_node_addr.u8[1], seqno,
+           str, clock_time(), linkaddr_node_addr.u8[0], linkaddr_node_addr.u8[1], seqno,
            s->proto, s->channel,
            s->num_input, s->input_txtime, s->input_rxtime,
            s->input_txtime - s->last_input_txtime,
@@ -287,7 +287,7 @@ output_sniffer(int mac_status)
 static void
 sniffprint(char *prefix, int seqno)
 {
-  const rimeaddr_t *sender, *receiver, *esender, *ereceiver;
+  const linkaddr_t *sender, *receiver, *esender, *ereceiver;
 
   sender = packetbuf_addr(PACKETBUF_ADDR_SENDER);
   receiver = packetbuf_addr(PACKETBUF_ADDR_RECEIVER);
@@ -298,7 +298,7 @@ sniffprint(char *prefix, int seqno)
   printf("%lu %s %d %u %d %d %d.%d %u %u\n",
          clock_time(),
          prefix,
-         rimeaddr_node_addr.u8[0], seqno,
+         linkaddr_node_addr.u8[0], seqno,
          packetbuf_attr(PACKETBUF_ATTR_CHANNEL),
          packetbuf_attr(PACKETBUF_ATTR_PACKET_TYPE),
          esender->u8[0], esender->u8[1],

--- a/apps/serial-shell/serial-shell.c
+++ b/apps/serial-shell/serial-shell.c
@@ -81,7 +81,7 @@ shell_default_output(const char *text1, int len1, const char *text2, int len2)
 void
 shell_prompt(char *str)
 {
-  printf("%d.%d: %s\r\n", rimeaddr_node_addr.u8[0], rimeaddr_node_addr.u8[1],
+  printf("%d.%d: %s\r\n", linkaddr_node_addr.u8[0], linkaddr_node_addr.u8[1],
 	 str);
 }
 /*---------------------------------------------------------------------------*/

--- a/apps/shell/shell-download.c
+++ b/apps/shell/shell-download.c
@@ -130,7 +130,7 @@ static const struct rucb_callbacks rucb_call = { write_chunk, read_chunk, timedo
 PROCESS_THREAD(shell_download_process, ev, data)
 {
   const char *nextptr;
-  static rimeaddr_t addr;
+  static linkaddr_t addr;
   int len;
   char buf[32];
 
@@ -185,7 +185,7 @@ PROCESS_THREAD(shell_download_process, ev, data)
 }
 /*---------------------------------------------------------------------------*/
 static void
-request_recv(struct runicast_conn *c, const rimeaddr_t *from, uint8_t seqno)
+request_recv(struct runicast_conn *c, const linkaddr_t *from, uint8_t seqno)
 {
   const char *filename;
   uint8_t seq;
@@ -224,14 +224,14 @@ request_recv(struct runicast_conn *c, const rimeaddr_t *from, uint8_t seqno)
 }
 /*---------------------------------------------------------------------------*/
 static void
-request_sent(struct runicast_conn *c, const rimeaddr_t *to,
+request_sent(struct runicast_conn *c, const linkaddr_t *to,
 	     uint8_t retransmissions)
 {
   process_poll(&shell_download_process);
 }
 /*---------------------------------------------------------------------------*/
 static void
-request_timedout(struct runicast_conn *c, const rimeaddr_t *to,
+request_timedout(struct runicast_conn *c, const linkaddr_t *to,
 		 uint8_t retransmissions)
 {
   shell_output_str(&download_command, "download: request timed out", "");

--- a/apps/shell/shell-netperf.c
+++ b/apps/shell/shell-netperf.c
@@ -76,7 +76,7 @@ enum {
 } datapath_commands;
 
 struct datapath_msg {
-  rimeaddr_t receiver;
+  linkaddr_t receiver;
   rtimer_clock_t tx, rx;
   uint8_t datapath_command;
   uint8_t received;
@@ -99,7 +99,7 @@ static struct broadcast_conn broadcast;
 static struct mesh_conn mesh;
 static struct rucb_conn rucb;
 
-static rimeaddr_t receiver;
+static linkaddr_t receiver;
 static uint8_t is_sender;
 static int left_to_send;
 
@@ -230,11 +230,11 @@ clear_stats(void)
 }
 /*---------------------------------------------------------------------------*/
 static void
-setup_sending(rimeaddr_t *to, int num)
+setup_sending(linkaddr_t *to, int num)
 {
   is_sender = 1;
   left_to_send = num;
-  rimeaddr_copy(&receiver, to);
+  linkaddr_copy(&receiver, to);
   clear_stats();
 }
 /*---------------------------------------------------------------------------*/
@@ -291,7 +291,7 @@ construct_next_packet(void)
 #else /* TIMESYNCH_CONF_ENABLED */
     msg->tx = msg->rx = 0;
 #endif /* TIMESYNCH_CONF_ENABLED */
-    rimeaddr_copy(&msg->receiver, &receiver);
+    linkaddr_copy(&msg->receiver, &receiver);
     left_to_send--;
     return 1;
   }
@@ -344,7 +344,7 @@ process_incoming_packet(void)
 }
 /*---------------------------------------------------------------------------*/
 static int
-construct_reply(const rimeaddr_t *from)
+construct_reply(const linkaddr_t *from)
 {
   struct datapath_msg *msg = packetbuf_dataptr();
 #if TIMESYNCH_CONF_ENABLED
@@ -390,7 +390,7 @@ timedout_mesh(struct mesh_conn *c)
   stats.timedout++;
 }
 static void
-recv_mesh(struct mesh_conn *c, const rimeaddr_t *from, uint8_t hops)
+recv_mesh(struct mesh_conn *c, const linkaddr_t *from, uint8_t hops)
 {
   process_incoming_packet();
   if(is_sender) {
@@ -407,18 +407,18 @@ const static struct mesh_callbacks mesh_callbacks =
   { recv_mesh, sent_mesh, timedout_mesh };
 /*---------------------------------------------------------------------------*/
 static void
-sent_ctrl(struct runicast_conn *c, const rimeaddr_t *to, uint8_t rexmits)
+sent_ctrl(struct runicast_conn *c, const linkaddr_t *to, uint8_t rexmits)
 {
   process_post(&shell_netperf_process, CONTINUE_EVENT, NULL);
 }
 static void
-timedout_ctrl(struct runicast_conn *c, const rimeaddr_t *to, uint8_t rexmits)
+timedout_ctrl(struct runicast_conn *c, const linkaddr_t *to, uint8_t rexmits)
 {
   shell_output_str(&netperf_command, "netperf control connection failed", "");
   process_exit(&shell_netperf_process);
 }
 static void
-recv_ctrl(struct runicast_conn *c, const rimeaddr_t *from, uint8_t seqno)
+recv_ctrl(struct runicast_conn *c, const linkaddr_t *from, uint8_t seqno)
 {
   static uint8_t last_seqno = -1;
   struct stats s;
@@ -450,7 +450,7 @@ const static struct runicast_callbacks runicast_callbacks =
   { recv_ctrl, sent_ctrl, timedout_ctrl };
 /*---------------------------------------------------------------------------*/
 static int
-send_ctrl_command(const rimeaddr_t *to, uint8_t command)
+send_ctrl_command(const linkaddr_t *to, uint8_t command)
 {
   struct ctrl_msg *msg;
   packetbuf_clear();
@@ -461,7 +461,7 @@ send_ctrl_command(const rimeaddr_t *to, uint8_t command)
 }
 /*---------------------------------------------------------------------------*/
 static void
-recv_broadcast(struct broadcast_conn *c, const rimeaddr_t *from)
+recv_broadcast(struct broadcast_conn *c, const linkaddr_t *from)
 {
   process_incoming_packet();
   if(is_sender) {
@@ -473,7 +473,7 @@ const static struct broadcast_callbacks broadcast_callbacks =
   { recv_broadcast };
 /*---------------------------------------------------------------------------*/
 static void
-recv_unicast(struct unicast_conn *c, const rimeaddr_t *from)
+recv_unicast(struct unicast_conn *c, const linkaddr_t *from)
 {
   process_incoming_packet();
   if(is_sender) {
@@ -517,7 +517,7 @@ shell_netperf_init(void)
 PROCESS_THREAD(shell_netperf_process, ev, data)
 {
   static struct etimer e;
-  static rimeaddr_t receiver;
+  static linkaddr_t receiver;
   const char *nextptr;
   const char *args;
   static char recvstr[40];

--- a/apps/shell/shell-rime-debug-runicast.c
+++ b/apps/shell/shell-rime-debug-runicast.c
@@ -74,7 +74,7 @@ SHELL_COMMAND(runicast_command,
 PROCESS_THREAD(shell_runicast_process, ev, data)
 {
   struct shell_input *input;
-  static rimeaddr_t receiver;
+  static linkaddr_t receiver;
   int len;
   const char *nextptr;
   struct collect_msg *msg;
@@ -122,7 +122,7 @@ PROCESS_THREAD(shell_runicast_process, ev, data)
   PROCESS_END();
 }
 static void
-recv_ruc(struct runicast_conn *c, const rimeaddr_t *from, uint8_t seqno)
+recv_ruc(struct runicast_conn *c, const linkaddr_t *from, uint8_t seqno)
 {
   struct collect_msg *msg;
   rtimer_clock_t latency;
@@ -147,14 +147,14 @@ recv_ruc(struct runicast_conn *c, const rimeaddr_t *from, uint8_t seqno)
 	 msg->data);
 }
 static void
-sent_ruc(struct runicast_conn *c, const rimeaddr_t *to, uint8_t tx)
+sent_ruc(struct runicast_conn *c, const linkaddr_t *to, uint8_t tx)
 {
   printf("runicast message sent to %d.%d, %d transmissions\n",
 	 to->u8[0], to->u8[1],
 	 tx);
 }
 static void
-timedout_ruc(struct runicast_conn *c, const rimeaddr_t *to, uint8_t tx)
+timedout_ruc(struct runicast_conn *c, const linkaddr_t *to, uint8_t tx)
 {
   printf("runicast message to %d.%d timed out after %d transmissions\n",
 	 to->u8[0], to->u8[1],

--- a/apps/shell/shell-rime-debug.c
+++ b/apps/shell/shell-rime-debug.c
@@ -114,7 +114,7 @@ PROCESS_THREAD(shell_broadcast_process, ev, data)
   PROCESS_END();
 }
 static void
-recv_broadcast(struct broadcast_conn *c, const rimeaddr_t *from)
+recv_broadcast(struct broadcast_conn *c, const linkaddr_t *from)
 {
   struct collect_msg *msg;
   rtimer_clock_t latency;
@@ -138,7 +138,7 @@ static const struct broadcast_callbacks broadcast_callbacks = {recv_broadcast};
 PROCESS_THREAD(shell_unicast_process, ev, data)
 {
   struct shell_input *input;
-  static rimeaddr_t receiver;
+  static linkaddr_t receiver;
   int len;
   const char *nextptr;
   struct collect_msg *msg;
@@ -186,7 +186,7 @@ PROCESS_THREAD(shell_unicast_process, ev, data)
   PROCESS_END();
 }
 static void
-recv_uc(struct unicast_conn *c, const rimeaddr_t *from)
+recv_uc(struct unicast_conn *c, const linkaddr_t *from)
 {
   struct collect_msg *msg;
   rtimer_clock_t latency;

--- a/apps/shell/shell-rime-neighbors.c
+++ b/apps/shell/shell-rime-neighbors.c
@@ -51,7 +51,7 @@ static uint8_t listening_for_neighbors = 0;
 
 /*---------------------------------------------------------------------------*/
 static void
-received_announcement(struct announcement *a, const rimeaddr_t *from,
+received_announcement(struct announcement *a, const linkaddr_t *from,
 		      uint16_t id, uint16_t value)
 {
   struct {
@@ -64,7 +64,7 @@ received_announcement(struct announcement *a, const rimeaddr_t *from,
   if(listening_for_neighbors) {
     memset(&msg, 0, sizeof(msg));
     msg.len = 3;
-    rimeaddr_copy((rimeaddr_t *)&msg.addr, from);
+    linkaddr_copy((linkaddr_t *)&msg.addr, from);
     msg.rssi = packetbuf_attr(PACKETBUF_ATTR_RSSI);
     msg.lqi = packetbuf_attr(PACKETBUF_ATTR_LINK_QUALITY);
     shell_output(&neighbors_command, &msg, sizeof(msg), "", 0);

--- a/apps/shell/shell-rime-ping.c
+++ b/apps/shell/shell-rime-ping.c
@@ -66,7 +66,7 @@ PROCESS_THREAD(shell_rime_ping_process, ev, data)
 {
   static int i;
   static struct etimer timeout, periodic;
-  static rimeaddr_t receiver;
+  static linkaddr_t receiver;
   struct rime_ping_msg *ping;
   const char *nextptr;
   char buf[32];
@@ -122,7 +122,7 @@ sent_mesh(struct mesh_conn *c)
 {
 }
 static void
-recv_mesh(struct mesh_conn *c, const rimeaddr_t *from, uint8_t hops)
+recv_mesh(struct mesh_conn *c, const linkaddr_t *from, uint8_t hops)
 {
   struct rime_ping_msg ping;
   char buf[64];

--- a/apps/shell/shell-rime-sendcmd.c
+++ b/apps/shell/shell-rime-sendcmd.c
@@ -95,7 +95,7 @@ PROCESS_THREAD(shell_sendcmd_process, ev, data)
 {
   struct cmd_msg  *msg;
   int len;
-  rimeaddr_t addr;
+  linkaddr_t addr;
   const char *nextptr;
   char buf[32];
 
@@ -141,7 +141,7 @@ PROCESS_THREAD(shell_sendcmd_process, ev, data)
 }
 /*---------------------------------------------------------------------------*/
 static void
-recv_uc(struct unicast_conn *c, const rimeaddr_t *from)
+recv_uc(struct unicast_conn *c, const linkaddr_t *from)
 {
   struct cmd_msg *msg;
   uint16_t crc;

--- a/apps/shell/shell-rime-sniff.c
+++ b/apps/shell/shell-rime-sniff.c
@@ -65,7 +65,7 @@ struct sniff_attributes_blob {
   uint16_t listen_time;
   uint16_t transmit_time;
   uint16_t channel;
-  rimeaddr_t src, dest;
+  linkaddr_t src, dest;
 };
 struct sniff_packet_blob {
   uint16_t len;
@@ -84,8 +84,8 @@ sniff_attributes_output(int type)
   msg.listen_time = packetbuf_attr(PACKETBUF_ATTR_LISTEN_TIME);
   msg.transmit_time = packetbuf_attr(PACKETBUF_ATTR_TRANSMIT_TIME);
   msg.channel = packetbuf_attr(PACKETBUF_ATTR_CHANNEL);
-  rimeaddr_copy(&msg.src, packetbuf_addr(PACKETBUF_ADDR_SENDER));
-  rimeaddr_copy(&msg.dest, packetbuf_addr(PACKETBUF_ADDR_RECEIVER));
+  linkaddr_copy(&msg.src, packetbuf_addr(PACKETBUF_ADDR_SENDER));
+  linkaddr_copy(&msg.dest, packetbuf_addr(PACKETBUF_ADDR_RECEIVER));
   
   shell_output(&sniff_command, &msg, sizeof(msg), NULL, 0);
 }

--- a/apps/shell/shell-rime-unicast.c
+++ b/apps/shell/shell-rime-unicast.c
@@ -81,7 +81,7 @@ SHELL_COMMAND(unicast_recv_command,
 PROCESS_THREAD(shell_unicast_send_process, ev, data)
 {
   struct shell_input *input;
-  static rimeaddr_t receiver;
+  static linkaddr_t receiver;
   int len;
   const char *nextptr;
   struct unicast_msg *msg;
@@ -131,7 +131,7 @@ PROCESS_THREAD(shell_unicast_send_process, ev, data)
 }
 /*---------------------------------------------------------------------------*/
 static void
-recv_uc(struct unicast_conn *c, const rimeaddr_t *from)
+recv_uc(struct unicast_conn *c, const linkaddr_t *from)
 {
   struct unicast_msg *msg;
 #define OUTPUT_BLOB_HDRSIZE 6
@@ -153,7 +153,7 @@ recv_uc(struct unicast_conn *c, const rimeaddr_t *from)
 #else
   output_blob.latency = 0;
 #endif
-  rimeaddr_copy((rimeaddr_t *)&output_blob.from, from);
+  linkaddr_copy((linkaddr_t *)&output_blob.from, from);
   memcpy(output_blob.data, msg->data, packetbuf_datalen() - UNICAST_MSG_HDRSIZE);
   output_blob.len = 2 + (packetbuf_datalen() - UNICAST_MSG_HDRSIZE) / 2;
   shell_output(&unicast_recv_command, &output_blob,

--- a/apps/shell/shell-rime.c
+++ b/apps/shell/shell-rime.c
@@ -200,8 +200,8 @@ PROCESS_THREAD(shell_routes_process, ev, data)
   msg.len = 4;
   for(i = 0; i < route_num(); ++i) {
     r = route_get(i);
-    rimeaddr_copy((rimeaddr_t *)&msg.dest, &r->dest);
-    rimeaddr_copy((rimeaddr_t *)&msg.nexthop, &r->nexthop);
+    linkaddr_copy((linkaddr_t *)&msg.dest, &r->dest);
+    linkaddr_copy((linkaddr_t *)&msg.nexthop, &r->nexthop);
     msg.hop_count = r->cost;
     msg.seqno = r->seqno;
     shell_output(&routes_command, &msg, sizeof(msg), "", 0);
@@ -292,7 +292,7 @@ PROCESS_THREAD(shell_send_process, ev, data)
 }
 /*---------------------------------------------------------------------------*/
 static void
-recv_collect(const rimeaddr_t *originator, uint8_t seqno, uint8_t hops)
+recv_collect(const linkaddr_t *originator, uint8_t seqno, uint8_t hops)
 {
   struct collect_msg collect_msg;
   char *dataptr;
@@ -323,7 +323,7 @@ recv_collect(const rimeaddr_t *originator, uint8_t seqno, uint8_t hops)
 
       if(collect_msg.crc == crc16_data(dataptr, len, 0)) {
 	msg.len = 5 + (packetbuf_datalen() - COLLECT_MSG_HDRSIZE) / 2;
-	rimeaddr_copy((rimeaddr_t *)&msg.originator, originator);
+	linkaddr_copy((linkaddr_t *)&msg.originator, originator);
 	msg.seqno = seqno;
 	msg.hops = hops;
 	msg.latency = latency;

--- a/apps/shell/shell-rsh.c
+++ b/apps/shell/shell-rsh.c
@@ -65,7 +65,7 @@ PROCESS(shell_rsh_server_process, "rsh server");
 /*---------------------------------------------------------------------------*/
 PROCESS_THREAD(shell_rsh_process, ev, data)
 {
-  static rimeaddr_t receiver;
+  static linkaddr_t receiver;
   struct shell_input *input;
   const char *nextptr;
   char buf[40];

--- a/apps/shell/shell-sendtest.c
+++ b/apps/shell/shell-sendtest.c
@@ -115,7 +115,7 @@ print_usage(void)
 /*---------------------------------------------------------------------------*/
 PROCESS_THREAD(shell_sendtest_process, ev, data)
 {
-  static rimeaddr_t receiver;
+  static linkaddr_t receiver;
   static unsigned long cpu, lpm, rx, tx;
   const char *nextptr;
   const char *args;

--- a/core/dev/slip.c
+++ b/core/dev/slip.c
@@ -192,7 +192,7 @@ slip_poll_handler(uint8_t *outbuf, uint16_t blen)
       
       rxbuf_init();
       
-      rimeaddr_t addr = get_mac_addr();
+      linkaddr_t addr = get_mac_addr();
       /* this is just a test so far... just to see if it works */
       slip_arch_writeb('!');
       slip_arch_writeb('M');

--- a/core/lib/print-stats.c
+++ b/core/lib/print-stats.c
@@ -57,7 +57,7 @@ print_stats(void)
 {
 #if RIMESTATS_CONF_ENABLED
   PRINTA("S %d.%d clock %lu tx %lu rx %lu rtx %lu rrx %lu rexmit %lu acktx %lu noacktx %lu ackrx %lu timedout %lu badackrx %lu toolong %lu tooshort %lu badsynch %lu badcrc %lu contentiondrop %lu sendingdrop %lu lltx %lu llrx %lu\n",
-	 rimeaddr_node_addr.u8[0], rimeaddr_node_addr.u8[1],
+	 linkaddr_node_addr.u8[0], linkaddr_node_addr.u8[1],
 	 clock_seconds(),
 	 RIMESTATS_GET(tx), RIMESTATS_GET(rx),
 	 RIMESTATS_GET(reliabletx), RIMESTATS_GET(reliablerx),
@@ -70,7 +70,7 @@ print_stats(void)
 #endif /* RIMESTATS_CONF_ENABLED */
 #if ENERGEST_CONF_ON
   PRINTA("E %d.%d clock %lu cpu %lu lpm %lu irq %lu gled %lu yled %lu rled %lu tx %lu listen %lu sensors %lu serial %lu\n",
-	 rimeaddr_node_addr.u8[0], rimeaddr_node_addr.u8[1],
+	 linkaddr_node_addr.u8[0], linkaddr_node_addr.u8[1],
 	 clock_seconds(),
 	 energest_total_time[ENERGEST_TYPE_CPU].current,
 	 energest_total_time[ENERGEST_TYPE_LPM].current,

--- a/core/net/ipv4/uip-over-mesh.h
+++ b/core/net/ipv4/uip-over-mesh.h
@@ -48,7 +48,7 @@ void uip_over_mesh_init(uint16_t channels);
 uint8_t uip_over_mesh_send(void);
 
 void uip_over_mesh_set_gateway_netif(struct uip_fw_netif *netif);
-void uip_over_mesh_set_gateway(rimeaddr_t *gw);
+void uip_over_mesh_set_gateway(linkaddr_t *gw);
 void uip_over_mesh_set_net(uip_ipaddr_t *addr, uip_ipaddr_t *mask);
 
 void uip_over_mesh_make_announced_gateway(void);

--- a/core/net/ipv6/sicslowpan.c
+++ b/core/net/ipv6/sicslowpan.c
@@ -244,7 +244,7 @@ static uint16_t my_tag;
 static uint16_t reass_tag;
 
 /** When reassembling, the source address of the fragments being merged */
-rimeaddr_t frag_sender;
+linkaddr_t frag_sender;
 
 /** Reassembly %process %timer. */
 static struct timer reass_timer;
@@ -488,7 +488,7 @@ uncompress_addr(uip_ipaddr_t *ipaddr, uint8_t const prefix[],
  * dest
  */
 static void
-compress_hdr_hc06(rimeaddr_t *rime_destaddr)
+compress_hdr_hc06(linkaddr_t *rime_destaddr)
 {
   uint8_t tmp, iphc0, iphc1;
 #if DEBUG
@@ -1076,7 +1076,7 @@ uncompress_hdr_hc06(uint16_t ip_len)
  * IP destination field
  */
 static void
-compress_hdr_hc1(rimeaddr_t *rime_destaddr)
+compress_hdr_hc1(linkaddr_t *rime_destaddr)
 {
   /*
    * Check if all the assumptions for full compression
@@ -1286,7 +1286,7 @@ uncompress_hdr_hc1(uint16_t ip_len)
  * \endverbatim
  */
 static void
-compress_hdr_ipv6(rimeaddr_t *rime_destaddr)
+compress_hdr_ipv6(linkaddr_t *rime_destaddr)
 {
   *rime_ptr = SICSLOWPAN_DISPATCH_IPV6;
   rime_hdr_len += SICSLOWPAN_IPV6_HDR_LEN;
@@ -1321,7 +1321,7 @@ packet_sent(void *ptr, int status, int transmissions)
  * \param dest the link layer destination address of the packet
  */
 static void
-send_packet(rimeaddr_t *dest)
+send_packet(linkaddr_t *dest)
 {
   /* Set the link layer destination address for the packet as a
    * packetbuf attribute. The MAC layer can access the destination
@@ -1363,7 +1363,7 @@ output(const uip_lladdr_t *localdest)
   int framer_hdrlen;
 
   /* The MAC address of the destination of the packet */
-  rimeaddr_t dest;
+  linkaddr_t dest;
 
   /* Number of bytes processed. */
   uint16_t processed_ip_out_len;
@@ -1406,9 +1406,9 @@ output(const uip_lladdr_t *localdest)
    * broadcast packet.
    */
   if(localdest == NULL) {
-    rimeaddr_copy(&dest, &rimeaddr_null);
+    linkaddr_copy(&dest, &linkaddr_null);
   } else {
-    rimeaddr_copy(&dest, (const rimeaddr_t *)localdest);
+    linkaddr_copy(&dest, (const linkaddr_t *)localdest);
   }
   
   PRINTFO("sicslowpan output: sending packet len %d\n", uip_len);
@@ -1677,7 +1677,7 @@ input(void)
     sicslowpan_len = 0;
     processed_ip_in_len = 0;
   } else if(processed_ip_in_len > 0 && first_fragment
-      && !rimeaddr_cmp(&frag_sender, packetbuf_addr(PACKETBUF_ADDR_SENDER))) {
+      && !linkaddr_cmp(&frag_sender, packetbuf_addr(PACKETBUF_ADDR_SENDER))) {
     sicslowpan_len = 0;
     processed_ip_in_len = 0;
   }
@@ -1689,7 +1689,7 @@ input(void)
     if((frag_size > 0 &&
         (frag_size != sicslowpan_len ||
          reass_tag  != frag_tag ||
-         !rimeaddr_cmp(&frag_sender, packetbuf_addr(PACKETBUF_ADDR_SENDER))))  ||
+         !linkaddr_cmp(&frag_sender, packetbuf_addr(PACKETBUF_ADDR_SENDER))))  ||
        frag_size == 0) {
       /*
        * the packet is a fragment that does not belong to the packet
@@ -1715,7 +1715,7 @@ input(void)
       timer_set(&reass_timer, SICSLOWPAN_REASS_MAXAGE * CLOCK_SECOND / 16);
       PRINTFI("sicslowpan input: INIT FRAGMENTATION (len %d, tag %d)\n",
              sicslowpan_len, reass_tag);
-      rimeaddr_copy(&frag_sender, packetbuf_addr(PACKETBUF_ADDR_SENDER));
+      linkaddr_copy(&frag_sender, packetbuf_addr(PACKETBUF_ADDR_SENDER));
     }
   }
 

--- a/core/net/ipv6/uip-ds6-nbr.c
+++ b/core/net/ipv6/uip-ds6-nbr.c
@@ -47,7 +47,7 @@
 #include <stdlib.h>
 #include <stddef.h>
 #include "lib/list.h"
-#include "net/rimeaddr.h"
+#include "net/linkaddr.h"
 #include "net/packetbuf.h"
 #include "net/ipv6/uip-ds6-nbr.h"
 
@@ -63,7 +63,7 @@ void NEIGHBOR_STATE_CHANGED(uip_ds6_nbr_t *n);
 
 #ifdef UIP_CONF_DS6_LINK_NEIGHBOR_CALLBACK
 #define LINK_NEIGHBOR_CALLBACK(addr, status, numtx) UIP_CONF_DS6_LINK_NEIGHBOR_CALLBACK(addr, status, numtx)
-void LINK_NEIGHBOR_CALLBACK(const rimeaddr_t *addr, int status, int numtx);
+void LINK_NEIGHBOR_CALLBACK(const linkaddr_t *addr, int status, int numtx);
 #else
 #define LINK_NEIGHBOR_CALLBACK(addr, status, numtx)
 #endif /* UIP_CONF_DS6_LINK_NEIGHBOR_CALLBACK */
@@ -81,7 +81,7 @@ uip_ds6_nbr_t *
 uip_ds6_nbr_add(const uip_ipaddr_t *ipaddr, const uip_lladdr_t *lladdr,
                 uint8_t isrouter, uint8_t state)
 {
-  uip_ds6_nbr_t *nbr = nbr_table_add_lladdr(ds6_neighbors, (rimeaddr_t*)lladdr);
+  uip_ds6_nbr_t *nbr = nbr_table_add_lladdr(ds6_neighbors, (linkaddr_t*)lladdr);
   if(nbr) {
     uip_ipaddr_copy(&nbr->ipaddr, ipaddr);
     nbr->isrouter = isrouter;
@@ -171,7 +171,7 @@ uip_ds6_nbr_lookup(const uip_ipaddr_t *ipaddr)
 uip_ds6_nbr_t *
 uip_ds6_nbr_ll_lookup(const uip_lladdr_t *lladdr)
 {
-  return nbr_table_get_from_lladdr(ds6_neighbors, (rimeaddr_t*)lladdr);
+  return nbr_table_get_from_lladdr(ds6_neighbors, (linkaddr_t*)lladdr);
 }
 
 /*---------------------------------------------------------------------------*/
@@ -193,8 +193,8 @@ uip_ds6_nbr_lladdr_from_ipaddr(const uip_ipaddr_t *ipaddr)
 void
 uip_ds6_link_neighbor_callback(int status, int numtx)
 {
-  const rimeaddr_t *dest = packetbuf_addr(PACKETBUF_ADDR_RECEIVER);
-  if(rimeaddr_cmp(dest, &rimeaddr_null)) {
+  const linkaddr_t *dest = packetbuf_addr(PACKETBUF_ADDR_RECEIVER);
+  if(linkaddr_cmp(dest, &linkaddr_null)) {
     return;
   }
 

--- a/core/net/ipv6/uip-ds6-route.c
+++ b/core/net/ipv6/uip-ds6-route.c
@@ -297,7 +297,7 @@ uip_ds6_route_add(uip_ipaddr_t *ipaddr, uint8_t length,
        list.
     */
     routes = nbr_table_get_from_lladdr(nbr_routes,
-                                       (rimeaddr_t *)nexthop_lladdr);
+                                       (linkaddr_t *)nexthop_lladdr);
 
     if(routes == NULL) {
       /* If the neighbor did not have an entry in our neighbor table,
@@ -306,7 +306,7 @@ uip_ds6_route_add(uip_ipaddr_t *ipaddr, uint8_t length,
          initialize this pointer with the list of routing entries that
          are attached to this neighbor. */
       routes = nbr_table_add_lladdr(nbr_routes,
-                                    (rimeaddr_t *)nexthop_lladdr);
+                                    (linkaddr_t *)nexthop_lladdr);
       if(routes == NULL) {
         /* This should not happen, as we explicitly deallocated one
            route table entry above. */
@@ -478,7 +478,7 @@ uip_ds6_route_rm_by_nexthop(uip_ipaddr_t *nexthop)
 
   nexthop_lladdr = uip_ds6_nbr_lladdr_from_ipaddr(nexthop);
   routes = nbr_table_get_from_lladdr(nbr_routes,
-                                     (rimeaddr_t *)nexthop_lladdr);
+                                     (linkaddr_t *)nexthop_lladdr);
   rm_routelist(routes);
 }
 /*---------------------------------------------------------------------------*/

--- a/core/net/linkaddr.c
+++ b/core/net/linkaddr.c
@@ -1,5 +1,5 @@
 /**
- * \addtogroup rimeaddr
+ * \addtogroup linkaddr
  * @{
  */
 
@@ -42,36 +42,36 @@
  *         Adam Dunkels <adam@sics.se>
  */
 
-#include "net/rimeaddr.h"
+#include "net/linkaddr.h"
 #include <string.h>
 
-rimeaddr_t rimeaddr_node_addr;
-#if RIMEADDR_SIZE == 2
-const rimeaddr_t rimeaddr_null = { { 0, 0 } };
-#else /*RIMEADDR_SIZE == 2*/
-#if RIMEADDR_SIZE == 8
-const rimeaddr_t rimeaddr_null = { { 0, 0, 0, 0, 0, 0, 0, 0 } };
-#endif /*RIMEADDR_SIZE == 8*/
-#endif /*RIMEADDR_SIZE == 2*/
+linkaddr_t linkaddr_node_addr;
+#if LINKADDR_SIZE == 2
+const linkaddr_t linkaddr_null = { { 0, 0 } };
+#else /*LINKADDR_SIZE == 2*/
+#if LINKADDR_SIZE == 8
+const linkaddr_t linkaddr_null = { { 0, 0, 0, 0, 0, 0, 0, 0 } };
+#endif /*LINKADDR_SIZE == 8*/
+#endif /*LINKADDR_SIZE == 2*/
 
 
 /*---------------------------------------------------------------------------*/
 void
-rimeaddr_copy(rimeaddr_t *dest, const rimeaddr_t *src)
+linkaddr_copy(linkaddr_t *dest, const linkaddr_t *src)
 {
-	memcpy(dest, src, RIMEADDR_SIZE);
+	memcpy(dest, src, LINKADDR_SIZE);
 }
 /*---------------------------------------------------------------------------*/
 int
-rimeaddr_cmp(const rimeaddr_t *addr1, const rimeaddr_t *addr2)
+linkaddr_cmp(const linkaddr_t *addr1, const linkaddr_t *addr2)
 {
-	return (memcmp(addr1, addr2, RIMEADDR_SIZE) == 0);
+	return (memcmp(addr1, addr2, LINKADDR_SIZE) == 0);
 }
 /*---------------------------------------------------------------------------*/
 void
-rimeaddr_set_node_addr(rimeaddr_t *t)
+linkaddr_set_node_addr(linkaddr_t *t)
 {
-  rimeaddr_copy(&rimeaddr_node_addr, t);
+  linkaddr_copy(&linkaddr_node_addr, t);
 }
 /*---------------------------------------------------------------------------*/
 /** @} */

--- a/core/net/linkaddr.h
+++ b/core/net/linkaddr.h
@@ -4,10 +4,10 @@
  */
 
 /**
- * \defgroup rimeaddr Rime addresses
+ * \defgroup linkaddr Rime addresses
  * @{
  *
- * The rimeaddr module is an abstract representation of addresses in
+ * The linkaddr module is an abstract representation of addresses in
  * Rime.
  *
  */
@@ -51,20 +51,20 @@
  *         Adam Dunkels <adam@sics.se>
  */
 
-#ifndef RIMEADDR_H_
-#define RIMEADDR_H_
+#ifndef LINKADDR_H_
+#define LINKADDR_H_
 
 #include "contiki-conf.h"
 
-#ifdef RIMEADDR_CONF_SIZE
-#define RIMEADDR_SIZE RIMEADDR_CONF_SIZE
-#else /* RIMEADDR_SIZE */
-#define RIMEADDR_SIZE 2
-#endif /* RIMEADDR_SIZE */
+#ifdef LINKADDR_CONF_SIZE
+#define LINKADDR_SIZE LINKADDR_CONF_SIZE
+#else /* LINKADDR_SIZE */
+#define LINKADDR_SIZE 2
+#endif /* LINKADDR_SIZE */
 
 typedef union {
-  unsigned char u8[RIMEADDR_SIZE];
-} rimeaddr_t;
+  unsigned char u8[LINKADDR_SIZE];
+} linkaddr_t;
 
 
 /**
@@ -76,7 +76,7 @@ typedef union {
  *             to another.
  *
  */
-void rimeaddr_copy(rimeaddr_t *dest, const rimeaddr_t *from);
+void linkaddr_copy(linkaddr_t *dest, const linkaddr_t *from);
 
 /**
  * \brief      Compare two Rime addresses
@@ -90,7 +90,7 @@ void rimeaddr_copy(rimeaddr_t *dest, const rimeaddr_t *from);
  *             are the same, and zero if the addresses are different.
  *
  */
-int rimeaddr_cmp(const rimeaddr_t *addr1, const rimeaddr_t *addr2);
+int linkaddr_cmp(const linkaddr_t *addr1, const linkaddr_t *addr2);
 
 
 /**
@@ -100,18 +100,18 @@ int rimeaddr_cmp(const rimeaddr_t *addr1, const rimeaddr_t *addr2);
  *             This function sets the Rime address of the node.
  *
  */
-void rimeaddr_set_node_addr(rimeaddr_t *addr);
+void linkaddr_set_node_addr(linkaddr_t *addr);
 
 /**
  * \brief      The Rime address of the node
  *
  *             This variable contains the Rime address of the
  *             node. This variable should not be changed directly;
- *             rather, the rimeaddr_set_node_addr() function should be
+ *             rather, the linkaddr_set_node_addr() function should be
  *             used.
  *
  */
-extern rimeaddr_t rimeaddr_node_addr;
+extern linkaddr_t linkaddr_node_addr;
 
 /**
  * \brief      The null Rime address
@@ -124,8 +124,8 @@ extern rimeaddr_t rimeaddr_node_addr;
  *             with other nodes.
  *
  */
-extern const rimeaddr_t rimeaddr_null;
+extern const linkaddr_t linkaddr_null;
 
-#endif /* RIMEADDR_H_ */
+#endif /* LINKADDR_H_ */
 /** @} */
 /** @} */

--- a/core/net/mac/contikimac/contikimac.c
+++ b/core/net/mac/contikimac/contikimac.c
@@ -554,9 +554,9 @@ send_packet(mac_callback_t mac_callback, void *mac_callback_ptr,
 
 #if !NETSTACK_CONF_BRIDGE_MODE
   /* If NETSTACK_CONF_BRIDGE_MODE is set, assume PACKETBUF_ADDR_SENDER is already set. */
-  packetbuf_set_addr(PACKETBUF_ADDR_SENDER, &rimeaddr_node_addr);
+  packetbuf_set_addr(PACKETBUF_ADDR_SENDER, &linkaddr_node_addr);
 #endif
-  if(rimeaddr_cmp(packetbuf_addr(PACKETBUF_ADDR_RECEIVER), &rimeaddr_null)) {
+  if(linkaddr_cmp(packetbuf_addr(PACKETBUF_ADDR_RECEIVER), &linkaddr_null)) {
     is_broadcast = 1;
     PRINTDEBUG("contikimac: send broadcast\n");
 
@@ -950,10 +950,10 @@ input_packet(void)
 
     if(packetbuf_datalen() > 0 &&
        packetbuf_totlen() > 0 &&
-       (rimeaddr_cmp(packetbuf_addr(PACKETBUF_ADDR_RECEIVER),
-                     &rimeaddr_node_addr) ||
-        rimeaddr_cmp(packetbuf_addr(PACKETBUF_ADDR_RECEIVER),
-                     &rimeaddr_null))) {
+       (linkaddr_cmp(packetbuf_addr(PACKETBUF_ADDR_RECEIVER),
+                     &linkaddr_node_addr) ||
+        linkaddr_cmp(packetbuf_addr(PACKETBUF_ADDR_RECEIVER),
+                     &linkaddr_null))) {
       /* This is a regular packet that is destined to us or to the
          broadcast address. */
 

--- a/core/net/mac/csma.c
+++ b/core/net/mac/csma.c
@@ -94,7 +94,7 @@ struct qbuf_metadata {
 /* Every neighbor has its own packet queue */
 struct neighbor_queue {
   struct neighbor_queue *next;
-  rimeaddr_t addr;
+  linkaddr_t addr;
   struct ctimer transmit_timer;
   uint8_t transmissions;
   uint8_t collisions, deferrals;
@@ -119,11 +119,11 @@ static void transmit_packet_list(void *ptr);
 
 /*---------------------------------------------------------------------------*/
 static struct neighbor_queue *
-neighbor_queue_from_addr(const rimeaddr_t *addr)
+neighbor_queue_from_addr(const linkaddr_t *addr)
 {
   struct neighbor_queue *n = list_head(neighbor_list);
   while(n != NULL) {
-    if(rimeaddr_cmp(&n->addr, addr)) {
+    if(linkaddr_cmp(&n->addr, addr)) {
       return n;
     }
     n = list_item_next(n);
@@ -308,7 +308,7 @@ send_packet(mac_callback_t sent, void *ptr)
   struct neighbor_queue *n;
   static uint8_t initialized = 0;
   static uint16_t seqno;
-  const rimeaddr_t *addr = packetbuf_addr(PACKETBUF_ADDR_RECEIVER);
+  const linkaddr_t *addr = packetbuf_addr(PACKETBUF_ADDR_RECEIVER);
 
   if(!initialized) {
     initialized = 1;
@@ -330,7 +330,7 @@ send_packet(mac_callback_t sent, void *ptr)
     n = memb_alloc(&neighbor_memb);
     if(n != NULL) {
       /* Init neighbor entry */
-      rimeaddr_copy(&n->addr, addr);
+      linkaddr_copy(&n->addr, addr);
       n->transmissions = 0;
       n->collisions = 0;
       n->deferrals = 0;

--- a/core/net/mac/frame802154.c
+++ b/core/net/mac/frame802154.c
@@ -290,7 +290,7 @@ frame802154_parse(uint8_t *data, int len, frame802154_t *pf)
 /*     } */
 /*     p += l; */
     if(fcf.dest_addr_mode == FRAME802154_SHORTADDRMODE) {
-      rimeaddr_copy((rimeaddr_t *)&(pf->dest_addr), &rimeaddr_null);
+      linkaddr_copy((linkaddr_t *)&(pf->dest_addr), &linkaddr_null);
       pf->dest_addr[0] = p[1];
       pf->dest_addr[1] = p[0];
       p += 2;
@@ -301,7 +301,7 @@ frame802154_parse(uint8_t *data, int len, frame802154_t *pf)
       p += 8;
     }
   } else {
-    rimeaddr_copy((rimeaddr_t *)&(pf->dest_addr), &rimeaddr_null);
+    linkaddr_copy((linkaddr_t *)&(pf->dest_addr), &linkaddr_null);
     pf->dest_pid = 0;
   }
 
@@ -322,7 +322,7 @@ frame802154_parse(uint8_t *data, int len, frame802154_t *pf)
 /*     } */
 /*     p += l; */
     if(fcf.src_addr_mode == FRAME802154_SHORTADDRMODE) {
-      rimeaddr_copy((rimeaddr_t *)&(pf->src_addr), &rimeaddr_null);
+      linkaddr_copy((linkaddr_t *)&(pf->src_addr), &linkaddr_null);
       pf->src_addr[0] = p[1];
       pf->src_addr[1] = p[0];
       p += 2;
@@ -333,7 +333,7 @@ frame802154_parse(uint8_t *data, int len, frame802154_t *pf)
       p += 8;
     }
   } else {
-    rimeaddr_copy((rimeaddr_t *)&(pf->src_addr), &rimeaddr_null);
+    linkaddr_copy((linkaddr_t *)&(pf->src_addr), &linkaddr_null);
     pf->src_pid = 0;
   }
 

--- a/core/net/mac/frame802154.h
+++ b/core/net/mac/frame802154.h
@@ -62,7 +62,7 @@
 #define FRAME_802154_H
 
 #include "contiki-conf.h"
-#include "net/rimeaddr.h"
+#include "net/linkaddr.h"
 
 #ifdef IEEE802154_CONF_PANID
 #define IEEE802154_PANID           IEEE802154_CONF_PANID

--- a/core/net/mac/framer-802154.c
+++ b/core/net/mac/framer-802154.c
@@ -104,7 +104,7 @@ create(void)
   params.fcf.frame_type = FRAME802154_DATAFRAME;
   params.fcf.security_enabled = 0;
   params.fcf.frame_pending = packetbuf_attr(PACKETBUF_ATTR_PENDING);
-  if(rimeaddr_cmp(packetbuf_addr(PACKETBUF_ADDR_RECEIVER), &rimeaddr_null)) {
+  if(linkaddr_cmp(packetbuf_addr(PACKETBUF_ADDR_RECEIVER), &linkaddr_null)) {
     params.fcf.ack_required = 0;
   } else {
     params.fcf.ack_required = packetbuf_attr(PACKETBUF_ATTR_MAC_ACK);
@@ -128,8 +128,8 @@ create(void)
      \todo For phase 1 the addresses are all long. We'll need a mechanism
      in the rime attributes to tell the mac to use long or short for phase 2.
   */
-  if(sizeof(rimeaddr_t) == 2) {
-    /* Use short address mode if rimeaddr size is short. */
+  if(sizeof(linkaddr_t) == 2) {
+    /* Use short address mode if linkaddr size is short. */
     params.fcf.src_addr_mode = FRAME802154_SHORTADDRMODE;
   } else {
     params.fcf.src_addr_mode = FRAME802154_LONGADDRMODE;
@@ -140,17 +140,17 @@ create(void)
    *  If the output address is NULL in the Rime buf, then it is broadcast
    *  on the 802.15.4 network.
    */
-  if(rimeaddr_cmp(packetbuf_addr(PACKETBUF_ADDR_RECEIVER), &rimeaddr_null)) {
+  if(linkaddr_cmp(packetbuf_addr(PACKETBUF_ADDR_RECEIVER), &linkaddr_null)) {
     /* Broadcast requires short address mode. */
     params.fcf.dest_addr_mode = FRAME802154_SHORTADDRMODE;
     params.dest_addr[0] = 0xFF;
     params.dest_addr[1] = 0xFF;
 
   } else {
-    rimeaddr_copy((rimeaddr_t *)&params.dest_addr,
+    linkaddr_copy((linkaddr_t *)&params.dest_addr,
                   packetbuf_addr(PACKETBUF_ADDR_RECEIVER));
-    /* Use short address mode if rimeaddr size is small */
-    if(sizeof(rimeaddr_t) == 2) {
+    /* Use short address mode if linkaddr size is small */
+    if(sizeof(linkaddr_t) == 2) {
       params.fcf.dest_addr_mode = FRAME802154_SHORTADDRMODE;
     } else {
       params.fcf.dest_addr_mode = FRAME802154_LONGADDRMODE;
@@ -164,7 +164,7 @@ create(void)
    * Set up the source address using only the long address mode for
    * phase 1.
    */
-  rimeaddr_copy((rimeaddr_t *)&params.src_addr, &rimeaddr_node_addr);
+  linkaddr_copy((linkaddr_t *)&params.src_addr, &linkaddr_node_addr);
 
   params.payload = packetbuf_dataptr();
   params.payload_len = packetbuf_datalen();
@@ -199,10 +199,10 @@ parse(void)
         return FRAMER_FAILED;
       }
       if(!is_broadcast_addr(frame.fcf.dest_addr_mode, frame.dest_addr)) {
-        packetbuf_set_addr(PACKETBUF_ADDR_RECEIVER, (rimeaddr_t *)&frame.dest_addr);
+        packetbuf_set_addr(PACKETBUF_ADDR_RECEIVER, (linkaddr_t *)&frame.dest_addr);
       }
     }
-    packetbuf_set_addr(PACKETBUF_ADDR_SENDER, (rimeaddr_t *)&frame.src_addr);
+    packetbuf_set_addr(PACKETBUF_ADDR_SENDER, (linkaddr_t *)&frame.src_addr);
     packetbuf_set_attr(PACKETBUF_ATTR_PENDING, frame.fcf.frame_pending);
     /*    packetbuf_set_attr(PACKETBUF_ATTR_RELIABLE, frame.fcf.ack_required);*/
     packetbuf_set_attr(PACKETBUF_ATTR_PACKET_ID, frame.seq);

--- a/core/net/mac/framer-nullmac.c
+++ b/core/net/mac/framer-nullmac.c
@@ -51,8 +51,8 @@
 #endif
 
 struct nullmac_hdr {
-  rimeaddr_t receiver;
-  rimeaddr_t sender;
+  linkaddr_t receiver;
+  linkaddr_t sender;
 };
 
 /*---------------------------------------------------------------------------*/
@@ -63,8 +63,8 @@ create(void)
 
   if(packetbuf_hdralloc(sizeof(struct nullmac_hdr))) {
     hdr = packetbuf_hdrptr();
-    rimeaddr_copy(&(hdr->sender), &rimeaddr_node_addr);
-    rimeaddr_copy(&(hdr->receiver), packetbuf_addr(PACKETBUF_ADDR_RECEIVER));
+    linkaddr_copy(&(hdr->sender), &linkaddr_node_addr);
+    linkaddr_copy(&(hdr->receiver), packetbuf_addr(PACKETBUF_ADDR_RECEIVER));
     return sizeof(struct nullmac_hdr);
   }
   PRINTF("PNULLMAC-UT: too large header: %u\n", sizeof(struct nullmac_hdr));

--- a/core/net/mac/mac-sequence.c
+++ b/core/net/mac/mac-sequence.c
@@ -50,7 +50,7 @@
 #include "net/rime/rime.h"
 
 struct seqno {
-  rimeaddr_t sender;
+  linkaddr_t sender;
   uint8_t seqno;
 };
 
@@ -72,7 +72,7 @@ mac_sequence_is_duplicate(void)
    * packet with the last few ones we saw.
    */
   for(i = 0; i < MAX_SEQNOS; ++i) {
-    if(rimeaddr_cmp(packetbuf_addr(PACKETBUF_ADDR_SENDER),
+    if(linkaddr_cmp(packetbuf_addr(PACKETBUF_ADDR_SENDER),
                     &received_seqnos[i].sender)) {
       if(packetbuf_attr(PACKETBUF_ATTR_PACKET_ID) == received_seqnos[i].seqno) {
         /* Duplicate packet. */
@@ -91,7 +91,7 @@ mac_sequence_register_seqno(void)
 
   /* Locate possible previous sequence number for this address. */
   for(i = 0; i < MAX_SEQNOS; ++i) {
-    if(rimeaddr_cmp(packetbuf_addr(PACKETBUF_ADDR_SENDER),
+    if(linkaddr_cmp(packetbuf_addr(PACKETBUF_ADDR_SENDER),
                     &received_seqnos[i].sender)) {
       i++;
       break;
@@ -103,7 +103,7 @@ mac_sequence_register_seqno(void)
     memcpy(&received_seqnos[j], &received_seqnos[j - 1], sizeof(struct seqno));
   }
   received_seqnos[0].seqno = packetbuf_attr(PACKETBUF_ATTR_PACKET_ID);
-  rimeaddr_copy(&received_seqnos[0].sender,
+  linkaddr_copy(&received_seqnos[0].sender,
                 packetbuf_addr(PACKETBUF_ADDR_SENDER));
 }
 /*---------------------------------------------------------------------------*/

--- a/core/net/mac/nullrdc.c
+++ b/core/net/mac/nullrdc.c
@@ -115,7 +115,7 @@ send_one_packet(mac_callback_t sent, void *ptr)
   int ret;
   int last_sent_ok = 0;
 
-  packetbuf_set_addr(PACKETBUF_ADDR_SENDER, &rimeaddr_node_addr);
+  packetbuf_set_addr(PACKETBUF_ADDR_SENDER, &linkaddr_node_addr);
 #if NULLRDC_802154_AUTOACK || NULLRDC_802154_AUTOACK_HW
   packetbuf_set_attr(PACKETBUF_ATTR_MAC_ACK, 1);
 #endif /* NULLRDC_802154_AUTOACK || NULLRDC_802154_AUTOACK_HW */
@@ -137,8 +137,8 @@ send_one_packet(mac_callback_t sent, void *ptr)
 
     NETSTACK_RADIO.prepare(packetbuf_hdrptr(), packetbuf_totlen());
 
-    is_broadcast = rimeaddr_cmp(packetbuf_addr(PACKETBUF_ADDR_RECEIVER),
-                                &rimeaddr_null);
+    is_broadcast = linkaddr_cmp(packetbuf_addr(PACKETBUF_ADDR_RECEIVER),
+                                &linkaddr_null);
 
     if(NETSTACK_RADIO.receiving_packet() ||
        (!is_broadcast && NETSTACK_RADIO.pending_packet())) {
@@ -288,10 +288,10 @@ packet_input(void)
   if(NETSTACK_FRAMER.parse() < 0) {
     PRINTF("nullrdc: failed to parse %u\n", packetbuf_datalen());
 #if NULLRDC_ADDRESS_FILTER
-  } else if(!rimeaddr_cmp(packetbuf_addr(PACKETBUF_ADDR_RECEIVER),
-                                         &rimeaddr_node_addr) &&
-            !rimeaddr_cmp(packetbuf_addr(PACKETBUF_ADDR_RECEIVER),
-                          &rimeaddr_null)) {
+  } else if(!linkaddr_cmp(packetbuf_addr(PACKETBUF_ADDR_RECEIVER),
+                                         &linkaddr_node_addr) &&
+            !linkaddr_cmp(packetbuf_addr(PACKETBUF_ADDR_RECEIVER),
+                          &linkaddr_null)) {
     PRINTF("nullrdc: not for us\n");
 #endif /* NULLRDC_ADDRESS_FILTER */
   } else {
@@ -315,8 +315,8 @@ packet_input(void)
       frame802154_parse(original_dataptr, original_datalen, &info154);
       if(info154.fcf.frame_type == FRAME802154_DATAFRAME &&
          info154.fcf.ack_required != 0 &&
-         rimeaddr_cmp((rimeaddr_t *)&info154.dest_addr,
-                      &rimeaddr_node_addr)) {
+         linkaddr_cmp((linkaddr_t *)&info154.dest_addr,
+                      &linkaddr_node_addr)) {
         uint8_t ackdata[ACK_LEN] = {0, 0, 0};
 
         ackdata[0] = FRAME802154_ACKFRAME;

--- a/core/net/mac/phase.c
+++ b/core/net/mac/phase.c
@@ -88,7 +88,7 @@ NBR_TABLE(struct phase, nbr_phase);
 #endif
 /*---------------------------------------------------------------------------*/
 void
-phase_update(const rimeaddr_t *neighbor, rtimer_clock_t time,
+phase_update(const linkaddr_t *neighbor, rtimer_clock_t time,
              int mac_status)
 {
   struct phase *e;
@@ -151,13 +151,13 @@ send_packet(void *ptr)
 }
 /*---------------------------------------------------------------------------*/
 phase_status_t
-phase_wait(const rimeaddr_t *neighbor, rtimer_clock_t cycle_time,
+phase_wait(const linkaddr_t *neighbor, rtimer_clock_t cycle_time,
            rtimer_clock_t guard_time,
            mac_callback_t mac_callback, void *mac_callback_ptr,
            struct rdc_buf_list *buf_list)
 {
   struct phase *e;
-  //  const rimeaddr_t *neighbor = packetbuf_addr(PACKETBUF_ADDR_RECEIVER);
+  //  const linkaddr_t *neighbor = packetbuf_addr(PACKETBUF_ADDR_RECEIVER);
   /* We go through the list of phases to find if we have recorded a
      phase for this particular neighbor. If so, we can compute the
      time for the next expected phase and setup a ctimer to switch on

--- a/core/net/mac/phase.h
+++ b/core/net/mac/phase.h
@@ -40,7 +40,7 @@
 #ifndef PHASE_H
 #define PHASE_H
 
-#include "net/rimeaddr.h"
+#include "net/linkaddr.h"
 #include "sys/timer.h"
 #include "sys/rtimer.h"
 #include "lib/list.h"
@@ -55,12 +55,12 @@ typedef enum {
 
 
 void phase_init(void);
-phase_status_t phase_wait(const rimeaddr_t *neighbor,
+phase_status_t phase_wait(const linkaddr_t *neighbor,
                           rtimer_clock_t cycle_time, rtimer_clock_t wait_before,
                           mac_callback_t mac_callback, void *mac_callback_ptr,
                           struct rdc_buf_list *buf_list);
-void phase_update(const rimeaddr_t *neighbor,
+void phase_update(const linkaddr_t *neighbor,
                   rtimer_clock_t time, int mac_status);
-void phase_remove(const rimeaddr_t *neighbor);
+void phase_remove(const linkaddr_t *neighbor);
 
 #endif /* PHASE_H */

--- a/core/net/mac/sicslowmac/sicslowmac.c
+++ b/core/net/mac/sicslowmac/sicslowmac.c
@@ -127,14 +127,14 @@ send_packet(mac_callback_t sent, void *ptr)
    *  If the output address is NULL in the Rime buf, then it is broadcast
    *  on the 802.15.4 network.
    */
-  if(rimeaddr_cmp(packetbuf_addr(PACKETBUF_ADDR_RECEIVER), &rimeaddr_null)) {
+  if(linkaddr_cmp(packetbuf_addr(PACKETBUF_ADDR_RECEIVER), &linkaddr_null)) {
     /* Broadcast requires short address mode. */
     params.fcf.dest_addr_mode = FRAME802154_SHORTADDRMODE;
     params.dest_addr[0] = 0xFF;
     params.dest_addr[1] = 0xFF;
 
   } else {
-    rimeaddr_copy((rimeaddr_t *)&params.dest_addr,
+    linkaddr_copy((linkaddr_t *)&params.dest_addr,
                   packetbuf_addr(PACKETBUF_ADDR_RECEIVER));
     params.fcf.dest_addr_mode = FRAME802154_LONGADDRMODE;
   }
@@ -147,9 +147,9 @@ send_packet(mac_callback_t sent, void *ptr)
    * phase 1.
    */
 #if NETSTACK_CONF_BRIDGE_MODE
-  rimeaddr_copy((rimeaddr_t *)&params.src_addr,packetbuf_addr(PACKETBUF_ADDR_SENDER));
+  linkaddr_copy((linkaddr_t *)&params.src_addr,packetbuf_addr(PACKETBUF_ADDR_SENDER));
 #else
-  rimeaddr_copy((rimeaddr_t *)&params.src_addr, &rimeaddr_node_addr);
+  linkaddr_copy((linkaddr_t *)&params.src_addr, &linkaddr_node_addr);
 #endif
 
   params.payload = packetbuf_dataptr();
@@ -206,10 +206,10 @@ input_packet(void)
         return;
       }
       if(!is_broadcast_addr(frame.fcf.dest_addr_mode, frame.dest_addr)) {
-        packetbuf_set_addr(PACKETBUF_ADDR_RECEIVER, (rimeaddr_t *)&frame.dest_addr);
+        packetbuf_set_addr(PACKETBUF_ADDR_RECEIVER, (linkaddr_t *)&frame.dest_addr);
 #if !NETSTACK_CONF_BRIDGE_MODE
-        if(!rimeaddr_cmp(packetbuf_addr(PACKETBUF_ADDR_RECEIVER),
-                         &rimeaddr_node_addr)) {
+        if(!linkaddr_cmp(packetbuf_addr(PACKETBUF_ADDR_RECEIVER),
+                         &linkaddr_node_addr)) {
           /* Not for this node */
           PRINTF("6MAC: not for us\n");
           return;
@@ -217,7 +217,7 @@ input_packet(void)
 #endif
       }
     }
-    packetbuf_set_addr(PACKETBUF_ADDR_SENDER, (rimeaddr_t *)&frame.src_addr);
+    packetbuf_set_addr(PACKETBUF_ADDR_SENDER, (linkaddr_t *)&frame.src_addr);
 
     PRINTF("6MAC-IN: %2X", frame.fcf.frame_type);
     PRINTADDR(packetbuf_addr(PACKETBUF_ADDR_SENDER));

--- a/core/net/nbr-table.c
+++ b/core/net/nbr-table.c
@@ -43,7 +43,7 @@
 /* List of link-layer addresses of the neighbors, used as key in the tables */
 typedef struct nbr_table_key {
   struct nbr_table_key *next;
-  rimeaddr_t lladdr;
+  linkaddr_t lladdr;
 } nbr_table_key_t;
 
 /* For each neighbor, a map of the tables that use the neighbor.
@@ -107,17 +107,17 @@ key_from_item(nbr_table_t *table, const nbr_table_item_t *item)
 /*---------------------------------------------------------------------------*/
 /* Get the index of a neighbor from its link-layer address */
 static int
-index_from_lladdr(const rimeaddr_t *lladdr)
+index_from_lladdr(const linkaddr_t *lladdr)
 {
   nbr_table_key_t *key;
   /* Allow lladdr-free insertion, useful e.g. for IPv6 ND.
-   * Only one such entry is possible at a time, indexed by rimeaddr_null. */
+   * Only one such entry is possible at a time, indexed by linkaddr_null. */
   if(lladdr == NULL) {
-    lladdr = &rimeaddr_null;
+    lladdr = &linkaddr_null;
   }
   key = list_head(nbr_table_keys);
   while(key != NULL) {
-    if(lladdr && rimeaddr_cmp(lladdr, &key->lladdr)) {
+    if(lladdr && linkaddr_cmp(lladdr, &key->lladdr)) {
       return index_from_key(key);
     }
     key = list_item_next(key);
@@ -269,16 +269,16 @@ nbr_table_next(nbr_table_t *table, nbr_table_item_t *item)
 /*---------------------------------------------------------------------------*/
 /* Add a neighbor indexed with its link-layer address */
 nbr_table_item_t *
-nbr_table_add_lladdr(nbr_table_t *table, const rimeaddr_t *lladdr)
+nbr_table_add_lladdr(nbr_table_t *table, const linkaddr_t *lladdr)
 {
   int index;
   nbr_table_item_t *item;
   nbr_table_key_t *key;
 
   /* Allow lladdr-free insertion, useful e.g. for IPv6 ND.
-   * Only one such entry is possible at a time, indexed by rimeaddr_null. */
+   * Only one such entry is possible at a time, indexed by linkaddr_null. */
   if(lladdr == NULL) {
-    lladdr = &rimeaddr_null;
+    lladdr = &linkaddr_null;
   }
 
   if((index = index_from_lladdr(lladdr)) == -1) {
@@ -297,7 +297,7 @@ nbr_table_add_lladdr(nbr_table_t *table, const rimeaddr_t *lladdr)
     index = index_from_key(key);
 
     /* Set link-layer address */
-    rimeaddr_copy(&key->lladdr, lladdr);
+    linkaddr_copy(&key->lladdr, lladdr);
   }
 
   /* Get item in the current table */
@@ -312,7 +312,7 @@ nbr_table_add_lladdr(nbr_table_t *table, const rimeaddr_t *lladdr)
 /*---------------------------------------------------------------------------*/
 /* Get an item from its link-layer address */
 void *
-nbr_table_get_from_lladdr(nbr_table_t *table, const rimeaddr_t *lladdr)
+nbr_table_get_from_lladdr(nbr_table_t *table, const linkaddr_t *lladdr)
 {
   void *item = item_from_index(table, index_from_lladdr(lladdr));
   return nbr_get_bit(used_map, table, item) ? item : NULL;
@@ -342,7 +342,7 @@ nbr_table_unlock(nbr_table_t *table, void *item)
 }
 /*---------------------------------------------------------------------------*/
 /* Get link-layer address of an item */
-rimeaddr_t *
+linkaddr_t *
 nbr_table_get_lladdr(nbr_table_t *table, const void *item)
 {
   nbr_table_key_t *key = key_from_item(table, item);

--- a/core/net/nbr-table.h
+++ b/core/net/nbr-table.h
@@ -36,7 +36,7 @@
 #define NBR_TABLE_H_
 
 #include "contiki.h"
-#include "net/rimeaddr.h"
+#include "net/linkaddr.h"
 #include "net/netstack.h"
 
 /* Neighbor table size */
@@ -84,8 +84,8 @@ nbr_table_item_t *nbr_table_next(nbr_table_t *table, nbr_table_item_t *item);
 
 /** \name Neighbor tables: add and get data */
 /** @{ */
-nbr_table_item_t *nbr_table_add_lladdr(nbr_table_t *table, const rimeaddr_t *lladdr);
-nbr_table_item_t *nbr_table_get_from_lladdr(nbr_table_t *table, const rimeaddr_t *lladdr);
+nbr_table_item_t *nbr_table_add_lladdr(nbr_table_t *table, const linkaddr_t *lladdr);
+nbr_table_item_t *nbr_table_get_from_lladdr(nbr_table_t *table, const linkaddr_t *lladdr);
 /** @} */
 
 /** \name Neighbor tables: set flags (unused, locked, unlocked) */
@@ -97,7 +97,7 @@ int nbr_table_unlock(nbr_table_t *table, nbr_table_item_t *item);
 
 /** \name Neighbor tables: address manipulation */
 /** @{ */
-rimeaddr_t *nbr_table_get_lladdr(nbr_table_t *table, const nbr_table_item_t *item);
+linkaddr_t *nbr_table_get_lladdr(nbr_table_t *table, const nbr_table_item_t *item);
 /** @} */
 
 #endif /* NBR_TABLE_H_ */

--- a/core/net/packetbuf.c
+++ b/core/net/packetbuf.c
@@ -261,7 +261,7 @@ packetbuf_attr_clear(void)
     packetbuf_attrs[i].val = 0;
   }
   for(i = 0; i < PACKETBUF_NUM_ADDRS; ++i) {
-    rimeaddr_copy(&packetbuf_addrs[i].addr, &rimeaddr_null);
+    linkaddr_copy(&packetbuf_addrs[i].addr, &linkaddr_null);
   }
 }
 /*---------------------------------------------------------------------------*/
@@ -297,14 +297,14 @@ packetbuf_attr(uint8_t type)
 }
 /*---------------------------------------------------------------------------*/
 int
-packetbuf_set_addr(uint8_t type, const rimeaddr_t *addr)
+packetbuf_set_addr(uint8_t type, const linkaddr_t *addr)
 {
 /*   packetbuf_addrs[type - PACKETBUF_ADDR_FIRST].type = type; */
-  rimeaddr_copy(&packetbuf_addrs[type - PACKETBUF_ADDR_FIRST].addr, addr);
+  linkaddr_copy(&packetbuf_addrs[type - PACKETBUF_ADDR_FIRST].addr, addr);
   return 1;
 }
 /*---------------------------------------------------------------------------*/
-const rimeaddr_t *
+const linkaddr_t *
 packetbuf_addr(uint8_t type)
 {
   return &packetbuf_addrs[type - PACKETBUF_ADDR_FIRST].addr;

--- a/core/net/packetbuf.h
+++ b/core/net/packetbuf.h
@@ -53,7 +53,7 @@
 #define PACKETBUF_H_
 
 #include "contiki-conf.h"
-#include "net/rimeaddr.h"
+#include "net/linkaddr.h"
 
 /**
  * \brief      The size of the packetbuf, in bytes
@@ -323,7 +323,7 @@ struct packetbuf_attr {
 };
 struct packetbuf_addr {
 /*   uint8_t type; */
-  rimeaddr_t addr;
+  linkaddr_t addr;
 };
 
 #define PACKETBUF_ATTR_PACKET_TYPE_DATA      0
@@ -386,8 +386,8 @@ extern struct packetbuf_addr packetbuf_addrs[];
 
 static int               packetbuf_set_attr(uint8_t type, const packetbuf_attr_t val);
 static packetbuf_attr_t    packetbuf_attr(uint8_t type);
-static int               packetbuf_set_addr(uint8_t type, const rimeaddr_t *addr);
-static const rimeaddr_t *packetbuf_addr(uint8_t type);
+static int               packetbuf_set_addr(uint8_t type, const linkaddr_t *addr);
+static const linkaddr_t *packetbuf_addr(uint8_t type);
 
 static inline int
 packetbuf_set_attr(uint8_t type, const packetbuf_attr_t val)
@@ -403,14 +403,14 @@ packetbuf_attr(uint8_t type)
 }
 
 static inline int
-packetbuf_set_addr(uint8_t type, const rimeaddr_t *addr)
+packetbuf_set_addr(uint8_t type, const linkaddr_t *addr)
 {
 /*   packetbuf_addrs[type - PACKETBUF_ADDR_FIRST].type = type; */
-  rimeaddr_copy(&packetbuf_addrs[type - PACKETBUF_ADDR_FIRST].addr, addr);
+  linkaddr_copy(&packetbuf_addrs[type - PACKETBUF_ADDR_FIRST].addr, addr);
   return 1;
 }
 
-static inline const rimeaddr_t *
+static inline const linkaddr_t *
 packetbuf_addr(uint8_t type)
 {
   return &packetbuf_addrs[type - PACKETBUF_ADDR_FIRST].addr;
@@ -418,8 +418,8 @@ packetbuf_addr(uint8_t type)
 #else /* PACKETBUF_CONF_ATTRS_INLINE */
 int               packetbuf_set_attr(uint8_t type, const packetbuf_attr_t val);
 packetbuf_attr_t packetbuf_attr(uint8_t type);
-int               packetbuf_set_addr(uint8_t type, const rimeaddr_t *addr);
-const rimeaddr_t *packetbuf_addr(uint8_t type);
+int               packetbuf_set_addr(uint8_t type, const linkaddr_t *addr);
+const linkaddr_t *packetbuf_addr(uint8_t type);
 #endif /* PACKETBUF_CONF_ATTRS_INLINE */
 
 void              packetbuf_attr_clear(void);
@@ -434,7 +434,7 @@ void              packetbuf_attr_copyfrom(struct packetbuf_attr *attrs,
 
 #define PACKETBUF_ATTR_BIT  1
 #define PACKETBUF_ATTR_BYTE 8
-#define PACKETBUF_ADDRSIZE (sizeof(rimeaddr_t) * PACKETBUF_ATTR_BYTE)
+#define PACKETBUF_ADDRSIZE (sizeof(linkaddr_t) * PACKETBUF_ATTR_BYTE)
 
 struct packetbuf_attrlist {
   uint8_t type;

--- a/core/net/queuebuf.c
+++ b/core/net/queuebuf.c
@@ -472,7 +472,7 @@ queuebuf_datalen(struct queuebuf *b)
   return buframptr->len;
 }
 /*---------------------------------------------------------------------------*/
-rimeaddr_t *
+linkaddr_t *
 queuebuf_addr(struct queuebuf *b, uint8_t type)
 {
   struct queuebuf_data *buframptr = queuebuf_load_to_ram(b);

--- a/core/net/queuebuf.h
+++ b/core/net/queuebuf.h
@@ -103,7 +103,7 @@ void queuebuf_free(struct queuebuf *b);
 void *queuebuf_dataptr(struct queuebuf *b);
 int queuebuf_datalen(struct queuebuf *b);
 
-rimeaddr_t *queuebuf_addr(struct queuebuf *b, uint8_t type);
+linkaddr_t *queuebuf_addr(struct queuebuf *b, uint8_t type);
 packetbuf_attr_t queuebuf_attr(struct queuebuf *b, uint8_t type);
 
 void queuebuf_debug_print(void);

--- a/core/net/rime/abc.c
+++ b/core/net/rime/abc.c
@@ -80,7 +80,7 @@ int
 abc_send(struct abc_conn *c)
 {
   PRINTF("%d.%d: abc: abc_send on channel %d\n",
-	 rimeaddr_node_addr.u8[0],rimeaddr_node_addr.u8[1],
+	 linkaddr_node_addr.u8[0],linkaddr_node_addr.u8[1],
 	 c->channel.channelno);
   return rime_output(&c->channel);
 }
@@ -90,7 +90,7 @@ abc_input(struct channel *channel)
 {
   struct abc_conn *c = (struct abc_conn *)channel;
   PRINTF("%d.%d: abc: abc_input_packet on channel %d\n",
-	 rimeaddr_node_addr.u8[0],rimeaddr_node_addr.u8[1],
+	 linkaddr_node_addr.u8[0],linkaddr_node_addr.u8[1],
 	 channel->channelno);
 
   if(c->u->recv) {
@@ -103,7 +103,7 @@ abc_sent(struct channel *channel, int status, int num_tx)
 {
   struct abc_conn *c = (struct abc_conn *)channel;
   PRINTF("%d.%d: abc: abc_sent on channel %d\n",
-	 rimeaddr_node_addr.u8[0],rimeaddr_node_addr.u8[1],
+	 linkaddr_node_addr.u8[0],linkaddr_node_addr.u8[1],
 	 channel->channelno);
 
   if(c->u->sent) {

--- a/core/net/rime/announcement.c
+++ b/core/net/rime/announcement.c
@@ -137,7 +137,7 @@ announcement_list(void)
 }
 /*---------------------------------------------------------------------------*/
 void
-announcement_heard(const rimeaddr_t *from, uint16_t id, uint16_t value)
+announcement_heard(const linkaddr_t *from, uint16_t id, uint16_t value)
 {
   struct announcement *a;
   for(a = list_head(announcements); a != NULL; a = list_item_next(a)) {

--- a/core/net/rime/announcement.h
+++ b/core/net/rime/announcement.h
@@ -66,12 +66,12 @@
 #ifndef ANNOUNCEMENT_H_
 #define ANNOUNCEMENT_H_
 
-#include "net/rimeaddr.h"
+#include "net/linkaddr.h"
 
 struct announcement;
 
 typedef void (*announcement_callback_t)(struct announcement *a,
-					const rimeaddr_t *from,
+					const linkaddr_t *from,
 					uint16_t id, uint16_t val);
 
 /**
@@ -224,7 +224,7 @@ struct announcement *announcement_list(void);
  *             neighbor has been heard.
  *
  */
-void announcement_heard(const rimeaddr_t *from, uint16_t id, uint16_t value);
+void announcement_heard(const linkaddr_t *from, uint16_t id, uint16_t value);
 
 /**
  * \brief      Register a listen callback with the announcement module

--- a/core/net/rime/broadcast-announcement.c
+++ b/core/net/rime/broadcast-announcement.c
@@ -114,19 +114,19 @@ send_adv(void *ptr)
 		      sizeof(struct announcement_data) * adata->num);
 
   PRINTF("%d.%d: sending neighbor advertisement with %d announcements\n",
-	 rimeaddr_node_addr.u8[0], rimeaddr_node_addr.u8[1], adata->num);
+	 linkaddr_node_addr.u8[0], linkaddr_node_addr.u8[1], adata->num);
 
   if(adata->num > 0) {
     /* Send the packet only if it contains more than zero announcements. */
     broadcast_send(&c.c);
   }
   PRINTF("%d.%d: sending neighbor advertisement with val %d\n",
-	 rimeaddr_node_addr.u8[0], rimeaddr_node_addr.u8[1],
+	 linkaddr_node_addr.u8[0], linkaddr_node_addr.u8[1],
 	 c.val);
 }
 /*---------------------------------------------------------------------------*/
 static void
-adv_packet_received(struct broadcast_conn *ibc, const rimeaddr_t *from)
+adv_packet_received(struct broadcast_conn *ibc, const linkaddr_t *from)
 {
   struct announcement_msg adata;
   struct announcement_data data;
@@ -138,7 +138,7 @@ adv_packet_received(struct broadcast_conn *ibc, const rimeaddr_t *from)
   /* Copy number of announcements */
   memcpy(&adata, ptr, sizeof(struct announcement_msg));
   PRINTF("%d.%d: adv_packet_received from %d.%d with %d announcements\n",
-	 rimeaddr_node_addr.u8[0], rimeaddr_node_addr.u8[1],
+	 linkaddr_node_addr.u8[0], linkaddr_node_addr.u8[1],
 	 from->u8[0], from->u8[1], adata.num);
 
   if(ANNOUNCEMENT_MSG_HEADERLEN + adata.num * sizeof(struct announcement_data) > packetbuf_datalen()) {

--- a/core/net/rime/broadcast.c
+++ b/core/net/rime/broadcast.c
@@ -62,13 +62,13 @@ static const struct packetbuf_attrlist attributes[] =
 static void
 recv_from_abc(struct abc_conn *bc)
 {
-  rimeaddr_t sender;
+  linkaddr_t sender;
   struct broadcast_conn *c = (struct broadcast_conn *)bc;
 
-  rimeaddr_copy(&sender, packetbuf_addr(PACKETBUF_ADDR_SENDER));
+  linkaddr_copy(&sender, packetbuf_addr(PACKETBUF_ADDR_SENDER));
   
   PRINTF("%d.%d: broadcast: from %d.%d\n",
-	 rimeaddr_node_addr.u8[0],rimeaddr_node_addr.u8[1],
+	 linkaddr_node_addr.u8[0],linkaddr_node_addr.u8[1],
 	 sender.u8[0], sender.u8[1]);
   if(c->u->recv) {
     c->u->recv(c, &sender);
@@ -81,7 +81,7 @@ sent_by_abc(struct abc_conn *bc, int status, int num_tx)
   struct broadcast_conn *c = (struct broadcast_conn *)bc;
 
   PRINTF("%d.%d: sent to %d.%d status %d num_tx %d\n",
-	 rimeaddr_node_addr.u8[0],rimeaddr_node_addr.u8[1],
+	 linkaddr_node_addr.u8[0],linkaddr_node_addr.u8[1],
 	 packetbuf_addr(PACKETBUF_ADDR_SENDER)->u8[0],
          packetbuf_addr(PACKETBUF_ADDR_SENDER)->u8[1],
          status, num_tx);
@@ -111,8 +111,8 @@ int
 broadcast_send(struct broadcast_conn *c)
 {
   PRINTF("%d.%d: broadcast_send\n",
-	 rimeaddr_node_addr.u8[0],rimeaddr_node_addr.u8[1]);
-  packetbuf_set_addr(PACKETBUF_ADDR_SENDER, &rimeaddr_node_addr);
+	 linkaddr_node_addr.u8[0],linkaddr_node_addr.u8[1]);
+  packetbuf_set_addr(PACKETBUF_ADDR_SENDER, &linkaddr_node_addr);
   return abc_send(&c->c);
 }
 /*---------------------------------------------------------------------------*/

--- a/core/net/rime/broadcast.h
+++ b/core/net/rime/broadcast.h
@@ -66,7 +66,7 @@
 #define BROADCAST_H_
 
 #include "net/rime/abc.h"
-#include "net/rimeaddr.h"
+#include "net/linkaddr.h"
 
 struct broadcast_conn;
 
@@ -79,7 +79,7 @@ struct broadcast_conn;
  */
 struct broadcast_callbacks {
   /** Called when a packet has been received by the broadcast module. */
-  void (* recv)(struct broadcast_conn *ptr, const rimeaddr_t *sender);
+  void (* recv)(struct broadcast_conn *ptr, const linkaddr_t *sender);
   void (* sent)(struct broadcast_conn *ptr, int status, int num_tx);
 };
 

--- a/core/net/rime/chameleon-bitopt.c
+++ b/core/net/rime/chameleon-bitopt.c
@@ -266,7 +266,7 @@ pack_header(struct channel *c)
     }
 #endif /* CHAMELEON_WITH_MAC_LINK_ADDRESSES */
     PRINTF("%d.%d: pack_header type %d, len %d, bitptr %d, ",
-	   rimeaddr_node_addr.u8[0], rimeaddr_node_addr.u8[1],
+	   linkaddr_node_addr.u8[0], linkaddr_node_addr.u8[1],
 	   a->type, a->len, bitptr);
     /*    len = (a->len & 0xf8) + ((a->len & 7) ? 8: 0);*/
     len = a->len;
@@ -275,7 +275,7 @@ pack_header(struct channel *c)
       set_bits(&hdrptr[byteptr], bitptr & 7,
 	       (uint8_t *)packetbuf_addr(a->type), len);
       PRINTF("address %d.%d\n",
-	    /*	    rimeaddr_node_addr.u8[0], rimeaddr_node_addr.u8[1],*/
+	    /*	    linkaddr_node_addr.u8[0], linkaddr_node_addr.u8[1],*/
 	    ((uint8_t *)packetbuf_addr(a->type))[0],
 	    ((uint8_t *)packetbuf_addr(a->type))[1]);
     } else {
@@ -284,7 +284,7 @@ pack_header(struct channel *c)
       set_bits(&hdrptr[byteptr], bitptr & 7,
 	       (uint8_t *)&val, len);
       PRINTF("value %d\n",
-	    /*rimeaddr_node_addr.u8[0], rimeaddr_node_addr.u8[1],*/
+	    /*linkaddr_node_addr.u8[0], linkaddr_node_addr.u8[1],*/
 	    val);
     }
     /*    printhdr(hdrptr, hdrbytesize);*/
@@ -336,16 +336,16 @@ unpack_header(void)
     }
 #endif /* CHAMELEON_WITH_MAC_LINK_ADDRESSES */
     PRINTF("%d.%d: unpack_header type %d, len %d, bitptr %d\n",
-	   rimeaddr_node_addr.u8[0], rimeaddr_node_addr.u8[1],
+	   linkaddr_node_addr.u8[0], linkaddr_node_addr.u8[1],
 	   a->type, a->len, bitptr);
     /*    len = (a->len & 0xf8) + ((a->len & 7) ? 8: 0);*/
     len = a->len;
     byteptr = bitptr / 8;
     if(PACKETBUF_IS_ADDR(a->type)) {
-      rimeaddr_t addr;
+      linkaddr_t addr;
       get_bits((uint8_t *)&addr, &hdrptr[byteptr], bitptr & 7, len);
       PRINTF("%d.%d: unpack_header type %d, addr %d.%d\n",
-	     rimeaddr_node_addr.u8[0], rimeaddr_node_addr.u8[1],
+	     linkaddr_node_addr.u8[0], linkaddr_node_addr.u8[1],
 	     a->type, addr.u8[0], addr.u8[1]);
       packetbuf_set_addr(a->type, &addr);
     } else {
@@ -354,7 +354,7 @@ unpack_header(void)
 
       packetbuf_set_attr(a->type, val);
       PRINTF("%d.%d: unpack_header type %d, val %d\n",
-	     rimeaddr_node_addr.u8[0], rimeaddr_node_addr.u8[1],
+	     linkaddr_node_addr.u8[0], linkaddr_node_addr.u8[1],
 	     a->type, val);
     }
     /*    byteptr += len / 8;*/

--- a/core/net/rime/chameleon-raw.c
+++ b/core/net/rime/chameleon-raw.c
@@ -104,14 +104,14 @@ input(void)
     }
 #endif /* CHAMELEON_WITH_MAC_LINK_ADDRESSES */
     PRINTF("%d.%d: unpack_header type %d, len %d\n",
-	   rimeaddr_node_addr.u8[0], rimeaddr_node_addr.u8[1],
+	   linkaddr_node_addr.u8[0], linkaddr_node_addr.u8[1],
 	   a->type, a->len);
     len = (a->len & 0xf8) + ((a->len & 7) ? 8: 0);
     if(PACKETBUF_IS_ADDR(a->type)) {
-      const rimeaddr_t addr;
+      const linkaddr_t addr;
       memcpy((uint8_t *)&addr, &hdrptr[byteptr], len / 8);
       PRINTF("%d.%d: unpack_header type %d, addr %d.%d\n",
-	     rimeaddr_node_addr.u8[0], rimeaddr_node_addr.u8[1],
+	     linkaddr_node_addr.u8[0], linkaddr_node_addr.u8[1],
 	     a->type, addr.u8[0], addr.u8[1]);
       packetbuf_set_addr(a->type, &addr);
     } else {
@@ -120,7 +120,7 @@ input(void)
 
       packetbuf_set_attr(a->type, val);
       PRINTF("%d.%d: unpack_header type %d, val %d\n",
-	     rimeaddr_node_addr.u8[0], rimeaddr_node_addr.u8[1],
+	     linkaddr_node_addr.u8[0], linkaddr_node_addr.u8[1],
 	     a->type, val);
     }
     byteptr += len / 8;
@@ -158,18 +158,18 @@ output(struct channel *c)
     }
 #endif /* CHAMELEON_WITH_MAC_LINK_ADDRESSES */
     PRINTF("%d.%d: pack_header type %d, len %d\n",
-	   rimeaddr_node_addr.u8[0], rimeaddr_node_addr.u8[1],
+	   linkaddr_node_addr.u8[0], linkaddr_node_addr.u8[1],
 	   a->type, a->len);
     len = (a->len & 0xf8) + ((a->len & 7) ? 8: 0);
     if(PACKETBUF_IS_ADDR(a->type)) {
-      const rimeaddr_t *rimeaddr;
+      const linkaddr_t *linkaddr;
       /*      memcpy(&hdrptr[byteptr], (uint8_t *)packetbuf_attr_aget(a->type), len / 8);*/
-      rimeaddr = packetbuf_addr(a->type);
-      hdrptr[byteptr] = rimeaddr->u8[0];
-      hdrptr[byteptr + 1] = rimeaddr->u8[1];
+      linkaddr = packetbuf_addr(a->type);
+      hdrptr[byteptr] = linkaddr->u8[0];
+      hdrptr[byteptr + 1] = linkaddr->u8[1];
       
       PRINTF("%d.%d: address %d.%d\n",
-	    rimeaddr_node_addr.u8[0], rimeaddr_node_addr.u8[1],
+	    linkaddr_node_addr.u8[0], linkaddr_node_addr.u8[1],
 	    ((uint8_t *)packetbuf_addr(a->type))[0],
 	    ((uint8_t *)packetbuf_addr(a->type))[1]);
     } else {
@@ -177,7 +177,7 @@ output(struct channel *c)
       val = packetbuf_attr(a->type);
       memcpy(&hdrptr[byteptr], &val, len / 8);
       PRINTF("%d.%d: value %d\n",
-	    rimeaddr_node_addr.u8[0], rimeaddr_node_addr.u8[1],
+	    linkaddr_node_addr.u8[0], linkaddr_node_addr.u8[1],
 	    val);
     }
     byteptr += len / 8;

--- a/core/net/rime/chameleon.c
+++ b/core/net/rime/chameleon.c
@@ -112,19 +112,19 @@ chameleon_parse(void)
 {
   struct channel *c = NULL;
   PRINTF("%d.%d: chameleon_input\n",
-	 rimeaddr_node_addr.u8[0],rimeaddr_node_addr.u8[1]);
+	 linkaddr_node_addr.u8[0],linkaddr_node_addr.u8[1]);
 #if DEBUG
   printhdr(packetbuf_dataptr(), packetbuf_datalen());
 #endif /* DEBUG */
   c = CHAMELEON_MODULE.input();
   if(c != NULL) {
     PRINTF("%d.%d: chameleon_input channel %d\n",
-           rimeaddr_node_addr.u8[0],rimeaddr_node_addr.u8[1],
+           linkaddr_node_addr.u8[0],linkaddr_node_addr.u8[1],
            c->channelno);
     packetbuf_set_attr(PACKETBUF_ATTR_CHANNEL, c->channelno);
   } else {
     PRINTF("%d.%d: chameleon_input channel not found for incoming packet\n",
-           rimeaddr_node_addr.u8[0],rimeaddr_node_addr.u8[1]);
+           linkaddr_node_addr.u8[0],linkaddr_node_addr.u8[1]);
   }
   return c;
 }
@@ -135,7 +135,7 @@ chameleon_create(struct channel *c)
   int ret;
 
   PRINTF("%d.%d: chameleon_output channel %d\n",
-	 rimeaddr_node_addr.u8[0],rimeaddr_node_addr.u8[1],
+	 linkaddr_node_addr.u8[0],linkaddr_node_addr.u8[1],
 	 c->channelno);
 
   ret = CHAMELEON_MODULE.output(c);

--- a/core/net/rime/collect-neighbor.c
+++ b/core/net/rime/collect-neighbor.c
@@ -126,14 +126,14 @@ collect_neighbor_list_new(struct collect_neighbor_list *neighbors_list)
 /*---------------------------------------------------------------------------*/
 struct collect_neighbor *
 collect_neighbor_list_find(struct collect_neighbor_list *neighbors_list,
-                           const rimeaddr_t *addr)
+                           const linkaddr_t *addr)
 {
   struct collect_neighbor *n;
   if(neighbors_list == NULL) {
     return NULL;
   }
   for(n = list_head(neighbors_list->list); n != NULL; n = list_item_next(n)) {
-    if(rimeaddr_cmp(&n->addr, addr)) {
+    if(linkaddr_cmp(&n->addr, addr)) {
       return n;
     }
   }
@@ -142,7 +142,7 @@ collect_neighbor_list_find(struct collect_neighbor_list *neighbors_list,
 /*---------------------------------------------------------------------------*/
 int
 collect_neighbor_list_add(struct collect_neighbor_list *neighbors_list,
-                          const rimeaddr_t *addr, uint16_t nrtmetric)
+                          const linkaddr_t *addr, uint16_t nrtmetric)
 {
   struct collect_neighbor *n;
 
@@ -159,7 +159,7 @@ collect_neighbor_list_add(struct collect_neighbor_list *neighbors_list,
 
   /* Check if the collect_neighbor is already on the list. */
   for(n = list_head(neighbors_list->list); n != NULL; n = list_item_next(n)) {
-    if(rimeaddr_cmp(&n->addr, addr)) {
+    if(linkaddr_cmp(&n->addr, addr)) {
       PRINTF("collect_neighbor_add: already on list %d.%d\n",
              addr->u8[0], addr->u8[1]);
       break;
@@ -214,7 +214,7 @@ collect_neighbor_list_add(struct collect_neighbor_list *neighbors_list,
 
   if(n != NULL) {
     n->age = 0;
-    rimeaddr_copy(&n->addr, addr);
+    linkaddr_copy(&n->addr, addr);
     n->rtmetric = nrtmetric;
     collect_link_estimate_new(&n->le);
     n->le_age = 0;
@@ -235,7 +235,7 @@ collect_neighbor_list(struct collect_neighbor_list *neighbors_list)
 /*---------------------------------------------------------------------------*/
 void
 collect_neighbor_list_remove(struct collect_neighbor_list *neighbors_list,
-                             const rimeaddr_t *addr)
+                             const linkaddr_t *addr)
 {
   struct collect_neighbor *n;
 
@@ -337,7 +337,7 @@ collect_neighbor_update_rtmetric(struct collect_neighbor *n, uint16_t rtmetric)
 {
   if(n != NULL) {
     PRINTF("%d.%d: collect_neighbor_update %d.%d rtmetric %d\n",
-           rimeaddr_node_addr.u8[0], rimeaddr_node_addr.u8[1],
+           linkaddr_node_addr.u8[0], linkaddr_node_addr.u8[1],
            n->addr.u8[0], n->addr.u8[1], rtmetric);
     n->rtmetric = rtmetric;
     n->age = 0;

--- a/core/net/rime/collect-neighbor.h
+++ b/core/net/rime/collect-neighbor.h
@@ -51,7 +51,7 @@
 #ifndef COLLECT_NEIGHBOR_H_
 #define COLLECT_NEIGHBOR_H_
 
-#include "net/rimeaddr.h"
+#include "net/linkaddr.h"
 #include "net/rime/collect-link-estimate.h"
 #include "lib/list.h"
 
@@ -62,7 +62,7 @@ struct collect_neighbor_list {
 
 struct collect_neighbor {
   struct collect_neighbor *next;
-  rimeaddr_t addr;
+  linkaddr_t addr;
   uint16_t rtmetric;
   uint16_t age;
   uint16_t le_age;
@@ -77,11 +77,11 @@ list_t collect_neighbor_list(struct collect_neighbor_list *neighbor_list);
 void collect_neighbor_list_new(struct collect_neighbor_list *neighbor_list);
 
 int collect_neighbor_list_add(struct collect_neighbor_list *neighbor_list,
-                              const rimeaddr_t *addr, uint16_t rtmetric);
+                              const linkaddr_t *addr, uint16_t rtmetric);
 void collect_neighbor_list_remove(struct collect_neighbor_list *neighbor_list,
-                                  const rimeaddr_t *addr);
+                                  const linkaddr_t *addr);
 struct collect_neighbor *collect_neighbor_list_find(struct collect_neighbor_list *neighbor_list,
-                                               const rimeaddr_t *addr);
+                                               const linkaddr_t *addr);
 struct collect_neighbor *collect_neighbor_list_best(struct collect_neighbor_list *neighbor_list);
 int collect_neighbor_list_num(struct collect_neighbor_list *neighbor_list);
 struct collect_neighbor *collect_neighbor_list_get(struct collect_neighbor_list *neighbor_list, int num);

--- a/core/net/rime/collect.h
+++ b/core/net/rime/collect.h
@@ -101,7 +101,7 @@
                             UNICAST_ATTRIBUTES
 
 struct collect_callbacks {
-  void (* recv)(const rimeaddr_t *originator, uint8_t seqno,
+  void (* recv)(const linkaddr_t *originator, uint8_t seqno,
 		uint8_t hops);
 };
 
@@ -133,7 +133,7 @@ struct collect_conn {
 
   struct ctimer proactive_probing_timer;
 
-  rimeaddr_t parent, current_parent;
+  linkaddr_t parent, current_parent;
   uint16_t rtmetric;
   uint8_t seqno;
   uint8_t sending, transmissions, max_rexmits;
@@ -158,7 +158,7 @@ int collect_send(struct collect_conn *c, int rexmits);
 void collect_set_sink(struct collect_conn *c, int should_be_sink);
 
 int collect_depth(struct collect_conn *c);
-const rimeaddr_t *collect_parent(struct collect_conn *c);
+const linkaddr_t *collect_parent(struct collect_conn *c);
 
 void collect_set_keepalive(struct collect_conn *c, clock_time_t period);
 

--- a/core/net/rime/ipolite.c
+++ b/core/net/rime/ipolite.c
@@ -66,7 +66,7 @@
 
 /*---------------------------------------------------------------------------*/
 static void
-recv(struct broadcast_conn *broadcast, const rimeaddr_t *from)
+recv(struct broadcast_conn *broadcast, const linkaddr_t *from)
 {
   struct ipolite_conn *c = (struct ipolite_conn *)broadcast;
   if(c->q != NULL &&
@@ -103,7 +103,7 @@ send(void *ptr)
   struct ipolite_conn *c = ptr;
   
   PRINTF("%d.%d: ipolite: send queuebuf %p\n",
-	 rimeaddr_node_addr.u8[0],rimeaddr_node_addr.u8[1],
+	 linkaddr_node_addr.u8[0],linkaddr_node_addr.u8[1],
 	 c->q);
   
   if(c->q != NULL) {
@@ -146,14 +146,14 @@ ipolite_send(struct ipolite_conn *c, clock_time_t interval, uint8_t hdrsize)
   if(c->q != NULL) {
     /* If we are already about to send a packet, we cancel the old one. */
     PRINTF("%d.%d: ipolite_send: cancel old send\n",
-	   rimeaddr_node_addr.u8[0],rimeaddr_node_addr.u8[1]);
+	   linkaddr_node_addr.u8[0],linkaddr_node_addr.u8[1]);
     queuebuf_free(c->q);
   }
   c->dups = 0;
   c->hdrsize = hdrsize;
   if(interval == 0) {
     PRINTF("%d.%d: ipolite_send: interval 0\n",
-	   rimeaddr_node_addr.u8[0],rimeaddr_node_addr.u8[1]);
+	   linkaddr_node_addr.u8[0],linkaddr_node_addr.u8[1]);
     if(broadcast_send(&c->c)) {
       if(c->cb->sent) {
 	c->cb->sent(c);
@@ -170,7 +170,7 @@ ipolite_send(struct ipolite_conn *c, clock_time_t interval, uint8_t hdrsize)
       return 1;
     }
     PRINTF("%d.%d: ipolite_send: could not allocate queue buffer\n",
-	   rimeaddr_node_addr.u8[0],rimeaddr_node_addr.u8[1]);
+	   linkaddr_node_addr.u8[0],linkaddr_node_addr.u8[1]);
   }
   return 0;
 }

--- a/core/net/rime/ipolite.h
+++ b/core/net/rime/ipolite.h
@@ -114,7 +114,7 @@ struct ipolite_callbacks {
   /**
    * Called when a packet is received on the connection.
    */
-  void (* recv)(struct ipolite_conn *c, const rimeaddr_t *from);
+  void (* recv)(struct ipolite_conn *c, const linkaddr_t *from);
 
   /**
    * Called when a packet is sent on the connection.

--- a/core/net/rime/mesh.c
+++ b/core/net/rime/mesh.c
@@ -62,8 +62,8 @@
 /*---------------------------------------------------------------------------*/
 static void
 data_packet_received(struct multihop_conn *multihop,
-		     const rimeaddr_t *from,
-		     const rimeaddr_t *prevhop, uint8_t hops)
+		     const linkaddr_t *from,
+		     const linkaddr_t *prevhop, uint8_t hops)
 {
   struct mesh_conn *c = (struct mesh_conn *)
     ((char *)multihop - offsetof(struct mesh_conn, multihop));
@@ -81,11 +81,11 @@ data_packet_received(struct multihop_conn *multihop,
   }
 }
 /*---------------------------------------------------------------------------*/
-static rimeaddr_t *
+static linkaddr_t *
 data_packet_forward(struct multihop_conn *multihop,
-		    const rimeaddr_t *originator,
-		    const rimeaddr_t *dest,
-		    const rimeaddr_t *prevhop, uint8_t hops)
+		    const linkaddr_t *originator,
+		    const linkaddr_t *dest,
+		    const linkaddr_t *prevhop, uint8_t hops)
 {
   struct route_entry *rt;
   struct mesh_conn *c = (struct mesh_conn *)
@@ -99,7 +99,7 @@ data_packet_forward(struct multihop_conn *multihop,
 
     PRINTF("data_packet_forward: queueing data, sending rreq\n");
     c->queued_data = queuebuf_new_from_packetbuf();
-    rimeaddr_copy(&c->queued_data_dest, dest);
+    linkaddr_copy(&c->queued_data_dest, dest);
     route_discovery_discover(&c->route_discovery_conn, dest, PACKET_TIMEOUT);
 
     return NULL;
@@ -111,7 +111,7 @@ data_packet_forward(struct multihop_conn *multihop,
 }
 /*---------------------------------------------------------------------------*/
 static void
-found_route(struct route_discovery_conn *rdc, const rimeaddr_t *dest)
+found_route(struct route_discovery_conn *rdc, const linkaddr_t *dest)
 {
   struct route_entry *rt;
   struct mesh_conn *c = (struct mesh_conn *)
@@ -120,7 +120,7 @@ found_route(struct route_discovery_conn *rdc, const rimeaddr_t *dest)
   PRINTF("found_route\n");
 
   if(c->queued_data != NULL &&
-     rimeaddr_cmp(dest, &c->queued_data_dest)) {
+     linkaddr_cmp(dest, &c->queued_data_dest)) {
     queuebuf_to_packetbuf(c->queued_data);
     queuebuf_free(c->queued_data);
     c->queued_data = NULL;
@@ -181,12 +181,12 @@ mesh_close(struct mesh_conn *c)
 }
 /*---------------------------------------------------------------------------*/
 int
-mesh_send(struct mesh_conn *c, const rimeaddr_t *to)
+mesh_send(struct mesh_conn *c, const linkaddr_t *to)
 {
   int could_send;
 
   PRINTF("%d.%d: mesh_send to %d.%d\n",
-	 rimeaddr_node_addr.u8[0], rimeaddr_node_addr.u8[1],
+	 linkaddr_node_addr.u8[0], linkaddr_node_addr.u8[1],
 	 to->u8[0], to->u8[1]);
   
   could_send = multihop_send(&c->multihop, to);

--- a/core/net/rime/mesh.h
+++ b/core/net/rime/mesh.h
@@ -72,7 +72,7 @@ struct mesh_conn;
  */
 struct mesh_callbacks {
   /** Called when a packet is received. */
-  void (* recv)(struct mesh_conn *c, const rimeaddr_t *from, uint8_t hops);
+  void (* recv)(struct mesh_conn *c, const linkaddr_t *from, uint8_t hops);
   /** Called when a packet, sent with mesh_send(), is actually transmitted. */
   void (* sent)(struct mesh_conn *c);
   /** Called when a packet, sent with mesh_send(), times out and is dropped. */
@@ -83,7 +83,7 @@ struct mesh_conn {
   struct multihop_conn multihop;
   struct route_discovery_conn route_discovery_conn;
   struct queuebuf *queued_data;
-  rimeaddr_t queued_data_dest;
+  linkaddr_t queued_data_dest;
   const struct mesh_callbacks *cb;
 };
 
@@ -131,7 +131,7 @@ void mesh_close(struct mesh_conn *c);
  *             must have previously been set up with mesh_open().
  *
  */
-int mesh_send(struct mesh_conn *c, const rimeaddr_t *dest);
+int mesh_send(struct mesh_conn *c, const linkaddr_t *dest);
 
 /**
  * \brief      Test if mesh is ready to send a packet (or packet is queued)

--- a/core/net/rime/multihop.c
+++ b/core/net/rime/multihop.c
@@ -65,17 +65,17 @@ static const struct packetbuf_attrlist attributes[] =
 
 /*---------------------------------------------------------------------------*/
 void
-data_packet_received(struct unicast_conn *uc, const rimeaddr_t *from)
+data_packet_received(struct unicast_conn *uc, const linkaddr_t *from)
 {
   struct multihop_conn *c = (struct multihop_conn *)uc;
-  rimeaddr_t *nexthop;
-  rimeaddr_t sender, receiver;
+  linkaddr_t *nexthop;
+  linkaddr_t sender, receiver;
 
   /* Copy the packet attributes to avoid them being overwritten or
      cleared by an application program that uses the packet buffer for
      its own needs. */
-  rimeaddr_copy(&sender, packetbuf_addr(PACKETBUF_ADDR_ESENDER));
-  rimeaddr_copy(&receiver, packetbuf_addr(PACKETBUF_ADDR_ERECEIVER));
+  linkaddr_copy(&sender, packetbuf_addr(PACKETBUF_ADDR_ESENDER));
+  linkaddr_copy(&receiver, packetbuf_addr(PACKETBUF_ADDR_ERECEIVER));
 
   PRINTF("data_packet_received from %d.%d towards %d.%d len %d\n",
 	 from->u8[0], from->u8[1],
@@ -83,8 +83,8 @@ data_packet_received(struct unicast_conn *uc, const rimeaddr_t *from)
 	 packetbuf_addr(PACKETBUF_ADDR_ERECEIVER)->u8[1],
 	 packetbuf_datalen());
 
-  if(rimeaddr_cmp(packetbuf_addr(PACKETBUF_ADDR_ERECEIVER),
-				 &rimeaddr_node_addr)) {
+  if(linkaddr_cmp(packetbuf_addr(PACKETBUF_ADDR_ERECEIVER),
+				 &linkaddr_node_addr)) {
     PRINTF("for us!\n");
     if(c->cb->recv) {
       c->cb->recv(c, &sender, from,
@@ -123,18 +123,18 @@ multihop_close(struct multihop_conn *c)
 }
 /*---------------------------------------------------------------------------*/
 int
-multihop_send(struct multihop_conn *c, const rimeaddr_t *to)
+multihop_send(struct multihop_conn *c, const linkaddr_t *to)
 {
-  rimeaddr_t *nexthop;
+  linkaddr_t *nexthop;
 
   if(c->cb->forward == NULL) {
     return 0;
   }
   packetbuf_compact();
   packetbuf_set_addr(PACKETBUF_ADDR_ERECEIVER, to);
-  packetbuf_set_addr(PACKETBUF_ADDR_ESENDER, &rimeaddr_node_addr);
+  packetbuf_set_addr(PACKETBUF_ADDR_ESENDER, &linkaddr_node_addr);
   packetbuf_set_attr(PACKETBUF_ATTR_HOPS, 1);
-  nexthop = c->cb->forward(c, &rimeaddr_node_addr, to, NULL, 0);
+  nexthop = c->cb->forward(c, &linkaddr_node_addr, to, NULL, 0);
   
   if(nexthop == NULL) {
     PRINTF("multihop_send: no route\n");
@@ -148,7 +148,7 @@ multihop_send(struct multihop_conn *c, const rimeaddr_t *to)
 }
 /*---------------------------------------------------------------------------*/
 void
-multihop_resend(struct multihop_conn *c, const rimeaddr_t *nexthop)
+multihop_resend(struct multihop_conn *c, const linkaddr_t *nexthop)
 {
   unicast_send(&c->c, nexthop);
 }

--- a/core/net/rime/multihop.h
+++ b/core/net/rime/multihop.h
@@ -71,7 +71,7 @@
 #define MULTIHOP_H_
 
 #include "net/rime/unicast.h"
-#include "net/rimeaddr.h"
+#include "net/linkaddr.h"
 
 struct multihop_conn;
 
@@ -84,13 +84,13 @@ struct multihop_conn;
 
 struct multihop_callbacks {
   void (* recv)(struct multihop_conn *ptr,
-		const rimeaddr_t *sender,
-		const rimeaddr_t *prevhop,
+		const linkaddr_t *sender,
+		const linkaddr_t *prevhop,
 		uint8_t hops);
-  rimeaddr_t *(* forward)(struct multihop_conn *ptr,
-			  const rimeaddr_t *originator,
-			  const rimeaddr_t *dest,
-			  const rimeaddr_t *prevhop,
+  linkaddr_t *(* forward)(struct multihop_conn *ptr,
+			  const linkaddr_t *originator,
+			  const linkaddr_t *dest,
+			  const linkaddr_t *prevhop,
 			  uint8_t hops);
 };
 
@@ -102,8 +102,8 @@ struct multihop_conn {
 void multihop_open(struct multihop_conn *c, uint16_t channel,
 	     const struct multihop_callbacks *u);
 void multihop_close(struct multihop_conn *c);
-int multihop_send(struct multihop_conn *c, const rimeaddr_t *to);
-void multihop_resend(struct multihop_conn *c, const rimeaddr_t *nexthop);
+int multihop_send(struct multihop_conn *c, const linkaddr_t *to);
+void multihop_resend(struct multihop_conn *c, const linkaddr_t *nexthop);
 
 #endif /* MULTIHOP_H_ */
 /** @} */

--- a/core/net/rime/neighbor-discovery.c
+++ b/core/net/rime/neighbor-discovery.c
@@ -87,12 +87,12 @@ send_adv(void *ptr)
     c->u->sent(c);
   }
   PRINTF("%d.%d: sending neighbor advertisement with val %d\n",
-	 rimeaddr_node_addr.u8[0], rimeaddr_node_addr.u8[1],
+	 linkaddr_node_addr.u8[0], linkaddr_node_addr.u8[1],
 	 c->val);
 }
 /*---------------------------------------------------------------------------*/
 static void
-adv_packet_received(struct broadcast_conn *ibc, const rimeaddr_t *from)
+adv_packet_received(struct broadcast_conn *ibc, const linkaddr_t *from)
 {
   struct neighbor_discovery_conn *c = (struct neighbor_discovery_conn *)ibc;
   struct adv_msg msg;
@@ -100,7 +100,7 @@ adv_packet_received(struct broadcast_conn *ibc, const rimeaddr_t *from)
   memcpy(&msg, packetbuf_dataptr(), sizeof(struct adv_msg));
 
   PRINTF("%d.%d: adv_packet_received from %d.%d with val %d\n",
-	 rimeaddr_node_addr.u8[0], rimeaddr_node_addr.u8[1],
+	 linkaddr_node_addr.u8[0], linkaddr_node_addr.u8[1],
 	 from->u8[0], from->u8[1], msg.val);
   
   /* If we receive an announcement with a lower value than ours, we
@@ -162,7 +162,7 @@ neighbor_discovery_open(struct neighbor_discovery_conn *c, uint16_t channel,
 			const struct neighbor_discovery_callbacks *cb)
 {
   PRINTF("%d.%d: neighbor discovery open channel %d\n",
-         rimeaddr_node_addr.u8[0], rimeaddr_node_addr.u8[1],
+         linkaddr_node_addr.u8[0], linkaddr_node_addr.u8[1],
 	 channel);
   broadcast_open(&c->c, channel, &broadcast_callbacks);
   c->u = cb;

--- a/core/net/rime/neighbor-discovery.h
+++ b/core/net/rime/neighbor-discovery.h
@@ -66,7 +66,7 @@ struct neighbor_discovery_conn;
 
 struct neighbor_discovery_callbacks {
   void (* recv)(struct neighbor_discovery_conn *c,
-		const rimeaddr_t *from, uint16_t val);
+		const linkaddr_t *from, uint16_t val);
   void (* sent)(struct neighbor_discovery_conn *c);
 };
 

--- a/core/net/rime/netflood.c
+++ b/core/net/rime/netflood.c
@@ -50,7 +50,7 @@
 
 struct netflood_hdr {
   uint16_t originator_seqno;
-  rimeaddr_t originator;
+  linkaddr_t originator;
   uint16_t hops;
 };
 
@@ -67,12 +67,12 @@ static int
 send(struct netflood_conn *c)
 {
   PRINTF("%d.%d: netflood send to ipolite\n",
-	 rimeaddr_node_addr.u8[0], rimeaddr_node_addr.u8[1]);
+	 linkaddr_node_addr.u8[0], linkaddr_node_addr.u8[1]);
   return ipolite_send(&c->c, c->queue_time, 4);
 }
 /*---------------------------------------------------------------------------*/
 static void
-recv_from_ipolite(struct ipolite_conn *ipolite, const rimeaddr_t *from)
+recv_from_ipolite(struct ipolite_conn *ipolite, const linkaddr_t *from)
 {
   struct netflood_conn *c = (struct netflood_conn *)ipolite;
   struct netflood_hdr hdr;
@@ -87,7 +87,7 @@ recv_from_ipolite(struct ipolite_conn *ipolite, const rimeaddr_t *from)
 
   packetbuf_hdrreduce(sizeof(struct netflood_hdr));
   if(c->u->recv != NULL) {
-    if(!(rimeaddr_cmp(&hdr.originator, &c->last_originator) &&
+    if(!(linkaddr_cmp(&hdr.originator, &c->last_originator) &&
 	 hdr.originator_seqno <= c->last_originator_seqno)) {
 
       if(c->u->recv(c, from, &hdr.originator, hdr.originator_seqno,
@@ -102,7 +102,7 @@ recv_from_ipolite(struct ipolite_conn *ipolite, const rimeaddr_t *from)
 	  /* Rebroadcast received packet. */
 	  if(hops < HOPS_MAX) {
 	    PRINTF("%d.%d: netflood rebroadcasting %d.%d/%d (%d.%d/%d) hops %d\n",
-		   rimeaddr_node_addr.u8[0], rimeaddr_node_addr.u8[1],
+		   linkaddr_node_addr.u8[0], linkaddr_node_addr.u8[1],
 		   hdr.originator.u8[0], hdr.originator.u8[1],
 		   hdr.originator_seqno,
 		   c->last_originator.u8[0], c->last_originator.u8[1],
@@ -111,7 +111,7 @@ recv_from_ipolite(struct ipolite_conn *ipolite, const rimeaddr_t *from)
 	    hdr.hops++;
 	    memcpy(packetbuf_dataptr(), &hdr, sizeof(struct netflood_hdr));
 	    send(c);
-	    rimeaddr_copy(&c->last_originator, &hdr.originator);
+	    linkaddr_copy(&c->last_originator, &hdr.originator);
 	    c->last_originator_seqno = hdr.originator_seqno;
 	  }
 	}
@@ -163,12 +163,12 @@ netflood_send(struct netflood_conn *c, uint8_t seqno)
 {
   if(packetbuf_hdralloc(sizeof(struct netflood_hdr))) {
     struct netflood_hdr *hdr = packetbuf_hdrptr();
-    rimeaddr_copy(&hdr->originator, &rimeaddr_node_addr);
-    rimeaddr_copy(&c->last_originator, &hdr->originator);
+    linkaddr_copy(&hdr->originator, &linkaddr_node_addr);
+    linkaddr_copy(&c->last_originator, &hdr->originator);
     c->last_originator_seqno = hdr->originator_seqno = seqno;
     hdr->hops = 0;
     PRINTF("%d.%d: netflood sending '%s'\n",
-	   rimeaddr_node_addr.u8[0], rimeaddr_node_addr.u8[1],
+	   linkaddr_node_addr.u8[0], linkaddr_node_addr.u8[1],
 	   (char *)packetbuf_dataptr());
     return ipolite_send(&c->c, 0, 4);
   }

--- a/core/net/rime/netflood.h
+++ b/core/net/rime/netflood.h
@@ -85,8 +85,8 @@ struct netflood_conn;
                                 IPOLITE_ATTRIBUTES
 
 struct netflood_callbacks {
-  int (* recv)(struct netflood_conn *c, const rimeaddr_t *from,
-	       const rimeaddr_t *originator, uint8_t seqno, uint8_t hops);
+  int (* recv)(struct netflood_conn *c, const linkaddr_t *from,
+	       const linkaddr_t *originator, uint8_t seqno, uint8_t hops);
   void (* sent)(struct netflood_conn *c);
   void (* dropped)(struct netflood_conn *c);
 };
@@ -95,7 +95,7 @@ struct netflood_conn {
   struct ipolite_conn c;
   const struct netflood_callbacks *u;
   clock_time_t queue_time;
-  rimeaddr_t last_originator;
+  linkaddr_t last_originator;
   uint8_t last_originator_seqno;
 };
 

--- a/core/net/rime/polite-announcement.c
+++ b/core/net/rime/polite-announcement.c
@@ -112,7 +112,7 @@ send_adv(clock_time_t interval)
 		      sizeof(struct announcement_data) * adata->num);
 
   PRINTF("%d.%d: sending neighbor advertisement with %d announcements\n",
-	 rimeaddr_node_addr.u8[0], rimeaddr_node_addr.u8[1], adata->num);
+	 linkaddr_node_addr.u8[0], linkaddr_node_addr.u8[1], adata->num);
 
   if(adata->num > 0) {
     /* Send the packet only if it contains more than zero announcements. */
@@ -121,7 +121,7 @@ send_adv(clock_time_t interval)
 }
 /*---------------------------------------------------------------------------*/
 static void
-adv_packet_received(struct ipolite_conn *ipolite, const rimeaddr_t *from)
+adv_packet_received(struct ipolite_conn *ipolite, const linkaddr_t *from)
 {
   struct announcement_msg adata;
   struct announcement_data data;
@@ -133,7 +133,7 @@ adv_packet_received(struct ipolite_conn *ipolite, const rimeaddr_t *from)
   /* Copy number of announcements */
   memcpy(&adata, ptr, sizeof(struct announcement_msg));
   PRINTF("%d.%d: adv_packet_received from %d.%d with %d announcements\n",
-	 rimeaddr_node_addr.u8[0], rimeaddr_node_addr.u8[1],
+	 linkaddr_node_addr.u8[0], linkaddr_node_addr.u8[1],
 	 from->u8[0], from->u8[1], adata.num);
 
   if(ANNOUNCEMENT_MSG_HEADERLEN + adata.num * sizeof(struct announcement_data) > packetbuf_datalen()) {

--- a/core/net/rime/rime.h
+++ b/core/net/rime/rime.h
@@ -55,7 +55,7 @@
 #include "net/rime/polite-announcement.h"
 #include "net/rime/polite.h"
 #include "net/queuebuf.h"
-#include "net/rimeaddr.h"
+#include "net/linkaddr.h"
 #include "net/packetbuf.h"
 #include "net/rime/rimestats.h"
 #include "net/rime/rmh.h"

--- a/core/net/rime/rmh.c
+++ b/core/net/rime/rmh.c
@@ -47,8 +47,8 @@
 #include "net/rime/rmh.h"
 
 struct data_hdr {
-  rimeaddr_t dest;
-  rimeaddr_t originator;
+  linkaddr_t dest;
+  linkaddr_t originator;
   uint8_t hops;
   uint8_t max_rexmits;
 };
@@ -63,18 +63,18 @@ struct data_hdr {
 
 /*---------------------------------------------------------------------------*/
 static void
-received(struct runicast_conn *uc, const rimeaddr_t *from, uint8_t seqno)
+received(struct runicast_conn *uc, const linkaddr_t *from, uint8_t seqno)
 {
   struct rmh_conn *c = (struct rmh_conn *)uc;
   struct data_hdr *msg = packetbuf_dataptr();
-  rimeaddr_t *nexthop;
+  linkaddr_t *nexthop;
 
   PRINTF("data_packet_received from %d.%d towards %d.%d len %d\n", 
          from->u8[0], from->u8[1],
 	 msg->dest.u8[0], msg->dest.u8[1],
 	 packetbuf_datalen());
 
-  if(rimeaddr_cmp(&msg->dest, &rimeaddr_node_addr)) {
+  if(linkaddr_cmp(&msg->dest, &linkaddr_node_addr)) {
     PRINTF("for us!\n");
     packetbuf_hdrreduce(sizeof(struct data_hdr));
     if(c->cb->recv) {
@@ -95,13 +95,13 @@ received(struct runicast_conn *uc, const rimeaddr_t *from, uint8_t seqno)
 }
 /*---------------------------------------------------------------------------*/
 static void
-sent(struct runicast_conn *c, const rimeaddr_t *to, uint8_t retransmissions)
+sent(struct runicast_conn *c, const linkaddr_t *to, uint8_t retransmissions)
 {
 
 }
 /*---------------------------------------------------------------------------*/
 static void
-timedout(struct runicast_conn *c, const rimeaddr_t *to, uint8_t retransmissions)
+timedout(struct runicast_conn *c, const linkaddr_t *to, uint8_t retransmissions)
 {
 
 }
@@ -125,9 +125,9 @@ rmh_close(struct rmh_conn *c)
 }
 /*---------------------------------------------------------------------------*/
 int
-rmh_send(struct rmh_conn *c, rimeaddr_t *to, uint8_t num_rexmit, uint8_t max_hops)
+rmh_send(struct rmh_conn *c, linkaddr_t *to, uint8_t num_rexmit, uint8_t max_hops)
 {
-  rimeaddr_t *nexthop;
+  linkaddr_t *nexthop;
   struct data_hdr *hdr;
   
   c->num_rexmit = num_rexmit;
@@ -136,7 +136,7 @@ rmh_send(struct rmh_conn *c, rimeaddr_t *to, uint8_t num_rexmit, uint8_t max_hop
     return 0;
   }
   
-  nexthop = c->cb->forward(c, &rimeaddr_node_addr, to, NULL, 0);
+  nexthop = c->cb->forward(c, &linkaddr_node_addr, to, NULL, 0);
   if(nexthop == NULL) {
     PRINTF("rmh_send: no route\n");
     return 0;
@@ -146,8 +146,8 @@ rmh_send(struct rmh_conn *c, rimeaddr_t *to, uint8_t num_rexmit, uint8_t max_hop
     
     if(packetbuf_hdralloc(sizeof(struct data_hdr))) {
       hdr = packetbuf_hdrptr();
-      rimeaddr_copy(&hdr->dest, to);
-      rimeaddr_copy(&hdr->originator, &rimeaddr_node_addr);
+      linkaddr_copy(&hdr->dest, to);
+      linkaddr_copy(&hdr->originator, &linkaddr_node_addr);
       hdr->hops = 1;
       hdr->max_rexmits = num_rexmit;
       runicast_send(&c->c, nexthop, num_rexmit);

--- a/core/net/rime/rmh.h
+++ b/core/net/rime/rmh.h
@@ -66,7 +66,7 @@
 #define RMH_H_
 
 #include "net/rime/runicast.h"
-#include "net/rimeaddr.h"
+#include "net/linkaddr.h"
 
 struct rmh_conn;
 
@@ -77,11 +77,11 @@ struct rmh_conn;
                         RUC_ATTRIBUTES
 
 struct rmh_callbacks {
-  void (* recv)(struct rmh_conn *ptr, rimeaddr_t *sender, uint8_t hops);
-  rimeaddr_t *(* forward)(struct rmh_conn *ptr,
-			  const rimeaddr_t *originator,
-			  const rimeaddr_t *dest,
-			  const rimeaddr_t *prevhop,
+  void (* recv)(struct rmh_conn *ptr, linkaddr_t *sender, uint8_t hops);
+  linkaddr_t *(* forward)(struct rmh_conn *ptr,
+			  const linkaddr_t *originator,
+			  const linkaddr_t *dest,
+			  const linkaddr_t *prevhop,
 			  uint8_t hops);
 };
 
@@ -94,7 +94,7 @@ struct rmh_conn {
 void rmh_open(struct rmh_conn *c, uint16_t channel,
 	      const struct rmh_callbacks *u);
 void rmh_close(struct rmh_conn *c);
-int rmh_send(struct rmh_conn *c, rimeaddr_t *to, uint8_t num_rexmit,
+int rmh_send(struct rmh_conn *c, linkaddr_t *to, uint8_t num_rexmit,
 	     uint8_t max_hops);
 
 #endif /* RMH_H_ */

--- a/core/net/rime/route-discovery.c
+++ b/core/net/rime/route-discovery.c
@@ -51,7 +51,7 @@
 #include <stdio.h>
 
 struct route_msg {
-  rimeaddr_t dest;
+  linkaddr_t dest;
   uint8_t rreq_id;
   uint8_t pad;
 };
@@ -59,8 +59,8 @@ struct route_msg {
 struct rrep_hdr {
   uint8_t rreq_id;
   uint8_t hops;
-  rimeaddr_t dest;
-  rimeaddr_t originator;
+  linkaddr_t dest;
+  linkaddr_t originator;
 };
 
 #if CONTIKI_TARGET_NETSIM
@@ -80,12 +80,12 @@ struct rrep_hdr {
 static char rrep_pending;		/* A reply for a request is pending. */
 /*---------------------------------------------------------------------------*/
 static void
-send_rreq(struct route_discovery_conn *c, const rimeaddr_t *dest)
+send_rreq(struct route_discovery_conn *c, const linkaddr_t *dest)
 {
-  rimeaddr_t dest_copy;
+  linkaddr_t dest_copy;
   struct route_msg *msg;
 
-  rimeaddr_copy(&dest_copy, dest);
+  linkaddr_copy(&dest_copy, dest);
   dest = &dest_copy;
 
   packetbuf_clear();
@@ -94,48 +94,48 @@ send_rreq(struct route_discovery_conn *c, const rimeaddr_t *dest)
 
   msg->pad = 0;
   msg->rreq_id = c->rreq_id;
-  rimeaddr_copy(&msg->dest, dest);
+  linkaddr_copy(&msg->dest, dest);
 
   netflood_send(&c->rreqconn, c->rreq_id);
   c->rreq_id++;
 }
 /*---------------------------------------------------------------------------*/
 static void
-send_rrep(struct route_discovery_conn *c, const rimeaddr_t *dest)
+send_rrep(struct route_discovery_conn *c, const linkaddr_t *dest)
 {
   struct rrep_hdr *rrepmsg;
   struct route_entry *rt;
-  rimeaddr_t saved_dest;
+  linkaddr_t saved_dest;
   
-  rimeaddr_copy(&saved_dest, dest);
+  linkaddr_copy(&saved_dest, dest);
 
   packetbuf_clear();
   dest = &saved_dest;
   rrepmsg = packetbuf_dataptr();
   packetbuf_set_datalen(sizeof(struct rrep_hdr));
   rrepmsg->hops = 0;
-  rimeaddr_copy(&rrepmsg->dest, dest);
-  rimeaddr_copy(&rrepmsg->originator, &rimeaddr_node_addr);
+  linkaddr_copy(&rrepmsg->dest, dest);
+  linkaddr_copy(&rrepmsg->originator, &linkaddr_node_addr);
   rt = route_lookup(dest);
   if(rt != NULL) {
     PRINTF("%d.%d: send_rrep to %d.%d via %d.%d\n",
-	   rimeaddr_node_addr.u8[0], rimeaddr_node_addr.u8[1],
+	   linkaddr_node_addr.u8[0], linkaddr_node_addr.u8[1],
 	   dest->u8[0],dest->u8[1],
 	   rt->nexthop.u8[0],rt->nexthop.u8[1]);
     unicast_send(&c->rrepconn, &rt->nexthop);
   } else {
     PRINTF("%d.%d: no route for rrep to %d.%d\n",
-	   rimeaddr_node_addr.u8[0], rimeaddr_node_addr.u8[1],
+	   linkaddr_node_addr.u8[0], linkaddr_node_addr.u8[1],
 	   dest->u8[0],dest->u8[1]);
   }
 }
 /*---------------------------------------------------------------------------*/
 static void
-insert_route(const rimeaddr_t *originator, const rimeaddr_t *last_hop,
+insert_route(const linkaddr_t *originator, const linkaddr_t *last_hop,
 	     uint8_t hops)
 {
   PRINTF("%d.%d: Inserting %d.%d into routing table, next hop %d.%d, hop count %d\n",
-	 rimeaddr_node_addr.u8[0], rimeaddr_node_addr.u8[1],
+	 linkaddr_node_addr.u8[0], linkaddr_node_addr.u8[1],
 	 originator->u8[0], originator->u8[1],
 	 last_hop->u8[0], last_hop->u8[1],
 	 hops);
@@ -147,7 +147,7 @@ insert_route(const rimeaddr_t *originator, const rimeaddr_t *last_hop,
   rt = route_lookup(originator);
   if(rt == NULL || hops < rt->hop_count) {
     PRINTF("%d.%d: Inserting %d.%d into routing table, next hop %d.%d, hop count %d\n",
-	   rimeaddr_node_addr.u8[0], rimeaddr_node_addr.u8[1],
+	   linkaddr_node_addr.u8[0], linkaddr_node_addr.u8[1],
 	   originator->u8[0], originator->u8[1],
 	   last_hop->u8[0], last_hop->u8[1],
 	   hops);
@@ -160,16 +160,16 @@ insert_route(const rimeaddr_t *originator, const rimeaddr_t *last_hop,
 }
 /*---------------------------------------------------------------------------*/
 static void
-rrep_packet_received(struct unicast_conn *uc, const rimeaddr_t *from)
+rrep_packet_received(struct unicast_conn *uc, const linkaddr_t *from)
 {
   struct rrep_hdr *msg = packetbuf_dataptr();
   struct route_entry *rt;
-  rimeaddr_t dest;
+  linkaddr_t dest;
   struct route_discovery_conn *c = (struct route_discovery_conn *)
     ((char *)uc - offsetof(struct route_discovery_conn, rrepconn));
 
   PRINTF("%d.%d: rrep_packet_received from %d.%d towards %d.%d len %d\n",
-	 rimeaddr_node_addr.u8[0], rimeaddr_node_addr.u8[1],
+	 linkaddr_node_addr.u8[0], linkaddr_node_addr.u8[1],
 	 from->u8[0],from->u8[1],
 	 msg->dest.u8[0],msg->dest.u8[1],
 	 packetbuf_datalen());
@@ -182,22 +182,22 @@ rrep_packet_received(struct unicast_conn *uc, const rimeaddr_t *from)
 
   insert_route(&msg->originator, from, msg->hops);
 
-  if(rimeaddr_cmp(&msg->dest, &rimeaddr_node_addr)) {
+  if(linkaddr_cmp(&msg->dest, &linkaddr_node_addr)) {
     PRINTF("rrep for us!\n");
     rrep_pending = 0;
     ctimer_stop(&c->t);
     if(c->cb->new_route) {
-      rimeaddr_t originator;
+      linkaddr_t originator;
 
       /* If the callback modifies the packet, the originator address
          will be lost. Therefore, we need to copy it into a local
          variable before calling the callback. */
-      rimeaddr_copy(&originator, &msg->originator);
+      linkaddr_copy(&originator, &msg->originator);
       c->cb->new_route(c, &originator);
     }
 
   } else {
-    rimeaddr_copy(&dest, &msg->dest);
+    linkaddr_copy(&dest, &msg->dest);
 
     rt = route_lookup(&msg->dest);
     if(rt != NULL) {
@@ -205,42 +205,42 @@ rrep_packet_received(struct unicast_conn *uc, const rimeaddr_t *from)
       msg->hops++;
       unicast_send(&c->rrepconn, &rt->nexthop);
     } else {
-      PRINTF("%d.%d: no route to %d.%d\n", rimeaddr_node_addr.u8[0], rimeaddr_node_addr.u8[1], msg->dest.u8[0], msg->dest.u8[1]);
+      PRINTF("%d.%d: no route to %d.%d\n", linkaddr_node_addr.u8[0], linkaddr_node_addr.u8[1], msg->dest.u8[0], msg->dest.u8[1]);
     }
   }
 }
 /*---------------------------------------------------------------------------*/
 static int
-rreq_packet_received(struct netflood_conn *nf, const rimeaddr_t *from,
-		     const rimeaddr_t *originator, uint8_t seqno, uint8_t hops)
+rreq_packet_received(struct netflood_conn *nf, const linkaddr_t *from,
+		     const linkaddr_t *originator, uint8_t seqno, uint8_t hops)
 {
   struct route_msg *msg = packetbuf_dataptr();
   struct route_discovery_conn *c = (struct route_discovery_conn *)
     ((char *)nf - offsetof(struct route_discovery_conn, rreqconn));
 
   PRINTF("%d.%d: rreq_packet_received from %d.%d hops %d rreq_id %d last %d.%d/%d\n",
-	 rimeaddr_node_addr.u8[0], rimeaddr_node_addr.u8[1],
+	 linkaddr_node_addr.u8[0], linkaddr_node_addr.u8[1],
 	 from->u8[0], from->u8[1],
 	 hops, msg->rreq_id,
      c->last_rreq_originator.u8[0],
      c->last_rreq_originator.u8[1],
 	 c->last_rreq_id);
 
-  if(!(rimeaddr_cmp(&c->last_rreq_originator, originator) &&
+  if(!(linkaddr_cmp(&c->last_rreq_originator, originator) &&
        c->last_rreq_id == msg->rreq_id)) {
 
     PRINTF("%d.%d: rreq_packet_received: request for %d.%d originator %d.%d / %d\n",
-	   rimeaddr_node_addr.u8[0], rimeaddr_node_addr.u8[1],
+	   linkaddr_node_addr.u8[0], linkaddr_node_addr.u8[1],
 	   msg->dest.u8[0], msg->dest.u8[1],
 	   originator->u8[0], originator->u8[1],
 	   msg->rreq_id);
 
-    rimeaddr_copy(&c->last_rreq_originator, originator);
+    linkaddr_copy(&c->last_rreq_originator, originator);
     c->last_rreq_id = msg->rreq_id;
 
-    if(rimeaddr_cmp(&msg->dest, &rimeaddr_node_addr)) {
+    if(linkaddr_cmp(&msg->dest, &linkaddr_node_addr)) {
       PRINTF("%d.%d: route_packet_received: route request for our address\n",
-	     rimeaddr_node_addr.u8[0], rimeaddr_node_addr.u8[1]);
+	     linkaddr_node_addr.u8[0], linkaddr_node_addr.u8[1]);
       PRINTF("from %d.%d hops %d rssi %d lqi %d\n",
 	     from->u8[0], from->u8[1],
 	     hops,
@@ -301,7 +301,7 @@ timeout_handler(void *ptr)
 }
 /*---------------------------------------------------------------------------*/
 int
-route_discovery_discover(struct route_discovery_conn *c, const rimeaddr_t *addr,
+route_discovery_discover(struct route_discovery_conn *c, const linkaddr_t *addr,
 			 clock_time_t timeout)
 {
   if(rrep_pending) {

--- a/core/net/rime/route-discovery.h
+++ b/core/net/rime/route-discovery.h
@@ -64,7 +64,7 @@
 struct route_discovery_conn;
 
 struct route_discovery_callbacks {
-  void (* new_route)(struct route_discovery_conn *c, const rimeaddr_t *to);
+  void (* new_route)(struct route_discovery_conn *c, const linkaddr_t *to);
   void (* timedout)(struct route_discovery_conn *c);
 };
 
@@ -74,7 +74,7 @@ struct route_discovery_conn {
   struct netflood_conn rreqconn;
   struct unicast_conn rrepconn;
   struct ctimer t;
-  rimeaddr_t last_rreq_originator;
+  linkaddr_t last_rreq_originator;
   uint16_t last_rreq_id;
   uint16_t rreq_id;
   const struct route_discovery_callbacks *cb;
@@ -83,7 +83,7 @@ struct route_discovery_conn {
 void route_discovery_open(struct route_discovery_conn *c, clock_time_t time,
 			  uint16_t channels,
 			  const struct route_discovery_callbacks *callbacks);
-int route_discovery_discover(struct route_discovery_conn *c, const rimeaddr_t *dest,
+int route_discovery_discover(struct route_discovery_conn *c, const linkaddr_t *dest,
 			     clock_time_t timeout);
 
 void route_discovery_close(struct route_discovery_conn *c);

--- a/core/net/rime/route.c
+++ b/core/net/rime/route.c
@@ -118,14 +118,14 @@ route_init(void)
 }
 /*---------------------------------------------------------------------------*/
 int
-route_add(const rimeaddr_t *dest, const rimeaddr_t *nexthop,
+route_add(const linkaddr_t *dest, const linkaddr_t *nexthop,
 	  uint8_t cost, uint8_t seqno)
 {
   struct route_entry *e;
 
   /* Avoid inserting duplicate entries. */
   e = route_lookup(dest);
-  if(e != NULL && rimeaddr_cmp(&e->nexthop, nexthop)) {
+  if(e != NULL && linkaddr_cmp(&e->nexthop, nexthop)) {
     list_remove(route_table, e);
   } else {
     /* Allocate a new entry or reuse the oldest entry with highest cost. */
@@ -140,8 +140,8 @@ route_add(const rimeaddr_t *dest, const rimeaddr_t *nexthop,
     }
   }
 
-  rimeaddr_copy(&e->dest, dest);
-  rimeaddr_copy(&e->nexthop, nexthop);
+  linkaddr_copy(&e->dest, dest);
+  linkaddr_copy(&e->nexthop, nexthop);
   e->cost = cost;
   e->seqno = seqno;
   e->time = 0;
@@ -159,7 +159,7 @@ route_add(const rimeaddr_t *dest, const rimeaddr_t *nexthop,
 }
 /*---------------------------------------------------------------------------*/
 struct route_entry *
-route_lookup(const rimeaddr_t *dest)
+route_lookup(const linkaddr_t *dest)
 {
   struct route_entry *e;
   uint8_t lowest_cost;
@@ -173,7 +173,7 @@ route_lookup(const rimeaddr_t *dest)
     /*    printf("route_lookup: comparing %d.%d.%d.%d with %d.%d.%d.%d\n",
 	   uip_ipaddr_to_quad(dest), uip_ipaddr_to_quad(&e->dest));*/
 
-    if(rimeaddr_cmp(dest, &e->dest)) {
+    if(linkaddr_cmp(dest, &e->dest)) {
       if(e->cost < lowest_cost) {
 	best_entry = e;
 	lowest_cost = e->cost;

--- a/core/net/rime/route.h
+++ b/core/net/rime/route.h
@@ -51,12 +51,12 @@
 #ifndef ROUTE_H_
 #define ROUTE_H_
 
-#include "net/rimeaddr.h"
+#include "net/linkaddr.h"
 
 struct route_entry {
   struct route_entry *next;
-  rimeaddr_t dest;
-  rimeaddr_t nexthop;
+  linkaddr_t dest;
+  linkaddr_t nexthop;
   uint8_t seqno;
   uint8_t cost;
   uint8_t time;
@@ -66,9 +66,9 @@ struct route_entry {
 };
 
 void route_init(void);
-int route_add(const rimeaddr_t *dest, const rimeaddr_t *nexthop,
+int route_add(const linkaddr_t *dest, const linkaddr_t *nexthop,
 	      uint8_t cost, uint8_t seqno);
-struct route_entry *route_lookup(const rimeaddr_t *dest);
+struct route_entry *route_lookup(const linkaddr_t *dest);
 void route_refresh(struct route_entry *e);
 void route_decay(struct route_entry *e);
 void route_remove(struct route_entry *e);

--- a/core/net/rime/rucb.c
+++ b/core/net/rime/rucb.c
@@ -65,12 +65,12 @@ read_data(struct rucb_conn *c)
 }
 /*---------------------------------------------------------------------------*/
 static void
-acked(struct runicast_conn *ruc, const rimeaddr_t *to, uint8_t retransmissions)
+acked(struct runicast_conn *ruc, const linkaddr_t *to, uint8_t retransmissions)
 {
   struct rucb_conn *c = (struct rucb_conn *)ruc;
   int len;
   PRINTF("%d.%d: rucb acked\n",
-	 rimeaddr_node_addr.u8[0],rimeaddr_node_addr.u8[1]);
+	 linkaddr_node_addr.u8[0],linkaddr_node_addr.u8[1]);
   c->chunk++;
   len = read_data(c);
   if(len == 0 && c->last_size == 0) {
@@ -86,23 +86,23 @@ acked(struct runicast_conn *ruc, const rimeaddr_t *to, uint8_t retransmissions)
 }
 /*---------------------------------------------------------------------------*/
 static void
-timedout(struct runicast_conn *ruc, const rimeaddr_t *to, uint8_t retransmissions)
+timedout(struct runicast_conn *ruc, const linkaddr_t *to, uint8_t retransmissions)
 {
   struct rucb_conn *c = (struct rucb_conn *)ruc;
   PRINTF("%d.%d: rucb timedout\n",
-	 rimeaddr_node_addr.u8[0],rimeaddr_node_addr.u8[1]);
+	 linkaddr_node_addr.u8[0],linkaddr_node_addr.u8[1]);
   if(c->u->timedout) {
     c->u->timedout(c);
   }
 }
 /*---------------------------------------------------------------------------*/
 static void
-recv(struct runicast_conn *ruc, const rimeaddr_t *from, uint8_t seqno)
+recv(struct runicast_conn *ruc, const linkaddr_t *from, uint8_t seqno)
 {
   struct rucb_conn *c = (struct rucb_conn *)ruc;
 
   PRINTF("%d.%d: rucb: recv from %d.%d len %d\n",
-	 rimeaddr_node_addr.u8[0],rimeaddr_node_addr.u8[1],
+	 linkaddr_node_addr.u8[0],linkaddr_node_addr.u8[1],
 	 from->u8[0], from->u8[1], packetbuf_totlen());
 
   if(seqno == c->last_seqno) {
@@ -110,19 +110,19 @@ recv(struct runicast_conn *ruc, const rimeaddr_t *from, uint8_t seqno)
   }
   c->last_seqno = seqno;
 
-  if(rimeaddr_cmp(&c->sender, &rimeaddr_null)) {
-    rimeaddr_copy(&c->sender, from);
+  if(linkaddr_cmp(&c->sender, &linkaddr_null)) {
+    linkaddr_copy(&c->sender, from);
     c->u->write_chunk(c, 0, RUCB_FLAG_NEWFILE, packetbuf_dataptr(), 0);
     c->chunk = 0;
   }
 
 
-  if(rimeaddr_cmp(&c->sender, from)) {
+  if(linkaddr_cmp(&c->sender, from)) {
     int datalen = packetbuf_datalen();
 
     if(datalen < RUCB_DATASIZE) {
       PRINTF("%d.%d: get %d bytes, file complete\n",
-	     rimeaddr_node_addr.u8[0], rimeaddr_node_addr.u8[1],
+	     linkaddr_node_addr.u8[0], linkaddr_node_addr.u8[1],
 	     datalen);
       c->u->write_chunk(c, c->chunk * RUCB_DATASIZE,
 			 RUCB_FLAG_LASTCHUNK, packetbuf_dataptr(), datalen);
@@ -134,7 +134,7 @@ recv(struct runicast_conn *ruc, const rimeaddr_t *from, uint8_t seqno)
   }
 
   if(packetbuf_datalen() < RUCB_DATASIZE) {
-    rimeaddr_copy(&c->sender, &rimeaddr_null);
+    linkaddr_copy(&c->sender, &linkaddr_null);
   }
 }
 /*---------------------------------------------------------------------------*/
@@ -144,7 +144,7 @@ void
 rucb_open(struct rucb_conn *c, uint16_t channel,
 	  const struct rucb_callbacks *u)
 {
-  rimeaddr_copy(&c->sender, &rimeaddr_null);
+  linkaddr_copy(&c->sender, &linkaddr_null);
   runicast_open(&c->c, channel, &ruc);
   c->u = u;
   c->last_seqno = -1;
@@ -158,12 +158,12 @@ rucb_close(struct rucb_conn *c)
 }
 /*---------------------------------------------------------------------------*/
 int
-rucb_send(struct rucb_conn *c, const rimeaddr_t *receiver)
+rucb_send(struct rucb_conn *c, const linkaddr_t *receiver)
 {
   c->chunk = 0;
   read_data(c);
-  rimeaddr_copy(&c->receiver, receiver);
-  rimeaddr_copy(&c->sender, &rimeaddr_node_addr);
+  linkaddr_copy(&c->receiver, receiver);
+  linkaddr_copy(&c->sender, &linkaddr_node_addr);
   runicast_send(&c->c, receiver, MAX_TRANSMISSIONS);
   return 0;
 }

--- a/core/net/rime/rucb.h
+++ b/core/net/rime/rucb.h
@@ -63,7 +63,7 @@ struct rucb_callbacks {
 struct rucb_conn {
   struct runicast_conn c;
   const struct rucb_callbacks *u;
-  rimeaddr_t receiver, sender;
+  linkaddr_t receiver, sender;
   uint16_t chunk;
   uint8_t last_seqno;
   int last_size;
@@ -73,7 +73,7 @@ void rucb_open(struct rucb_conn *c, uint16_t channel,
 	      const struct rucb_callbacks *u);
 void rucb_close(struct rucb_conn *c);
 
-int rucb_send(struct rucb_conn *c, const rimeaddr_t *receiver);
+int rucb_send(struct rucb_conn *c, const linkaddr_t *receiver);
 
 
 #endif /* RUCB_H_ */

--- a/core/net/rime/rudolph1.c
+++ b/core/net/rime/rudolph1.c
@@ -122,7 +122,7 @@ write_data(struct rudolph1_conn *c, int chunk, uint8_t *data, int datalen)
 
   if(datalen < RUDOLPH1_DATASIZE) {
     PRINTF("%d.%d: get %d bytes, file complete\n",
-	   rimeaddr_node_addr.u8[0], rimeaddr_node_addr.u8[1],
+	   linkaddr_node_addr.u8[0], linkaddr_node_addr.u8[1],
 	   datalen);
     c->cb->write_chunk(c, chunk * RUDOLPH1_DATASIZE,
 		       RUDOLPH1_FLAG_LASTCHUNK, data, datalen);
@@ -145,7 +145,7 @@ send_nack(struct rudolph1_conn *c)
   hdr->chunk = c->chunk;
 
   PRINTF("%d.%d: Sending nack for %d:%d\n",
-	 rimeaddr_node_addr.u8[0], rimeaddr_node_addr.u8[1],
+	 linkaddr_node_addr.u8[0], linkaddr_node_addr.u8[1],
 	 hdr->version, hdr->chunk);
   ipolite_send(&c->ipolite, NACK_TIMEOUT, sizeof(struct rudolph1_hdr));
 }
@@ -155,7 +155,7 @@ handle_data(struct rudolph1_conn *c, struct rudolph1_datapacket *p)
 {
   if(LT(c->version, p->h.version)) {
     PRINTF("%d.%d: rudolph1 new version %d, chunk %d\n",
-	   rimeaddr_node_addr.u8[0], rimeaddr_node_addr.u8[1],
+	   linkaddr_node_addr.u8[0], linkaddr_node_addr.u8[1],
 	   p->h.version, p->h.chunk);
     c->version = p->h.version;
     c->highest_chunk_heard = c->chunk = 0;
@@ -168,12 +168,12 @@ handle_data(struct rudolph1_conn *c, struct rudolph1_datapacket *p)
       /*    }*/
   } else if(p->h.version == c->version) {
     PRINTF("%d.%d: got chunk %d (%d) highest heard %d\n",
-	   rimeaddr_node_addr.u8[0], rimeaddr_node_addr.u8[1],
+	   linkaddr_node_addr.u8[0], linkaddr_node_addr.u8[1],
 	   p->h.chunk, c->chunk, c->highest_chunk_heard);
 
     if(p->h.chunk == c->chunk) {
       PRINTF("%d.%d: received chunk %d\n",
-	     rimeaddr_node_addr.u8[0], rimeaddr_node_addr.u8[1],
+	     linkaddr_node_addr.u8[0], linkaddr_node_addr.u8[1],
 	     p->h.chunk);
       write_data(c, p->h.chunk, p->data, p->datalen);
       if(c->highest_chunk_heard < c->chunk) {
@@ -182,7 +182,7 @@ handle_data(struct rudolph1_conn *c, struct rudolph1_datapacket *p)
       c->chunk++;
     } else if(p->h.chunk > c->chunk) {
       PRINTF("%d.%d: received chunk %d > %d, sending NACK\n",
-	     rimeaddr_node_addr.u8[0], rimeaddr_node_addr.u8[1],
+	     linkaddr_node_addr.u8[0], linkaddr_node_addr.u8[1],
 	     p->h.chunk, c->chunk);
       send_nack(c);
       c->highest_chunk_heard = p->h.chunk;
@@ -210,7 +210,7 @@ recv_trickle(struct trickle_conn *trickle)
 
   if(p->h.type == TYPE_DATA) {
     PRINTF("%d.%d: received trickle with chunk %d\n",
-	   rimeaddr_node_addr.u8[0], rimeaddr_node_addr.u8[1],
+	   linkaddr_node_addr.u8[0], linkaddr_node_addr.u8[1],
 	   p->h.chunk);
     handle_data(c, p);
   }
@@ -220,39 +220,39 @@ static void
 sent_ipolite(struct ipolite_conn *ipolite)
 {
   PRINTF("%d.%d: Sent ipolite\n",
-	 rimeaddr_node_addr.u8[0], rimeaddr_node_addr.u8[1]);
+	 linkaddr_node_addr.u8[0], linkaddr_node_addr.u8[1]);
 }
 /*---------------------------------------------------------------------------*/
 static void
 dropped_ipolite(struct ipolite_conn *ipolite)
 {
   PRINTF("%d.%d: dropped ipolite\n",
-	 rimeaddr_node_addr.u8[0], rimeaddr_node_addr.u8[1]);
+	 linkaddr_node_addr.u8[0], linkaddr_node_addr.u8[1]);
 }
 /*---------------------------------------------------------------------------*/
 static void
-recv_ipolite(struct ipolite_conn *ipolite, const rimeaddr_t *from)
+recv_ipolite(struct ipolite_conn *ipolite, const linkaddr_t *from)
 {
   struct rudolph1_conn *c = (struct rudolph1_conn *)
     ((char *)ipolite - offsetof(struct rudolph1_conn, ipolite));
   struct rudolph1_datapacket *p = packetbuf_dataptr();
 
   PRINTF("%d.%d: Got ipolite type %d\n",
-	 rimeaddr_node_addr.u8[0], rimeaddr_node_addr.u8[1],
+	 linkaddr_node_addr.u8[0], linkaddr_node_addr.u8[1],
 	 p->h.type);
 
   c->nacks++;
 
   if(p->h.type == TYPE_NACK) {
     PRINTF("%d.%d: Got NACK for %d:%d (%d:%d)\n",
-	   rimeaddr_node_addr.u8[0], rimeaddr_node_addr.u8[1],
+	   linkaddr_node_addr.u8[0], linkaddr_node_addr.u8[1],
 	   p->h.version, p->h.chunk,
 	   c->version, c->chunk);
     if(p->h.version == c->version) {
       if(p->h.chunk < c->chunk) {
 	/* Format and send a repair packet */
 	PRINTF("%d.%d: sending repair for chunk %d\n",
-	       rimeaddr_node_addr.u8[0], rimeaddr_node_addr.u8[1],
+	       linkaddr_node_addr.u8[0], linkaddr_node_addr.u8[1],
 	       p->h.chunk);
 	format_data(c, p->h.chunk);
 	ipolite_send(&c->ipolite, REPAIR_TIMEOUT, sizeof(struct rudolph1_hdr));
@@ -264,7 +264,7 @@ recv_ipolite(struct ipolite_conn *ipolite, const rimeaddr_t *from)
   } else if(p->h.type == TYPE_DATA) {
     /* This is a repair packet from someone else. */
     PRINTF("%d.%d: got repair for chunk %d\n",
-	   rimeaddr_node_addr.u8[0], rimeaddr_node_addr.u8[1],
+	   linkaddr_node_addr.u8[0], linkaddr_node_addr.u8[1],
 	   p->h.chunk);
     handle_data(c, p);
   }
@@ -282,7 +282,7 @@ send_next_packet(void *ptr)
       ctimer_set(&c->t, c->send_interval, send_next_packet, c);
     }
     PRINTF("%d.%d: send_next_packet chunk %d, next %d\n",
-	   rimeaddr_node_addr.u8[0], rimeaddr_node_addr.u8[1],
+	   linkaddr_node_addr.u8[0], linkaddr_node_addr.u8[1],
 	   c->chunk, c->chunk + 1);
 
     c->highest_chunk_heard = c->chunk;

--- a/core/net/rime/rudolph2.c
+++ b/core/net/rime/rudolph2.c
@@ -135,13 +135,13 @@ write_data(struct rudolph2_conn *c, int chunk, uint8_t *data, int datalen)
   }
   
   PRINTF("%d.%d: get %d bytes\n",
-	 rimeaddr_node_addr.u8[0], rimeaddr_node_addr.u8[1],
+	 linkaddr_node_addr.u8[0], linkaddr_node_addr.u8[1],
 	 datalen);
 
   
   if(datalen < RUDOLPH2_DATASIZE) {
     PRINTF("%d.%d: get %d bytes, file complete\n",
-	   rimeaddr_node_addr.u8[0], rimeaddr_node_addr.u8[1],
+	   linkaddr_node_addr.u8[0], linkaddr_node_addr.u8[1],
 	   datalen);
     c->cb->write_chunk(c, chunk * RUDOLPH2_DATASIZE,
 		       RUDOLPH2_FLAG_LASTCHUNK, data, datalen);
@@ -159,7 +159,7 @@ send_data(struct rudolph2_conn *c, clock_time_t interval)
   len = format_data(c, c->snd_nxt);
   polite_send(&c->c, interval, POLITE_HEADER);
   PRINTF("%d.%d: send_data chunk %d, rcv_nxt %d\n",
-	 rimeaddr_node_addr.u8[0], rimeaddr_node_addr.u8[1],
+	 linkaddr_node_addr.u8[0], linkaddr_node_addr.u8[1],
 	 c->snd_nxt, c->rcv_nxt);
 
   return len;
@@ -179,7 +179,7 @@ send_nack(struct rudolph2_conn *c)
   hdr->chunk = c->rcv_nxt;
 
   PRINTF("%d.%d: Sending nack for %d\n",
-	 rimeaddr_node_addr.u8[0], rimeaddr_node_addr.u8[1],
+	 linkaddr_node_addr.u8[0], linkaddr_node_addr.u8[1],
 	 hdr->chunk);
   polite_send(&c->c, NACK_TIMEOUT, POLITE_HEADER);
 }
@@ -297,7 +297,7 @@ recv(struct polite_conn *polite)
   if(hdr->type == TYPE_NACK && hdr->hops_from_base > c->hops_from_base) {
     c->nacks++;
     PRINTF("%d.%d: Got NACK for %d:%d (%d:%d)\n",
-	   rimeaddr_node_addr.u8[0], rimeaddr_node_addr.u8[1],
+	   linkaddr_node_addr.u8[0], linkaddr_node_addr.u8[1],
 	   hdr->version, hdr->chunk,
 	   c->version, c->rcv_nxt);
     if(hdr->version == c->version) {
@@ -316,7 +316,7 @@ recv(struct polite_conn *polite)
       c->hops_from_base = hdr->hops_from_base + 1;
       if(LT(c->version, hdr->version)) {
 	PRINTF("%d.%d: rudolph2 new version %d, chunk %d\n",
-	       rimeaddr_node_addr.u8[0], rimeaddr_node_addr.u8[1],
+	       linkaddr_node_addr.u8[0], linkaddr_node_addr.u8[1],
 	       hdr->version, hdr->chunk);
 	c->version = hdr->version;
 	c->snd_nxt = c->rcv_nxt = 0;
@@ -330,14 +330,14 @@ recv(struct polite_conn *polite)
 	}
       } else if(hdr->version == c->version) {
 	PRINTF("%d.%d: got chunk %d snd_nxt %d rcv_nxt %d\n",
-	       rimeaddr_node_addr.u8[0], rimeaddr_node_addr.u8[1],
+	       linkaddr_node_addr.u8[0], linkaddr_node_addr.u8[1],
 	       hdr->chunk, c->snd_nxt, c->rcv_nxt);
 	
 	if(hdr->chunk == c->rcv_nxt) {
 	  int len;
 	  packetbuf_hdrreduce(sizeof(struct rudolph2_hdr));
 	  PRINTF("%d.%d: received chunk %d len %d\n",
-		 rimeaddr_node_addr.u8[0], rimeaddr_node_addr.u8[1],
+		 linkaddr_node_addr.u8[0], linkaddr_node_addr.u8[1],
 		 hdr->chunk, packetbuf_totlen());
 	  len = packetbuf_totlen();
 	  write_data(c, hdr->chunk, packetbuf_dataptr(), packetbuf_totlen());
@@ -349,7 +349,7 @@ recv(struct polite_conn *polite)
 	  }
 	} else if(hdr->chunk > c->rcv_nxt) {
 	  PRINTF("%d.%d: received chunk %d > %d, sending NACK\n",
-		 rimeaddr_node_addr.u8[0], rimeaddr_node_addr.u8[1],
+		 linkaddr_node_addr.u8[0], linkaddr_node_addr.u8[1],
 		 hdr->chunk, c->rcv_nxt);
 	  send_nack(c);
 	} else if(hdr->chunk < c->rcv_nxt) {

--- a/core/net/rime/runicast.c
+++ b/core/net/rime/runicast.c
@@ -85,7 +85,7 @@ sent_by_stunicast(struct stunicast_conn *stunicast, int status, int num_tx)
     if(c->rxmit != 0) {
       RIMESTATS_ADD(rexmit);
       PRINTF("%d.%d: runicast: sent_by_stunicast packet %u (%u) resent %u\n",
-             rimeaddr_node_addr.u8[0], rimeaddr_node_addr.u8[1],
+             linkaddr_node_addr.u8[0], linkaddr_node_addr.u8[1],
              packetbuf_attr(PACKETBUF_ATTR_PACKET_ID),
              c->sndnxt, c->rxmit);
     }
@@ -98,7 +98,7 @@ sent_by_stunicast(struct stunicast_conn *stunicast, int status, int num_tx)
       }
       c->rxmit = 0;
       PRINTF("%d.%d: runicast: packet %d timed out\n",
-             rimeaddr_node_addr.u8[0],rimeaddr_node_addr.u8[1],
+             linkaddr_node_addr.u8[0],linkaddr_node_addr.u8[1],
              c->sndnxt);
       c->sndnxt = (c->sndnxt + 1) % (1 << RUNICAST_PACKET_ID_BITS);
     } else {
@@ -111,13 +111,13 @@ sent_by_stunicast(struct stunicast_conn *stunicast, int status, int num_tx)
 }
 /*---------------------------------------------------------------------------*/
 static void
-recv_from_stunicast(struct stunicast_conn *stunicast, const rimeaddr_t *from)
+recv_from_stunicast(struct stunicast_conn *stunicast, const linkaddr_t *from)
 {
   struct runicast_conn *c = (struct runicast_conn *)stunicast;
   /*  struct runicast_hdr *hdr = packetbuf_dataptr();*/
 
   PRINTF("%d.%d: runicast: recv_from_stunicast from %d.%d type %d seqno %d\n",
-	 rimeaddr_node_addr.u8[0],rimeaddr_node_addr.u8[1],
+	 linkaddr_node_addr.u8[0],linkaddr_node_addr.u8[1],
 	 from->u8[0], from->u8[1],
 	 packetbuf_attr(PACKETBUF_ATTR_PACKET_TYPE),
 	 packetbuf_attr(PACKETBUF_ATTR_PACKET_ID));
@@ -125,14 +125,14 @@ recv_from_stunicast(struct stunicast_conn *stunicast, const rimeaddr_t *from)
   if(packetbuf_attr(PACKETBUF_ATTR_PACKET_TYPE) ==
      PACKETBUF_ATTR_PACKET_TYPE_ACK) {
       PRINTF("%d.%d: runicast: got ACK from %d.%d, seqno %d (%d)\n",
-	     rimeaddr_node_addr.u8[0], rimeaddr_node_addr.u8[1],
+	     linkaddr_node_addr.u8[0], linkaddr_node_addr.u8[1],
 	     from->u8[0], from->u8[1],
 	     packetbuf_attr(PACKETBUF_ATTR_PACKET_ID),
 	     c->sndnxt);
     if(packetbuf_attr(PACKETBUF_ATTR_PACKET_ID) == c->sndnxt) {
       RIMESTATS_ADD(ackrx);
       PRINTF("%d.%d: runicast: ACKed %d\n",
-	     rimeaddr_node_addr.u8[0], rimeaddr_node_addr.u8[1],
+	     linkaddr_node_addr.u8[0], linkaddr_node_addr.u8[1],
 	     packetbuf_attr(PACKETBUF_ATTR_PACKET_ID));
       c->sndnxt = (c->sndnxt + 1) % (1 << RUNICAST_PACKET_ID_BITS);
       c->is_tx = 0;
@@ -142,7 +142,7 @@ recv_from_stunicast(struct stunicast_conn *stunicast, const rimeaddr_t *from)
       }
     } else {
       PRINTF("%d.%d: runicast: received bad ACK %d for %d\n",
-	     rimeaddr_node_addr.u8[0],rimeaddr_node_addr.u8[1],
+	     linkaddr_node_addr.u8[0],linkaddr_node_addr.u8[1],
 	     packetbuf_attr(PACKETBUF_ATTR_PACKET_ID),
 	     c->sndnxt);
       RIMESTATS_ADD(badackrx);
@@ -156,7 +156,7 @@ recv_from_stunicast(struct stunicast_conn *stunicast, const rimeaddr_t *from)
     RIMESTATS_ADD(reliablerx);
 
     PRINTF("%d.%d: runicast: got packet %d\n",
-	   rimeaddr_node_addr.u8[0],rimeaddr_node_addr.u8[1],
+	   linkaddr_node_addr.u8[0],linkaddr_node_addr.u8[1],
 	   packetbuf_attr(PACKETBUF_ATTR_PACKET_ID));
 
     packet_seqno = packetbuf_attr(PACKETBUF_ATTR_PACKET_ID);
@@ -166,7 +166,7 @@ recv_from_stunicast(struct stunicast_conn *stunicast, const rimeaddr_t *from)
     q = queuebuf_new_from_packetbuf();
     if(q != NULL) {
       PRINTF("%d.%d: runicast: Sending ACK to %d.%d for %d\n",
-	     rimeaddr_node_addr.u8[0],rimeaddr_node_addr.u8[1],
+	     linkaddr_node_addr.u8[0],linkaddr_node_addr.u8[1],
 	     from->u8[0], from->u8[1],
 	     packet_seqno);
       packetbuf_clear();
@@ -183,7 +183,7 @@ recv_from_stunicast(struct stunicast_conn *stunicast, const rimeaddr_t *from)
       queuebuf_free(q);
     } else {
       PRINTF("%d.%d: runicast: could not send ACK to %d.%d for %d: no queued buffers\n",
-	     rimeaddr_node_addr.u8[0],rimeaddr_node_addr.u8[1],
+	     linkaddr_node_addr.u8[0],linkaddr_node_addr.u8[1],
 	     from->u8[0], from->u8[1],
 	     packet_seqno);
     }
@@ -221,13 +221,13 @@ runicast_is_transmitting(struct runicast_conn *c)
 }
 /*---------------------------------------------------------------------------*/
 int
-runicast_send(struct runicast_conn *c, const rimeaddr_t *receiver,
+runicast_send(struct runicast_conn *c, const linkaddr_t *receiver,
 	      uint8_t max_retransmissions)
 {
   int ret;
   if(runicast_is_transmitting(c)) {
     PRINTF("%d.%d: runicast: already transmitting\n",
-        rimeaddr_node_addr.u8[0],rimeaddr_node_addr.u8[1]);
+        linkaddr_node_addr.u8[0],linkaddr_node_addr.u8[1]);
     return 0;
   }
   packetbuf_set_attr(PACKETBUF_ATTR_RELIABLE, 1);
@@ -239,7 +239,7 @@ runicast_send(struct runicast_conn *c, const rimeaddr_t *receiver,
   c->is_tx = 1;
   RIMESTATS_ADD(reliabletx);
   PRINTF("%d.%d: runicast: sending packet %d\n",
-	 rimeaddr_node_addr.u8[0],rimeaddr_node_addr.u8[1],
+	 linkaddr_node_addr.u8[0],linkaddr_node_addr.u8[1],
 	 c->sndnxt);
   ret = stunicast_send_stubborn(&c->c, receiver, REXMIT_TIME);
   if(!ret) {

--- a/core/net/rime/runicast.h
+++ b/core/net/rime/runicast.h
@@ -89,9 +89,9 @@ struct runicast_conn;
                              { PACKETBUF_ATTR_PACKET_ID, PACKETBUF_ATTR_BIT * RUNICAST_PACKET_ID_BITS }, \
                              STUNICAST_ATTRIBUTES
 struct runicast_callbacks {
-  void (* recv)(struct runicast_conn *c, const rimeaddr_t *from, uint8_t seqno);
-  void (* sent)(struct runicast_conn *c, const rimeaddr_t *to, uint8_t retransmissions);
-  void (* timedout)(struct runicast_conn *c, const rimeaddr_t *to, uint8_t retransmissions);
+  void (* recv)(struct runicast_conn *c, const linkaddr_t *from, uint8_t seqno);
+  void (* sent)(struct runicast_conn *c, const linkaddr_t *to, uint8_t retransmissions);
+  void (* timedout)(struct runicast_conn *c, const linkaddr_t *to, uint8_t retransmissions);
 };
 
 struct runicast_conn {
@@ -107,7 +107,7 @@ void runicast_open(struct runicast_conn *c, uint16_t channel,
 	       const struct runicast_callbacks *u);
 void runicast_close(struct runicast_conn *c);
 
-int runicast_send(struct runicast_conn *c, const rimeaddr_t *receiver,
+int runicast_send(struct runicast_conn *c, const linkaddr_t *receiver,
 		  uint8_t max_retransmissions);
 
 uint8_t runicast_is_transmitting(struct runicast_conn *c);

--- a/core/net/rime/stbroadcast.c
+++ b/core/net/rime/stbroadcast.c
@@ -49,7 +49,7 @@
 
 /*---------------------------------------------------------------------------*/
 static void
-recv_from_broadcast(struct broadcast_conn *broadcast, const rimeaddr_t *sender)
+recv_from_broadcast(struct broadcast_conn *broadcast, const linkaddr_t *sender)
 {
   register struct stbroadcast_conn *c = (struct stbroadcast_conn *)broadcast;
   /*  DEBUGF(3, "stbroadcast: recv_from_broadcast from %d\n", from_id);*/

--- a/core/net/rime/stunicast.c
+++ b/core/net/rime/stunicast.c
@@ -56,11 +56,11 @@
 
 /*---------------------------------------------------------------------------*/
 static void
-recv_from_uc(struct unicast_conn *uc, const rimeaddr_t *from)
+recv_from_uc(struct unicast_conn *uc, const linkaddr_t *from)
 {
   register struct stunicast_conn *c = (struct stunicast_conn *)uc;
   PRINTF("%d.%d: stunicast: recv_from_uc from %d.%d\n",
-	 rimeaddr_node_addr.u8[0],rimeaddr_node_addr.u8[1],
+	 linkaddr_node_addr.u8[0],linkaddr_node_addr.u8[1],
 	from->u8[0], from->u8[1]);
   if(c->u->recv != NULL) {
     c->u->recv(c, from);
@@ -72,7 +72,7 @@ sent_by_uc(struct unicast_conn *uc, int status, int num_tx)
 {
   register struct stunicast_conn *c = (struct stunicast_conn *)uc;
   PRINTF("%d.%d: stunicast: recv_from_uc from %d.%d\n",
-	 rimeaddr_node_addr.u8[0],rimeaddr_node_addr.u8[1],
+	 linkaddr_node_addr.u8[0],linkaddr_node_addr.u8[1],
          packetbuf_addr(PACKETBUF_ADDR_SENDER)->u8[0],
          packetbuf_addr(PACKETBUF_ADDR_SENDER)->u8[1]);
   if(c->u->sent != NULL) {
@@ -98,7 +98,7 @@ stunicast_close(struct stunicast_conn *c)
   stunicast_cancel(c);
 }
 /*---------------------------------------------------------------------------*/
-rimeaddr_t *
+linkaddr_t *
 stunicast_receiver(struct stunicast_conn *c)
 {
   return &c->receiver;
@@ -110,7 +110,7 @@ send(void *ptr)
   struct stunicast_conn *c = ptr;
 
   PRINTF("%d.%d: stunicast: resend to %d.%d\n",
-	 rimeaddr_node_addr.u8[0],rimeaddr_node_addr.u8[1],
+	 linkaddr_node_addr.u8[0],linkaddr_node_addr.u8[1],
 	 c->receiver.u8[0], c->receiver.u8[1]);
 	 if(c->buf) {
   	queuebuf_to_packetbuf(c->buf);
@@ -129,7 +129,7 @@ stunicast_set_timer(struct stunicast_conn *c, clock_time_t t)
 }
 /*---------------------------------------------------------------------------*/
 int
-stunicast_send_stubborn(struct stunicast_conn *c, const rimeaddr_t *receiver,
+stunicast_send_stubborn(struct stunicast_conn *c, const linkaddr_t *receiver,
 		  clock_time_t rxmittime)
 {
   if(c->buf != NULL) {
@@ -139,11 +139,11 @@ stunicast_send_stubborn(struct stunicast_conn *c, const rimeaddr_t *receiver,
   if(c->buf == NULL) {
     return 0;
   }
-  rimeaddr_copy(&c->receiver, receiver);
+  linkaddr_copy(&c->receiver, receiver);
   ctimer_set(&c->t, rxmittime, send, c);
 
   PRINTF("%d.%d: stunicast_send_stubborn to %d.%d\n",
-	 rimeaddr_node_addr.u8[0],rimeaddr_node_addr.u8[1],
+	 linkaddr_node_addr.u8[0],linkaddr_node_addr.u8[1],
 	 c->receiver.u8[0],c->receiver.u8[1]);
   unicast_send(&c->c, &c->receiver);
   /*  if(c->u->sent != NULL) {
@@ -155,10 +155,10 @@ stunicast_send_stubborn(struct stunicast_conn *c, const rimeaddr_t *receiver,
 }
 /*---------------------------------------------------------------------------*/
 int
-stunicast_send(struct stunicast_conn *c, const rimeaddr_t *receiver)
+stunicast_send(struct stunicast_conn *c, const linkaddr_t *receiver)
 {
   PRINTF("%d.%d: stunicast_send to %d.%d\n",
-	 rimeaddr_node_addr.u8[0], rimeaddr_node_addr.u8[1],
+	 linkaddr_node_addr.u8[0], linkaddr_node_addr.u8[1],
 	 receiver->u8[0], receiver->u8[1]);
   return unicast_send(&c->c, receiver);
 }

--- a/core/net/rime/stunicast.h
+++ b/core/net/rime/stunicast.h
@@ -81,7 +81,7 @@ struct stunicast_conn;
 #define STUNICAST_ATTRIBUTES  UNICAST_ATTRIBUTES
 
 struct stunicast_callbacks {
-  void (* recv)(struct stunicast_conn *c, const rimeaddr_t *from);
+  void (* recv)(struct stunicast_conn *c, const linkaddr_t *from);
   void (* sent)(struct stunicast_conn *c, int status, int num_tx);
 };
 
@@ -90,22 +90,22 @@ struct stunicast_conn {
   struct ctimer t;
   struct queuebuf *buf;
   const struct stunicast_callbacks *u;
-  rimeaddr_t receiver;
+  linkaddr_t receiver;
 };
 
 void stunicast_open(struct stunicast_conn *c, uint16_t channel,
 	       const struct stunicast_callbacks *u);
 void stunicast_close(struct stunicast_conn *c);
 
-int stunicast_send_stubborn(struct stunicast_conn *c, const rimeaddr_t *receiver,
+int stunicast_send_stubborn(struct stunicast_conn *c, const linkaddr_t *receiver,
 		      clock_time_t rxmittime);
 void stunicast_cancel(struct stunicast_conn *c);
 
-int stunicast_send(struct stunicast_conn *c, const rimeaddr_t *receiver);
+int stunicast_send(struct stunicast_conn *c, const linkaddr_t *receiver);
 
 void stunicast_set_timer(struct stunicast_conn *c, clock_time_t t);
 
-rimeaddr_t *stunicast_receiver(struct stunicast_conn *c);
+linkaddr_t *stunicast_receiver(struct stunicast_conn *c);
 
 #endif /* STUNICAST_H_ */
 /** @} */

--- a/core/net/rime/timesynch.c
+++ b/core/net/rime/timesynch.c
@@ -128,7 +128,7 @@ adjust_offset(rtimer_clock_t authoritative_time, rtimer_clock_t local_time)
 }
 /*---------------------------------------------------------------------------*/
 static void
-broadcast_recv(struct broadcast_conn *c, const rimeaddr_t *from)
+broadcast_recv(struct broadcast_conn *c, const linkaddr_t *from)
 {
   struct timesynch_msg msg;
 

--- a/core/net/rime/trickle.c
+++ b/core/net/rime/trickle.c
@@ -82,7 +82,7 @@ send(void *ptr)
     broadcast_send(&c->c);
   } else {
     PRINTF("%d.%d: trickle send but c->q == NULL\n",
-	 rimeaddr_node_addr.u8[0], rimeaddr_node_addr.u8[1]);
+	 linkaddr_node_addr.u8[0], linkaddr_node_addr.u8[1]);
   }
 }
 /*---------------------------------------------------------------------------*/
@@ -132,13 +132,13 @@ run_trickle(struct trickle_conn *c)
 }
 /*---------------------------------------------------------------------------*/
 static void
-recv(struct broadcast_conn *bc, const rimeaddr_t *from)
+recv(struct broadcast_conn *bc, const linkaddr_t *from)
 {
   struct trickle_conn *c = (struct trickle_conn *)bc;
   uint16_t seqno = packetbuf_attr(PACKETBUF_ATTR_EPACKET_ID);
 
   PRINTF("%d.%d: trickle recv seqno %d from %d.%d our %d data len %d channel %d\n",
-	 rimeaddr_node_addr.u8[0], rimeaddr_node_addr.u8[1],
+	 linkaddr_node_addr.u8[0], linkaddr_node_addr.u8[1],
 	 seqno,
 	 from->u8[0], from->u8[1],
 	 c->seqno,
@@ -201,7 +201,7 @@ trickle_send(struct trickle_conn *c)
   packetbuf_set_attr(PACKETBUF_ATTR_EPACKET_ID, c->seqno);
   c->q = queuebuf_new_from_packetbuf();
   PRINTF("%d.%d: trickle send seqno %d\n",
-	 rimeaddr_node_addr.u8[0], rimeaddr_node_addr.u8[1],
+	 linkaddr_node_addr.u8[0], linkaddr_node_addr.u8[1],
 	 c->seqno);
   reset_interval(c);
   send(c);

--- a/core/net/rime/unicast.c
+++ b/core/net/rime/unicast.c
@@ -63,15 +63,15 @@ static const struct packetbuf_attrlist attributes[] =
 
 /*---------------------------------------------------------------------------*/
 static void
-recv_from_broadcast(struct broadcast_conn *broadcast, const rimeaddr_t *from)
+recv_from_broadcast(struct broadcast_conn *broadcast, const linkaddr_t *from)
 {
   struct unicast_conn *c = (struct unicast_conn *)broadcast;
 
   PRINTF("%d.%d: uc: recv_from_broadcast, receiver %d.%d\n",
-	 rimeaddr_node_addr.u8[0], rimeaddr_node_addr.u8[1],
+	 linkaddr_node_addr.u8[0], linkaddr_node_addr.u8[1],
 	 packetbuf_addr(PACKETBUF_ADDR_RECEIVER)->u8[0],
 	 packetbuf_addr(PACKETBUF_ADDR_RECEIVER)->u8[1]);
-  if(rimeaddr_cmp(packetbuf_addr(PACKETBUF_ADDR_RECEIVER), &rimeaddr_node_addr)) {
+  if(linkaddr_cmp(packetbuf_addr(PACKETBUF_ADDR_RECEIVER), &linkaddr_node_addr)) {
     if(c->u->recv) {
       c->u->recv(c, from);
     }
@@ -84,7 +84,7 @@ sent_by_broadcast(struct broadcast_conn *broadcast, int status, int num_tx)
   struct unicast_conn *c = (struct unicast_conn *)broadcast;
 
   PRINTF("%d.%d: uc: sent_by_broadcast, receiver %d.%d\n",
-	 rimeaddr_node_addr.u8[0], rimeaddr_node_addr.u8[1],
+	 linkaddr_node_addr.u8[0], linkaddr_node_addr.u8[1],
 	 packetbuf_addr(PACKETBUF_ADDR_RECEIVER)->u8[0],
 	 packetbuf_addr(PACKETBUF_ADDR_RECEIVER)->u8[1]);
 
@@ -112,10 +112,10 @@ unicast_close(struct unicast_conn *c)
 }
 /*---------------------------------------------------------------------------*/
 int
-unicast_send(struct unicast_conn *c, const rimeaddr_t *receiver)
+unicast_send(struct unicast_conn *c, const linkaddr_t *receiver)
 {
   PRINTF("%d.%d: unicast_send to %d.%d\n",
-	 rimeaddr_node_addr.u8[0],rimeaddr_node_addr.u8[1],
+	 linkaddr_node_addr.u8[0],linkaddr_node_addr.u8[1],
 	 receiver->u8[0], receiver->u8[1]);
   packetbuf_set_addr(PACKETBUF_ADDR_RECEIVER, receiver);
   return broadcast_send(&c->c);

--- a/core/net/rime/unicast.h
+++ b/core/net/rime/unicast.h
@@ -70,7 +70,7 @@ struct unicast_conn;
                         BROADCAST_ATTRIBUTES
 
 struct unicast_callbacks {
-  void (* recv)(struct unicast_conn *c, const rimeaddr_t *from);
+  void (* recv)(struct unicast_conn *c, const linkaddr_t *from);
   void (* sent)(struct unicast_conn *ptr, int status, int num_tx);
 };
 
@@ -83,7 +83,7 @@ void unicast_open(struct unicast_conn *c, uint16_t channel,
 	      const struct unicast_callbacks *u);
 void unicast_close(struct unicast_conn *c);
 
-int unicast_send(struct unicast_conn *c, const rimeaddr_t *receiver);
+int unicast_send(struct unicast_conn *c, const linkaddr_t *receiver);
 
 #endif /* UNICAST_H_ */
 /** @} */

--- a/core/net/rpl/rpl-dag.c
+++ b/core/net/rpl/rpl-dag.c
@@ -93,7 +93,7 @@ rpl_dag_init(void)
 rpl_rank_t
 rpl_get_parent_rank(uip_lladdr_t *addr)
 {
-  rpl_parent_t *p = nbr_table_get_from_lladdr(rpl_parents, (rimeaddr_t *)addr);
+  rpl_parent_t *p = nbr_table_get_from_lladdr(rpl_parents, (linkaddr_t *)addr);
   if(p != NULL) {
     return p->rank;
   } else {
@@ -104,7 +104,7 @@ rpl_get_parent_rank(uip_lladdr_t *addr)
 uint16_t
 rpl_get_parent_link_metric(const uip_lladdr_t *addr)
 {
-  rpl_parent_t *p = nbr_table_get_from_lladdr(rpl_parents, (const rimeaddr_t *)addr);
+  rpl_parent_t *p = nbr_table_get_from_lladdr(rpl_parents, (const linkaddr_t *)addr);
   if(p != NULL) {
     return p->link_metric;
   } else {
@@ -115,7 +115,7 @@ rpl_get_parent_link_metric(const uip_lladdr_t *addr)
 uip_ipaddr_t *
 rpl_get_parent_ipaddr(rpl_parent_t *p)
 {
-  rimeaddr_t *lladdr = nbr_table_get_lladdr(rpl_parents, p);
+  linkaddr_t *lladdr = nbr_table_get_lladdr(rpl_parents, p);
   return uip_ds6_nbr_ipaddr_from_lladdr((uip_lladdr_t *)lladdr);
 }
 /*---------------------------------------------------------------------------*/
@@ -552,7 +552,7 @@ rpl_add_parent(rpl_dag_t *dag, rpl_dio_t *dio, uip_ipaddr_t *addr)
   PRINTF("\n");
   if(lladdr != NULL) {
     /* Add parent in rpl_parents */
-    p = nbr_table_add_lladdr(rpl_parents, (rimeaddr_t *)lladdr);
+    p = nbr_table_add_lladdr(rpl_parents, (linkaddr_t *)lladdr);
     if(p == NULL) {
       PRINTF("RPL: rpl_add_parent p NULL\n");
     } else {
@@ -574,7 +574,7 @@ find_parent_any_dag_any_instance(uip_ipaddr_t *addr)
 {
   uip_ds6_nbr_t *ds6_nbr = uip_ds6_nbr_lookup(addr);
   const uip_lladdr_t *lladdr = uip_ds6_nbr_get_ll(ds6_nbr);
-  return nbr_table_get_from_lladdr(rpl_parents, (rimeaddr_t *)lladdr);
+  return nbr_table_get_from_lladdr(rpl_parents, (linkaddr_t *)lladdr);
 }
 /*---------------------------------------------------------------------------*/
 rpl_parent_t *

--- a/core/net/rpl/rpl.c
+++ b/core/net/rpl/rpl.c
@@ -209,7 +209,7 @@ rpl_add_route(rpl_dag_t *dag, uip_ipaddr_t *prefix, int prefix_len,
 }
 /*---------------------------------------------------------------------------*/
 void
-rpl_link_neighbor_callback(const rimeaddr_t *addr, int status, int numtx)
+rpl_link_neighbor_callback(const linkaddr_t *addr, int status, int numtx)
 {
   uip_ipaddr_t ipaddr;
   rpl_parent_t *parent;

--- a/cpu/avr/radio/mac/sicslowmac.c
+++ b/cpu/avr/radio/mac/sicslowmac.c
@@ -256,8 +256,8 @@ sicslowmac_dataIndication(void)
 	byte_reverse((uint8_t *)dest_reversed, UIP_LLADDR_LEN);
 	byte_reverse((uint8_t *)src_reversed, UIP_LLADDR_LEN);
   
-	packetbuf_set_addr(PACKETBUF_ADDR_RECEIVER, (const rimeaddr_t *)dest_reversed);
-	packetbuf_set_addr(PACKETBUF_ADDR_SENDER, (const rimeaddr_t *)src_reversed);
+	packetbuf_set_addr(PACKETBUF_ADDR_RECEIVER, (const linkaddr_t *)dest_reversed);
+	packetbuf_set_addr(PACKETBUF_ADDR_SENDER, (const linkaddr_t *)src_reversed);
 	
   #elif UIP_CONF_USE_RUM	
     /* Finally, get the stuff into the rime buffer.... */
@@ -297,8 +297,8 @@ sicslowmac_dataIndication(void)
 	src_reversed[4] = MSB(parsed_frame->src_addr->addr16);
 	src_reversed[5] = LSB(parsed_frame->src_addr->addr16);
 
-	packetbuf_set_addr(PACKETBUF_ADDR_RECEIVER, (const rimeaddr_t *)dest_reversed);
-	packetbuf_set_addr(PACKETBUF_ADDR_SENDER, (const rimeaddr_t *)src_reversed);	
+	packetbuf_set_addr(PACKETBUF_ADDR_RECEIVER, (const linkaddr_t *)dest_reversed);
+	packetbuf_set_addr(PACKETBUF_ADDR_SENDER, (const linkaddr_t *)src_reversed);	
   
   #endif
 
@@ -325,8 +325,8 @@ sicslowmac_unknownIndication(void)
 	byte_reverse((uint8_t *)dest_reversed, UIP_LLADDR_LEN);
 	byte_reverse((uint8_t *)src_reversed, UIP_LLADDR_LEN);
   
-	packetbuf_set_addr(PACKETBUF_ADDR_RECEIVER, (const rimeaddr_t *)dest_reversed);
-	packetbuf_set_addr(PACKETBUF_ADDR_SENDER, (const rimeaddr_t *)src_reversed);
+	packetbuf_set_addr(PACKETBUF_ADDR_RECEIVER, (const linkaddr_t *)dest_reversed);
+	packetbuf_set_addr(PACKETBUF_ADDR_SENDER, (const linkaddr_t *)src_reversed);
 	
   #elif UIP_CONF_USE_RUM	
 	
@@ -360,8 +360,8 @@ sicslowmac_unknownIndication(void)
 	src_reversed[4] = MSB(parsed_frame->src_addr->addr16);
 	src_reversed[5] = LSB(parsed_frame->src_addr->addr16);
 
-	packetbuf_set_addr(PACKETBUF_ADDR_RECEIVER, (const rimeaddr_t *)dest_reversed);
-	packetbuf_set_addr(PACKETBUF_ADDR_SENDER, (const rimeaddr_t *)src_reversed);	
+	packetbuf_set_addr(PACKETBUF_ADDR_RECEIVER, (const linkaddr_t *)dest_reversed);
+	packetbuf_set_addr(PACKETBUF_ADDR_SENDER, (const linkaddr_t *)src_reversed);	
   
   #endif
 
@@ -430,7 +430,7 @@ sicslowmac_dataRequest(void)
    *  If the output address is NULL in the Rime buf, then it is broadcast
    *  on the 802.15.4 network.
    */
-  if(rimeaddr_cmp(packetbuf_addr(PACKETBUF_ADDR_RECEIVER), &rimeaddr_null) ) {
+  if(linkaddr_cmp(packetbuf_addr(PACKETBUF_ADDR_RECEIVER), &linkaddr_null) ) {
     /* Broadcast requires short address mode. */
     params.fcf.destAddrMode = SHORTADDRMODE;
     params.dest_pid = BROADCASTPANDID;

--- a/cpu/cc2538/dev/cc2538-rf.c
+++ b/cpu/cc2538/dev/cc2538-rf.c
@@ -41,7 +41,7 @@
 #include "sys/rtimer.h"
 #include "net/packetbuf.h"
 #include "net/rime/rimestats.h"
-#include "net/rimeaddr.h"
+#include "net/linkaddr.h"
 #include "net/netstack.h"
 #include "sys/energest.h"
 #include "dev/cc2538-rf.h"
@@ -169,21 +169,21 @@ cc2538_rf_power_set(uint8_t new_power)
 void
 cc2538_rf_set_addr(uint16_t pan)
 {
-#if RIMEADDR_SIZE==8
+#if LINKADDR_SIZE==8
   /* EXT_ADDR[7:0] is ignored when using short addresses */
   int i;
 
-  for(i = (RIMEADDR_SIZE - 1); i >= 0; --i) {
+  for(i = (LINKADDR_SIZE - 1); i >= 0; --i) {
     ((uint32_t *)RFCORE_FFSM_EXT_ADDR0)[i] =
-        rimeaddr_node_addr.u8[RIMEADDR_SIZE - 1 - i];
+        linkaddr_node_addr.u8[LINKADDR_SIZE - 1 - i];
   }
 #endif
 
   REG(RFCORE_FFSM_PAN_ID0) = pan & 0xFF;
   REG(RFCORE_FFSM_PAN_ID1) = pan >> 8;
 
-  REG(RFCORE_FFSM_SHORT_ADDR0) = rimeaddr_node_addr.u8[RIMEADDR_SIZE - 1];
-  REG(RFCORE_FFSM_SHORT_ADDR1) = rimeaddr_node_addr.u8[RIMEADDR_SIZE - 2];
+  REG(RFCORE_FFSM_SHORT_ADDR0) = linkaddr_node_addr.u8[LINKADDR_SIZE - 1];
+  REG(RFCORE_FFSM_SHORT_ADDR1) = linkaddr_node_addr.u8[LINKADDR_SIZE - 2];
 }
 /*---------------------------------------------------------------------------*/
 int

--- a/cpu/cc2538/dev/cc2538-rf.h
+++ b/cpu/cc2538/dev/cc2538-rf.h
@@ -163,7 +163,7 @@ uint8_t cc2538_rf_power_set(uint8_t new_power);
  * \param pan The PAN Identifier
  *
  * Values for short and extended addresses are not needed as parameters
- * since they exist in the rimeaddr buffer in the contiki core. They
+ * since they exist in the linkaddr buffer in the contiki core. They
  * are thus simply copied over from there.
  */
 void cc2538_rf_set_addr(uint16_t pan);

--- a/cpu/cc2538/ieee-addr.c
+++ b/cpu/cc2538/ieee-addr.c
@@ -36,7 +36,7 @@
  * Driver for the cc2538 IEEE addresses
  */
 #include "contiki-conf.h"
-#include "net/rimeaddr.h"
+#include "net/linkaddr.h"
 #include "ieee-addr.h"
 
 #include <stdint.h>

--- a/cpu/cc2538/usb/usb-serial.c
+++ b/cpu/cc2538/usb/usb-serial.c
@@ -46,7 +46,7 @@
  */
 #include "contiki.h"
 #include "sys/process.h"
-#include "net/rimeaddr.h"
+#include "net/linkaddr.h"
 #include "usb-api.h"
 #include "usb.h"
 #include "usb-arch.h"

--- a/cpu/cc253x/dev/cc2530-rf.c
+++ b/cpu/cc253x/dev/cc2530-rf.c
@@ -46,7 +46,7 @@
 
 #include "net/packetbuf.h"
 #include "net/rime/rimestats.h"
-#include "net/rimeaddr.h"
+#include "net/linkaddr.h"
 #include "net/netstack.h"
 
 #include <string.h>
@@ -146,18 +146,18 @@ cc2530_rf_power_set(uint8_t new_power)
 void
 cc2530_rf_set_addr(uint16_t pan)
 {
-#if RIMEADDR_SIZE==8 /* EXT_ADDR[7:0] is ignored when using short addresses */
+#if LINKADDR_SIZE==8 /* EXT_ADDR[7:0] is ignored when using short addresses */
   int i;
-  for(i = (RIMEADDR_SIZE - 1); i >= 0; --i) {
-    ((uint8_t *)&EXT_ADDR0)[i] = rimeaddr_node_addr.u8[RIMEADDR_SIZE - 1 - i];
+  for(i = (LINKADDR_SIZE - 1); i >= 0; --i) {
+    ((uint8_t *)&EXT_ADDR0)[i] = linkaddr_node_addr.u8[LINKADDR_SIZE - 1 - i];
   }
 #endif
 
   PAN_ID0 = pan & 0xFF;
   PAN_ID1 = pan >> 8;
 
-  SHORT_ADDR0 = rimeaddr_node_addr.u8[RIMEADDR_SIZE - 1];
-  SHORT_ADDR1 = rimeaddr_node_addr.u8[RIMEADDR_SIZE - 2];
+  SHORT_ADDR0 = linkaddr_node_addr.u8[LINKADDR_SIZE - 1];
+  SHORT_ADDR1 = linkaddr_node_addr.u8[LINKADDR_SIZE - 2];
 }
 /*---------------------------------------------------------------------------*/
 /* Netstack API radio driver functions */

--- a/cpu/mc1322x/contiki-maca.c
+++ b/cpu/mc1322x/contiki-maca.c
@@ -101,7 +101,7 @@ static process_event_t event_data_ready;
 static volatile packet_t prepped_p;
 
 void contiki_maca_set_mac_address(uint64_t eui) {
-	rimeaddr_t addr;
+	linkaddr_t addr;
 	uint8_t i;
 
 	/* setup mac address registers in maca hardware */
@@ -116,14 +116,14 @@ void contiki_maca_set_mac_address(uint64_t eui) {
 	ANNOTATE("setting long mac 0x%08x_%08x\n\r", *MACA_MAC64HI, *MACA_MAC64LO);
 
 	/* setup mac addresses in Contiki (RIME) */
-	rimeaddr_copy(&addr, &rimeaddr_null);
+	linkaddr_copy(&addr, &linkaddr_null);
 
-	for(i=0; i < RIMEADDR_CONF_SIZE; i++) {
-		addr.u8[RIMEADDR_CONF_SIZE - 1 - i] = (mc1322x_config.eui >> (i * 8)) & 0xff;
+	for(i=0; i < LINKADDR_CONF_SIZE; i++) {
+		addr.u8[LINKADDR_CONF_SIZE - 1 - i] = (mc1322x_config.eui >> (i * 8)) & 0xff;
 	}
 
 	node_id = (addr.u8[6] << 8 | addr.u8[7]);
-	rimeaddr_set_node_addr(&addr);
+	linkaddr_set_node_addr(&addr);
 
 #if DEBUG_ANNOTATE
 	ANNOTATE("Rime configured with address ");

--- a/cpu/stm32w108/dev/stm32w-radio.c
+++ b/cpu/stm32w108/dev/stm32w-radio.c
@@ -294,7 +294,7 @@ stm32w_radio_init(void)
   CLEAN_RXBUFS();
   CLEAN_TXBUF();
 
-#if ST_RADIO_AUTOACK && !(UIP_CONF_LL_802154 && RIMEADDR_CONF_SIZE==8)
+#if ST_RADIO_AUTOACK && !(UIP_CONF_LL_802154 && LINKADDR_CONF_SIZE==8)
 #error "Autoack and address filtering can only be used with EUI 64"
 #endif
   ST_RadioEnableAutoAck(ST_RADIO_AUTOACK);

--- a/examples/antelope/netdb/netdb-client.c
+++ b/examples/antelope/netdb/netdb-client.c
@@ -62,7 +62,7 @@ PROCESS(shell_process, "Shell Process");
 
 PROCESS_THREAD(shell_process, ev, data)
 {
-  rimeaddr_t addr;
+  linkaddr_t addr;
 
   PROCESS_BEGIN();
 
@@ -99,7 +99,7 @@ timedout(struct mesh_conn *c)
 }
 
 static void
-received(struct mesh_conn *c, const rimeaddr_t *from, uint8_t hops)
+received(struct mesh_conn *c, const linkaddr_t *from, uint8_t hops)
 {
   char *data;
   unsigned len;

--- a/examples/antelope/netdb/netdb-server.c
+++ b/examples/antelope/netdb/netdb-server.c
@@ -71,7 +71,7 @@ PROCESS(netdb_process, "NetDB");
 AUTOSTART_PROCESSES(&netdb_process);
 
 static struct mesh_conn mesh;
-static rimeaddr_t reply_addr;
+static linkaddr_t reply_addr;
 static uint8_t buffer_offset;
 static char buffer[MAX_BUFFER_SIZE];
 /*---------------------------------------------------------------------------*/
@@ -263,7 +263,7 @@ timedout(struct mesh_conn *c)
 }
 
 static void
-received(struct mesh_conn *c, const rimeaddr_t *from, uint8_t hops)
+received(struct mesh_conn *c, const linkaddr_t *from, uint8_t hops)
 {
   char *data;
   unsigned len;
@@ -282,7 +282,7 @@ received(struct mesh_conn *c, const rimeaddr_t *from, uint8_t hops)
 
   printf("Query received from %d.%d: %s (%d hops)\n",
          from->u8[0], from->u8[1], query, (int)hops);
-  rimeaddr_copy(&reply_addr, from);
+  linkaddr_copy(&reply_addr, from);
 
   process_post(&query_process, serial_line_event_message, query);
 }

--- a/examples/cc2538dk/cc2538-demo.c
+++ b/examples/cc2538dk/cc2538-demo.c
@@ -93,7 +93,7 @@ PROCESS(cc2538_demo_process, "cc2538 demo process");
 AUTOSTART_PROCESSES(&cc2538_demo_process);
 /*---------------------------------------------------------------------------*/
 static void
-broadcast_recv(struct broadcast_conn *c, const rimeaddr_t *from)
+broadcast_recv(struct broadcast_conn *c, const linkaddr_t *from)
 {
   leds_toggle(LEDS_RF_RX);
   printf("Received %u bytes: '0x%04x'\n", packetbuf_datalen(),

--- a/examples/ipv6/native-border-router/border-router-rdc.c
+++ b/examples/ipv6/native-border-router/border-router-rdc.c
@@ -105,7 +105,7 @@ send_packet(mac_callback_t sent, void *ptr)
   uint8_t buf[PACKETBUF_NUM_ATTRS * 3 + PACKETBUF_SIZE + 3];
   uint8_t sid;
 
-  packetbuf_set_addr(PACKETBUF_ADDR_SENDER, &rimeaddr_node_addr);
+  packetbuf_set_addr(PACKETBUF_ADDR_SENDER, &linkaddr_node_addr);
 
   /* ack or not ? */
   packetbuf_set_attr(PACKETBUF_ATTR_MAC_ACK, 1);

--- a/examples/ipv6/native-border-router/border-router.c
+++ b/examples/ipv6/native-border-router/border-router.c
@@ -245,7 +245,7 @@ void
 border_router_set_mac(const uint8_t *data)
 {
   memcpy(uip_lladdr.addr, data, sizeof(uip_lladdr.addr));
-  rimeaddr_set_node_addr((rimeaddr_t *)uip_lladdr.addr);
+  linkaddr_set_node_addr((linkaddr_t *)uip_lladdr.addr);
 
   /* is this ok - should instead remove all addresses and
      add them back again - a bit messy... ?*/

--- a/examples/ipv6/rpl-collect/collect-common.c
+++ b/examples/ipv6/rpl-collect/collect-common.c
@@ -81,7 +81,7 @@ collect_common_set_send_active(int active)
 }
 /*---------------------------------------------------------------------------*/
 void
-collect_common_recv(const rimeaddr_t *originator, uint8_t seqno, uint8_t hops,
+collect_common_recv(const linkaddr_t *originator, uint8_t seqno, uint8_t hops,
                     uint8_t *payload, uint16_t payload_len)
 {
   unsigned long time;

--- a/examples/ipv6/rpl-collect/collect-common.h
+++ b/examples/ipv6/rpl-collect/collect-common.h
@@ -39,13 +39,13 @@
 #define COLLECT_COMMON_H_
 
 #include "contiki.h"
-#include "net/rimeaddr.h"
+#include "net/linkaddr.h"
 
 void collect_common_net_init(void);
 void collect_common_net_print(void);
 void collect_common_set_sink(void);
 void collect_common_send(void);
-void collect_common_recv(const rimeaddr_t *originator, uint8_t seqno,
+void collect_common_recv(const linkaddr_t *originator, uint8_t seqno,
                          uint8_t hops,
                          uint8_t *payload,
                          uint16_t payload_len);

--- a/examples/ipv6/rpl-collect/udp-sender.c
+++ b/examples/ipv6/rpl-collect/udp-sender.c
@@ -108,7 +108,7 @@ collect_common_send(void)
   uint16_t num_neighbors;
   uint16_t beacon_interval;
   rpl_parent_t *preferred_parent;
-  rimeaddr_t parent;
+  linkaddr_t parent;
   rpl_dag_t *dag;
 
   if(client_conn == NULL) {
@@ -123,7 +123,7 @@ collect_common_send(void)
   }
   msg.seqno = seqno;
 
-  rimeaddr_copy(&parent, &rimeaddr_null);
+  linkaddr_copy(&parent, &linkaddr_null);
   parent_etx = 0;
 
   /* Let's suppose we have only one instance */
@@ -135,9 +135,9 @@ collect_common_send(void)
       nbr = uip_ds6_nbr_lookup(rpl_get_parent_ipaddr(preferred_parent));
       if(nbr != NULL) {
         /* Use parts of the IPv6 address as the parent address, in reversed byte order. */
-        parent.u8[RIMEADDR_SIZE - 1] = nbr->ipaddr.u8[sizeof(uip_ipaddr_t) - 2];
-        parent.u8[RIMEADDR_SIZE - 2] = nbr->ipaddr.u8[sizeof(uip_ipaddr_t) - 1];
-        parent_etx = rpl_get_parent_rank((rimeaddr_t *) uip_ds6_nbr_get_ll(nbr)) / 2;
+        parent.u8[LINKADDR_SIZE - 1] = nbr->ipaddr.u8[sizeof(uip_ipaddr_t) - 2];
+        parent.u8[LINKADDR_SIZE - 2] = nbr->ipaddr.u8[sizeof(uip_ipaddr_t) - 1];
+        parent_etx = rpl_get_parent_rank((linkaddr_t *) uip_ds6_nbr_get_ll(nbr)) / 2;
       }
     }
     rtmetric = dag->rank;

--- a/examples/ipv6/rpl-collect/udp-sink.c
+++ b/examples/ipv6/rpl-collect/udp-sink.c
@@ -32,7 +32,7 @@
 #include "contiki-net.h"
 #include "net/ip/uip.h"
 #include "net/rpl/rpl.h"
-#include "net/rimeaddr.h"
+#include "net/linkaddr.h"
 
 #include "net/netstack.h"
 #include "dev/button-sensor.h"
@@ -96,7 +96,7 @@ static void
 tcpip_handler(void)
 {
   uint8_t *appdata;
-  rimeaddr_t sender;
+  linkaddr_t sender;
   uint8_t seqno;
   uint8_t hops;
 

--- a/examples/ipv6/slip-radio/no-framer.c
+++ b/examples/ipv6/slip-radio/no-framer.c
@@ -97,10 +97,10 @@ parse(void)
         return 0;
       }
       if(!is_broadcast_addr(frame.fcf.dest_addr_mode, frame.dest_addr)) {
-        packetbuf_set_addr(PACKETBUF_ADDR_RECEIVER, (rimeaddr_t *)&frame.dest_addr);
+        packetbuf_set_addr(PACKETBUF_ADDR_RECEIVER, (linkaddr_t *)&frame.dest_addr);
       }
     }
-    packetbuf_set_addr(PACKETBUF_ADDR_SENDER, (rimeaddr_t *)&frame.src_addr);
+    packetbuf_set_addr(PACKETBUF_ADDR_SENDER, (linkaddr_t *)&frame.src_addr);
     packetbuf_set_attr(PACKETBUF_ATTR_PENDING, frame.fcf.frame_pending);
     /*    packetbuf_set_attr(PACKETBUF_ATTR_RELIABLE, frame.fcf.ack_required);*/
     packetbuf_set_attr(PACKETBUF_ATTR_PACKET_ID, frame.seq);

--- a/examples/mbxxx/webserver-ajax/ajax-cgi.c
+++ b/examples/mbxxx/webserver-ajax/ajax-cgi.c
@@ -85,14 +85,14 @@ PT_THREAD(nodeidcall(struct httpd_state *s, char *ptr))
   static char buf[24];
   PSOCK_BEGIN(&s->sout);
   snprintf(buf, sizeof(buf), "%02X:%02X:%02X:%02X:%02X:%02X:%02X:%02X",
-	   rimeaddr_node_addr.u8[0],
-       rimeaddr_node_addr.u8[1],
-       rimeaddr_node_addr.u8[2],
-       rimeaddr_node_addr.u8[3],
-       rimeaddr_node_addr.u8[4],
-       rimeaddr_node_addr.u8[5],
-       rimeaddr_node_addr.u8[6],
-       rimeaddr_node_addr.u8[7]);
+	   linkaddr_node_addr.u8[0],
+       linkaddr_node_addr.u8[1],
+       linkaddr_node_addr.u8[2],
+       linkaddr_node_addr.u8[3],
+       linkaddr_node_addr.u8[4],
+       linkaddr_node_addr.u8[5],
+       linkaddr_node_addr.u8[6],
+       linkaddr_node_addr.u8[7]);
   PSOCK_SEND_STR(&s->sout, buf);
   PSOCK_END(&s->sout);
 }
@@ -237,7 +237,7 @@ PT_THREAD(neighborscall(struct httpd_state *s, char *ptr))
 /*---------------------------------------------------------------------------*/
 
 static void
-received_announcement(struct announcement *a, const rimeaddr_t *from,
+received_announcement(struct announcement *a, const linkaddr_t *from,
 	     uint16_t id, uint16_t value)
 {
   struct collect_neighbor *n;

--- a/examples/powertrace/example-powertrace.c
+++ b/examples/powertrace/example-powertrace.c
@@ -53,7 +53,7 @@ PROCESS(example_broadcast_process, "BROADCAST example");
 AUTOSTART_PROCESSES(&example_broadcast_process);
 /*---------------------------------------------------------------------------*/
 static void
-broadcast_recv(struct broadcast_conn *c, const rimeaddr_t *from)
+broadcast_recv(struct broadcast_conn *c, const linkaddr_t *from)
 {
   printf("broadcast message received from %d.%d: '%s'\n",
          from->u8[0], from->u8[1], (char *)packetbuf_dataptr());

--- a/examples/rime/example-announcement.c
+++ b/examples/rime/example-announcement.c
@@ -53,7 +53,7 @@ PROCESS(example_announcement_process, "Example announcement process");
 AUTOSTART_PROCESSES(&example_announcement_process);
 /*---------------------------------------------------------------------------*/
 static void
-received_announcement(struct announcement *a, const rimeaddr_t *from,
+received_announcement(struct announcement *a, const linkaddr_t *from,
 		      uint16_t id, uint16_t value)
 {
   /* We set our own announced value to one plus that of our neighbor. */
@@ -88,7 +88,7 @@ PROCESS_THREAD(example_announcement_process, ev, data)
 			received_announcement);
 
   /* Set the lowest eight bytes of the Rime address as the value. */
-  announcement_set_value(&example_announcement, rimeaddr_node_addr.u8[0]);
+  announcement_set_value(&example_announcement, linkaddr_node_addr.u8[0]);
 
   while(1) {
     static struct etimer et;

--- a/examples/rime/example-broadcast.c
+++ b/examples/rime/example-broadcast.c
@@ -51,7 +51,7 @@ PROCESS(example_broadcast_process, "Broadcast example");
 AUTOSTART_PROCESSES(&example_broadcast_process);
 /*---------------------------------------------------------------------------*/
 static void
-broadcast_recv(struct broadcast_conn *c, const rimeaddr_t *from)
+broadcast_recv(struct broadcast_conn *c, const linkaddr_t *from)
 {
   printf("broadcast message received from %d.%d: '%s'\n",
          from->u8[0], from->u8[1], (char *)packetbuf_dataptr());

--- a/examples/rime/example-collect.c
+++ b/examples/rime/example-collect.c
@@ -55,7 +55,7 @@ PROCESS(example_collect_process, "Test collect process");
 AUTOSTART_PROCESSES(&example_collect_process);
 /*---------------------------------------------------------------------------*/
 static void
-recv(const rimeaddr_t *originator, uint8_t seqno, uint8_t hops)
+recv(const linkaddr_t *originator, uint8_t seqno, uint8_t hops)
 {
   printf("Sink got message from %d.%d, seqno %d, hops %d: len %d '%s'\n",
 	 originator->u8[0], originator->u8[1],
@@ -75,8 +75,8 @@ PROCESS_THREAD(example_collect_process, ev, data)
 
   collect_open(&tc, 130, COLLECT_ROUTER, &callbacks);
 
-  if(rimeaddr_node_addr.u8[0] == 1 &&
-     rimeaddr_node_addr.u8[1] == 0) {
+  if(linkaddr_node_addr.u8[0] == 1 &&
+     linkaddr_node_addr.u8[1] == 0) {
 	printf("I am sink\n");
 	collect_set_sink(&tc, 1);
   }
@@ -97,8 +97,8 @@ PROCESS_THREAD(example_collect_process, ev, data)
 
 
     if(etimer_expired(&et)) {
-      static rimeaddr_t oldparent;
-      const rimeaddr_t *parent;
+      static linkaddr_t oldparent;
+      const linkaddr_t *parent;
 
       printf("Sending\n");
       packetbuf_clear();
@@ -107,14 +107,14 @@ PROCESS_THREAD(example_collect_process, ev, data)
       collect_send(&tc, 15);
 
       parent = collect_parent(&tc);
-      if(!rimeaddr_cmp(parent, &oldparent)) {
-        if(!rimeaddr_cmp(&oldparent, &rimeaddr_null)) {
+      if(!linkaddr_cmp(parent, &oldparent)) {
+        if(!linkaddr_cmp(&oldparent, &linkaddr_null)) {
           printf("#L %d 0\n", oldparent.u8[0]);
         }
-        if(!rimeaddr_cmp(parent, &rimeaddr_null)) {
+        if(!linkaddr_cmp(parent, &linkaddr_null)) {
           printf("#L %d 1\n", parent->u8[0]);
         }
-        rimeaddr_copy(&oldparent, parent);
+        linkaddr_copy(&oldparent, parent);
       }
     }
 

--- a/examples/rime/example-mesh.c
+++ b/examples/rime/example-mesh.c
@@ -68,7 +68,7 @@ timedout(struct mesh_conn *c)
 }
 
 static void
-recv(struct mesh_conn *c, const rimeaddr_t *from, uint8_t hops)
+recv(struct mesh_conn *c, const linkaddr_t *from, uint8_t hops)
 {
   printf("Data received from %d.%d: %.*s (%d)\n",
 	 from->u8[0], from->u8[1],
@@ -90,7 +90,7 @@ PROCESS_THREAD(example_mesh_process, ev, data)
   SENSORS_ACTIVATE(button_sensor);
 
   while(1) {
-    rimeaddr_t addr;
+    linkaddr_t addr;
 
     /* Wait for button click before sending the first message. */
     PROCESS_WAIT_EVENT_UNTIL(ev == sensors_event && data == &button_sensor);

--- a/examples/rime/example-multihop.c
+++ b/examples/rime/example-multihop.c
@@ -85,7 +85,7 @@
 
 struct example_neighbor {
   struct example_neighbor *next;
-  rimeaddr_t addr;
+  linkaddr_t addr;
   struct ctimer ctimer;
 };
 
@@ -120,7 +120,7 @@ remove_neighbor(void *n)
  */
 static void
 received_announcement(struct announcement *a,
-                      const rimeaddr_t *from,
+                      const linkaddr_t *from,
 		      uint16_t id, uint16_t value)
 {
   struct example_neighbor *e;
@@ -131,7 +131,7 @@ received_announcement(struct announcement *a,
   /* We received an announcement from a neighbor so we need to update
      the neighbor list, or add a new entry to the table. */
   for(e = list_head(neighbor_table); e != NULL; e = e->next) {
-    if(rimeaddr_cmp(from, &e->addr)) {
+    if(linkaddr_cmp(from, &e->addr)) {
       /* Our neighbor was found, so we update the timeout. */
       ctimer_set(&e->ctimer, NEIGHBOR_TIMEOUT, remove_neighbor, e);
       return;
@@ -143,7 +143,7 @@ received_announcement(struct announcement *a,
      necessary fields, and add it to the list. */
   e = memb_alloc(&neighbor_mem);
   if(e != NULL) {
-    rimeaddr_copy(&e->addr, from);
+    linkaddr_copy(&e->addr, from);
     list_add(neighbor_table, e);
     ctimer_set(&e->ctimer, NEIGHBOR_TIMEOUT, remove_neighbor, e);
   }
@@ -154,8 +154,8 @@ static struct announcement example_announcement;
  * This function is called at the final recepient of the message.
  */
 static void
-recv(struct multihop_conn *c, const rimeaddr_t *sender,
-     const rimeaddr_t *prevhop,
+recv(struct multihop_conn *c, const linkaddr_t *sender,
+     const linkaddr_t *prevhop,
      uint8_t hops)
 {
   printf("multihop message received '%s'\n", (char *)packetbuf_dataptr());
@@ -167,10 +167,10 @@ recv(struct multihop_conn *c, const rimeaddr_t *sender,
  * found, the function returns NULL to signal to the multihop layer
  * that the packet should be dropped.
  */
-static rimeaddr_t *
+static linkaddr_t *
 forward(struct multihop_conn *c,
-	const rimeaddr_t *originator, const rimeaddr_t *dest,
-	const rimeaddr_t *prevhop, uint8_t hops)
+	const linkaddr_t *originator, const linkaddr_t *dest,
+	const linkaddr_t *prevhop, uint8_t hops)
 {
   /* Find a random neighbor to send to. */
   int num, i;
@@ -184,14 +184,14 @@ forward(struct multihop_conn *c,
     }
     if(n != NULL) {
       printf("%d.%d: Forwarding packet to %d.%d (%d in list), hops %d\n",
-	     rimeaddr_node_addr.u8[0], rimeaddr_node_addr.u8[1],
+	     linkaddr_node_addr.u8[0], linkaddr_node_addr.u8[1],
 	     n->addr.u8[0], n->addr.u8[1], num,
 	     packetbuf_attr(PACKETBUF_ATTR_HOPS));
       return &n->addr;
     }
   }
   printf("%d.%d: did not find a neighbor to foward to\n",
-	 rimeaddr_node_addr.u8[0], rimeaddr_node_addr.u8[1]);
+	 linkaddr_node_addr.u8[0], linkaddr_node_addr.u8[1]);
   return NULL;
 }
 static const struct multihop_callbacks multihop_call = {recv, forward};
@@ -227,7 +227,7 @@ PROCESS_THREAD(example_multihop_process, ev, data)
 
   /* Loop forever, send a packet when the button is pressed. */
   while(1) {
-    rimeaddr_t to;
+    linkaddr_t to;
 
     /* Wait until we get a sensor event with the button sensor as data. */
     PROCESS_WAIT_EVENT_UNTIL(ev == sensors_event &&

--- a/examples/rime/example-neighbors.c
+++ b/examples/rime/example-neighbors.c
@@ -83,7 +83,7 @@ struct neighbor {
   struct neighbor *next;
 
   /* The ->addr field holds the Rime address of the neighbor. */
-  rimeaddr_t addr;
+  linkaddr_t addr;
 
   /* The ->last_rssi and ->last_lqi fields hold the Received Signal
      Strength Indicator (RSSI) and CC2420 Link Quality Indicator (LQI)
@@ -133,7 +133,7 @@ AUTOSTART_PROCESSES(&broadcast_process, &unicast_process);
 /*---------------------------------------------------------------------------*/
 /* This function is called whenever a broadcast message is received. */
 static void
-broadcast_recv(struct broadcast_conn *c, const rimeaddr_t *from)
+broadcast_recv(struct broadcast_conn *c, const linkaddr_t *from)
 {
   struct neighbor *n;
   struct broadcast_message *m;
@@ -149,7 +149,7 @@ broadcast_recv(struct broadcast_conn *c, const rimeaddr_t *from)
     /* We break out of the loop if the address of the neighbor matches
        the address of the neighbor from which we received this
        broadcast message. */
-    if(rimeaddr_cmp(&n->addr, from)) {
+    if(linkaddr_cmp(&n->addr, from)) {
       break;
     }
   }
@@ -168,7 +168,7 @@ broadcast_recv(struct broadcast_conn *c, const rimeaddr_t *from)
     }
 
     /* Initialize the fields. */
-    rimeaddr_copy(&n->addr, from);
+    linkaddr_copy(&n->addr, from);
     n->last_seqno = m->seqno - 1;
     n->avg_seqno_gap = SEQNO_EWMA_UNITY;
 
@@ -207,7 +207,7 @@ static const struct broadcast_callbacks broadcast_call = {broadcast_recv};
 /*---------------------------------------------------------------------------*/
 /* This function is called for every incoming unicast packet. */
 static void
-recv_uc(struct unicast_conn *c, const rimeaddr_t *from)
+recv_uc(struct unicast_conn *c, const linkaddr_t *from)
 {
   struct unicast_message *msg;
 

--- a/examples/rime/example-rucb.c
+++ b/examples/rime/example-rucb.c
@@ -115,17 +115,17 @@ PROCESS_THREAD(example_rucb_process, ev, data)
 
   PROCESS_PAUSE();
 
-  if(rimeaddr_node_addr.u8[0] == 51 &&
-      rimeaddr_node_addr.u8[1] == 0) {
-    rimeaddr_t recv;
+  if(linkaddr_node_addr.u8[0] == 51 &&
+      linkaddr_node_addr.u8[1] == 0) {
+    linkaddr_t recv;
 
     recv.u8[0] = 52;
     recv.u8[1] = 0;
     start_time = clock_time();
 
     /*printf("%u.%u: sending rucb to address %u.%u at time %u\n",
-        rimeaddr_node_addr.u8[0],
-        rimeaddr_node_addr.u8[1],
+        linkaddr_node_addr.u8[0],
+        linkaddr_node_addr.u8[1],
         recv.u8[0],
         recv.u8[1],
         start_time);*/

--- a/examples/rime/example-rudolph1.c
+++ b/examples/rime/example-rudolph1.c
@@ -93,7 +93,7 @@ write_chunk(struct rudolph1_conn *c, int offset, int flag,
   if(flag == RUDOLPH1_FLAG_LASTCHUNK) {
     int i;
     printf("+++ rudolph1 entire file received at %d, %d\n",
-	   rimeaddr_node_addr.u8[0], rimeaddr_node_addr.u8[1]);
+	   linkaddr_node_addr.u8[0], linkaddr_node_addr.u8[1]);
     leds_off(LEDS_RED);
     leds_on(LEDS_YELLOW);
 
@@ -103,7 +103,7 @@ write_chunk(struct rudolph1_conn *c, int offset, int flag,
       cfs_read(fd, &buf, 1);
       if(buf != (unsigned char)i) {
 	printf("%d.%d: error: diff at %d, %d != %d\n",
-	       rimeaddr_node_addr.u8[0], rimeaddr_node_addr.u8[1],
+	       linkaddr_node_addr.u8[0], linkaddr_node_addr.u8[1],
 	       i, i, buf);
 	break;
       }
@@ -125,7 +125,7 @@ read_chunk(struct rudolph1_conn *c, int offset, uint8_t *to, int maxsize)
   cfs_seek(fd, offset, CFS_SEEK_SET);
   ret = cfs_read(fd, to, maxsize);
   /*  printf("%d.%d: read_chunk %d bytes at %d, %d\n",
-	 rimeaddr_node_addr.u8[0], rimeaddr_node_addr.u8[1],
+	 linkaddr_node_addr.u8[0], linkaddr_node_addr.u8[1],
 	 ret, offset, (unsigned char)to[0]);*/
   cfs_close(fd);
   return ret;
@@ -166,8 +166,8 @@ PROCESS_THREAD(example_rudolph1_process, ev, data)
   
   PROCESS_PAUSE();
   
-  if(rimeaddr_node_addr.u8[0] == 1 &&
-     rimeaddr_node_addr.u8[1] == 1) {
+  if(linkaddr_node_addr.u8[0] == 1 &&
+     linkaddr_node_addr.u8[1] == 1) {
     {
       int i;
  

--- a/examples/rime/example-rudolph2.c
+++ b/examples/rime/example-rudolph2.c
@@ -93,7 +93,7 @@ write_chunk(struct rudolph2_conn *c, int offset, int flag,
   if(flag == RUDOLPH2_FLAG_LASTCHUNK) {
     int i;
     printf("+++ rudolph2 entire file received at %d, %d\n",
-	   rimeaddr_node_addr.u8[0], rimeaddr_node_addr.u8[1]);
+	   linkaddr_node_addr.u8[0], linkaddr_node_addr.u8[1]);
     leds_off(LEDS_RED);
     leds_on(LEDS_YELLOW);
 
@@ -103,13 +103,13 @@ write_chunk(struct rudolph2_conn *c, int offset, int flag,
       int r = cfs_read(fd, &buf, 1);
       if (r != 1) {
 	printf("%d.%d: error: read failed at %d\n",
-	       rimeaddr_node_addr.u8[0], rimeaddr_node_addr.u8[1],
+	       linkaddr_node_addr.u8[0], linkaddr_node_addr.u8[1],
 	       i);
 	break;
       }       
       else if(buf != (unsigned char)i) {
 	printf("%d.%d: error: diff at %d, %d != %d\n",
-	       rimeaddr_node_addr.u8[0], rimeaddr_node_addr.u8[1],
+	       linkaddr_node_addr.u8[0], linkaddr_node_addr.u8[1],
 	       i, (unsigned char)i, buf);
 	break;
       }
@@ -131,7 +131,7 @@ read_chunk(struct rudolph2_conn *c, int offset, uint8_t *to, int maxsize)
   cfs_seek(fd, offset, CFS_SEEK_SET);
   ret = cfs_read(fd, to, maxsize);
   /*  printf("%d.%d: read_chunk %d bytes at %d, %d\n",
-	 rimeaddr_node_addr.u8[0], rimeaddr_node_addr.u8[1],
+	 linkaddr_node_addr.u8[0], linkaddr_node_addr.u8[1],
 	 ret, offset, (unsigned char)to[0]);*/
   cfs_close(fd);
   return ret;
@@ -156,13 +156,13 @@ PROCESS_THREAD(example_rudolph2_process, ev, data)
 
   PROCESS_PAUSE();
   
-  if(rimeaddr_node_addr.u8[0] == 1 &&
-     rimeaddr_node_addr.u8[1] == 0) {
+  if(linkaddr_node_addr.u8[0] == 1 &&
+     linkaddr_node_addr.u8[1] == 0) {
     {
       int i;
       
       printf("%d.%d: selected data source\n",
-	     rimeaddr_node_addr.u8[0], rimeaddr_node_addr.u8[1]);
+	     linkaddr_node_addr.u8[0], linkaddr_node_addr.u8[1]);
       
       fd = cfs_open("hej", CFS_WRITE);
       for(i = 0; i < FILESIZE; i++) {
@@ -170,7 +170,7 @@ PROCESS_THREAD(example_rudolph2_process, ev, data)
 	int w = cfs_write(fd, &buf, 1);
 	if (w != 1) {
 	  printf("%d.%d: error: write failed at %d\n",
-	       rimeaddr_node_addr.u8[0], rimeaddr_node_addr.u8[1],
+	       linkaddr_node_addr.u8[0], linkaddr_node_addr.u8[1],
 	       i);
 	  break;
 	}       

--- a/examples/rime/example-runicast.c
+++ b/examples/rime/example-runicast.c
@@ -60,19 +60,19 @@ AUTOSTART_PROCESSES(&test_runicast_process);
  * Duplicates appear when ack messages are lost. */
 struct history_entry {
   struct history_entry *next;
-  rimeaddr_t addr;
+  linkaddr_t addr;
   uint8_t seq;
 };
 LIST(history_table);
 MEMB(history_mem, struct history_entry, NUM_HISTORY_ENTRIES);
 /*---------------------------------------------------------------------------*/
 static void
-recv_runicast(struct runicast_conn *c, const rimeaddr_t *from, uint8_t seqno)
+recv_runicast(struct runicast_conn *c, const linkaddr_t *from, uint8_t seqno)
 {
   /* OPTIONAL: Sender history */
   struct history_entry *e = NULL;
   for(e = list_head(history_table); e != NULL; e = e->next) {
-    if(rimeaddr_cmp(&e->addr, from)) {
+    if(linkaddr_cmp(&e->addr, from)) {
       break;
     }
   }
@@ -82,7 +82,7 @@ recv_runicast(struct runicast_conn *c, const rimeaddr_t *from, uint8_t seqno)
     if(e == NULL) {
       e = list_chop(history_table); /* Remove oldest at full history */
     }
-    rimeaddr_copy(&e->addr, from);
+    linkaddr_copy(&e->addr, from);
     e->seq = seqno;
     list_push(history_table, e);
   } else {
@@ -100,13 +100,13 @@ recv_runicast(struct runicast_conn *c, const rimeaddr_t *from, uint8_t seqno)
 	 from->u8[0], from->u8[1], seqno);
 }
 static void
-sent_runicast(struct runicast_conn *c, const rimeaddr_t *to, uint8_t retransmissions)
+sent_runicast(struct runicast_conn *c, const linkaddr_t *to, uint8_t retransmissions)
 {
   printf("runicast message sent to %d.%d, retransmissions %d\n",
 	 to->u8[0], to->u8[1], retransmissions);
 }
 static void
-timedout_runicast(struct runicast_conn *c, const rimeaddr_t *to, uint8_t retransmissions)
+timedout_runicast(struct runicast_conn *c, const linkaddr_t *to, uint8_t retransmissions)
 {
   printf("runicast message timed out when sending to %d.%d, retransmissions %d\n",
 	 to->u8[0], to->u8[1], retransmissions);
@@ -129,8 +129,8 @@ PROCESS_THREAD(test_runicast_process, ev, data)
   memb_init(&history_mem);
 
   /* Receiver node: do nothing */
-  if(rimeaddr_node_addr.u8[0] == 1 &&
-     rimeaddr_node_addr.u8[1] == 0) {
+  if(linkaddr_node_addr.u8[0] == 1 &&
+     linkaddr_node_addr.u8[1] == 0) {
     PROCESS_WAIT_EVENT_UNTIL(0);
   }
 
@@ -141,15 +141,15 @@ PROCESS_THREAD(test_runicast_process, ev, data)
     PROCESS_WAIT_EVENT_UNTIL(etimer_expired(&et));
 
     if(!runicast_is_transmitting(&runicast)) {
-      rimeaddr_t recv;
+      linkaddr_t recv;
 
       packetbuf_copyfrom("Hello", 5);
       recv.u8[0] = 1;
       recv.u8[1] = 0;
 
       printf("%u.%u: sending runicast to address %u.%u\n",
-	     rimeaddr_node_addr.u8[0],
-	     rimeaddr_node_addr.u8[1],
+	     linkaddr_node_addr.u8[0],
+	     linkaddr_node_addr.u8[1],
 	     recv.u8[0],
 	     recv.u8[1]);
 

--- a/examples/rime/example-trickle.c
+++ b/examples/rime/example-trickle.c
@@ -53,7 +53,7 @@ static void
 trickle_recv(struct trickle_conn *c)
 {
   printf("%d.%d: trickle message received '%s'\n",
-	 rimeaddr_node_addr.u8[0], rimeaddr_node_addr.u8[1],
+	 linkaddr_node_addr.u8[0], linkaddr_node_addr.u8[1],
 	 (char *)packetbuf_dataptr());
 }
 const static struct trickle_callbacks trickle_call = {trickle_recv};

--- a/examples/rime/example-unicast.c
+++ b/examples/rime/example-unicast.c
@@ -51,7 +51,7 @@ PROCESS(example_unicast_process, "Example unicast");
 AUTOSTART_PROCESSES(&example_unicast_process);
 /*---------------------------------------------------------------------------*/
 static void
-recv_uc(struct unicast_conn *c, const rimeaddr_t *from)
+recv_uc(struct unicast_conn *c, const linkaddr_t *from)
 {
   printf("unicast message received from %d.%d\n",
 	 from->u8[0], from->u8[1]);
@@ -69,7 +69,7 @@ PROCESS_THREAD(example_unicast_process, ev, data)
 
   while(1) {
     static struct etimer et;
-    rimeaddr_t addr;
+    linkaddr_t addr;
     
     etimer_set(&et, CLOCK_SECOND);
     
@@ -78,7 +78,7 @@ PROCESS_THREAD(example_unicast_process, ev, data)
     packetbuf_copyfrom("Hello", 5);
     addr.u8[0] = 1;
     addr.u8[1] = 0;
-    if(!rimeaddr_cmp(&addr, &rimeaddr_node_addr)) {
+    if(!linkaddr_cmp(&addr, &linkaddr_node_addr)) {
       unicast_send(&uc, &addr);
     }
 

--- a/examples/sensinode/broadcast-rime.c
+++ b/examples/sensinode/broadcast-rime.c
@@ -58,7 +58,7 @@ PROCESS(example_broadcast_process, "BROADCAST example");
 AUTOSTART_PROCESSES(&example_broadcast_process);
 /*---------------------------------------------------------------------------*/
 static void
-broadcast_recv(struct broadcast_conn *c, const rimeaddr_t *from)
+broadcast_recv(struct broadcast_conn *c, const linkaddr_t *from)
 {
   leds_toggle(LEDS_RED);
   PRINTF("broadcast message received from %02x.%02x\n", from->u8[0],

--- a/examples/sensinode/cc2431-location-engine/blind-node.c
+++ b/examples/sensinode/cc2431-location-engine/blind-node.c
@@ -169,7 +169,7 @@ calculate()
  * with rime address ending in [0 , 15]
  */
 static void
-broadcast_recv(struct broadcast_conn *c, const rimeaddr_t *from)
+broadcast_recv(struct broadcast_conn *c, const linkaddr_t *from)
 {
   packetbuf_attr_t rssi; /* Careful here, this is uint16_t */
 

--- a/examples/sensinode/sensors/sensors-example.c
+++ b/examples/sensinode/sensors/sensors-example.c
@@ -111,7 +111,7 @@
 #if SEND_BATTERY_INFO
 #include "sensors-example.h"
 static void
-bc_rx(struct broadcast_conn *c, const rimeaddr_t *from)
+bc_rx(struct broadcast_conn *c, const linkaddr_t *from)
 {
   return;
 }

--- a/examples/sky-ip/ajax-cgi.c
+++ b/examples/sky-ip/ajax-cgi.c
@@ -83,7 +83,7 @@ PT_THREAD(nodeidcall(struct httpd_state *s, char *ptr))
   static char buf[10];
   PSOCK_BEGIN(&s->sout);
   snprintf(buf, sizeof(buf), "%d.%d",
-	   rimeaddr_node_addr.u8[0], rimeaddr_node_addr.u8[1]);
+	   linkaddr_node_addr.u8[0], linkaddr_node_addr.u8[1]);
   PSOCK_SEND_STR(&s->sout, buf);
   PSOCK_END(&s->sout);
 }
@@ -203,7 +203,7 @@ PT_THREAD(neighborscall(struct httpd_state *s, char *ptr))
 /*---------------------------------------------------------------------------*/
 
 static void
-received_announcement(struct announcement *a, const rimeaddr_t *from,
+received_announcement(struct announcement *a, const linkaddr_t *from,
 	     uint16_t id, uint16_t value)
 {
   struct collect_neighbor *n;

--- a/examples/sky-ip/sky-telnet-server.c
+++ b/examples/sky-ip/sky-telnet-server.c
@@ -63,7 +63,7 @@ PROCESS_THREAD(shell_id_process, ev, data)
   snprintf(buf, sizeof(buf), "%d.%d.%d.%d", uip_ipaddr_to_quad(&uip_hostaddr));
   shell_output_str(&id_command, "IP address: ", buf);
   snprintf(buf, sizeof(buf), "%d.%d",
-	   rimeaddr_node_addr.u8[0], rimeaddr_node_addr.u8[1]);
+	   linkaddr_node_addr.u8[0], linkaddr_node_addr.u8[1]);
   shell_output_str(&id_command, "Rime address: ", buf);
   PROCESS_END();
 }

--- a/examples/sky-ip/telnet-webserver.c
+++ b/examples/sky-ip/telnet-webserver.c
@@ -63,7 +63,7 @@ PROCESS_THREAD(shell_id_process, ev, data)
   snprintf(buf, sizeof(buf), "%d.%d.%d.%d", uip_ipaddr_to_quad(&uip_hostaddr));
   shell_output_str(&id_command, "IP address: ", buf);
   snprintf(buf, sizeof(buf), "%d.%d",
-	   rimeaddr_node_addr.u8[0], rimeaddr_node_addr.u8[1]);
+	   linkaddr_node_addr.u8[0], linkaddr_node_addr.u8[1]);
   shell_output_str(&id_command, "Rime address: ", buf);
   PROCESS_END();
 }

--- a/examples/sky/sky-collect.c
+++ b/examples/sky/sky-collect.c
@@ -61,7 +61,7 @@ struct sky_collect_msg {
   uint16_t temperature;
   uint16_t humidity;
   uint16_t rssi;
-  rimeaddr_t best_neighbor;
+  linkaddr_t best_neighbor;
   uint16_t best_neighbor_etx;
   uint16_t best_neighbor_rtmetric;
   uint32_t energy_lpm;
@@ -161,7 +161,7 @@ do_rssi(void)
 }
 /*---------------------------------------------------------------------------*/
 static void
-recv(const rimeaddr_t *originator, uint8_t seqno, uint8_t hops)
+recv(const linkaddr_t *originator, uint8_t seqno, uint8_t hops)
 {
   struct sky_collect_msg *msg;
   
@@ -236,12 +236,12 @@ PROCESS_THREAD(test_collect_process, ev, data)
       msg->energy_rx = energest_type_time(ENERGEST_TYPE_LISTEN);
       msg->energy_tx = energest_type_time(ENERGEST_TYPE_TRANSMIT);
       msg->energy_rled = energest_type_time(ENERGEST_TYPE_LED_RED);
-      rimeaddr_copy(&msg->best_neighbor, &rimeaddr_null);
+      linkaddr_copy(&msg->best_neighbor, &linkaddr_null);
       msg->best_neighbor_etx =
 	msg->best_neighbor_rtmetric = 0;
       n = collect_neighbor_list_best(&tc.neighbor_list);
       if(n != NULL) {
-	rimeaddr_copy(&msg->best_neighbor, &n->addr);
+	linkaddr_copy(&msg->best_neighbor, &n->addr);
 	msg->best_neighbor_etx = collect_neighbor_link_estimate(n);
 	msg->best_neighbor_rtmetric = n->rtmetric;
       }

--- a/examples/z1/tutorials/example-unicast-temp.c
+++ b/examples/z1/tutorials/example-unicast-temp.c
@@ -76,7 +76,7 @@ PROCESS(example_unicast_process, "Example unicast");
 AUTOSTART_PROCESSES(&example_unicast_process);
 /*---------------------------------------------------------------------------*/
 static void
-recv_uc(struct unicast_conn *c, const rimeaddr_t *from)
+recv_uc(struct unicast_conn *c, const linkaddr_t *from)
 {
   printf("unicast message received from %d.%d\n",
      from->u8[0], from->u8[1]);
@@ -92,7 +92,7 @@ PROCESS_THREAD(example_unicast_process, ev, data)
 
 
   tmp102_init();
-  rimeaddr_t addr;
+  linkaddr_t addr;
   unicast_open(&uc, 133, &unicast_callbacks);
   SENSORS_ACTIVATE(button_sensor);
   while(1) {

--- a/examples/z1/tutorials/example-unicast2.c
+++ b/examples/z1/tutorials/example-unicast2.c
@@ -51,7 +51,7 @@ PROCESS(example_unicast_process, "Example unicast");
 AUTOSTART_PROCESSES(&example_unicast_process);
 /*---------------------------------------------------------------------------*/
 static void
-recv_uc(struct unicast_conn *c, const rimeaddr_t *from)
+recv_uc(struct unicast_conn *c, const linkaddr_t *from)
 {
   printf("unicast message received from %d.%d\n",
 	 from->u8[0], from->u8[1]);
@@ -69,7 +69,7 @@ PROCESS_THREAD(example_unicast_process, ev, data)
 
   while(1) {
     static struct etimer et;
-    rimeaddr_t addr;
+    linkaddr_t addr;
     
     etimer_set(&et, CLOCK_SECOND);
     
@@ -78,7 +78,7 @@ PROCESS_THREAD(example_unicast_process, ev, data)
     //packetbuf_copyfrom("Enric Here!", 12);
     //addr.u8[0] = 200;
     //addr.u8[1] = 0;
-    //if(!rimeaddr_cmp(&addr, &rimeaddr_node_addr)) {
+    //if(!linkaddr_cmp(&addr, &linkaddr_node_addr)) {
       //unicast_send(&uc, &addr);
     //}
 

--- a/platform/avr-atmega128rfa1/contiki-conf.h
+++ b/platform/avr-atmega128rfa1/contiki-conf.h
@@ -143,7 +143,7 @@ typedef unsigned short uip_stats_t;
 #define RDC_CONF_MCU_SLEEP         1
 
 #if UIP_CONF_IPV6
-#define RIMEADDR_CONF_SIZE        8
+#define LINKADDR_CONF_SIZE        8
 #define UIP_CONF_ICMP6            1
 #define UIP_CONF_UDP              1
 #define UIP_CONF_TCP              1
@@ -151,7 +151,7 @@ typedef unsigned short uip_stats_t;
 #define SICSLOWPAN_CONF_COMPRESSION SICSLOWPAN_COMPRESSION_HC06
 #else
 /* ip4 should build but is largely untested */
-#define RIMEADDR_CONF_SIZE        2
+#define LINKADDR_CONF_SIZE        2
 #define NETSTACK_CONF_NETWORK     rime_driver
 #endif
 

--- a/platform/avr-atmega128rfa1/contiki-main.c
+++ b/platform/avr-atmega128rfa1/contiki-main.c
@@ -258,21 +258,21 @@ uint8_t i;
 
   /* Set addresses BEFORE starting tcpip process */
 
-  rimeaddr_t addr;
+  linkaddr_t addr;
 
   if (params_get_eui64(addr.u8)) {
       PRINTA("Random EUI64 address generated\n");
   }
  
 #if UIP_CONF_IPV6 
-  memcpy(&uip_lladdr.addr, &addr.u8, sizeof(rimeaddr_t));
+  memcpy(&uip_lladdr.addr, &addr.u8, sizeof(linkaddr_t));
 #elif WITH_NODE_ID
   node_id=get_panaddr_from_eeprom();
   addr.u8[1]=node_id&0xff;
   addr.u8[0]=(node_id&0xff00)>>8;
   PRINTA("Node ID from eeprom: %X\n",node_id);
 #endif  
-  rimeaddr_set_node_addr(&addr); 
+  linkaddr_set_node_addr(&addr); 
 
   rf230_set_pan_addr(params_get_panid(),params_get_panaddr(),(uint8_t *)&addr.u8);
   rf230_set_channel(params_get_channel());
@@ -283,7 +283,7 @@ uint8_t i;
 #else
   PRINTA("MAC address ");
   uint8_t i;
-  for (i=sizeof(rimeaddr_t); i>0; i--){
+  for (i=sizeof(linkaddr_t); i>0; i--){
     PRINTA("%x:",addr.u8[i-1]);
   }
   PRINTA("\n");

--- a/platform/avr-atmega128rfa1/params.c
+++ b/platform/avr-atmega128rfa1/params.c
@@ -159,7 +159,7 @@ params_get_channel(void) {
 uint8_t
 params_get_eui64(uint8_t *eui64) {
   cli();
-  eeprom_read_block ((void *)eui64, &eemem_mac_address, sizeof(rimeaddr_t));
+  eeprom_read_block ((void *)eui64, &eemem_mac_address, sizeof(linkaddr_t));
   sei();
 #if CONTIKI_CONF_RANDOM_MAC
   return randomeui64;
@@ -199,7 +199,7 @@ params_get_channel() {
 }
 uint8_t
 params_get_eui64(uint8_t *eui64) {
-  size_t size = sizeof(rimeaddr_t); 
+  size_t size = sizeof(linkaddr_t); 
   if(settings_get(SETTINGS_KEY_EUI64, 0, (unsigned char*)eui64, &size) == SETTINGS_STATUS_OK) {
     PRINTD("<-Get EUI64 MAC\n");
     return 0;		

--- a/platform/avr-raven/contiki-conf.h
+++ b/platform/avr-raven/contiki-conf.h
@@ -158,7 +158,7 @@ typedef unsigned short uip_stats_t;
 #endif /*RF230BB */
 
 #if UIP_CONF_IPV6
-#define RIMEADDR_CONF_SIZE        8
+#define LINKADDR_CONF_SIZE        8
 #define UIP_CONF_ICMP6            1
 #define UIP_CONF_UDP              1
 #define UIP_CONF_TCP              1
@@ -167,7 +167,7 @@ typedef unsigned short uip_stats_t;
 #define SICSLOWPAN_CONF_COMPRESSION SICSLOWPAN_COMPRESSION_HC06
 #else
 /* ip4 should build but is largely untested */
-#define RIMEADDR_CONF_SIZE        2
+#define LINKADDR_CONF_SIZE        2
 #define NETSTACK_CONF_NETWORK     rime_driver
 #endif /* UIP_CONF_IPV6 */
 

--- a/platform/avr-raven/contiki-raven-main.c
+++ b/platform/avr-raven/contiki-raven-main.c
@@ -260,14 +260,14 @@ uint8_t i;
 
   /* Set addresses BEFORE starting tcpip process */
 
-  rimeaddr_t addr;
+  linkaddr_t addr;
   if (params_get_eui64(addr.u8)) {
       PRINTA("Random EUI64 address generated\n");
   }
  
 #if UIP_CONF_IPV6 
-  memcpy(&uip_lladdr.addr, &addr.u8, sizeof(rimeaddr_t));
-  rimeaddr_set_node_addr(&addr);  
+  memcpy(&uip_lladdr.addr, &addr.u8, sizeof(linkaddr_t));
+  linkaddr_set_node_addr(&addr);  
   rf230_set_pan_addr(params_get_panid(),params_get_panaddr(),(uint8_t *)&addr.u8);
 #elif WITH_NODE_ID
   node_id=get_panaddr_from_eeprom();
@@ -275,10 +275,10 @@ uint8_t i;
   addr.u8[0]=(node_id&0xff00)>>8;
   PRINTA("Node ID from eeprom: %X\n",node_id);
   uint16_t inv_node_id=((node_id&0xff00)>>8)+((node_id&0xff)<<8); // change order of bytes for rf23x
-  rimeaddr_set_node_addr(&addr);
+  linkaddr_set_node_addr(&addr);
   rf230_set_pan_addr(params_get_panid(),inv_node_id,NULL);
 #else
-  rimeaddr_set_node_addr(&addr);
+  linkaddr_set_node_addr(&addr);
   rf230_set_pan_addr(params_get_panid(),params_get_panaddr(),(uint8_t *)&addr.u8);
 #endif
   rf230_set_channel(params_get_channel());
@@ -289,7 +289,7 @@ uint8_t i;
 #else
   PRINTA("MAC address ");
   uint8_t i;
-  for (i=sizeof(rimeaddr_t); i>0; i--){
+  for (i=sizeof(linkaddr_t); i>0; i--){
     PRINTA("%x:",addr.u8[i-1]);
   }
   PRINTA("\n");

--- a/platform/avr-raven/params.c
+++ b/platform/avr-raven/params.c
@@ -159,7 +159,7 @@ params_get_channel(void) {
 uint8_t
 params_get_eui64(uint8_t *eui64) {
   cli();
-  eeprom_read_block ((void *)eui64, &eemem_mac_address, sizeof(rimeaddr_t));
+  eeprom_read_block ((void *)eui64, &eemem_mac_address, sizeof(linkaddr_t));
   sei();
 #if CONTIKI_CONF_RANDOM_MAC
   return randomeui64;
@@ -199,7 +199,7 @@ params_get_channel() {
 }
 uint8_t
 params_get_eui64(uint8_t *eui64) {
-  size_t size = sizeof(rimeaddr_t); 
+  size_t size = sizeof(linkaddr_t); 
   if(settings_get(SETTINGS_KEY_EUI64, 0, (unsigned char*)eui64, &size) == SETTINGS_STATUS_OK) {
     PRINTD("<-Get EUI64 MAC\n");
     return 0;		

--- a/platform/avr-ravenusb/Makefile.avr-ravenusb
+++ b/platform/avr-ravenusb/Makefile.avr-ravenusb
@@ -71,5 +71,5 @@ MODULES+=core/net/ip core/net/ipv4 core/net core/net/ipv6 \
          core/net/rime core/net/mac core/net/mac/sicslowmac
 else
 vpath %.c $(CONTIKI)/core/net/ipv6
-CONTIKI_SOURCEFILES += sicslowpan.c rimeaddr.c
+CONTIKI_SOURCEFILES += sicslowpan.c linkaddr.c
 endif

--- a/platform/avr-ravenusb/contiki-conf.h
+++ b/platform/avr-ravenusb/contiki-conf.h
@@ -218,7 +218,7 @@ extern void mac_log_802_15_4_rx(const uint8_t* buffer, size_t total_len);
 #endif /*RF230BB */
 
 #if UIP_CONF_IPV6
-#define RIMEADDR_CONF_SIZE       8
+#define LINKADDR_CONF_SIZE       8
 #define UIP_CONF_ICMP6           1
 #define UIP_CONF_UDP             1
 #define UIP_CONF_TCP             0
@@ -227,7 +227,7 @@ extern void mac_log_802_15_4_rx(const uint8_t* buffer, size_t total_len);
 #define SICSLOWPAN_CONF_COMPRESSION SICSLOWPAN_COMPRESSION_HC06
 #else
 /* ip4 should build but is thoroughly untested */
-#define RIMEADDR_CONF_SIZE       2
+#define LINKADDR_CONF_SIZE       2
 #define NETSTACK_CONF_NETWORK    rime_driver
 #endif /* UIP_CONF_IPV6 */
 

--- a/platform/avr-ravenusb/contiki-raven-main.c
+++ b/platform/avr-ravenusb/contiki-raven-main.c
@@ -98,7 +98,7 @@
 #include "radio/rf230bb/rf230bb.h"
 #include "net/mac/frame802154.h"
 #define UIP_IP_BUF ((struct uip_ip_hdr *)&uip_buf[UIP_LLH_LEN])
-rimeaddr_t macLongAddr;
+linkaddr_t macLongAddr;
 #define	tmp_addr	macLongAddr
 #else                 //legacy radio driver using Atmel/Cisco 802.15.4'ish MAC
 #include <stdbool.h>
@@ -493,7 +493,7 @@ uint16_t p=(uint16_t)&__bss_end;
 
   /* Set addresses BEFORE starting tcpip process */
 
-  memset(&tmp_addr, 0, sizeof(rimeaddr_t));
+  memset(&tmp_addr, 0, sizeof(linkaddr_t));
 
   if(get_eui64_from_eeprom(tmp_addr.u8));
    
@@ -513,7 +513,7 @@ uint16_t p=(uint16_t)&__bss_end;
   rf230_set_channel(get_channel_from_eeprom());
   rf230_set_txpower(get_txpower_from_eeprom());
 
-  rimeaddr_set_node_addr(&tmp_addr); 
+  linkaddr_set_node_addr(&tmp_addr); 
 
   /* Initialize stack protocols */
   queuebuf_init();

--- a/platform/avr-ravenusb/sicslow_ethernet.c
+++ b/platform/avr-ravenusb/sicslow_ethernet.c
@@ -484,8 +484,8 @@ void mac_LowpanToEthernet(void)
   //Check for broadcast message
   
 #if RF230BB
-  if(rimeaddr_cmp(packetbuf_addr(PACKETBUF_ADDR_RECEIVER), &rimeaddr_null)) {
-//  if(rimeaddr_cmp((const rimeaddr_t *)destAddr, &rimeaddr_null)) {
+  if(linkaddr_cmp(packetbuf_addr(PACKETBUF_ADDR_RECEIVER), &linkaddr_null)) {
+//  if(linkaddr_cmp((const linkaddr_t *)destAddr, &linkaddr_null)) {
 #else
   if(  ( parsed_frame->fcf->destAddrMode == SHORTADDRMODE) &&
        ( parsed_frame->dest_addr->addr16 == 0xffff) ) {
@@ -977,7 +977,7 @@ mac_log_802_15_4_tx(const uint8_t* buffer, size_t total_len) {
     ETHBUF(raw_buf)->type = uip_htons(0x809A);  //UIP_ETHTYPE_802154 0x809A
  
   /* Check for broadcast message */
-    if(rimeaddr_cmp(packetbuf_addr(PACKETBUF_ADDR_RECEIVER), &rimeaddr_null)) {
+    if(linkaddr_cmp(packetbuf_addr(PACKETBUF_ADDR_RECEIVER), &linkaddr_null)) {
       ETHBUF(raw_buf)->dest.addr[0] = 0x33;
       ETHBUF(raw_buf)->dest.addr[1] = 0x33;
       ETHBUF(raw_buf)->dest.addr[2] = 0x00;
@@ -1018,7 +1018,7 @@ mac_log_802_15_4_rx(const uint8_t* buf, size_t len) {
     ETHBUF(raw_buf)->type = uip_htons(0x809A);  //UIP_ETHTYPE_802154 0x809A
   
   /* Check for broadcast message */
-    if(rimeaddr_cmp(packetbuf_addr(PACKETBUF_ADDR_RECEIVER), &rimeaddr_null)) {
+    if(linkaddr_cmp(packetbuf_addr(PACKETBUF_ADDR_RECEIVER), &linkaddr_null)) {
       ETHBUF(raw_buf)->dest.addr[0] = 0x33;
       ETHBUF(raw_buf)->dest.addr[1] = 0x33;
       ETHBUF(raw_buf)->dest.addr[2] = 0x00;

--- a/platform/avr-rcb/contiki-conf.h
+++ b/platform/avr-rcb/contiki-conf.h
@@ -94,7 +94,7 @@ void clock_adjust_ticks(clock_time_t howmany);
 
 //#define UIP_CONF_IPV6            1  //Let makefile determine this so ipv4 hello-world will compile
 
-#define RIMEADDR_CONF_SIZE       8
+#define LINKADDR_CONF_SIZE       8
 #define PACKETBUF_CONF_HDR_SIZE    0
 
 /* 0 for IPv6, or 1 for HC1, 2 for HC01 */

--- a/platform/avr-zigbit/contiki-avr-zigbit-main.c
+++ b/platform/avr-zigbit/contiki-avr-zigbit-main.c
@@ -120,8 +120,8 @@ init_lowlevel(void)
 
   /* Set addresses BEFORE starting tcpip process */
 
-  rimeaddr_t addr;
-  memset(&addr, 0, sizeof(rimeaddr_t));
+  linkaddr_t addr;
+  memset(&addr, 0, sizeof(linkaddr_t));
   eeprom_read_block ((void *)&addr.u8,  &mac_address, 8);
  
 #if UIP_CONF_IPV6
@@ -134,7 +134,7 @@ init_lowlevel(void)
   rf230_set_channel(26);
 #endif
 
-  rimeaddr_set_node_addr(&addr); 
+  linkaddr_set_node_addr(&addr); 
 
   PRINTF("MAC address %x:%x:%x:%x:%x:%x:%x:%x\n",addr.u8[0],addr.u8[1],addr.u8[2],addr.u8[3],addr.u8[4],addr.u8[5],addr.u8[6],addr.u8[7]);
 

--- a/platform/avr-zigbit/contiki-conf.h
+++ b/platform/avr-zigbit/contiki-conf.h
@@ -95,7 +95,7 @@ void clock_adjust_ticks(clock_time_t howmany);
 #define CC_CONF_INLINE inline
 #endif
 
-#define RIMEADDR_CONF_SIZE       8
+#define LINKADDR_CONF_SIZE       8
 #define PACKETBUF_CONF_HDR_SIZE    0
 
 //define UIP_CONF_IPV6            1 //Let the makefile do this, allows hello-world to compile

--- a/platform/cc2530dk/contiki-conf.h
+++ b/platform/cc2530dk/contiki-conf.h
@@ -206,7 +206,7 @@
 #if UIP_CONF_IPV6
 /* Addresses, Sizes and Interfaces */
 /* 8-byte addresses here, 2 otherwise */
-#define RIMEADDR_CONF_SIZE                   8
+#define LINKADDR_CONF_SIZE                   8
 #define UIP_CONF_LL_802154                   1
 #define UIP_CONF_LLH_LEN                     0
 #define UIP_CONF_NETIF_MAX_ADDRESSES         3

--- a/platform/cc2530dk/contiki-main.c
+++ b/platform/cc2530dk/contiki-main.c
@@ -45,7 +45,7 @@ PROCESS_NAME(viztool_process);
 extern volatile uint8_t sleep_flag;
 #endif
 /*---------------------------------------------------------------------------*/
-extern rimeaddr_t rimeaddr_node_addr;
+extern linkaddr_t linkaddr_node_addr;
 static CC_AT_DATA uint16_t len;
 /*---------------------------------------------------------------------------*/
 #if ENERGEST_CONF_ON
@@ -90,7 +90,7 @@ set_rime_addr(void) CC_NON_BANKED
 #endif
 
   PUTSTRING("Rime is 0x");
-  PUTHEX(sizeof(rimeaddr_t));
+  PUTHEX(sizeof(linkaddr_t));
   PUTSTRING(" bytes long\n");
 
 #if CC2530_CONF_MAC_FROM_PRIMARY
@@ -114,8 +114,8 @@ set_rime_addr(void) CC_NON_BANKED
   FMAP = CC2530_LAST_FLASH_BANK;
 #endif
 
-  for(i = (RIMEADDR_SIZE - 1); i >= 0; --i) {
-    rimeaddr_node_addr.u8[i] = *macp;
+  for(i = (LINKADDR_SIZE - 1); i >= 0; --i) {
+    linkaddr_node_addr.u8[i] = *macp;
     macp++;
   }
 
@@ -128,11 +128,11 @@ set_rime_addr(void) CC_NON_BANKED
   /* Now the address is stored MSB first */
 #if STARTUP_CONF_VERBOSE
   PUTSTRING("Rime configured with address ");
-  for(i = 0; i < RIMEADDR_SIZE - 1; i++) {
-    PUTHEX(rimeaddr_node_addr.u8[i]);
+  for(i = 0; i < LINKADDR_SIZE - 1; i++) {
+    PUTHEX(linkaddr_node_addr.u8[i]);
     PUTCHAR(':');
   }
-  PUTHEX(rimeaddr_node_addr.u8[i]);
+  PUTHEX(linkaddr_node_addr.u8[i]);
   PUTCHAR('\n');
 #endif
 
@@ -244,7 +244,7 @@ main(void) CC_NON_BANKED
 #endif
 
 #if UIP_CONF_IPV6
-  memcpy(&uip_lladdr.addr, &rimeaddr_node_addr, sizeof(uip_lladdr.addr));
+  memcpy(&uip_lladdr.addr, &linkaddr_node_addr, sizeof(uip_lladdr.addr));
   queuebuf_init();
   process_start(&tcpip_process, NULL);
 #endif /* UIP_CONF_IPV6 */

--- a/platform/cc2538dk/contiki-conf.h
+++ b/platform/cc2538dk/contiki-conf.h
@@ -311,7 +311,7 @@ typedef uint32_t rtimer_clock_t;
 #if UIP_CONF_IPV6
 /* Addresses, Sizes and Interfaces */
 /* 8-byte addresses here, 2 otherwise */
-#define RIMEADDR_CONF_SIZE                   8
+#define LINKADDR_CONF_SIZE                   8
 #define UIP_CONF_LL_802154                   1
 #define UIP_CONF_LLH_LEN                     0
 #define UIP_CONF_NETIF_MAX_ADDRESSES         3

--- a/platform/cc2538dk/contiki-main.c
+++ b/platform/cc2538dk/contiki-main.c
@@ -105,16 +105,16 @@ fade(unsigned char l)
 static void
 set_rime_addr()
 {
-  ieee_addr_cpy_to(&rimeaddr_node_addr.u8[0], RIMEADDR_SIZE);
+  ieee_addr_cpy_to(&linkaddr_node_addr.u8[0], LINKADDR_SIZE);
 
 #if STARTUP_CONF_VERBOSE
   {
     int i;
     printf("Rime configured with address ");
-    for(i = 0; i < RIMEADDR_SIZE - 1; i++) {
-      printf("%02x:", rimeaddr_node_addr.u8[i]);
+    for(i = 0; i < LINKADDR_SIZE - 1; i++) {
+      printf("%02x:", linkaddr_node_addr.u8[i]);
     }
-    printf("%02x\n", rimeaddr_node_addr.u8[i]);
+    printf("%02x\n", linkaddr_node_addr.u8[i]);
   }
 #endif
 
@@ -190,7 +190,7 @@ main(void)
   cc2538_rf_set_addr(IEEE802154_PANID);
 
 #if UIP_CONF_IPV6
-  memcpy(&uip_lladdr.addr, &rimeaddr_node_addr, sizeof(uip_lladdr.addr));
+  memcpy(&uip_lladdr.addr, &linkaddr_node_addr, sizeof(uip_lladdr.addr));
   queuebuf_init();
   process_start(&tcpip_process, NULL);
 #endif /* UIP_CONF_IPV6 */

--- a/platform/cooja/contiki-conf.h
+++ b/platform/cooja/contiki-conf.h
@@ -118,7 +118,7 @@
 #define NETSTACK_CONF_FRAMER        framer_802154
 #define UIP_CONF_IPV6               1
 
-#define RIMEADDR_CONF_SIZE          8
+#define LINKADDR_CONF_SIZE          8
 
 #define UIP_CONF_LL_802154          1
 #define UIP_CONF_LLH_LEN            0
@@ -142,7 +142,7 @@
 #define UIP_CONF_ND6_REACHABLE_TIME     600000
 #define UIP_CONF_ND6_RETRANS_TIMER      10000
 
-#define RIMEADDR_CONF_SIZE            8
+#define LINKADDR_CONF_SIZE            8
 #define UIP_CONF_NETIF_MAX_ADDRESSES  3
 #define UIP_CONF_ND6_MAX_PREFIXES     3
 #define UIP_CONF_ND6_MAX_DEFROUTERS   2

--- a/platform/cooja/contiki-cooja-main.c
+++ b/platform/cooja/contiki-cooja-main.c
@@ -143,10 +143,10 @@ set_gateway(void)
 {
   if(!is_gateway) {
     printf("%d.%d: making myself the IP network gateway.\n\n",
-       rimeaddr_node_addr.u8[0], rimeaddr_node_addr.u8[1]);
+       linkaddr_node_addr.u8[0], linkaddr_node_addr.u8[1]);
     printf("IPv4 address of the gateway: %d.%d.%d.%d\n\n",
        uip_ipaddr_to_quad(&uip_hostaddr));
-    uip_over_mesh_set_gateway(&rimeaddr_node_addr);
+    uip_over_mesh_set_gateway(&linkaddr_node_addr);
     uip_over_mesh_make_announced_gateway();
     is_gateway = 1;
   }
@@ -180,10 +180,10 @@ rtimer_thread_loop(void *data)
 static void
 set_rime_addr(void)
 {
-  rimeaddr_t addr;
+  linkaddr_t addr;
   int i;
 
-  memset(&addr, 0, sizeof(rimeaddr_t));
+  memset(&addr, 0, sizeof(linkaddr_t));
 #if WITH_UIP6
   for(i = 0; i < sizeof(uip_lladdr.addr); i += 2) {
     addr.u8[i + 1] = node_id & 0xff;
@@ -193,7 +193,7 @@ set_rime_addr(void)
   addr.u8[0] = node_id & 0xff;
   addr.u8[1] = node_id >> 8;
 #endif /* WITH_UIP6 */
-  rimeaddr_set_node_addr(&addr);
+  linkaddr_set_node_addr(&addr);
   printf("Rime started with address ");
   for(i = 0; i < sizeof(addr.u8) - 1; i++) {
     printf("%d.", addr.u8[i]);
@@ -229,10 +229,10 @@ contiki_init()
     uint8_t longaddr[8];
     uint16_t shortaddr;
     
-    shortaddr = (rimeaddr_node_addr.u8[0] << 8) +
-      rimeaddr_node_addr.u8[1];
+    shortaddr = (linkaddr_node_addr.u8[0] << 8) +
+      linkaddr_node_addr.u8[1];
     memset(longaddr, 0, sizeof(longaddr));
-    rimeaddr_copy((rimeaddr_t *)&longaddr, &rimeaddr_node_addr);
+    linkaddr_copy((linkaddr_t *)&longaddr, &linkaddr_node_addr);
     printf("MAC %02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x ",
            longaddr[0], longaddr[1], longaddr[2], longaddr[3],
            longaddr[4], longaddr[5], longaddr[6], longaddr[7]);
@@ -260,7 +260,7 @@ contiki_init()
 
     uip_init();
     uip_fw_init();
-    uip_ipaddr(&hostaddr, 172,16,rimeaddr_node_addr.u8[0],rimeaddr_node_addr.u8[1]);
+    uip_ipaddr(&hostaddr, 172,16,linkaddr_node_addr.u8[0],linkaddr_node_addr.u8[1]);
     uip_ipaddr(&netmask, 255,255,0,0);
     uip_ipaddr_copy(&meshif.ipaddr, &hostaddr);
 
@@ -285,7 +285,7 @@ contiki_init()
       addr[i + 1] = node_id & 0xff;
       addr[i + 0] = node_id >> 8;
     }
-    rimeaddr_copy(addr, &rimeaddr_node_addr);
+    linkaddr_copy(addr, &linkaddr_node_addr);
     memcpy(&uip_lladdr.addr, addr, sizeof(uip_lladdr.addr));
 
     process_start(&tcpip_process, NULL);

--- a/platform/econotag/contiki-conf.h
+++ b/platform/econotag/contiki-conf.h
@@ -106,7 +106,7 @@
 #define PLATFORM_HAS_LEDS 1
 #define PLATFORM_HAS_BUTTON 1
 
-#define RIMEADDR_CONF_SIZE              8
+#define LINKADDR_CONF_SIZE              8
 
 #if WITH_UIP6
 /* Network setup for IPv6 */
@@ -171,7 +171,7 @@
 
 #ifdef WITH_UIP6
 
-#define RIMEADDR_CONF_SIZE              8
+#define LINKADDR_CONF_SIZE              8
 
 #define UIP_CONF_LL_802154              1
 #define UIP_CONF_LLH_LEN                0

--- a/platform/econotag/main.c
+++ b/platform/econotag/main.c
@@ -39,7 +39,7 @@
 /* contiki */
 #include "contiki.h"
 #include "dev/button-sensor.h"
-#include "net/rimeaddr.h"
+#include "net/linkaddr.h"
 #include "net/netstack.h"
 
 /* mc1322x */
@@ -123,7 +123,7 @@ int main(void) {
 	contiki_maca_set_mac_address(mc1322x_config.eui);
 
 #if WITH_UIP6
-	memcpy(&uip_lladdr.addr, &rimeaddr_node_addr.u8, sizeof(uip_lladdr.addr));
+	memcpy(&uip_lladdr.addr, &linkaddr_node_addr.u8, sizeof(uip_lladdr.addr));
 	queuebuf_init();
 	NETSTACK_RDC.init();
 	NETSTACK_MAC.init();

--- a/platform/eval-adf7xxxmb4z/contiki-main.c
+++ b/platform/eval-adf7xxxmb4z/contiki-main.c
@@ -72,15 +72,15 @@ static uint16_t node_id = 0x0102;
 static void
 set_rime_addr(void)
 {
-  rimeaddr_t addr;
+  linkaddr_t addr;
   int i;
 
-  memset(&addr, 0, sizeof(rimeaddr_t));
+  memset(&addr, 0, sizeof(linkaddr_t));
 #if UIP_CONF_IPV6
   memcpy(addr.u8, serial_id, sizeof(addr.u8));
 #else
   if(node_id == 0) {
-    for(i = 0; i < sizeof(rimeaddr_t); ++i) {
+    for(i = 0; i < sizeof(linkaddr_t); ++i) {
       addr.u8[i] = serial_id[7 - i];
     }
   } else {
@@ -88,7 +88,7 @@ set_rime_addr(void)
     addr.u8[1] = node_id >> 8;
   }
 #endif
-  rimeaddr_set_node_addr(&addr);
+  linkaddr_set_node_addr(&addr);
   printf("Rime started with address ");
   for(i = 0; i < sizeof(addr.u8) - 1; i++) {
     printf("%d.", addr.u8[i]);

--- a/platform/exp5438/contiki-conf.h
+++ b/platform/exp5438/contiki-conf.h
@@ -134,7 +134,7 @@
 
 #ifdef WITH_UIP6
 
-#define RIMEADDR_CONF_SIZE              8
+#define LINKADDR_CONF_SIZE              8
 
 #define UIP_CONF_LL_802154              1
 #define UIP_CONF_LLH_LEN                0

--- a/platform/exp5438/contiki-exp5438-main.c
+++ b/platform/exp5438/contiki-exp5438-main.c
@@ -73,15 +73,15 @@ extern unsigned char node_mac[8];
 static void
 set_rime_addr(void)
 {
-  rimeaddr_t addr;
+  linkaddr_t addr;
   int i;
 
-  memset(&addr, 0, sizeof(rimeaddr_t));
+  memset(&addr, 0, sizeof(linkaddr_t));
 #if UIP_CONF_IPV6
   memcpy(addr.u8, node_mac, sizeof(addr.u8));
 #else
   if(node_id == 0) {
-    for(i = 0; i < sizeof(rimeaddr_t); ++i) {
+    for(i = 0; i < sizeof(linkaddr_t); ++i) {
       addr.u8[i] = node_mac[7 - i];
     }
   } else {
@@ -89,7 +89,7 @@ set_rime_addr(void)
     addr.u8[1] = node_id >> 8;
   }
 #endif
-  rimeaddr_set_node_addr(&addr);
+  linkaddr_set_node_addr(&addr);
   printf("Rime addr ");
   for(i = 0; i < sizeof(addr.u8) - 1; i++) {
     printf("%u.", addr.u8[i]);
@@ -184,10 +184,10 @@ main(int argc, char **argv)
     uint8_t longaddr[8];
     uint16_t shortaddr;
 
-    shortaddr = (rimeaddr_node_addr.u8[0] << 8) +
-      rimeaddr_node_addr.u8[1];
+    shortaddr = (linkaddr_node_addr.u8[0] << 8) +
+      linkaddr_node_addr.u8[1];
     memset(longaddr, 0, sizeof(longaddr));
-    rimeaddr_copy((rimeaddr_t *)&longaddr, &rimeaddr_node_addr);
+    linkaddr_copy((linkaddr_t *)&longaddr, &linkaddr_node_addr);
     printf("MAC %02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x\n",
            longaddr[0], longaddr[1], longaddr[2], longaddr[3],
            longaddr[4], longaddr[5], longaddr[6], longaddr[7]);
@@ -268,7 +268,7 @@ main(int argc, char **argv)
 
 #if TIMESYNCH_CONF_ENABLED
   timesynch_init();
-  timesynch_set_authority_level(rimeaddr_node_addr.u8[0]);
+  timesynch_set_authority_level(linkaddr_node_addr.u8[0]);
 #endif /* TIMESYNCH_CONF_ENABLED */
 
 

--- a/platform/iris/contiki-conf.h
+++ b/platform/iris/contiki-conf.h
@@ -104,7 +104,7 @@
 
 #ifdef WITH_UIP6
 
-#define RIMEADDR_CONF_SIZE              8
+#define LINKADDR_CONF_SIZE              8
 
 #define UIP_CONF_LL_802154              1
 #define UIP_CONF_LLH_LEN                0

--- a/platform/iris/init-net.c
+++ b/platform/iris/init-net.c
@@ -77,15 +77,15 @@ static uint8_t is_gateway;
 static void
 set_rime_addr(void)
 {
-  rimeaddr_t addr;
+  linkaddr_t addr;
   int i;
 
-  memset(&addr, 0, sizeof(rimeaddr_t));
+  memset(&addr, 0, sizeof(linkaddr_t));
 #if UIP_CONF_IPV6
   memcpy(addr.u8, ds2401_id, sizeof(addr.u8));
 #else
   if(node_id == 0) {
-    for(i = 0; i < sizeof(rimeaddr_t); ++i) {
+    for(i = 0; i < sizeof(linkaddr_t); ++i) {
       addr.u8[i] = ds2401_id[7 - i];
     }
   } else {
@@ -93,7 +93,7 @@ set_rime_addr(void)
     addr.u8[1] = node_id >> 8;
   }
 #endif
-  rimeaddr_set_node_addr(&addr);
+  linkaddr_set_node_addr(&addr);
   printf_P(PSTR("Rime started with address "));
   for(i = 0; i < sizeof(addr.u8) - 1; i++) {
     printf_P(PSTR("%d."), addr.u8[i]);
@@ -109,10 +109,10 @@ set_gateway(void)
   if(!is_gateway) {
     leds_on(LEDS_RED);
     printf_P(PSTR("%d.%d: making myself the IP network gateway.\n\n"),
-	              rimeaddr_node_addr.u8[0], rimeaddr_node_addr.u8[1]);
+	              linkaddr_node_addr.u8[0], linkaddr_node_addr.u8[1]);
     printf_P(PSTR("IPv4 address of the gateway: %d.%d.%d.%d\n\n"),
 	              uip_ipaddr_to_quad(&uip_hostaddr));
-    uip_over_mesh_set_gateway(&rimeaddr_node_addr);
+    uip_over_mesh_set_gateway(&linkaddr_node_addr);
     uip_over_mesh_make_announced_gateway();
     is_gateway = 1;
   }
@@ -129,10 +129,10 @@ init_net(void)
     uint8_t longaddr[8];
     uint16_t shortaddr;
     
-    shortaddr = (rimeaddr_node_addr.u8[0] << 8) +
-                 rimeaddr_node_addr.u8[1];
+    shortaddr = (linkaddr_node_addr.u8[0] << 8) +
+                 linkaddr_node_addr.u8[1];
     memset(longaddr, 0, sizeof(longaddr));
-    rimeaddr_copy((rimeaddr_t *)&longaddr, &rimeaddr_node_addr);
+    linkaddr_copy((linkaddr_t *)&longaddr, &linkaddr_node_addr);
     printf_P(PSTR("MAC %02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x\n"),
              longaddr[0], longaddr[1], longaddr[2], longaddr[3],
              longaddr[4], longaddr[5], longaddr[6], longaddr[7]);
@@ -216,8 +216,8 @@ init_net(void)
   slip_set_input_callback(set_gateway);
 
   /* Construct ip address from four bytes. */
-  uip_ipaddr(&hostaddr, 172, 16, rimeaddr_node_addr.u8[0],
-                                  rimeaddr_node_addr.u8[1]);
+  uip_ipaddr(&hostaddr, 172, 16, linkaddr_node_addr.u8[0],
+                                  linkaddr_node_addr.u8[1]);
   /* Construct netmask from four bytes. */
   uip_ipaddr(&netmask, 255,255,0,0);
 

--- a/platform/mbxxx/contiki-conf.h
+++ b/platform/mbxxx/contiki-conf.h
@@ -63,7 +63,7 @@
 /* 802.15.4 PAN ID */
 #define IEEE802154_CONF_PANID					0x1234
 /* Use EID 64, enable hardware autoack and address filtering */
-#define RIMEADDR_CONF_SIZE					8
+#define LINKADDR_CONF_SIZE					8
 #define UIP_CONF_LL_802154					1
 #define ST_CONF_RADIO_AUTOACK					1
 /* Number of buffers for incoming frames */

--- a/platform/mbxxx/contiki-main.c
+++ b/platform/mbxxx/contiki-main.c
@@ -68,7 +68,7 @@
 
 #include "dev/stm32w-radio.h"
 #include "net/netstack.h"
-#include "net/rimeaddr.h"
+#include "net/linkaddr.h"
 #include "net/rime/rime.h"
 #include "net/ip/uip.h"
 
@@ -126,16 +126,16 @@ set_rime_addr(void)
 #endif
 
 #if UIP_CONF_IPV6
-  rimeaddr_set_node_addr((rimeaddr_t *)&eui64);
+  linkaddr_set_node_addr((linkaddr_t *)&eui64);
 #else
-  rimeaddr_set_node_addr((rimeaddr_t *)&eui64.u8[8 - RIMEADDR_SIZE]);
+  linkaddr_set_node_addr((linkaddr_t *)&eui64.u8[8 - LINKADDR_SIZE]);
 #endif
 
   printf("Rime started with address ");
-  for(i = 0; i < sizeof(rimeaddr_t) - 1; i++) {
-    printf("%d.", rimeaddr_node_addr.u8[i]);
+  for(i = 0; i < sizeof(linkaddr_t) - 1; i++) {
+    printf("%d.", linkaddr_node_addr.u8[i]);
   }
-  printf("%d\n", rimeaddr_node_addr.u8[i]);
+  printf("%d\n", linkaddr_node_addr.u8[i]);
 }
 /*---------------------------------------------------------------------------*/
 int
@@ -189,7 +189,7 @@ main(void)
                                   NETSTACK_RDC.channel_check_interval()));
   printf("802.15.4 PAN ID 0x%x, EUI-%d:",
       IEEE802154_CONF_PANID, UIP_CONF_LL_802154?64:16);
-  uip_debug_lladdr_print(&rimeaddr_node_addr);
+  uip_debug_lladdr_print(&linkaddr_node_addr);
   printf(", radio channel %u\n", RF_CHANNEL);
 
   procinit_init();

--- a/platform/micaz/contiki-conf.h
+++ b/platform/micaz/contiki-conf.h
@@ -117,7 +117,7 @@
 
 #ifdef WITH_UIP6
 
-#define RIMEADDR_CONF_SIZE              8
+#define LINKADDR_CONF_SIZE              8
 
 #define UIP_CONF_LL_802154              1
 #define UIP_CONF_LLH_LEN                0

--- a/platform/micaz/init-net.c
+++ b/platform/micaz/init-net.c
@@ -77,15 +77,15 @@ static uint8_t is_gateway;
 static void
 set_rime_addr(void)
 {
-  rimeaddr_t addr;
+  linkaddr_t addr;
   int i;
 
-  memset(&addr, 0, sizeof(rimeaddr_t));
+  memset(&addr, 0, sizeof(linkaddr_t));
 #if UIP_CONF_IPV6
   memcpy(addr.u8, ds2401_id, sizeof(addr.u8));
 #else
   if(node_id == 0) {
-    for(i = 0; i < sizeof(rimeaddr_t); ++i) {
+    for(i = 0; i < sizeof(linkaddr_t); ++i) {
       addr.u8[i] = ds2401_id[7 - i];
     }
   } else {
@@ -93,7 +93,7 @@ set_rime_addr(void)
     addr.u8[1] = node_id >> 8;
   }
 #endif
-  rimeaddr_set_node_addr(&addr);
+  linkaddr_set_node_addr(&addr);
   printf_P(PSTR("Rime started with address "));
   for(i = 0; i < sizeof(addr.u8) - 1; i++) {
     printf_P(PSTR("%d."), addr.u8[i]);
@@ -109,10 +109,10 @@ set_gateway(void)
   if(!is_gateway) {
     leds_on(LEDS_RED);
     printf_P(PSTR("%d.%d: making myself the IP network gateway.\n\n"),
-	              rimeaddr_node_addr.u8[0], rimeaddr_node_addr.u8[1]);
+	              linkaddr_node_addr.u8[0], linkaddr_node_addr.u8[1]);
     printf_P(PSTR("IPv4 address of the gateway: %d.%d.%d.%d\n\n"),
 	              uip_ipaddr_to_quad(&uip_hostaddr));
-    uip_over_mesh_set_gateway(&rimeaddr_node_addr);
+    uip_over_mesh_set_gateway(&linkaddr_node_addr);
     uip_over_mesh_make_announced_gateway();
     is_gateway = 1;
   }
@@ -129,10 +129,10 @@ init_net(void)
     uint8_t longaddr[8];
     uint16_t shortaddr;
     
-    shortaddr = (rimeaddr_node_addr.u8[0] << 8) +
-                 rimeaddr_node_addr.u8[1];
+    shortaddr = (linkaddr_node_addr.u8[0] << 8) +
+                 linkaddr_node_addr.u8[1];
     memset(longaddr, 0, sizeof(longaddr));
-    rimeaddr_copy((rimeaddr_t *)&longaddr, &rimeaddr_node_addr);
+    linkaddr_copy((linkaddr_t *)&longaddr, &linkaddr_node_addr);
     printf_P(PSTR("MAC %02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x\n"),
              longaddr[0], longaddr[1], longaddr[2], longaddr[3],
              longaddr[4], longaddr[5], longaddr[6], longaddr[7]);
@@ -214,8 +214,8 @@ init_net(void)
   slip_set_input_callback(set_gateway);
 
   /* Construct ip address from four bytes. */
-  uip_ipaddr(&hostaddr, 172, 16, rimeaddr_node_addr.u8[0],
-                                  rimeaddr_node_addr.u8[1]);
+  uip_ipaddr(&hostaddr, 172, 16, linkaddr_node_addr.u8[0],
+                                  linkaddr_node_addr.u8[1]);
   /* Construct netmask from four bytes. */
   uip_ipaddr(&netmask, 255,255,0,0);
 

--- a/platform/native/contiki-conf.h
+++ b/platform/native/contiki-conf.h
@@ -81,7 +81,7 @@ typedef unsigned short uip_stats_t;
 
 #if UIP_CONF_IPV6
 
-#define RIMEADDR_CONF_SIZE              8
+#define LINKADDR_CONF_SIZE              8
 
 #ifndef NETSTACK_CONF_MAC
 #define NETSTACK_CONF_MAC     nullmac_driver

--- a/platform/native/contiki-main.c
+++ b/platform/native/contiki-main.c
@@ -129,15 +129,15 @@ const static struct select_callback stdin_fd = {
 static void
 set_rime_addr(void)
 {
-  rimeaddr_t addr;
+  linkaddr_t addr;
   int i;
 
-  memset(&addr, 0, sizeof(rimeaddr_t));
+  memset(&addr, 0, sizeof(linkaddr_t));
 #if UIP_CONF_IPV6
   memcpy(addr.u8, serial_id, sizeof(addr.u8));
 #else
   if(node_id == 0) {
-    for(i = 0; i < sizeof(rimeaddr_t); ++i) {
+    for(i = 0; i < sizeof(linkaddr_t); ++i) {
       addr.u8[i] = serial_id[7 - i];
     }
   } else {
@@ -145,7 +145,7 @@ set_rime_addr(void)
     addr.u8[1] = node_id >> 8;
   }
 #endif
-  rimeaddr_set_node_addr(&addr);
+  linkaddr_set_node_addr(&addr);
   printf("Rime started with address ");
   for(i = 0; i < sizeof(addr.u8) - 1; i++) {
     printf("%d.", addr.u8[i]);

--- a/platform/seedeye/contiki-conf.h
+++ b/platform/seedeye/contiki-conf.h
@@ -75,14 +75,14 @@ typedef uint32_t rtimer_clock_t;
 #define NETSTACK_CONF_MAC                       nullmac_driver
 #define NETSTACK_CONF_RDC                       nullrdc_driver
 #define NETSTACK_CONF_RADIO                     mrf24j40_driver
-#define RIMEADDR_CONF_SIZE                      8
+#define LINKADDR_CONF_SIZE                      8
 #else
 #define NETSTACK_CONF_NETWORK                   rime_driver
 #define NETSTACK_CONF_FRAMER                    framer_802154
 #define NETSTACK_CONF_MAC                       nullmac_driver
 #define NETSTACK_CONF_RDC                       nullrdc_driver
 #define NETSTACK_CONF_RADIO                     mrf24j40_driver
-#define RIMEADDR_CONF_SIZE                      2
+#define LINKADDR_CONF_SIZE                      2
 #endif
 
 #define RDC_CONF_HARDWARE_CSMA                  1

--- a/platform/seedeye/init-net.c
+++ b/platform/seedeye/init-net.c
@@ -72,7 +72,7 @@ init_net(uint8_t node_id)
 {
   uint16_t shortaddr;
   uint64_t longaddr;
-  rimeaddr_t addr;
+  linkaddr_t addr;
 #if WITH_UIP6
   uip_ds6_addr_t *lladdr;
   uip_ipaddr_t ipaddr;
@@ -103,13 +103,13 @@ init_net(uint8_t node_id)
          *((uint8_t *)&longaddr + 6),
          *((uint8_t *)&longaddr + 7));
 
-  memset(&addr, 0, sizeof(rimeaddr_t));
+  memset(&addr, 0, sizeof(linkaddr_t));
 
   for(i = 0; i < sizeof(addr.u8); ++i) {
     addr.u8[i] = ((uint8_t *)&longaddr)[i];
   }
 
-  rimeaddr_set_node_addr(&addr);
+  linkaddr_set_node_addr(&addr);
   
   PRINTF("Rime started with address: ");
   for(i = 0; i < sizeof(addr.u8) - 1; ++i) {
@@ -137,7 +137,7 @@ init_net(uint8_t node_id)
 
 #if WITH_UIP6
 
-#if RIMEADDR_CONF_SIZE == 2
+#if LINKADDR_CONF_SIZE == 2
   memset(&uip_lladdr.addr, 0, sizeof(uip_lladdr.addr));
   uip_lladdr.addr[3] = 0xff;
   uip_lladdr.addr[4]= 0xfe;

--- a/platform/sensinode/contiki-conf.h
+++ b/platform/sensinode/contiki-conf.h
@@ -204,7 +204,7 @@
 #if UIP_CONF_IPV6
 /* Addresses, Sizes and Interfaces */
 /* 8-byte addresses here, 2 otherwise */
-#define RIMEADDR_CONF_SIZE                   8
+#define LINKADDR_CONF_SIZE                   8
 #define UIP_CONF_LL_802154                   1
 #define UIP_CONF_LLH_LEN                     0
 #define UIP_CONF_NETIF_MAX_ADDRESSES         3

--- a/platform/sensinode/contiki-sensinode-main.c
+++ b/platform/sensinode/contiki-sensinode-main.c
@@ -59,7 +59,7 @@ static CC_AT_DATA uint16_t len;
 extern volatile uint8_t sleep_flag;
 #endif
 
-extern rimeaddr_t rimeaddr_node_addr;
+extern linkaddr_t linkaddr_node_addr;
 #if ENERGEST_CONF_ON
 static unsigned long irq_energest = 0;
 #define ENERGEST_IRQ_SAVE(a) do { \
@@ -99,7 +99,7 @@ set_rime_addr(void) CC_NON_BANKED
   __code unsigned char *macp;
 
   PUTSTRING("Rime is 0x");
-  PUTHEX(sizeof(rimeaddr_t));
+  PUTHEX(sizeof(linkaddr_t));
   PUTSTRING(" bytes long\n");
 
   if(node_id == 0) {
@@ -121,8 +121,8 @@ set_rime_addr(void) CC_NON_BANKED
     /* Set our pointer to the correct address and fetch 8 bytes of MAC */
     macp = (__code unsigned char *)0xFFF8;
 
-    for(i = (RIMEADDR_SIZE - 1); i >= 0; --i) {
-      rimeaddr_node_addr.u8[i] = *macp;
+    for(i = (LINKADDR_SIZE - 1); i >= 0; --i) {
+      linkaddr_node_addr.u8[i] = *macp;
       macp++;
     }
 
@@ -132,27 +132,27 @@ set_rime_addr(void) CC_NON_BANKED
 
   } else {
     PUTSTRING("Setting manual address from node_id\n");
-    rimeaddr_node_addr.u8[RIMEADDR_SIZE - 1] = node_id >> 8;
-    rimeaddr_node_addr.u8[RIMEADDR_SIZE - 2] = node_id & 0xff;
+    linkaddr_node_addr.u8[LINKADDR_SIZE - 1] = node_id >> 8;
+    linkaddr_node_addr.u8[LINKADDR_SIZE - 2] = node_id & 0xff;
   }
 
   /* Now the address is stored MSB first */
 #if STARTUP_VERBOSE
   PUTSTRING("Rime configured with address ");
-  for(i = 0; i < RIMEADDR_SIZE - 1; i++) {
-    PUTHEX(rimeaddr_node_addr.u8[i]);
+  for(i = 0; i < LINKADDR_SIZE - 1; i++) {
+    PUTHEX(linkaddr_node_addr.u8[i]);
     PUTCHAR(':');
   }
-  PUTHEX(rimeaddr_node_addr.u8[i]);
+  PUTHEX(linkaddr_node_addr.u8[i]);
   PUTCHAR('\n');
 #endif
 
   /* Set the cc2430 RF addresses */
-#if (RIMEADDR_SIZE==8)
-  addr_short = (rimeaddr_node_addr.u8[6] * 256) + rimeaddr_node_addr.u8[7];
-  addr_long = (uint8_t *) &rimeaddr_node_addr;
+#if (LINKADDR_SIZE==8)
+  addr_short = (linkaddr_node_addr.u8[6] * 256) + linkaddr_node_addr.u8[7];
+  addr_long = (uint8_t *) &linkaddr_node_addr;
 #else
-  addr_short = (rimeaddr_node_addr.u8[0] * 256) + rimeaddr_node_addr.u8[1];
+  addr_short = (linkaddr_node_addr.u8[0] * 256) + linkaddr_node_addr.u8[1];
 #endif
   cc2430_rf_set_addr(IEEE802154_PANID, addr_short, addr_long);
 }
@@ -246,7 +246,7 @@ main(void)
 #endif
 
 #if UIP_CONF_IPV6
-  memcpy(&uip_lladdr.addr, &rimeaddr_node_addr, sizeof(uip_lladdr.addr));
+  memcpy(&uip_lladdr.addr, &linkaddr_node_addr, sizeof(uip_lladdr.addr));
   queuebuf_init();
   process_start(&tcpip_process, NULL);
 

--- a/platform/sky/contiki-conf.h
+++ b/platform/sky/contiki-conf.h
@@ -134,7 +134,7 @@
 
 #ifdef WITH_UIP6
 
-#define RIMEADDR_CONF_SIZE              8
+#define LINKADDR_CONF_SIZE              8
 
 #define UIP_CONF_LL_802154              1
 #define UIP_CONF_LLH_LEN                0

--- a/platform/sky/contiki-sky-main.c
+++ b/platform/sky/contiki-sky-main.c
@@ -127,15 +127,15 @@ force_inclusion(int d1, int d2)
 static void
 set_rime_addr(void)
 {
-  rimeaddr_t addr;
+  linkaddr_t addr;
   int i;
 
-  memset(&addr, 0, sizeof(rimeaddr_t));
+  memset(&addr, 0, sizeof(linkaddr_t));
 #if UIP_CONF_IPV6
   memcpy(addr.u8, ds2411_id, sizeof(addr.u8));
 #else
   if(node_id == 0) {
-    for(i = 0; i < sizeof(rimeaddr_t); ++i) {
+    for(i = 0; i < sizeof(linkaddr_t); ++i) {
       addr.u8[i] = ds2411_id[7 - i];
     }
   } else {
@@ -143,7 +143,7 @@ set_rime_addr(void)
     addr.u8[1] = node_id >> 8;
   }
 #endif
-  rimeaddr_set_node_addr(&addr);
+  linkaddr_set_node_addr(&addr);
   printf("Rime started with address ");
   for(i = 0; i < sizeof(addr.u8) - 1; i++) {
     printf("%d.", addr.u8[i]);
@@ -172,10 +172,10 @@ set_gateway(void)
   if(!is_gateway) {
     leds_on(LEDS_RED);
     printf("%d.%d: making myself the IP network gateway.\n\n",
-	   rimeaddr_node_addr.u8[0], rimeaddr_node_addr.u8[1]);
+	   linkaddr_node_addr.u8[0], linkaddr_node_addr.u8[1]);
     printf("IPv4 address of the gateway: %d.%d.%d.%d\n\n",
 	   uip_ipaddr_to_quad(&uip_hostaddr));
-    uip_over_mesh_set_gateway(&rimeaddr_node_addr);
+    uip_over_mesh_set_gateway(&linkaddr_node_addr);
     uip_over_mesh_make_announced_gateway();
     is_gateway = 1;
   }
@@ -258,10 +258,10 @@ main(int argc, char **argv)
     uint8_t longaddr[8];
     uint16_t shortaddr;
     
-    shortaddr = (rimeaddr_node_addr.u8[0] << 8) +
-      rimeaddr_node_addr.u8[1];
+    shortaddr = (linkaddr_node_addr.u8[0] << 8) +
+      linkaddr_node_addr.u8[1];
     memset(longaddr, 0, sizeof(longaddr));
-    rimeaddr_copy((rimeaddr_t *)&longaddr, &rimeaddr_node_addr);
+    linkaddr_copy((linkaddr_t *)&longaddr, &linkaddr_node_addr);
     printf("MAC %02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x ",
            longaddr[0], longaddr[1], longaddr[2], longaddr[3],
            longaddr[4], longaddr[5], longaddr[6], longaddr[7]);
@@ -350,7 +350,7 @@ main(int argc, char **argv)
 
 #if TIMESYNCH_CONF_ENABLED
   timesynch_init();
-  timesynch_set_authority_level((rimeaddr_node_addr.u8[0] << 4) + 16);
+  timesynch_set_authority_level((linkaddr_node_addr.u8[0] << 4) + 16);
 #endif /* TIMESYNCH_CONF_ENABLED */
 
 #if WITH_UIP
@@ -366,7 +366,7 @@ main(int argc, char **argv)
     uip_init();
 
     uip_ipaddr(&hostaddr, 172,16,
-	       rimeaddr_node_addr.u8[0],rimeaddr_node_addr.u8[1]);
+	       linkaddr_node_addr.u8[0],linkaddr_node_addr.u8[1]);
     uip_ipaddr(&netmask, 255,255,0,0);
     uip_ipaddr_copy(&meshif.ipaddr, &hostaddr);
 

--- a/platform/wismote/contiki-conf.h
+++ b/platform/wismote/contiki-conf.h
@@ -122,7 +122,7 @@
 
 #ifdef WITH_UIP6
 
-#define RIMEADDR_CONF_SIZE              8
+#define LINKADDR_CONF_SIZE              8
 
 #define UIP_CONF_LL_802154              1
 #define UIP_CONF_LLH_LEN                0

--- a/platform/wismote/contiki-wismote-main.c
+++ b/platform/wismote/contiki-wismote-main.c
@@ -127,10 +127,10 @@ force_inclusion(int d1, int d2)
 static void
 set_rime_addr(void)
 {
-  rimeaddr_t n_addr;
+  linkaddr_t n_addr;
   int i;
 
-  memset(&n_addr, 0, sizeof(rimeaddr_t));
+  memset(&n_addr, 0, sizeof(linkaddr_t));
 
   //	Set node address
 #if UIP_CONF_IPV6
@@ -139,7 +139,7 @@ set_rime_addr(void)
   n_addr.u8[6] = node_id >> 8;
 #else
  /* if(node_id == 0) {
-    for(i = 0; i < sizeof(rimeaddr_t); ++i) {
+    for(i = 0; i < sizeof(linkaddr_t); ++i) {
       addr.u8[i] = ds2411_id[7 - i];
     }
   } else {
@@ -150,7 +150,7 @@ set_rime_addr(void)
   n_addr.u8[1] = node_id >> 8;
 #endif
 
-  rimeaddr_set_node_addr(&n_addr);
+  linkaddr_set_node_addr(&n_addr);
   printf("Rime started with address ");
   for(i = 0; i < sizeof(n_addr.u8) - 1; i++) {
     printf("%d.", n_addr.u8[i]);
@@ -179,10 +179,10 @@ set_gateway(void)
   if(!is_gateway) {
     leds_on(LEDS_RED);
     //printf("%d.%d: making myself the IP network gateway.\n\n",
-	//   rimeaddr_node_addr.u8[0], rimeaddr_node_addr.u8[1]);
+	//   linkaddr_node_addr.u8[0], linkaddr_node_addr.u8[1]);
     //printf("IPv4 address of the gateway: %d.%d.%d.%d\n\n",
 	 //  uip_ipaddr_to_quad(&uip_hostaddr));
-    uip_over_mesh_set_gateway(&rimeaddr_node_addr);
+    uip_over_mesh_set_gateway(&linkaddr_node_addr);
     uip_over_mesh_make_announced_gateway();
     is_gateway = 1;
   }
@@ -263,10 +263,10 @@ main(int argc, char **argv)
     uint8_t longaddr[8];
     uint16_t shortaddr;
 
-    shortaddr = (rimeaddr_node_addr.u8[0] << 8) +
-      rimeaddr_node_addr.u8[1];
+    shortaddr = (linkaddr_node_addr.u8[0] << 8) +
+      linkaddr_node_addr.u8[1];
     memset(longaddr, 0, sizeof(longaddr));
-    rimeaddr_copy((rimeaddr_t *)&longaddr, &rimeaddr_node_addr);
+    linkaddr_copy((linkaddr_t *)&longaddr, &linkaddr_node_addr);
 
     printf("MAC %02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x ",
            longaddr[0], longaddr[1], longaddr[2], longaddr[3],
@@ -285,8 +285,8 @@ main(int argc, char **argv)
 
 #if WITH_UIP6
   /* memcpy(&uip_lladdr.addr, ds2411_id, sizeof(uip_lladdr.addr)); */
-  memcpy(&uip_lladdr.addr, rimeaddr_node_addr.u8,
-         UIP_LLADDR_LEN > RIMEADDR_SIZE ? RIMEADDR_SIZE : UIP_LLADDR_LEN);
+  memcpy(&uip_lladdr.addr, linkaddr_node_addr.u8,
+         UIP_LLADDR_LEN > LINKADDR_SIZE ? LINKADDR_SIZE : UIP_LLADDR_LEN);
 
   /* Setup nullmac-like MAC for 802.15.4 */
 /*   sicslowpan_init(sicslowmac_init(&cc2520_driver)); */
@@ -355,7 +355,7 @@ main(int argc, char **argv)
 
 #if TIMESYNCH_CONF_ENABLED
   timesynch_init();
-  timesynch_set_authority_level((rimeaddr_node_addr.u8[0] << 4) + 16);
+  timesynch_set_authority_level((linkaddr_node_addr.u8[0] << 4) + 16);
 #endif /* TIMESYNCH_CONF_ENABLED */
 
 #if WITH_UIP
@@ -371,7 +371,7 @@ main(int argc, char **argv)
     uip_init();
 
     uip_ipaddr(&hostaddr, 172,16,
-	       rimeaddr_node_addr.u8[0],rimeaddr_node_addr.u8[1]);
+	       linkaddr_node_addr.u8[0],linkaddr_node_addr.u8[1]);
     uip_ipaddr(&netmask, 255,255,0,0);
     uip_ipaddr_copy(&meshif.ipaddr, &hostaddr);
 

--- a/platform/z1/contiki-conf.h
+++ b/platform/z1/contiki-conf.h
@@ -133,7 +133,7 @@
 
 #ifdef WITH_UIP6
 
-#define RIMEADDR_CONF_SIZE              8
+#define LINKADDR_CONF_SIZE              8
 
 #define UIP_CONF_LL_802154              1
 #define UIP_CONF_LLH_LEN                0

--- a/platform/z1/contiki-z1-main.c
+++ b/platform/z1/contiki-z1-main.c
@@ -132,15 +132,15 @@ force_inclusion(int d1, int d2)
 static void
 set_rime_addr(void)
 {
-  rimeaddr_t addr;
+  linkaddr_t addr;
   int i;
 
-  memset(&addr, 0, sizeof(rimeaddr_t));
+  memset(&addr, 0, sizeof(linkaddr_t));
 #if UIP_CONF_IPV6
   memcpy(addr.u8, node_mac, sizeof(addr.u8));
 #else
   if(node_id == 0) {
-    for(i = 0; i < sizeof(rimeaddr_t); ++i) {
+    for(i = 0; i < sizeof(linkaddr_t); ++i) {
       addr.u8[i] = node_mac[7 - i];
     }
   } else {
@@ -148,7 +148,7 @@ set_rime_addr(void)
     addr.u8[1] = node_id >> 8;
   }
 #endif
-  rimeaddr_set_node_addr(&addr);
+  linkaddr_set_node_addr(&addr);
   printf("Rime started with address ");
   for(i = 0; i < sizeof(addr.u8) - 1; i++) {
     printf("%d.", addr.u8[i]);
@@ -175,10 +175,10 @@ set_gateway(void)
   if(!is_gateway) {
     leds_on(LEDS_RED);
     printf("%d.%d: making myself the IP network gateway.\n\n",
-	   rimeaddr_node_addr.u8[0], rimeaddr_node_addr.u8[1]);
+	   linkaddr_node_addr.u8[0], linkaddr_node_addr.u8[1]);
     printf("IPv4 address of the gateway: %d.%d.%d.%d\n\n",
 	   uip_ipaddr_to_quad(&uip_hostaddr));
-    uip_over_mesh_set_gateway(&rimeaddr_node_addr);
+    uip_over_mesh_set_gateway(&linkaddr_node_addr);
     uip_over_mesh_make_announced_gateway();
     is_gateway = 1;
   }
@@ -273,10 +273,10 @@ main(int argc, char **argv)
     uint8_t longaddr[8];
     uint16_t shortaddr;
     
-    shortaddr = (rimeaddr_node_addr.u8[0] << 8) +
-      rimeaddr_node_addr.u8[1];
+    shortaddr = (linkaddr_node_addr.u8[0] << 8) +
+      linkaddr_node_addr.u8[1];
     memset(longaddr, 0, sizeof(longaddr));
-    rimeaddr_copy((rimeaddr_t *)&longaddr, &rimeaddr_node_addr);
+    linkaddr_copy((linkaddr_t *)&longaddr, &linkaddr_node_addr);
     printf("MAC %02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x ",
            longaddr[0], longaddr[1], longaddr[2], longaddr[3],
            longaddr[4], longaddr[5], longaddr[6], longaddr[7]);
@@ -365,7 +365,7 @@ main(int argc, char **argv)
 
 #if TIMESYNCH_CONF_ENABLED
   timesynch_init();
-  timesynch_set_authority_level(rimeaddr_node_addr.u8[0]);
+  timesynch_set_authority_level(linkaddr_node_addr.u8[0]);
 #endif /* TIMESYNCH_CONF_ENABLED */
 
 #if WITH_UIP
@@ -381,7 +381,7 @@ main(int argc, char **argv)
     uip_init();
 
     uip_ipaddr(&hostaddr, 172,16,
-	       rimeaddr_node_addr.u8[0],rimeaddr_node_addr.u8[1]);
+	       linkaddr_node_addr.u8[0],linkaddr_node_addr.u8[1]);
     uip_ipaddr(&netmask, 255,255,0,0);
     uip_ipaddr_copy(&meshif.ipaddr, &hostaddr);
 

--- a/platform/z1sp/contiki-conf.h
+++ b/platform/z1sp/contiki-conf.h
@@ -124,7 +124,7 @@
 
 #ifdef WITH_UIP6
 
-#define RIMEADDR_CONF_SIZE              8
+#define LINKADDR_CONF_SIZE              8
 
 #define UIP_CONF_LL_802154              1
 #define UIP_CONF_LLH_LEN                0

--- a/regression-tests/04-rime/code/mesh-node.c
+++ b/regression-tests/04-rime/code/mesh-node.c
@@ -37,10 +37,10 @@ PROCESS(mesh_node_process, "Mesh node");
 AUTOSTART_PROCESSES(&mesh_node_process);
 /*---------------------------------------------------------------------------*/
 static void
-mesh_recv(struct mesh_conn *c, const rimeaddr_t *from, uint8_t hops)
+mesh_recv(struct mesh_conn *c, const linkaddr_t *from, uint8_t hops)
 {
   printf("%d.%d: mesh message received '%s'\n",
-	 rimeaddr_node_addr.u8[0], rimeaddr_node_addr.u8[1],
+	 linkaddr_node_addr.u8[0], linkaddr_node_addr.u8[1],
 	 (char *)packetbuf_dataptr());
 }
 const static struct mesh_callbacks mesh_callback = {mesh_recv, NULL, NULL};
@@ -57,7 +57,7 @@ PROCESS_THREAD(mesh_node_process, ev, data)
     etimer_set(&et, CLOCK_SECOND * 20);
     PROCESS_WAIT_UNTIL(etimer_expired(&et));
     if(node_id == 200) {
-      rimeaddr_t receiver;
+      linkaddr_t receiver;
       packetbuf_copyfrom("Hello, world", 13);
 
       receiver.u8[0] = 1;

--- a/regression-tests/04-rime/code/trickle-node.c
+++ b/regression-tests/04-rime/code/trickle-node.c
@@ -40,7 +40,7 @@ static void
 trickle_recv(struct trickle_conn *c)
 {
   printf("%d.%d: trickle message received '%s'\n",
-	 rimeaddr_node_addr.u8[0], rimeaddr_node_addr.u8[1],
+	 linkaddr_node_addr.u8[0], linkaddr_node_addr.u8[1],
 	 (char *)packetbuf_dataptr());
 }
 const static struct trickle_callbacks trickle_callback = {trickle_recv};

--- a/tools/sky/uip6-bridge/sicslow_ethernet.c
+++ b/tools/sky/uip6-bridge/sicslow_ethernet.c
@@ -312,7 +312,7 @@ void mac_LowpanToEthernet(void)
   ETHBUF(uip_buf)->type = uip_htons(UIP_ETHTYPE_IPV6);
 
   //Check for broadcast message
-  if(rimeaddr_cmp(packetbuf_addr(PACKETBUF_ADDR_RECEIVER), &rimeaddr_null)) {
+  if(linkaddr_cmp(packetbuf_addr(PACKETBUF_ADDR_RECEIVER), &linkaddr_null)) {
 /*   if(  ( parsed_frame->fcf->destAddrMode == SHORTADDRMODE) && */
 /*        ( parsed_frame->dest_addr->addr16 == 0xffff) ) { */
     ETHBUF(uip_buf)->dest.addr[0] = 0x33;
@@ -788,7 +788,7 @@ void mac_logTXtoEthernet(frame_create_params_t *p,frame_result_t *frame_result)
 
 
   //Check for broadcast message
-  //if(rimeaddr_cmp((const rimeaddr_t *)destAddr, &rimeaddr_null)) {
+  //if(linkaddr_cmp((const linkaddr_t *)destAddr, &linkaddr_null)) {
   if(  ( p->fcf.destAddrMode == SHORTADDRMODE) &&
        ( p->dest_addr.addr16 == 0xffff) ) {
     ETHBUF(raw_buf)->dest.addr[0] = 0x33;
@@ -849,7 +849,7 @@ void mac_802154raw(const struct mac_driver *r)
 
 
   //Check for broadcast message
-  //if(rimeaddr_cmp((const rimeaddr_t *)destAddr, &rimeaddr_null)) {
+  //if(linkaddr_cmp((const linkaddr_t *)destAddr, &linkaddr_null)) {
   if(  ( parsed_frame->fcf->destAddrMode == SHORTADDRMODE) &&
        ( parsed_frame->dest_addr->addr16 == 0xffff) ) {
     ETHBUF(raw_buf)->dest.addr[0] = 0x33;

--- a/tools/stm32w/uip6_bridge/dev/slip.c
+++ b/tools/stm32w/uip6_bridge/dev/slip.c
@@ -36,7 +36,7 @@
 #include <string.h>
 #include "contiki.h"
 
-#include "net/rimeaddr.h"
+#include "net/linkaddr.h"
 #include "sys/ctimer.h"
 
 #include "net/ip/uip.h"
@@ -264,9 +264,9 @@ slip_poll_handler(uint8_t *outbuf, uint16_t blen)
 				/* this is just a test so far... just to see if it works */
 				slip_arch_writeb('!');
 				slip_arch_writeb('M');
-				for(j = 0; j < RIMEADDR_SIZE; j++) {
-					slip_arch_writeb(hexchar[rimeaddr_node_addr.u8[j] >> 4]);
-					slip_arch_writeb(hexchar[rimeaddr_node_addr.u8[j] & 15]);
+				for(j = 0; j < LINKADDR_SIZE; j++) {
+					slip_arch_writeb(hexchar[linkaddr_node_addr.u8[j] >> 4]);
+					slip_arch_writeb(hexchar[linkaddr_node_addr.u8[j] & 15]);
 				}
 				slip_arch_writeb(SLIP_END);
 				return 0;

--- a/tools/stm32w/uip6_bridge/sicslow_ethernet.c
+++ b/tools/stm32w/uip6_bridge/sicslow_ethernet.c
@@ -339,7 +339,7 @@ void mac_LowpanToEthernet(void)
   ETHBUF(uip_buf)->type = htons(UIP_ETHTYPE_IPV6);
 
   //Check for broadcast message
-  if(rimeaddr_cmp(packetbuf_addr(PACKETBUF_ADDR_RECEIVER), &rimeaddr_null)) {
+  if(linkaddr_cmp(packetbuf_addr(PACKETBUF_ADDR_RECEIVER), &linkaddr_null)) {
 /*   if(  ( parsed_frame->fcf->destAddrMode == SHORTADDRMODE) && */
 /*        ( parsed_frame->dest_addr->addr16 == 0xffff) ) { */
     ETHBUF(uip_buf)->dest.addr[0] = 0x33;
@@ -825,7 +825,7 @@ void mac_logTXtoEthernet(frame_create_params_t *p,frame_result_t *frame_result)
 
 
   //Check for broadcast message
-  //if(rimeaddr_cmp((const rimeaddr_t *)destAddr, &rimeaddr_null)) {
+  //if(linkaddr_cmp((const linkaddr_t *)destAddr, &linkaddr_null)) {
   if(  ( p->fcf.destAddrMode == SHORTADDRMODE) &&
        ( p->dest_addr.addr16 == 0xffff) ) {
     ETHBUF(raw_buf)->dest.addr[0] = 0x33;
@@ -940,7 +940,7 @@ void mac_802154raw(const struct radio_driver *radio)
 
 #if 0
   //Check for broadcast message
-  //if(rimeaddr_cmp((const rimeaddr_t *)destAddr, &rimeaddr_null)) {
+  //if(linkaddr_cmp((const linkaddr_t *)destAddr, &linkaddr_null)) {
   if(  ( parsed_frame->fcf->destAddrMode == SHORTADDRMODE) &&
        ( parsed_frame->dest_addr->addr16 == 0xffff) ) {
     ETHBUF(raw_buf)->dest.addr[0] = 0x33;


### PR DESCRIPTION
The `rimeaddr` module is used by other stacks than just Rime, so we should rename it to something less rimey. 

This pull request renames the `rimeaddr` module to `linkaddr` to better reflect its purpose. 
