### PR TITLE
CC2538: Add WATCHDOG_CONF_ENABLE to optionally disable the watchdog timer

### DIFF
--- a/cpu/cc2538/dev/watchdog.c
+++ b/cpu/cc2538/dev/watchdog.c
@@ -87,6 +87,7 @@ void
 watchdog_reboot(void)
 {
   INTERRUPTS_DISABLE();
+  watchdog_start(); /* just in case the WDT hasn't been started yet */
   while(1);
 }
 /**

--- a/platform/cc2538dk/contiki-conf.h
+++ b/platform/cc2538dk/contiki-conf.h
@@ -51,6 +51,16 @@ typedef uint32_t rtimer_clock_t;
 /** @} */
 /*---------------------------------------------------------------------------*/
 /**
+ * \name Watchdog Timer configuration
+ *
+ * @{
+ */
+#ifndef WATCHDOG_CONF_ENABLE
+#define WATCHDOG_CONF_ENABLE	1 /**<Enable the watchdog timer */
+#endif
+/** @} */
+/*---------------------------------------------------------------------------*/
+/**
  * \name USB 'core' configuration
  *
  * Those values are not meant to be modified by the user, except where stated

--- a/platform/cc2538dk/contiki-main.c
+++ b/platform/cc2538dk/contiki-main.c
@@ -203,7 +203,9 @@ main(void)
 
   autostart_start(autostart_processes);
 
+#if WATCHDOG_CONF_ENABLE
   watchdog_start();
+#endif
   fade(LEDS_ORANGE);
 
   while(1) {


### PR DESCRIPTION
Once the CC2538 watchdog timer is started, it cannot be disabled. This simple mod allows the project to override the default behavior of the platform and control the watchdog directly by adding `#define WATCHDOG_CONF_ENABLE 0` to project-conf.h.
