### PR TITLE
Added function coap_poll_connection

### DIFF
--- a/apps/er-coap-03/er-coap-03.c
+++ b/apps/er-coap-03/er-coap-03.c
@@ -181,6 +181,11 @@ coap_init_connection(uint16_t port)
   /* Initialize transaction ID. */
   current_tid = random_rand();
 }
+void
+coap_poll_connection(void)
+{
+	tcpip_poll_udp(udp_conn);
+}
 /*-----------------------------------------------------------------------------------*/
 uint16_t
 coap_get_tid()

--- a/apps/er-coap-03/er-coap-03.h
+++ b/apps/er-coap-03/er-coap-03.h
@@ -235,6 +235,7 @@ typedef enum
 } error_t;
 
 void coap_init_connection(uint16_t port);
+void coap_poll_connection(void);
 uint16_t coap_get_tid(void);
 void coap_send_message(uip_ipaddr_t *addr, uint16_t port, const uint8_t *data, uint16_t length);
 

--- a/apps/er-coap-07/er-coap-07.c
+++ b/apps/er-coap-07/er-coap-07.c
@@ -276,6 +276,11 @@ coap_init_connection(uint16_t port)
   /* Initialize transaction ID. */
   current_mid = random_rand();
 }
+void
+coap_poll_connection(void)
+{
+	tcpip_poll_udp(udp_conn);
+}
 /*-----------------------------------------------------------------------------------*/
 uint16_t
 coap_get_mid()

--- a/apps/er-coap-07/er-coap-07.h
+++ b/apps/er-coap-07/er-coap-07.h
@@ -254,6 +254,7 @@ extern coap_status_t coap_error_code;
 extern char *coap_error_message;
 
 void coap_init_connection(uint16_t port);
+void coap_poll_connection(void);
 uint16_t coap_get_mid(void);
 
 void coap_init_message(void *packet, coap_message_type_t type, uint8_t code, uint16_t mid);

--- a/apps/er-coap-12/er-coap-12.c
+++ b/apps/er-coap-12/er-coap-12.c
@@ -314,6 +314,11 @@ coap_init_connection(uint16_t port)
   /* Initialize transaction ID. */
   current_mid = random_rand();
 }
+void
+coap_poll_connection(void)
+{
+	tcpip_poll_udp(udp_conn);
+}
 /*-----------------------------------------------------------------------------------*/
 uint16_t
 coap_get_mid()

--- a/apps/er-coap-12/er-coap-12.h
+++ b/apps/er-coap-12/er-coap-12.h
@@ -319,6 +319,7 @@ extern coap_status_t coap_error_code;
 extern char *coap_error_message;
 
 void coap_init_connection(uint16_t port);
+void coap_poll_connection(void);
 uint16_t coap_get_mid(void);
 
 void coap_init_message(void *packet, coap_message_type_t type, uint8_t code, uint16_t mid);

--- a/apps/er-coap-13/er-coap-13.c
+++ b/apps/er-coap-13/er-coap-13.c
@@ -283,6 +283,11 @@ coap_init_connection(uint16_t port)
   /* Initialize transaction ID. */
   current_mid = random_rand();
 }
+void
+coap_poll_connection(void)
+{
+	tcpip_poll_udp(udp_conn);
+}
 /*-----------------------------------------------------------------------------------*/
 uint16_t
 coap_get_mid()

--- a/apps/er-coap-13/er-coap-13.h
+++ b/apps/er-coap-13/er-coap-13.h
@@ -311,6 +311,7 @@ extern coap_status_t coap_error_code;
 extern char *coap_error_message;
 
 void coap_init_connection(uint16_t port);
+void coap_poll_connection(void);
 uint16_t coap_get_mid(void);
 
 void coap_init_message(void *packet, coap_message_type_t type, uint8_t code, uint16_t mid);


### PR DESCRIPTION
If you want to POST some data to coap server with contiki, you MUST wait for udp_poll , and you have no way to force poll on coap-engine, this pull request give a method to do that.
