### PR TITLE
CC2538: Poll all processes before going to sleep in case some are pending on PROCESS_WAIT_UNTIL()

### DIFF
--- a/platform/cc2538dk/contiki-main.c
+++ b/platform/cc2538dk/contiki-main.c
@@ -207,12 +207,24 @@ main(void)
 
   while(1) {
     uint8_t r;
+    struct process* p;
+
     do {
       /* Reset watchdog and handle polls and events */
       watchdog_periodic();
 
       r = process_run();
     } while(r > 0);
+
+    /* Poll all processes before going to sleep in case some are pending on PROCESS_WAIT_UNTIL() or PT_SEM_WAIT(): */
+    for (p = process_list; p != NULL; p = p->next) process_poll(p);
+
+    /* Service any events that the polled processes may have posted: */
+    r = process_nevents();
+    while (r > 0) {
+      watchdog_periodic();
+      r = process_run();
+    }
 
     /* We have serviced all pending events. Enter a Low-Power mode. */
     lpm_enter();


### PR DESCRIPTION
This platform goes to sleep when there are no more process events in the queue, but it doesn't check for processes that are pending on non-event-related conditions, for example PROCESS_WAIT_UNTIL(), or in my case PT_SEM_WAIT(). The result is that these processes aren't serviced until another unrelated event occurs and after significant time has passed.

My fix: when the main loop would otherwise go to sleep, it instead polls every process once, then services any events that may result from the series of polls, then finally goes to sleep.
