### PR TITLE
remove a bunch of compiler warnings

### DIFF
--- a/core/lib/petsciiconv.c
+++ b/core/lib/petsciiconv.c
@@ -73,7 +73,7 @@ static unsigned char ascii2petscii[128] = {
 };
 
 static unsigned int i;
-static unsigned char *ptr;
+static char *ptr;
 
 /*-----------------------------------------------------------------------------------*/
 void

--- a/core/net/ip/resolv.c
+++ b/core/net/ip/resolv.c
@@ -405,7 +405,7 @@ dns_name_isequal(const unsigned char *queryptr, const char *name,
         return 0;
       }
 
-      if(tolower(*name++) != tolower(*queryptr++)) {
+      if(tolower(*(unsigned char *)name++) != tolower(*queryptr++)) {
         return 0;
       }
     }
@@ -506,8 +506,6 @@ start_name_collision_check(clock_time_t after)
 static unsigned char *
 mdns_write_announce_records(unsigned char *queryptr, uint8_t *count)
 {
-  struct dns_answer *ans;
-
 #if UIP_CONF_IPV6
   uint8_t i;
 
@@ -524,7 +522,6 @@ mdns_write_announce_records(unsigned char *queryptr, uint8_t *count)
         *queryptr++ = 0xc0;
         *queryptr++ = sizeof(struct dns_hdr);
       }
-      ans = (struct dns_answer *)queryptr;
 
       *queryptr++ = (uint8_t) ((NATIVE_DNS_TYPE) >> 8);
       *queryptr++ = (uint8_t) ((NATIVE_DNS_TYPE));
@@ -546,6 +543,8 @@ mdns_write_announce_records(unsigned char *queryptr, uint8_t *count)
     }
   }
 #else /* UIP_CONF_IPV6 */
+  struct dns_answer *ans;
+
   queryptr = encode_name(queryptr, resolv_hostname);
   ans = (struct dns_answer *)queryptr;
   ans->type = UIP_HTONS(NATIVE_DNS_TYPE);
@@ -602,8 +601,6 @@ mdns_prep_host_announce_packet(void)
   unsigned char *queryptr;
 
   uint8_t total_answers = 0;
-
-  struct dns_answer *ans;
 
   /* Be aware that, unless `ARCH_DOESNT_NEED_ALIGNED_STRUCTS` is set,
    * writing directly to the uint16_t members of this struct is an error. */

