### PR TITLE
Network filter for contiki

### DIFF
--- a/core/contiki-default-conf.h
+++ b/core/contiki-default-conf.h
@@ -166,13 +166,19 @@
 #define UIP_CONF_MAX_CONNECTIONS 8
 #endif /* UIP_CONF_MAX_CONNECTIONS */
 
-
 /* UIP_CONF_TCP_SPLIT enables a performance optimization hack, where
    each maximum-sized TCP segment is split into two, to avoid the
    performance degradation that is caused by delayed ACKs. */
 #ifndef UIP_CONF_TCP_SPLIT
 #define UIP_CONF_TCP_SPLIT 0
 #endif /* UIP_CONF_TCP_SPLIT */
+
+/* UIP_CONF_NETFILTER_ENABLE specifies if the netfilter is enabled
+   on the platform and therefore if the incoming packets should be
+   pre- processed before delivering them to the IP stack. */
+#ifndef UIP_CONF_NETFILTER_ENABLE
+#define UIP_CONF_NETFILTER_ENABLE 0
+#endif /* UIP_CONF_NETFILTER_ENABLE */
 
 /* NBR_TABLE_CONF_MAX_NEIGHBORS specifies the maximum number of neighbors
    that each node will be able to handle. */
@@ -238,6 +244,5 @@
 #ifndef CONTIKIMAC_CONF_WITH_PHASE_OPTIMIZATION
 #define CONTIKIMAC_CONF_WITH_PHASE_OPTIMIZATION 0
 #endif /* CONTIKIMAC_CONF_WITH_PHASE_OPTIMIZATION */
-
 
 #endif /* CONTIKI_DEFAULT_CONF_H */

