### PR TITLE
Fixed distclean to work when CONTIKI_PROJECT is set to multiple files.

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -183,7 +183,7 @@ clean:
 	-rm -rf $(OBJECTDIR)
 
 distclean: clean
-	-rm -rf $(CONTIKI_PROJECT).$(TARGET)
+	-rm -f ${addsuffix .$(TARGET),$(CONTIKI_PROJECT)}
 
 -include $(CONTIKI)/platform/$(TARGET)/Makefile.customrules-$(TARGET)
 


### PR DESCRIPTION
CONTIKI_PROJECT is sometimes set to multiple files (see for example contiki/examples/z1/Makefile), which caused distclean to fail.
