### PR TITLE
exit when RPL-Border router is started, so that tunslip6 can be invoked

### DIFF
--- a/cpu/mc1322x/tools/mc1322x-load.pl
+++ b/cpu/mc1322x/tools/mc1322x-load.pl
@@ -159,9 +159,17 @@ if(defined($do_exit)) {
 }
 
 my $c; my $count;
+my $str="";
 while(1) {
     ($count, $c) = $ob->read(1);
-    print $c if (defined($count) && ($count != 0));
+    if (defined($count) && ($count != 0)) {
+      print $c;
+      $str = $str.$c;
+    }
+    if($str =~ /RPL-Border/) {
+      print "Existing because RPL-Border found\n";
+      exit;
+    }
 }
 
 $ob -> close or die "Close failed: $!\n";


### PR DESCRIPTION
This lets the programming section exit so that a script can bring up tunslip6 immediately.
