### PR TITLE
[Cooja] plugins/LogListener: Prevent from throwing ArrayIndexOutOfBoundsException

### DIFF
--- a/tools/cooja/java/org/contikios/cooja/plugins/LogListener.java
+++ b/tools/cooja/java/org/contikios/cooja/plugins/LogListener.java
@@ -383,6 +383,9 @@ public class LogListener extends VisPlugin implements HasQuickHelp {
         }
 
         int rowIndex = logTable.rowAtPoint(e.getPoint());
+        if (rowIndex == -1) {
+          return;
+        }
         LogData d = logs.get(logTable.getRowSorter().convertRowIndexToModel(rowIndex));
         if (d == null) {
         	return;


### PR DESCRIPTION
When you click on the _Mote_ column in an empty `LogListener` plugin
an uncaught `ArrayIndexOutOfBoundsException` is thrown.

As I always hear all alarm bells ringing when seeing a stacktrace in the Cooja log I would suggest preventing this exception by checking that `rowIndex` is `!= -1 before using it.
