### PR TITLE
CC2538: add secondary location to ieee address

### DIFF
--- a/cpu/cc2538/ieee-addr.c
+++ b/cpu/cc2538/ieee-addr.c
@@ -52,7 +52,7 @@ ieee_addr_cpy_to(uint8_t *dst, uint8_t len)
     /* Reading from Info Page, we need to invert byte order */
     int i;
     for(i = 0; i < len; i++) {
-      dst[i] = ((uint8_t *)IEEE_ADDR_LOCATION_PRIMARY)[len - 1 - i];
+      dst[i] = ((uint8_t *)IEEE_ADDR_LOCATION)[len - 1 - i];
     }
   }
 

--- a/cpu/cc2538/ieee-addr.h
+++ b/cpu/cc2538/ieee-addr.h
@@ -53,6 +53,18 @@
  * @{
  */
 #define IEEE_ADDR_LOCATION_PRIMARY   0x00280028 /**< IEEE address location */
+#define IEEE_ADDR_LOCATION_SECONDARY 0x0027FFCC /**< IEEE address location */
+/** @} */
+/*---------------------------------------------------------------------------*/
+/**
+ * \brief Select which address location to use
+ * @{
+ */
+#if IEEE_ADDR_CONF_USE_SECONDARY_LOCATION
+#define IEEE_ADDR_LOCATION IEEE_ADDR_LOCATION_SECONDARY
+#else
+#define IEEE_ADDR_LOCATION IEEE_ADDR_LOCATION_PRIMARY
+#endif
 /** @} */
 /*---------------------------------------------------------------------------*/
 /*

--- a/platform/cc2538dk/README.md
+++ b/platform/cc2538dk/README.md
@@ -243,7 +243,7 @@ To configure the IEEE address source location (Info Page or hard-coded), use the
 * 0: Info Page
 * 1: Hard-coded
 
-If `IEEE_ADDR_CONF_HARDCODED` is defined as 1, the IEEE address will take its value from the `IEEE_ADDR_CONF_ADDRESS` define.
+If `IEEE_ADDR_CONF_HARDCODED` is defined as 1, the IEEE address will take its value from the `IEEE_ADDR_CONF_ADDRESS` define. If `IEEE_ADDR_CONF_HARDCODED` is defined as 0, the IEEE address can come from either the primary or secondary location in the Info Page. To use the secondary address, define `IEEE_ADDR_CONF_USE_SECONDARY_LOCATION` as 1.
 
 Additionally, you can override the IEEE's 2 LSBs, by using the `NODEID` make variable. The value of `NODEID` will become the value of the `IEEE_ADDR_NODE_ID` pre-processor define. If `NODEID` is not defined, `IEEE_ADDR_NODE_ID` will not get defined either. For example:
 

--- a/platform/cc2538dk/contiki-conf.h
+++ b/platform/cc2538dk/contiki-conf.h
@@ -268,6 +268,16 @@ typedef uint32_t rtimer_clock_t;
 #ifndef IEEE_ADDR_CONF_ADDRESS
 #define IEEE_ADDR_CONF_ADDRESS { 0x00, 0x12, 0x4B, 0x00, 0x89, 0xAB, 0xCD, 0xEF }
 #endif
+
+/**
+ * \brief Location of the IEEE address in the InfoPage when
+ * IEEE_ADDR_CONF_HARDCODED is defined as 0
+ * 0 => Use the primary address location
+ * 1 => Use the secondary address location
+ */
+#ifndef IEEE_ADDR_CONF_USE_SECONDARY_LOCATION
+#define IEEE_ADDR_CONF_USE_SECONDARY_LOCATION 0
+#endif
 /** @} */
 /*---------------------------------------------------------------------------*/
 /**


### PR DESCRIPTION
The CC2538 currently has two addressing options: a hardcoded address set
at compile time or the address stored in primary address section of the
info page. This commit adds the option to choose the secondary location
of the ieee address from the info page, or any memory address.

To use, define `IEEE_ADDR_CONF_LOCATION` in `project-conf.h` or similar.

For example:

```
#define IEEE_ADDR_CONF_LOCATION IEEE_ADDR_LOCATION_SECONDARY
```
