### PR TITLE
native: Add CTK to the module list

### DIFF
--- a/platform/native/Makefile.native
+++ b/platform/native/Makefile.native
@@ -47,4 +47,4 @@ CURSES_LIBS ?= -lncurses
 TARGET_LIBFILES += $(CURSES_LIBS)
 
 MODULES+=core/net/ip core/net/ipv4 core/net core/net/ipv6 core/net/rime \
-         core/net/mac core/net/rpl
+         core/net/mac core/net/rpl core/ctk


### PR DESCRIPTION
It is needed for apps compiled WITH_GUI.
