### PR TITLE
Makefile.include: Fix git version string generation for external projects

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -153,7 +153,7 @@ CFLAGS += ${addprefix -I,$(SOURCEDIRS) $(CONTIKI)}
 ### Check for a git repo and pass version if found
 ### git.exe in Windows cmd shells may require no stderr redirection
 #RELSTR=${shell git describe --tags}
-RELSTR=${shell git describe --tags 2>/dev/null}
+RELSTR=${shell git --git-dir ${CONTIKI}/.git describe --tags 2>/dev/null}
 ifneq ($(RELSTR),)
 CFLAGS += -DCONTIKI_VERSION_STRING=\"Contiki-$(RELSTR)\"
 endif


### PR DESCRIPTION
For contiki projects not located in the contiki tree the generation of `RELSTR` in `Makefile.include` will return the description for the projects git but not for the contiki git.

This can be fixed by setting `--git-dir` explicitely to `${CONTIKI}/.git`
