### PR TITLE
Confine CC2538 WDT on/off conf inside the driver

### DIFF
--- a/cpu/cc2538/dev/watchdog.c
+++ b/cpu/cc2538/dev/watchdog.c
@@ -46,6 +46,17 @@
 #include "cpu.h"
 #include "dev/smwdthrosc.h"
 /*---------------------------------------------------------------------------*/
+/* Enabled by default */
+#ifndef WATCHDOG_CONF_ENABLE
+#define WATCHDOG_CONF_ENABLE 1
+#endif
+
+#if WATCHDOG_CONF_ENABLE
+#define WATCHDOG_ENABLE SMWDTHROSC_WDCTL_EN
+#else
+#define WATCHDOG_ENABLE 0
+#endif
+/*---------------------------------------------------------------------------*/
 /** \brief Initialisation function for the WDT. Currently simply explicitly
  * sets the WDT interval to max interval */
 void
@@ -55,20 +66,24 @@ watchdog_init(void)
   REG(SMWDTHROSC_WDCTL) = 0;
 }
 /*---------------------------------------------------------------------------*/
-/** \brief Starts the WDT in watchdog mode, maximum interval */
+/** \brief Starts the WDT in watchdog mode if enabled by user configuration,
+ * maximum interval */
 void
 watchdog_start(void)
 {
-  /* Max interval (32768), watchdog mode, Enable */
-  REG(SMWDTHROSC_WDCTL) = SMWDTHROSC_WDCTL_EN;
+  /* Max interval (32768), watchdog mode, enable if configured to do so */
+  REG(SMWDTHROSC_WDCTL) = WATCHDOG_ENABLE;
 }
 /*---------------------------------------------------------------------------*/
-/** \brief Writes the WDT clear sequence. This function assumes that we are
- * in watchdog mode and that interval bits (bits [1:0]) are 00 */
+/**
+ * \brief Writes the WDT clear sequence.
+ *
+ * Due to how the SMWDTHROSC_WDCTL works, it is OK to simply write these bits
+ * rather than use RMW operations.
+ */
 void
 watchdog_periodic(void)
 {
-  /* Safe to write to bits [3:0] since EN is 1 */
   REG(SMWDTHROSC_WDCTL) = (SMWDTHROSC_WDCTL_CLR_3 | SMWDTHROSC_WDCTL_CLR_1);
   REG(SMWDTHROSC_WDCTL) = (SMWDTHROSC_WDCTL_CLR_2 | SMWDTHROSC_WDCTL_CLR_0);
 }
@@ -82,12 +97,19 @@ watchdog_stop(void)
   return;
 }
 /*---------------------------------------------------------------------------*/
-/** \brief Keeps control until the WDT throws a reset signal */
+/** \brief Keeps control until the WDT throws a reset signal. Starts the WDT
+ * if not already started. */
 void
 watchdog_reboot(void)
 {
   INTERRUPTS_DISABLE();
-  watchdog_start(); /* just in case the WDT hasn't been started yet */
+
+  /*
+   * If the WDT is not started, set minimum interval and start
+   * If the WDT is started, this will have no effect
+   */
+  REG(SMWDTHROSC_WDCTL) = SMWDTHROSC_WDCTL_INT | SMWDTHROSC_WDCTL_EN;
+
   while(1);
 }
 /**

--- a/platform/cc2538dk/contiki-conf.h
+++ b/platform/cc2538dk/contiki-conf.h
@@ -79,7 +79,7 @@ typedef uint32_t rtimer_clock_t;
  * @{
  */
 #ifndef WATCHDOG_CONF_ENABLE
-#define WATCHDOG_CONF_ENABLE	1 /**<Enable the watchdog timer */
+#define WATCHDOG_CONF_ENABLE	      1 /**< Enable the watchdog timer */
 #endif
 /** @} */
 /*---------------------------------------------------------------------------*/

--- a/platform/cc2538dk/contiki-main.c
+++ b/platform/cc2538dk/contiki-main.c
@@ -203,9 +203,7 @@ main(void)
 
   autostart_start(autostart_processes);
 
-#if WATCHDOG_CONF_ENABLE
   watchdog_start();
-#endif
   fade(LEDS_ORANGE);
 
   while(1) {


### PR DESCRIPTION
Instead of requiring all calls to `watchdog_start` to be wrapped inside `#if WATCHDOG_CONF_ENABLE` guards, we control things from within the WDT driver itself. If user configuration has disabled the watchdog, `watchdog_start` will now always respect that.

This pull also includes some documentation and indentation cleanups
