### PR TITLE
Remove duplicated RPL configuration parameters definition

### DIFF
--- a/core/net/rpl/rpl-private.h
+++ b/core/net/rpl/rpl-private.h
@@ -134,29 +134,6 @@
 
 #define INFINITE_RANK                   0xffff
 
-/* Represents 2^n ms. */
-/* Default value according to the specification is 3 which
-   means 8 milliseconds, but that is an unreasonable value if
-   using power-saving / duty-cycling    */
-#ifdef RPL_CONF_DIO_INTERVAL_MIN
-#define RPL_DIO_INTERVAL_MIN        RPL_CONF_DIO_INTERVAL_MIN
-#else
-#define RPL_DIO_INTERVAL_MIN        12
-#endif
-
-/* Maximum amount of timer doublings. */
-#ifdef RPL_CONF_DIO_INTERVAL_DOUBLINGS
-#define RPL_DIO_INTERVAL_DOUBLINGS  RPL_CONF_DIO_INTERVAL_DOUBLINGS
-#else
-#define RPL_DIO_INTERVAL_DOUBLINGS  8
-#endif
-
-/* Default DIO redundancy. */
-#ifdef RPL_CONF_DIO_REDUNDANCY
-#define RPL_DIO_REDUNDANCY          RPL_CONF_DIO_REDUNDANCY
-#else
-#define RPL_DIO_REDUNDANCY          10
-#endif
 
 /* Expire DAOs from neighbors that do not respond in this time. (seconds) */
 #define DAO_EXPIRATION_TIMEOUT          60


### PR DESCRIPTION
RPL configuration parameters RPL_CONF_DIO_INTERVAL_MIN, RPL_CONF_DIO_INTERVAL_DOUBLINGS, RPL_CONF_DIO_REDUNDANCY are defined in rpl-conf.h and redefined in rpl-private.h. This PR removes the latter definitions.
