### PR TITLE
Fix CC2538 random_init lockup

### DIFF
--- a/cpu/cc2538/dev/random.c
+++ b/cpu/cc2538/dev/random.c
@@ -92,6 +92,9 @@ random_init(unsigned short seed)
   /* Enable clock for the RF Core */
   REG(SYS_CTRL_RCGCRFC) = 1;
 
+  /* Wait for the clock ungating to take effect */
+  while(REG(SYS_CTRL_RCGCRFC) != 1);
+
   /* Infinite RX - FRMCTRL0[3:2] = 10
    * This will mess with radio operation - see note above */
   REG(RFCORE_XREG_FRMCTRL0) = 0x00000008;


### PR DESCRIPTION
This is a fix for a lockup condition in the CC2538 RNG initialisation routine.

This has been discussed/reported/tested (thanks) under various incarnations recently:
- In #623
- In the mailing list: http://thread.gmane.org/gmane.os.contiki.devel/21884

This pull implements the fix proposed by @bthebaudeau in #623

I tested this with `SMALL=0` as well as `SMALL=1` with the following versions of the launchpad.net arm-gcc toolchain:
- gcc version 4.7.4 20130913
- gcc version 4.8.3 20131129
- gcc version 4.8.3 20140228

This problem only manifests itself for specific versions of the arm-gcc toolchain and then again only for specific levels of optimisation (`-Os` vs `-O2`, depending on the value of the `SMALL` make variable)

The lockup is caused when we access an RFCORE XREG before the RF clock ungating has taken effect, which in turn only occurs depending on the assembly generated for those two instructions:

```
  REG(SYS_CTRL_RCGCRFC) = 1;

  REG(RFCORE_XREG_FRMCTRL0) = 0x00000008;
```

This commit makes the RNG wait for the ungating to take effect before attempting to write the register