--- a/core/net/ip/slipdev.c
+++ b/core/net/ip/slipdev.c
@@ -103,7 +103,7 @@ slipdev_send(void)
   ptr = &uip_buf[UIP_LLH_LEN];
   for(i = 0; i < uip_len; ++i) {
     if(i == UIP_TCPIP_HLEN) {
-      ptr = (char *)uip_appdata;
+      ptr = uip_appdata;
     }
     c = *ptr++;
     switch(c) {

--- a/core/net/ip/tcpip.c
+++ b/core/net/ip/tcpip.c
@@ -155,6 +155,7 @@ unsigned char tcpip_is_forwarding; /* Forwarding right now? */
 PROCESS(tcpip_process, "TCP/IP stack");
 
 /*---------------------------------------------------------------------------*/
+#if UIP_TCP || UIP_CONF_IP_FORWARD
 static void
 start_periodic_tcp_timer(void)
 {
@@ -162,6 +163,7 @@ start_periodic_tcp_timer(void)
     etimer_restart(&periodic);
   }
 }
+#endif /* UIP_TCP || UIP_CONF_IP_FORWARD */
 /*---------------------------------------------------------------------------*/
 static void
 check_for_tcp_syn(void)

--- a/core/net/mac/contikimac/contikimac.c
+++ b/core/net/mac/contikimac/contikimac.c
@@ -372,7 +372,6 @@ powercycle(struct rtimer *t, void *ptr)
 
   while(1) {
     static uint8_t packet_seen;
-    static rtimer_clock_t t0;
     static uint8_t count;
 
 #if SYNC_CYCLE_STARTS
@@ -396,7 +395,6 @@ powercycle(struct rtimer *t, void *ptr)
     packet_seen = 0;
 
     for(count = 0; count < CCA_COUNT_MAX; ++count) {
-      t0 = RTIMER_NOW();
       if(we_are_sending == 0 && we_are_receiving_burst == 0) {
         powercycle_turn_radio_on();
         /* Check if a packet is seen in the air. If so, we keep the
@@ -530,7 +528,6 @@ send_packet(mac_callback_t mac_callback, void *mac_callback_ptr,
   uint8_t got_strobe_ack = 0;
   int hdrlen, len;
   uint8_t is_broadcast = 0;
-  uint8_t is_reliable = 0;
   uint8_t is_known_receiver = 0;
   uint8_t collisions;
   int transmit_len;
@@ -580,8 +577,6 @@ send_packet(mac_callback_t mac_callback, void *mac_callback_ptr,
                packetbuf_addr(PACKETBUF_ADDR_RECEIVER)->u8[1]);
 #endif /* UIP_CONF_IPV6 */
   }
-  is_reliable = packetbuf_attr(PACKETBUF_ATTR_RELIABLE) ||
-    packetbuf_attr(PACKETBUF_ATTR_ERELIABLE);
 
   packetbuf_set_attr(PACKETBUF_ATTR_MAC_ACK, 1);
 
@@ -752,7 +747,6 @@ send_packet(mac_callback_t mac_callback, void *mac_callback_ptr,
     {
       rtimer_clock_t wt;
       rtimer_clock_t txtime;
-      int ret;
 
       txtime = RTIMER_NOW();
       ret = NETSTACK_RADIO.transmit(transmit_len);
@@ -848,6 +842,9 @@ send_packet(mac_callback_t mac_callback, void *mac_callback_ptr,
 		   encounter_time, ret);
     }
   }
+#else
+  /* Remove warning. */
+  (void)encounter_time;
 #endif /* WITH_PHASE_OPTIMIZATION */
 
   return ret;

--- a/core/net/mac/nullrdc.c
+++ b/core/net/mac/nullrdc.c
@@ -270,11 +270,14 @@ send_list(mac_callback_t sent, void *ptr, struct rdc_buf_list *buf_list)
 static void
 packet_input(void)
 {
+#if NULLRDC_SEND_802154_ACK
   int original_datalen;
   uint8_t *original_dataptr;
 
   original_datalen = packetbuf_datalen();
   original_dataptr = packetbuf_dataptr();
+#endif /* NULLRDC_SEND_802154_ACK */
+
 #ifdef NETSTACK_DECRYPT
     NETSTACK_DECRYPT();
 #endif /* NETSTACK_DECRYPT */

--- a/core/net/rime/collect-neighbor.c
+++ b/core/net/rime/collect-neighbor.c
@@ -254,13 +254,11 @@ collect_neighbor_list_remove(struct collect_neighbor_list *neighbors_list,
 struct collect_neighbor *
 collect_neighbor_list_best(struct collect_neighbor_list *neighbors_list)
 {
-  int found;
   struct collect_neighbor *n, *best;
   uint16_t rtmetric;
 
   rtmetric = RTMETRIC_MAX;
   best = NULL;
-  found = 0;
 
   if(neighbors_list == NULL) {
     return NULL;

--- a/core/net/rime/collect.c
+++ b/core/net/rime/collect.c
@@ -951,14 +951,12 @@ node_packet_received(struct unicast_conn *c, const linkaddr_t *from)
   if(packetbuf_attr(PACKETBUF_ATTR_PACKET_TYPE) ==
      PACKETBUF_ATTR_PACKET_TYPE_DATA) {
     linkaddr_t ack_to;
-    uint8_t packet_seqno;
 
     stats.datarecv++;
 
     /* Remember to whom we should send the ACK, since we reuse the
        packet buffer and its attributes when sending the ACK. */
     linkaddr_copy(&ack_to, packetbuf_addr(PACKETBUF_ADDR_SENDER));
-    packet_seqno = packetbuf_attr(PACKETBUF_ATTR_PACKET_ID);
 
     /* If the queue is more than half filled, we add the CONGESTED
        flag to our outgoing acks. */
@@ -1006,7 +1004,7 @@ node_packet_received(struct unicast_conn *c, const linkaddr_t *from)
         PRINTF("%d.%d: collect: could not send ACK to %d.%d for %d: no queued buffers\n",
                linkaddr_node_addr.u8[0],linkaddr_node_addr.u8[1],
                ack_to.u8[0], ack_to.u8[1],
-               packet_seqno);
+               packetbuf_attr(PACKETBUF_ATTR_PACKET_ID));
         stats.ackdrop++;
       }
 

--- a/core/net/rpl/rpl-icmp6.c
+++ b/core/net/rpl/rpl-icmp6.c
@@ -582,6 +582,7 @@ dao_input(void)
   uip_ds6_nbr_t *nbr;
 
   prefixlen = 0;
+  p = NULL;
 
   uip_ipaddr_copy(&dao_sender_addr, &UIP_IP_BUF->srcipaddr);
 

--- a/cpu/cc2538/usb/usb-arch.c
+++ b/cpu/cc2538/usb/usb-arch.c
@@ -872,7 +872,7 @@ fill_buffers(usb_buffer *buffer, uint8_t hw_ep, unsigned int len,
 static uint8_t
 ep0_get_setup_pkt(void)
 {
-  uint8_t res;
+  uint8_t res = 0;
   usb_buffer *buffer =
     skip_buffers_until(usb_endpoints[0].buffer, USB_BUFFER_SETUP,
                        USB_BUFFER_SETUP, &res);
@@ -916,8 +916,6 @@ ep0_get_data_pkt(void)
   }
 
   if(buffer->flags & (USB_BUFFER_SETUP | USB_BUFFER_IN)) {
-    uint8_t temp;
-
     buffer->flags |= USB_BUFFER_FAILED;
     buffer->flags &= ~USB_BUFFER_SUBMITTED;
     if(buffer->flags & USB_BUFFER_NOTIFY) {
@@ -925,7 +923,7 @@ ep0_get_data_pkt(void)
     }
     /* Flush the fifo */
     while(len--) {
-      temp = REG(USB_F0);
+      (void)REG(USB_F0);
     }
     usb_endpoints[0].buffer = buffer->next;
     /* Force data stage end */


### PR DESCRIPTION
This makes examples/cc2538dk/udp-ipv6-echo-server and my custom CoAP server compile with zero warnings using the GCC 4.8.3 toolchain. Nothing really intimidating except a few uninitialized variables. It's better to build a completely clean project. Nothing breaking as far as I tested.
