### PR TITLE
Undefine the assert macro to avoid compiler warning.

### DIFF
--- a/core/lib/assert.h
+++ b/core/lib/assert.h
@@ -28,9 +28,10 @@
  *
  */
 
-#ifndef ASSERT_H
-#define ASSERT_H
+#ifndef ASSERT_H_
+#define ASSERT_H_
 
+#undef assert
 #ifdef NDEBUG
 #define assert(e) ((void)0)
 #else
@@ -44,4 +45,4 @@ void _xassert(const char *, int);
 #define __CTASSERT(x, y)        typedef char __assert ## y[(x) ? 1 : -1]
 #endif
 
-#endif /* ASSERT_H */
+#endif /* ASSERT_H_ */


### PR DESCRIPTION
Undefine the assert macro before it is defined. STM32W defines its own assert macro and generates a compiler warning because it is redefined in Contiki's lib/assert.h.
