### PR TITLE
CSMA bugfix: count transmissions correctly

### DIFF
--- a/core/net/mac/csma.c
+++ b/core/net/mac/csma.c
@@ -212,16 +212,17 @@ packet_sent(void *ptr, int status, int num_transmissions)
   switch(status) {
   case MAC_TX_OK:
   case MAC_TX_NOACK:
-    n->transmissions++;
+    n->transmissions += num_transmissions;
     break;
   case MAC_TX_COLLISION:
-    n->collisions++;
+    n->collisions += num_transmissions;
     break;
   case MAC_TX_DEFERRED:
-    n->deferrals++;
+    n->deferrals += num_transmissions;
     break;
   }
 
+  /* Find out what packet this callback refers to */
   for(q = list_head(n->queued_packet_list);
       q != NULL; q = list_item_next(q)) {
     if(queuebuf_attr(q->buf, PACKETBUF_ATTR_MAC_SEQNO) ==


### PR DESCRIPTION
This pull request fixes a bug in the CSMA layer that causes the number of transmissions to be misrepresented to the higher layers. The RDC layer counts the number of transmissions it does for each packet, and provides this as an argument to the MAC layer callback, but the CSMA code did not previously take this number into account, which caused erroneous ETX data in RPL. This pull request fixes the problem.
