### PR TITLE
Fix inconsistent usage of short/long integer type in mbxxx platform's configuration file.

### DIFF
--- a/platform/mbxxx/platform-conf.h
+++ b/platform/mbxxx/platform-conf.h
@@ -85,7 +85,7 @@ typedef unsigned long clock_time_t;
 
 typedef unsigned long rtimer_clock_t;
 
-#define RTIMER_CLOCK_LT(a,b)     ((signed short)((a)-(b)) < 0)
+#define RTIMER_CLOCK_LT(a,b)     ((signed long)((a)-(b)) < 0)
 
 #define LEDS_CONF_RED_PIN     boardDescription->io->leds[1].gpioPin
 #define LEDS_CONF_GREEN_PIN   boardDescription->io->leds[0].gpioPin


### PR DESCRIPTION
The type used to store rtimer ticks on this platform is 32-bit integer, but the macro uses 16-bit comparison. As a result, the output of the RTIMER_CLOCK_LT(a,b) macro was incorrect when used for comparisons between time values with sufficiently large difference.
The code to repeat this problem on mbxxx platform:

  rtimer_clock_t a = 6 \* RTIMER_ARCH_SECOND;
  rtimer_clock_t b = 0;
  printf("%d\n", RTIMER_CLOCK_LT(a,b)); // expected output: "0", actual: "1"
