### PR TITLE
patch for issue #601 & #602

### DIFF
--- a/core/net/ip/simple-udp.c
+++ b/core/net/ip/simple-udp.c
@@ -176,6 +176,7 @@ simple_udp_register(struct simple_udp_connection *c,
     uip_ipaddr_copy(&c->remote_addr, remote_addr);
   }
   c->receive_callback = receive_callback;
+  c->client_process=PROCESS_CURRENT();
 
   PROCESS_CONTEXT_BEGIN(&simple_udp_process);
   c->udp_conn = udp_new(remote_addr, UIP_HTONS(remote_port), c);

--- a/core/net/ip/uip-udp-packet.c
+++ b/core/net/ip/uip-udp-packet.c
@@ -54,9 +54,10 @@ uip_udp_packet_send(struct uip_udp_conn *c, const void *data, int len)
   if(data != NULL) {
     uip_udp_conn = c;
     uip_slen = len;
-    memcpy(&uip_buf[UIP_LLH_LEN + UIP_IPUDPH_LEN], data,
-           len > UIP_BUFSIZE - UIP_LLH_LEN - UIP_IPUDPH_LEN?
-           UIP_BUFSIZE - UIP_LLH_LEN - UIP_IPUDPH_LEN: len);
+    if (uip_slen > UIP_BUFSIZE - UIP_LLH_LEN - UIP_IPUDPH_LEN){
+      uip_slen = UIP_BUFSIZE - UIP_LLH_LEN - UIP_IPUDPH_LEN;
+    }
+    memcpy(&uip_buf[UIP_LLH_LEN + UIP_IPUDPH_LEN], data, uip_slen);
     uip_process(UIP_UDP_SEND_CONN);
 
 #if UIP_CONF_IPV6_MULTICAST

--- a/core/net/ip/uipopt.h
+++ b/core/net/ip/uipopt.h
@@ -71,7 +71,7 @@
 #define UIP_BIG_ENDIAN     1234
 #endif /* UIP_BIG_ENDIAN */
 
-#include "contiki-conf.h"
+#include "contiki.h"
 
 /*------------------------------------------------------------------------------*/
 


### PR DESCRIPTION
1)The field client_process is not initialized when function simple_udp_register() called,
but used by thead function simple_udp_process().

add below line in function simple_udp_register() 
c->client_process = PROCESS_CURRENT();

2)There is a bug about UIP_CONNS in tcpip.c & uip6.c/uip.c.
Because the difference of include files,the value UIP_CONNS in tcpip.c is greater than UIP_CONNS in uip6.c/uip.c,
,this can cause overflow error when access uip_conns in tcpip.c.

when we does not define PROJECT_CONF_H or does not define UIP_CONF_MAX_CONNECTIONS in project-conf.h file,
the value of UIP_CONNS in file tcpip.c is 10,but the value of UIP_CONNS in file uip6.c is 8.
