### PR TITLE
[Cooja] Set location of newly created plugins relative to second last activated plugin

### DIFF
--- a/tools/cooja/java/org/contikios/cooja/Cooja.java
+++ b/tools/cooja/java/org/contikios/cooja/Cooja.java
@@ -1659,7 +1659,6 @@ public class Cooja extends Observable {
           return false;
         }
 
-        int nrFrames = myDesktopPane.getAllFrames().length;
         myDesktopPane.add(pluginFrame);
 
         /* Set size if not already specified by plugin */
@@ -1667,11 +1666,9 @@ public class Cooja extends Observable {
           pluginFrame.setSize(FRAME_STANDARD_WIDTH, FRAME_STANDARD_HEIGHT);
         }
 
-        /* Set location if not already visible */
+        /* Set location if not already set */
         if (pluginFrame.getLocation().x <= 0 && pluginFrame.getLocation().y <= 0) {
-          pluginFrame.setLocation(
-              nrFrames * FRAME_NEW_OFFSET,
-              nrFrames * FRAME_NEW_OFFSET);
+          pluginFrame.setLocation(determineNewPluginLocation());
         }
 
         pluginFrame.setVisible(true);
@@ -1688,6 +1685,29 @@ public class Cooja extends Observable {
         return true;
       }
     }.invokeAndWait();
+  }
+
+  /**
+   * Determines suitable location for placing new plugin.
+   * <p>
+   * If possible, this is below right of the second last activated
+   * internfal frame (offset is determined by FRAME_NEW_OFFSET).
+   *
+   * @return Resulting placement position
+   */
+  private Point determineNewPluginLocation() {
+    Point topFrameLoc;
+    JInternalFrame[] iframes = myDesktopPane.getAllFrames();
+    if (iframes.length > 1) {
+      topFrameLoc = iframes[1].getLocation();
+    } else {
+      topFrameLoc = new Point(
+              myDesktopPane.getSize().width / 2,
+              myDesktopPane.getSize().height / 2);
+    }
+    return new Point(
+            topFrameLoc.x + FRAME_NEW_OFFSET,
+            topFrameLoc.y + FRAME_NEW_OFFSET);
   }
 
   /**


### PR DESCRIPTION
I felt very uncomfortable with the default plugin placement in Cooja.
It just counts the number of total frames on the desktop pane (including invisible ones!)
and computes the placement offset by that.

This is unflexible and for larger numbers of frames this might even result in opening new frames 
below the currently visual area of the desktop pane.

So my approach for a (hopefully) slightly improved placement strategy is
to set the location of newly created plugins relative to the second last activated plugin.

For explanation, this tries to meet two requirements:
- Avoid covering the last activated plugin frame,
  i.e. the one from that was active when new plugin
  start was invoked.
- Set the new plugin near an actively used desktop pane
  location and allow 'diagonal stacking'
