### PR TITLE
typo in event resource handler comment

### DIFF
--- a/examples/er-rest-example/er-example-server.c
+++ b/examples/er-rest-example/er-example-server.c
@@ -528,7 +528,7 @@ event_handler(void* request, void* response, uint8_t *buffer, uint16_t preferred
   /* A post_handler that handles subscriptions/observing will be called for periodic resources by the framework. */
 }
 
-/* Additionally, a handler function named [resource name]_event_handler must be implemented for each PERIODIC_RESOURCE defined.
+/* Additionally, a handler function named [resource name]_event_handler must be implemented for each EVENT_RESOURCE defined.
  * It will be called by the REST manager process with the defined period. */
 void
 event_event_handler(resource_t *r)


### PR DESCRIPTION
at line 531 says PERIODIC_RESOURCE, shouldn't it be EVENT_RESOURCE, since it's a EVENT_RESOURCE demo?
