### PR TITLE
Align start of data segment initialisers to 8 byte boundary.

### DIFF
--- a/cpu/cc2538/cc2538.lds
+++ b/cpu/cc2538/cc2538.lds
@@ -61,6 +61,7 @@ SECTIONS
         KEEP(*(.vectors))
         *(.text*)
         *(.rodata*)
+        . = ALIGN(8);
         _etext = .;
     } > FLASH= 0
 


### PR DESCRIPTION
Using gcc 4.7.3, I have observed that adding code to an application can stop it
from successfully booting, even if this code is not called at boot time. I do
not have a small test case, because the bug only seems to appear when I pull a
large external project into the app.

Visually, on the CC2538DK, I see one of the LEDs fade and I get the Contiki
banner over the UART, then a hang.

When the failure occurs, the map file shows that &.etext is 4 bytes lower than
the load address for the .data section, when they should be equal. The result
of this is that the initialiser copy code in reset_handler() will copy at an
offset. This first manifests itself (for me), when serial_line_process() is
called early after boot, causing a data fault.

Using GDB, I observe that the data I'd expect to find in RAM at
&serial_line_process is actually at an offset of +4 bytes. Removing my extra
code and recompiling removes the problem.

I do not fully understand why this fix works. Perhaps it's something to do with
my extra code pulling in library functions using the ARM EABI which require 8
byte stack alignment.