### PR TITLE
CC2538: Add FLASH_CONF_ORIGIN and FLASH_CONF_SIZE config parameters.

### DIFF
--- a/cpu/cc2538/cc2538.lds
+++ b/cpu/cc2538/cc2538.lds
@@ -43,10 +43,26 @@
 #define SRAM_LEN        0x00008000
 #endif
 
+#ifdef FLASH_CONF_ORIGIN
+#define FLASH_ORIGIN    FLASH_CONF_ORIGIN
+#else
+#error FLASH_CONF_ORIGIN is not specified. Please define FLASH_CONF_ORIGIN in contiki-conf.h.
+#endif
+
+#ifdef FLASH_CONF_SIZE
+#define FLASH_SIZE      FLASH_CONF_SIZE
+#else
+#error FLASH_CONF_SIZE is not specified. Please define FLASH_CONF_SIZE in contiki-conf.h.
+#endif
+
+#define FLASH_CCA_LENGTH 44
+#define FLASH_LENGTH     (FLASH_SIZE - FLASH_CCA_LENGTH)
+#define FLASH_CCA_ORIGIN (FLASH_ORIGIN + FLASH_LENGTH)
+
 MEMORY
 {
-    FLASH (rx) : ORIGIN = 0x200000, LENGTH = 0x0007FFD4
-    FLASH_CCA (RX) : ORIGIN = 0x0027FFD4, LENGTH = 44
+    FLASH (rx) : ORIGIN = FLASH_ORIGIN, LENGTH = FLASH_LENGTH
+    FLASH_CCA (RX) : ORIGIN = FLASH_CCA_ORIGIN, LENGTH = FLASH_CCA_LENGTH
 #if (LPM_CONF_MAX_PM==2) && (LPM_CONF_ENABLE != 0)
     NRSRAM (RWX) : ORIGIN = NRSRAM_START, LENGTH = NRSRAM_LEN
 #endif

--- a/platform/cc2538dk/contiki-conf.h
+++ b/platform/cc2538dk/contiki-conf.h
@@ -51,6 +51,20 @@ typedef uint32_t rtimer_clock_t;
 /** @} */
 /*---------------------------------------------------------------------------*/
 /**
+ * \name Flash Memory configuration
+ *
+ * @{
+ */
+#ifndef FLASH_CONF_ORIGIN
+#define FLASH_CONF_ORIGIN  0x00200000
+#endif
+
+#ifndef FLASH_CONF_SIZE
+#define FLASH_CONF_SIZE    0x00080000 /* 512 KiB */
+#endif
+/** @} */
+/*---------------------------------------------------------------------------*/
+/**
  * \name USB 'core' configuration
  *
  * Those values are not meant to be modified by the user, except where stated


### PR DESCRIPTION
This permits the project or platform to define the flash memory size and/or origin, allowing MCUs with different amounts of flash memory to be used. It also allows the MCU to store multiple different Contiki images and switch between them by modifying the Application Entry Point word in the Customer Configuration Area.
