### PR TITLE
Adding static analysis through the scan-build command

### DIFF
--- a/regression-tests/Makefile
+++ b/regression-tests/Makefile
@@ -47,3 +47,5 @@ cooja: $(CONTIKI)/tools/cooja/dist/cooja.jar
 $(CONTIKI)/tools/cooja/dist/cooja.jar:
 	(cd $(CONTIKI)/tools/cooja; ant jar)
 
+scan-build:
+	cd scan_build && scan-build $(MAKE)

--- a/regression-tests/scan_build/Makefile
+++ b/regression-tests/scan_build/Makefile
@@ -1,0 +1,16 @@
+EXAMPLESDIR=../../examples
+TOOLSDIR=../../tools
+
+EXAMPLES = \
+hello-world/minimal-net \
+hello-world/native \
+eeprom-test/native \
+example-shell/native \
+tcp-socket/minimal-net \
+telnet-server/minimal-net \
+webserver/minimal-net \
+wget/minimal-net \
+
+TOOLS=
+
+include ../Makefile.compile-test


### PR DESCRIPTION
scan-build http://clang-analyzer.llvm.org/scan-build.html is a clang
based tool designed to provide static analysis over C code files.

I don't know how to integrate this as elegantly as possible with the already existing regression-tests but it let you experiment with the report and the scan-build command.
This is not a regression-tests for say, it will inspect code and will provide a set of insights on the code.

scan-build works best on the native platform and clang the underlying backend doesn't work well yet with msp430. But for examples code it should be fine with the native platform :)

Here's what the results look like : http://leone.iiens.net/scan-build-2014-05-28-175201-3054-1/
TODO: 
- Where do we put reports and how do we review them?
- What are the examples we want to analyze? 
