### PR TITLE
New MACRO for creating jsontree_array

### DIFF
--- a/apps/json/jsontree.h
+++ b/apps/json/jsontree.h
@@ -115,6 +115,12 @@ struct jsontree_array {
     JSON_TYPE_OBJECT,							\
     sizeof(jsontree_pair_##name)/sizeof(struct jsontree_pair),          \
     jsontree_pair_##name }
+    
+#define JSONTREE_ARRAY(name,count)                                      \
+static struct jsontree_value *jsontree_value##name[count];              \
+static struct jsontree_array name={                                     \
+JSON_TYPE_ARRAY,count,jsontree_value##name}
+
 
 void jsontree_setup(struct jsontree_context *js_ctx,
                     struct jsontree_value *root, int (* putchar)(int));


### PR DESCRIPTION
This proposed MACRO simplifies jsontree_array declarations. It takes as arguments the name of the array and its size.
