### PR TITLE
Fix Travis failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_script:
 
   ## Install toolchain for mc1233x, cc2538 and mbxxx in care-free way
   - "[ ${BUILD_ARCH:-0} = arm ] && curl -s \
-       https://raw.github.com/wiki/malvira/libmc1322x/files/arm-2008q3-66-arm-none-eabi-i686-pc-linux-gnu.tar.bz2 \
+       https://raw.githubusercontent.com/wiki/malvira/libmc1322x/files/arm-2008q3-66-arm-none-eabi-i686-pc-linux-gnu.tar.bz2 \
          | tar xjf - -C /tmp/ && sudo cp -f -r /tmp/arm-2008q3/* /usr/ && rm -rf /tmp/arm-2008q3 && arm-none-eabi-gcc --version || true"
 
   ## Install RL78 GCC chain (following the instructions in platform/eval-adf7xxxmb4z/README.md)
@@ -23,7 +23,7 @@ before_script:
 
   ## Install SDCC from a purpose-built bundle
   - "[ ${BUILD_ARCH:-0} = 8051 ] && curl -s \
-       https://raw.github.com/wiki/g-oikonomou/contiki-sensinode/files/sdcc.tar.gz \
+       https://raw.githubusercontent.com/wiki/g-oikonomou/contiki-sensinode/files/sdcc.tar.gz \
          | tar xzf - -C /tmp/ && sudo cp -f -r /tmp/sdcc/* /usr/local/ && rm -rf /tmp/sdcc && sdcc --version || true"
   - "[ ${BUILD_ARCH:-0} = 8051 ] && sudo apt-get -qq install srecord || true"
 


### PR DESCRIPTION
For travis tests, we host pre-built bundles of the arm-gcc and sdcc toolchains on github, and we download them with curl.

Apparently, the URL for those bundles changed at some point, and the HTTP response is now a 301 redirect. curl doesn't follow it.

This pull changes .travis.yml to download the bundles from the new location

Reported by @cmorty (thanks) At the start I thought it was transient, but apparently it's not.

http://article.gmane.org/gmane.os.contiki.devel/22053
