### PR TITLE
CC2538: Set RTIMER_ARCH_SECOND based on XOSC frequencies and SYS_CTRL(_CONF)_OSC32K_USE_XTAL.

### DIFF
--- a/cpu/cc2538/rtimer-arch.h
+++ b/cpu/cc2538/rtimer-arch.h
@@ -62,8 +62,14 @@
 
 #include "contiki.h"
 #include "dev/gptimer.h"
+#include "dev/sys-ctrl.h"           /* for SYS_CTRL_OSC32K_USE_XTAL */
 
-#define RTIMER_ARCH_SECOND 32768
+#define HF_XOSC_FREQ       32000000 /* 32 MHz */
+#define LF_XOSC_FREQ          32768 /* 32.768 kHz */
+#define LF_RCOSC_CAL_RATIO      977 /* Essentially round(32 MHz / 32.768 kHz) */
+#define LF_RCOSC_FREQ      ( SYS_CTRL_OSC32K_USE_XTAL? LF_XOSC_FREQ : (HF_XOSC_FREQ / LF_RCOSC_CAL_RATIO) )
+
+#define RTIMER_ARCH_SECOND LF_RCOSC_FREQ
 
 /** \sa RTIMER_NOW() */
 rtimer_clock_t rtimer_arch_now(void);


### PR DESCRIPTION
The rtimer frequency depends on the clock configuration, specifically whether the low-frequency crystal or internal RC oscillator is selected. This patch computes the proper frequency in both cases.
