### PR TITLE
Adding tunslip to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ symbols.*
 Makefile.target
 doc/html
 patches-*
+tools/tunslip
 tools/tunslip6
 build
 tools/coffee-manager/build/


### PR DESCRIPTION
There is two tunslip (tunslip & tunslip6) seems fair that they both get ignored ;-)
