### PR TITLE
RPL MRHOF: bypass EWMA when setting a parent's link metric for the first time

### DIFF
--- a/core/net/rpl/rpl-dag.c
+++ b/core/net/rpl/rpl-dag.c
@@ -1082,8 +1082,8 @@ rpl_recalculate_ranks(void)
    */
   p = nbr_table_head(rpl_parents);
   while(p != NULL) {
-    if(p->dag != NULL && p->dag->instance && p->updated) {
-      p->updated = 0;
+    if(p->dag != NULL && p->dag->instance && (p->flags & RPL_PARENT_FLAG_UPDATED)) {
+      p->flags &= ~RPL_PARENT_FLAG_UPDATED;
       PRINTF("RPL: rpl_process_parent_event recalculate_ranks\n");
       if(!rpl_process_parent_event(p->dag->instance, p)) {
         PRINTF("RPL: A parent was dropped\n");

--- a/core/net/rpl/rpl-icmp6.c
+++ b/core/net/rpl/rpl-icmp6.c
@@ -652,7 +652,7 @@ dao_input(void)
       PRINTF("RPL: Loop detected when receiving a unicast DAO from a node with a lower rank! (%u < %u)\n",
           DAG_RANK(parent->rank, instance), DAG_RANK(dag->rank, instance));
       parent->rank = INFINITE_RANK;
-      parent->updated = 1;
+      parent->flags |= RPL_PARENT_FLAG_UPDATED;
       return;
     }
 
@@ -660,7 +660,7 @@ dao_input(void)
     if(parent != NULL && parent == dag->preferred_parent) {
       PRINTF("RPL: Loop detected when receiving a unicast DAO from our parent\n");
       parent->rank = INFINITE_RANK;
-      parent->updated = 1;
+      parent->flags |= RPL_PARENT_FLAG_UPDATED;
       return;
     }
   }

--- a/core/net/rpl/rpl.c
+++ b/core/net/rpl/rpl.c
@@ -260,7 +260,7 @@ rpl_link_neighbor_callback(const linkaddr_t *addr, int status, int numtx)
       if(parent != NULL) {
         /* Trigger DAG rank recalculation. */
         PRINTF("RPL: rpl_link_neighbor_callback triggering update\n");
-        parent->updated = 1;
+        parent->flags |= RPL_PARENT_FLAG_UPDATED;
         if(instance->of->neighbor_link_callback != NULL) {
           instance->of->neighbor_link_callback(parent, status, numtx);
         }
@@ -286,7 +286,7 @@ rpl_ipv6_neighbor_callback(uip_ds6_nbr_t *nbr)
         p->rank = INFINITE_RANK;
         /* Trigger DAG rank recalculation. */
         PRINTF("RPL: rpl_ipv6_neighbor_callback infinite rank\n");
-        p->updated = 1;
+        p->flags |= RPL_PARENT_FLAG_UPDATED;
       }
     }
   }

--- a/core/net/rpl/rpl.h
+++ b/core/net/rpl/rpl.h
@@ -104,6 +104,9 @@ typedef struct rpl_metric_container rpl_metric_container_t;
 struct rpl_instance;
 struct rpl_dag;
 /*---------------------------------------------------------------------------*/
+#define RPL_PARENT_FLAG_UPDATED           0x1
+#define RPL_PARENT_FLAG_LINK_METRIC_VALID 0x2
+
 struct rpl_parent {
   struct rpl_parent *next;
   struct rpl_dag *dag;
@@ -113,7 +116,7 @@ struct rpl_parent {
   rpl_rank_t rank;
   uint16_t link_metric;
   uint8_t dtsn;
-  uint8_t updated;
+  uint8_t flags;
 };
 typedef struct rpl_parent rpl_parent_t;
 /*---------------------------------------------------------------------------*/


### PR DESCRIPTION
Whenever getting a first neighbor callback, set the link metric to the current packet's ETX rather than using a weighted moving average with RPL_INIT_LINK_METRIC. Makes it faster to converge to an accurate link estimate. For instance, over a perfect link, with RPL_INIT_LINK_METRIC of 5 and an EWMA alpha of 0.9, it took about 50 transmissions to drop link_metric from 1280 (ETX of 5) to 256 (ETX of 1). With this fix, the first successful transmission sets link_metric to 256.
