### PR TITLE
Add UIP_CONF_ND6_SEND_NA to contiki-default-conf.h

### DIFF
--- a/core/contiki-default-conf.h
+++ b/core/contiki-default-conf.h
@@ -180,6 +180,12 @@
 #define NBR_TABLE_CONF_MAX_NEIGHBORS 8
 #endif /* NBR_TABLE_CONF_MAX_NEIGHBORS */
 
+/* UIP_CONF_ND6_SEND_NA enables standard IPv6 Neighbor Discovery Protocol.
+   This is unneeded when RPL is used. Disable to save ROM and a little RAM. */
+#ifndef UIP_CONF_ND6_SEND_NA
+#define UIP_CONF_ND6_SEND_NA 1
+#endif /* UIP_CONF_ND6_SEND_NA */
+
 /*---------------------------------------------------------------------------*/
 /* 6lowpan configuration options.
  *


### PR DESCRIPTION
Documenting a flag that helps saving nearly 2k ROM on sky (I would even unset it by default, at least in the sky platform, to solve Travis out-of-memory compilation errors)
