### PR TITLE
Re-create a routing table entry if the next hop is changed.

### DIFF
--- a/core/net/ipv6/uip-ds6-route.c
+++ b/core/net/ipv6/uip-ds6-route.c
@@ -262,14 +262,16 @@ uip_ds6_route_add(uip_ipaddr_t *ipaddr, uint8_t length,
   }
 
   /* First make sure that we don't add a route twice. If we find an
-     existing route for our destination, we'll just update the old
-     one. */
+     existing route for our destination, we'll delete the old
+     one first. */
   r = uip_ds6_route_lookup(ipaddr);
   if(r != NULL) {
-    PRINTF("uip_ds6_route_add: old route already found, updating this one instead: ");
+    PRINTF("uip_ds6_route_add: old route for ");
     PRINT6ADDR(ipaddr);
-    PRINTF("\n");
-  } else {
+    PRINTF(" found, deleting it\n");
+    uip_ds6_route_rm(r);
+  }
+  {
     struct uip_ds6_route_neighbor_routes *routes;
     /* If there is no routing entry, create one. We first need to
        check if we have room for this route. If not, we remove the


### PR DESCRIPTION
The next-hop address did not get updated in the routing table
in case an entry for the destination already existed.

This patch resolves the issue by removing the entry and
having it re-created from scratch.

The issue causes a routing error triggering reconstruction of
the DODAG through version increase.

In case of somewhat frequent downward traffic in not (yet) stabilized DODAG
a vicious circle is formed: unstable topology means churn, downward
routing under churn causes reconstruction of DODAG. In this situation
the network does not have chance to stabilize.

We encountered a constant churn caused by this bug
in a network of 50 nodes and a periodic traffic (a packet every 5
seconds) generated at the root.

More info and a PCAP demonstrating the issue can be found here:
https://github.com/contiki-os/contiki/issues/496
