### PR TITLE
Added function to framer that returns the estimated header length

### DIFF
--- a/core/net/ipv6/sicslowpan.c
+++ b/core/net/ipv6/sicslowpan.c
@@ -1434,19 +1434,12 @@ output(const uip_lladdr_t *localdest)
    * needs to be fragmented or not. */
 #define USE_FRAMER_HDRLEN 1
 #if USE_FRAMER_HDRLEN
-  packetbuf_clear();
   packetbuf_set_addr(PACKETBUF_ADDR_RECEIVER, &dest);
-  framer_hdrlen = NETSTACK_FRAMER.create();
+  framer_hdrlen = NETSTACK_FRAMER.length();
   if(framer_hdrlen < 0) {
     /* Framing failed, we assume the maximum header length */
     framer_hdrlen = 21;
   }
-  packetbuf_clear();
-
-  /* We must set the max transmissions attribute again after clearing
-     the buffer. */
-  packetbuf_set_attr(PACKETBUF_ATTR_MAX_MAC_TRANSMISSIONS,
-                     SICSLOWPAN_MAX_MAC_TRANSMISSIONS);
 #else /* USE_FRAMER_HDRLEN */
   framer_hdrlen = 21;
 #endif /* USE_FRAMER_HDRLEN */

--- a/core/net/mac/framer-802154.c
+++ b/core/net/mac/framer-802154.c
@@ -87,7 +87,7 @@ is_broadcast_addr(uint8_t mode, uint8_t *addr)
 }
 /*---------------------------------------------------------------------------*/
 static int
-create(void)
+create_frame(int type, int do_create)
 {
   frame802154_t params;
   int len;
@@ -115,13 +115,17 @@ create(void)
   params.fcf.frame_version = FRAME802154_IEEE802154_2003;
 
   /* Increment and set the data sequence number. */
-  if(packetbuf_attr(PACKETBUF_ATTR_MAC_SEQNO)) {
+  if(!do_create) {
+    /* Only length calculation - no sequence number is needed and
+       should not be consumed. */
+
+  } else if(packetbuf_attr(PACKETBUF_ATTR_MAC_SEQNO)) {
     params.seq = packetbuf_attr(PACKETBUF_ATTR_MAC_SEQNO);
+
   } else {
     params.seq = mac_dsn++;
     packetbuf_set_attr(PACKETBUF_ATTR_MAC_SEQNO, params.seq);
   }
-/*   params.seq = packetbuf_attr(PACKETBUF_ATTR_PACKET_ID); */
 
   /* Complete the addressing fields. */
   /**
@@ -169,7 +173,11 @@ create(void)
   params.payload = packetbuf_dataptr();
   params.payload_len = packetbuf_datalen();
   len = frame802154_hdrlen(&params);
-  if(packetbuf_hdralloc(len)) {
+  if(!do_create) {
+    /* Only calculate header length */
+    return len;
+
+  } else if(packetbuf_hdralloc(len)) {
     frame802154_create(&params, packetbuf_hdrptr(), len);
 
     PRINTF("15.4-OUT: %2X", params.fcf.frame_type);
@@ -181,6 +189,18 @@ create(void)
     PRINTF("15.4-OUT: too large header: %u\n", len);
     return FRAMER_FAILED;
   }
+}
+/*---------------------------------------------------------------------------*/
+static int
+hdr_length(void)
+{
+  return create_frame(FRAME802154_DATAFRAME, 0);
+}
+/*---------------------------------------------------------------------------*/
+static int
+create(void)
+{
+  return create_frame(FRAME802154_DATAFRAME, 1);
 }
 /*---------------------------------------------------------------------------*/
 static int
@@ -218,5 +238,5 @@ parse(void)
 }
 /*---------------------------------------------------------------------------*/
 const struct framer framer_802154 = {
-  create, parse
+  hdr_length, create, parse
 };

--- a/core/net/mac/framer-nullmac.c
+++ b/core/net/mac/framer-nullmac.c
@@ -57,6 +57,12 @@ struct nullmac_hdr {
 
 /*---------------------------------------------------------------------------*/
 static int
+hdr_length(void)
+{
+  return sizeof(struct nullmac_hdr);
+}
+/*---------------------------------------------------------------------------*/
+static int
 create(void)
 {
   struct nullmac_hdr *hdr;
@@ -91,5 +97,5 @@ parse(void)
 }
 /*---------------------------------------------------------------------------*/
 const struct framer framer_nullmac = {
-  create, parse
+  hdr_length, create, parse
 };

--- a/core/net/mac/framer.h
+++ b/core/net/mac/framer.h
@@ -45,6 +45,7 @@
 
 struct framer {
 
+  int (* length)(void);
   int (* create)(void);
   int (* parse)(void);
 

--- a/examples/ipv6/slip-radio/no-framer.c
+++ b/examples/ipv6/slip-radio/no-framer.c
@@ -76,6 +76,13 @@ is_broadcast_addr(uint8_t mode, uint8_t *addr)
 }
 /*---------------------------------------------------------------------------*/
 static int
+hdr_length(void)
+{
+  /* never adds any header */
+  return 0;
+}
+/*---------------------------------------------------------------------------*/
+static int
 create(void)
 {
   /* nothing extra... */
@@ -116,5 +123,5 @@ parse(void)
 }
 /*---------------------------------------------------------------------------*/
 const struct framer no_framer = {
-  create, parse
+  hdr_length, create, parse
 };


### PR DESCRIPTION
Added function to framer that returns the estimated header length if the framer would create a header with the current packet information.

This allows sicslowpan.c to calculate the max payload size without consuming a sequence number in framer-802154.c or clearing/restoring the packet information.
