### PR TITLE
Use LINKADDR_SIZE instead of sizeof(linkaddr_t) to avoid struct padding problems.

### DIFF
--- a/core/net/mac/framer-802154.c
+++ b/core/net/mac/framer-802154.c
@@ -128,7 +128,7 @@ create(void)
      \todo For phase 1 the addresses are all long. We'll need a mechanism
      in the rime attributes to tell the mac to use long or short for phase 2.
   */
-  if(sizeof(linkaddr_t) == 2) {
+  if(LINKADDR_SIZE == 2) {
     /* Use short address mode if linkaddr size is short. */
     params.fcf.src_addr_mode = FRAME802154_SHORTADDRMODE;
   } else {
@@ -150,7 +150,7 @@ create(void)
     linkaddr_copy((linkaddr_t *)&params.dest_addr,
                   packetbuf_addr(PACKETBUF_ADDR_RECEIVER));
     /* Use short address mode if linkaddr size is small */
-    if(sizeof(linkaddr_t) == 2) {
+    if(LINKADDR_SIZE == 2) {
       params.fcf.dest_addr_mode = FRAME802154_SHORTADDRMODE;
     } else {
       params.fcf.dest_addr_mode = FRAME802154_LONGADDRMODE;

--- a/core/net/packetbuf.h
+++ b/core/net/packetbuf.h
@@ -434,7 +434,7 @@ void              packetbuf_attr_copyfrom(struct packetbuf_attr *attrs,
 
 #define PACKETBUF_ATTR_BIT  1
 #define PACKETBUF_ATTR_BYTE 8
-#define PACKETBUF_ADDRSIZE (sizeof(linkaddr_t) * PACKETBUF_ATTR_BYTE)
+#define PACKETBUF_ADDRSIZE (LINKADDR_SIZE * PACKETBUF_ATTR_BYTE)
 
 struct packetbuf_attrlist {
   uint8_t type;


### PR DESCRIPTION
Changed to use LINKADDR_SIZE instead of sizeof(linkaddr_t) to select between short address and long address in framer-80215.4.c as some platforms might use padding in the struct. Fixed similar issue in packetbuf.h. This should resolve #555.
