### PR TITLE
Set initial link ETX to 2

### DIFF
--- a/core/net/rpl/rpl-conf.h
+++ b/core/net/rpl/rpl-conf.h
@@ -162,7 +162,7 @@
  * Initial metric attributed to a link when the ETX is unknown
  */
 #ifndef RPL_CONF_INIT_LINK_METRIC
-#define RPL_INIT_LINK_METRIC        5
+#define RPL_INIT_LINK_METRIC        2
 #else
 #define RPL_INIT_LINK_METRIC        RPL_CONF_INIT_LINK_METRIC
 #endif


### PR DESCRIPTION
Makes link estimation less conservative, i.e. assume unknown links are usable, so that parents advertising lower rank than the current preferred parent can be considered. Note that excessive route flapping is avoided by the hysteresis in MRHOF.

Without this fix, nodes need to see their link to the preferred parent degrade to etx 5 + hysteresis threshold (reception rate below 20%) before considering another parent with equivalent rank.
