### PR TITLE
Improve travis RL78 tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,8 @@ before_script:
          | tar xjf - -C /tmp/ && sudo cp -f -r /tmp/arm-2008q3/* /usr/ && rm -rf /tmp/arm-2008q3 && arm-none-eabi-gcc --version || true"
 
   ## Install RL78 GCC chain (following the instructions in platform/eval-adf7xxxmb4z/README.md)
-  - "sudo apt-get install git make gcc libc-dev multiarch-support libncurses5:i386 zlib1g:i386"
-  - "wget https://dl.dropboxusercontent.com/u/60522916/gnurl78-v13.02-elf_1-2_i386.deb"
-  - "sudo dpkg -i gnurl78*.deb"
+  - "sudo apt-get install libncurses5:i386 zlib1g:i386 || true"
+  - "wget https://dl.dropboxusercontent.com/u/60522916/gnurl78-v13.02-elf_1-2_i386.deb && sudo dpkg -i gnurl78*.deb || true"
 
   ## Install SDCC from a purpose-built bundle
   - "[ ${BUILD_ARCH:-0} = 8051 ] && curl -s \


### PR DESCRIPTION
These tests apt-get install a bunch of what seems to be unnecessary packages. I've removed a couple. @hexluthor , do we _really_ need `libncurses5:i386 zlib1g:i386` for these tests?

Also:
- I've added `|| true` so that we can fail properly if we... fail
- Only dpkg -i gnurl78 if its download succeeded