--- a/core/net/ip/tcpip.c
+++ b/core/net/ip/tcpip.c
@@ -183,6 +183,9 @@ check_for_tcp_syn(void)
 static void
 packet_input(void)
 {
+#if UIP_CONF_NETFILTER_ENABLE
+  uip_netfilter_input();
+#endif /* UIP_CONF_NETFILTER_ENABLE */
 #if UIP_CONF_IP_FORWARD
   if(uip_len > 0) {
     tcpip_is_forwarding = 1;

--- a/core/net/ip/uip-netfilter.c
+++ b/core/net/ip/uip-netfilter.c
@@ -1,0 +1,110 @@
+/**
+ * \addtogroup uip6
+ * @{
+ */
+
+/**
+ * \file
+ *         uIP Netfilter
+ * \author Víctor Ariño <victor.arino@tado.com>
+ */
+
+/*
+ * Copyright (c) 2014, tado° GmbH.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * This file is part of the Contiki operating system.
+ *
+ */
+
+#include "net/ip/uip.h"
+#include "net/ip/uip-netfilter.h"
+#include "lib/list.h"
+
+#include <string.h>
+
+#define UIP_IP_BUF   ((struct uip_ip_hdr *)&uip_buf[UIP_LLH_LEN])
+#define UIP_TCP_UDP_BUF  ((struct uip_udp_hdr *)&uip_buf[UIP_LLH_LEN + UIP_IPH_LEN])
+
+/*---------------------------------------------------------------------------*/
+LIST(netlist_input);
+LIST(netlist_output);
+/*---------------------------------------------------------------------------*/
+/** \brief Compare port if not 0 */
+#define COMPARE_PORT_IFF(filter_port, pkt_port) \
+  ((*(uint16_t *)(filter_port)) == 0 \
+   || (*(uint16_t *)(pkt_port)) == (*(uint16_t *)(filter_port)))
+/** \brief Compare address if not NULL */
+#define COMPARE_ADDR_IFF(filter_addr, pkt_addr) \
+  ((filter_addr == NULL) \
+   || uip_ipaddr_cmp(filter_addr, pkt_addr))
+/*---------------------------------------------------------------------------*/
+void
+uip_netfilter_register(uint8_t dir, uip_netfilter_filter_t *f)
+{
+  if(dir == UIP_NETFILTER_INPUT) {
+    list_add(netlist_input, f);
+  } else {
+    list_add(netlist_output, f);
+  }
+}
+/*---------------------------------------------------------------------------*/
+void
+uip_netfilter_unregister(uint8_t dir, uip_netfilter_filter_t *f)
+{
+  if(dir == UIP_NETFILTER_INPUT) {
+    list_remove(netlist_input, f);
+  } else {
+    list_remove(netlist_output, f);
+  }
+}
+/*---------------------------------------------------------------------------*/
+void
+uip_netfilter_input(void)
+{
+  register struct uip_netfilter_filter_st *p;
+  uint8_t *buff = NULL;
+  for(p = list_head(netlist_input);
+      p != NULL && uip_len > 0;
+      p = list_item_next(p)) {
+    if(p->proto == UIP_IP_BUF->proto) {
+      if(p->proto == UIP_PROTO_TCP || p->proto == UIP_PROTO_UDP) {
+        buff = (uint8_t *)UIP_TCP_UDP_BUF;
+      } else {
+        /* xxx not supported */
+        continue;
+      } if(COMPARE_PORT_IFF(&p->srcport, &buff[0])
+           && COMPARE_PORT_IFF(&p->destport, &buff[2])
+           && COMPARE_ADDR_IFF(p->srcaddr, &UIP_IP_BUF->srcipaddr)
+           && COMPARE_ADDR_IFF(p->dstaddr, &UIP_IP_BUF->destipaddr)) {
+        p->callback();
+      }
+    }
+  }
+}
+/*---------------------------------------------------------------------------*/
+/** @} */

--- a/core/net/ip/uip-netfilter.h
+++ b/core/net/ip/uip-netfilter.h
@@ -1,0 +1,89 @@
+/**
+ * \addtogroup uip6
+ * @{
+ */
+
+/**
+ * \file
+ *         uIP Netfilter
+ * \author Víctor Ariño <victor.arino@tado.com>
+ */
+
+/*
+ * Copyright (c) 2014, tado° GmbH.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * This file is part of the Contiki operating system.
+ *
+ */
+
+#ifndef UIP_NETFILTER_H_
+#define UIP_NETFILTER_H_
+
+typedef struct uip_netfilter_filter_st {
+  struct uip_netfilter_filter_st *next;
+  uint8_t proto;
+  uint16_t srcport, destport;
+  uip_ipaddr_t *srcaddr, *dstaddr;
+  void (*callback)(void);
+} uip_netfilter_filter_t;
+
+/** \brief Input filter */
+#define UIP_NETFILTER_INPUT  0
+/** \brief Output filter */
+#define UIP_NETFILTER_OUTPUT 1
+
+/**
+ * \brief Register a network filter
+ *
+ * \param dir     Direction of the filter: \sa UIP_NETFILTER_INPUT,
+ *                \sa UIP_NETFILTER_OUTPUT.
+ * \param filter  Filter to register. Note it must be a static variable due
+ *                to implementation.
+ */
+void
+uip_netfilter_register(uint8_t dir, uip_netfilter_filter_t *filter);
+
+/**
+ * \brief Unregister the filter
+ *
+ * \param dir     Direction of the filter: \sa UIP_NETFILTER_INPUT,
+ *                \sa UIP_NETFILTER_OUTPUT.
+ * \param filter  Filter to unregister
+ */
+void
+uip_netfilter_unregister(uint8_t dir, uip_netfilter_filter_t *filter);
+
+/**
+ * \internal
+ * \brief Hook for the tcpip input
+ */
+void
+uip_netfilter_input(void);
+
+#endif /* UIP_NETFILTER_H_ */
+/** @} */


### PR DESCRIPTION
Implements capabilities for filtering TCP/UDP packets before they reach the uip interface. Currently only for input packages.