### PR TITLE
sky: Initialize energest as early as possible

### DIFF
--- a/platform/sky/contiki-sky-main.c
+++ b/platform/sky/contiki-sky-main.c
@@ -217,6 +217,10 @@ main(int argc, char **argv)
    * Hardware initialization done!
    */
 
+  /* Initialize energest first (but after rtimer)
+   */
+  energest_init();
+  ENERGEST_ON(ENERGEST_TYPE_CPU);
   
 #if WITH_TINYOS_AUTO_IDS
   node_id = TOS_NODE_ID;
@@ -381,9 +385,6 @@ main(int argc, char **argv)
 	   uip_ipaddr_to_quad(&hostaddr));
   }
 #endif /* WITH_UIP */
-
-  energest_init();
-  ENERGEST_ON(ENERGEST_TYPE_CPU);
 
   watchdog_start();
 


### PR DESCRIPTION
If energest is initialized too late and the radio is not accounted
until the first switch. This is a problem when the radio is always
listening.
