### PR TITLE
Added flags to enable 20-bit support from msp430-gcc 4.7.x

### DIFF
--- a/cpu/msp430/Makefile.msp430
+++ b/cpu/msp430/Makefile.msp430
@@ -145,6 +145,18 @@ ifndef CC_MCU
  CC_MCU := $(MCU)
 endif
 
+### Checks for compiler version to enable 20-bit support
+ifndef IAR
+ifneq (,$(findstring 4.7.,$(shell msp430-gcc -dumpversion)))
+ifdef CPU_HAS_MSP430X
+  TARGET_MEMORY_MODEL ?= medium
+  CFLAGS += -mmemory-model=$(TARGET_MEMORY_MODEL)
+  CFLAGS += -ffunction-sections -fdata-sections -mcode-region=far
+  LDFLAGS += -mmemory-model=$(TARGET_MEMORY_MODEL) -Wl,-gc-sections
+endif
+endif
+endif
+
 ifndef CFLAGSNO
 CFLAGSNO = -Wall -mmcu=$(CC_MCU) $(CFLAGSWERROR)
 endif

--- a/platform/exp5438/Makefile.exp5438
+++ b/platform/exp5438/Makefile.exp5438
@@ -48,15 +48,6 @@ ifeq ($(UIP_CONF_IPV6),1)
 CFLAGS += -DWITH_UIP6=1
 endif
 
-ifndef IAR
-ifneq (,$(findstring 4.7.,$(shell msp430-gcc -dumpversion)))
-TARGET_MEMORY_MODEL ?= medium
-CFLAGS += -mmemory-model=$(TARGET_MEMORY_MODEL)
-CFLAGS += -ffunction-sections -fdata-sections -mcode-region=far
-LDFLAGS += -mmemory-model=$(TARGET_MEMORY_MODEL) -Wl,-gc-sections
-endif
-endif
-
 CONTIKI_TARGET_SOURCEFILES += $(ARCH) $(UIPDRIVERS)
 
 ifdef IAR
@@ -64,6 +55,10 @@ MCU=msp430f5438a
 else
 MCU=msp430f5438
 endif
+
+# Platform has a MSP430X MCU with 20-bit support
+CPU_HAS_MSP430X=1
+
 include $(CONTIKI)/cpu/msp430/Makefile.msp430
 
 contiki-$(TARGET).a: ${addprefix $(OBJECTDIR)/,symbols.o}

--- a/platform/wismote/Makefile.wismote
+++ b/platform/wismote/Makefile.wismote
@@ -22,15 +22,6 @@ ifeq ($(UIP_CONF_IPV6),1)
 CFLAGS += -DWITH_UIP6=1
 endif
 
-ifndef IAR
-  ifneq (,$(findstring 4.7.,$(shell msp430-gcc -dumpversion)))
-  TARGET_MEMORY_MODEL ?= medium
-  CFLAGS += -mmemory-model=$(TARGET_MEMORY_MODEL)
-  CFLAGS += -ffunction-sections -fdata-sections -mcode-region=far
-  LDFLAGS += -mmemory-model=$(TARGET_MEMORY_MODEL) -Wl,-gc-sections
-endif
-endif
-
 ifdef IAR
 CFLAGS += -D__MSP430F5437__=1 -e --vla -Ohz --multiplier=32 --multiplier_location=4C0 --hw_workaround=CPU40 --core=430X --double=32
 else
@@ -40,6 +31,10 @@ endif
 CONTIKI_TARGET_SOURCEFILES += $(ARCH) $(UIPDRIVERS)
 
 MCU=msp430f5437
+
+# Platform has a MSP430X MCU with 20-bit support
+CPU_HAS_MSP430X=1
+
 include $(CONTIKI)/cpu/msp430/Makefile.msp430
 
 ifdef IAR

--- a/platform/z1/Makefile.common
+++ b/platform/z1/Makefile.common
@@ -36,6 +36,10 @@ CONTIKI_TARGET_SOURCEFILES += $(ARCH) $(UIPDRIVERS)
 CONTIKI_TARGET_SOURCEFILES += i2cmaster.c adxl345.c
 
 MCU=msp430f2617
+
+# Platform has a MSP430X MCU with 20-bit support
+CPU_HAS_MSP430X=1
+
 include $(CONTIKI)/cpu/msp430/Makefile.msp430
 
 # Add LDFLAGS after IAR_PATH is set


### PR DESCRIPTION
This commit adds the required flags to enable 20-bit support on the Z1 platform using the msp430-gcc 4.7.x toolchain, copied from Wismote Makefile.  This PR complements https://github.com/contiki-os/contiki/pull/630.
