### PR TITLE
CC2538: Creating a base CC2538 platform

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -74,7 +74,7 @@ endif
 
 ifeq ($(CONTIKI_WITH_RIME),1)
   HAS_STACK = 1
-  CFLAGS += -DNETSTACK_CONF_WITH_RIME=1 
+  CFLAGS += -DNETSTACK_CONF_WITH_RIME=1
   MODULES += core/net/rime
 endif
 
@@ -177,8 +177,8 @@ CFLAGS += ${addprefix -D,${subst $(COMMA), ,$(DEFINES)}}
 
 ### Setup directory search path for source and header files
 
-CONTIKI_TARGET_DIRS_CONCAT = ${addprefix ${dir $(target_makefile)}, \
-                               $(CONTIKI_TARGET_DIRS)}
+CONTIKI_TARGET_DIRS_CONCAT ?= ${addprefix ${dir $(target_makefile)}, \
+                              $(CONTIKI_TARGET_DIRS)}
 CONTIKI_CPU_DIRS_CONCAT    = ${addprefix $(CONTIKI_CPU)/, \
                                $(CONTIKI_CPU_DIRS)}
 

--- a/platform/cc2538/Makefile.cc2538
+++ b/platform/cc2538/Makefile.cc2538
@@ -1,0 +1,33 @@
+# cc2538 base platform makefile
+
+ifndef CONTIKI
+  $(error CONTIKI not defined! You must specify where CONTIKI resides!)
+endif
+
+### These files must exist for all CC2538 platforms
+CONTIKI_TARGET_SOURCEFILES += leds.c leds-arch.c
+CONTIKI_TARGET_SOURCEFILES += contiki-main.c platform.c
+
+CONTIKI_SOURCEFILES += $(CONTIKI_TARGET_SOURCEFILES)
+
+### Unless the example dictates otherwise, build with code size optimisations
+ifndef SMALL
+  SMALL = 1
+endif
+
+### Define the CPU directory
+CONTIKI_CPU=$(CONTIKI)/cpu/cc2538
+include $(CONTIKI_CPU)/Makefile.cc2538
+
+MODULES += core/net core/net/mac \
+           core/net/mac/contikimac \
+		   core/net/llsec
+
+BSL = $(CONTIKI)/tools/cc2538-bsl/cc2538-bsl.py
+
+%.upload: %.bin
+ifeq ($(wildcard $(BSL)), )
+	@echo "ERROR: Could not find the cc2538-bsl script. Did you run 'git submodule update --init' ?"
+else
+	python $(BSL) -e -w -v $<
+endif

--- a/platform/cc2538/README.md
+++ b/platform/cc2538/README.md
@@ -1,0 +1,87 @@
+CC2538 Base Platform
+====================
+
+This platform is designed to be a base platform for any other CC2538
+based hardware platform. This should allow other platforms to reuse the code
+in this folder instead of having to copy it to create a new platform.
+
+As an example, the cc2538dk platform is based off of this one.
+
+
+Creating a New CC2538-based Platform
+------------------------------------
+
+To create a platform based on the CC2538 you must define a couple files
+that are specific to your platform.
+
+First, the Makefile. Create a file named `Makefile.<platform>`
+
+    Makefile.<platform>:
+
+    ### Include the files from the base platform (cc2538)
+    CONTIKI_TARGET_DIRS =  $(CONTIKI)/platform/cc2538
+
+    ### Also include any folders specific to this platform
+    CONTIKI_TARGET_DIRS += . dev
+
+    ### Include the .c files that need to be compiled for this
+    CONTIKI_TARGET_SOURCEFILES += sensors.c smartrf-sensors.c
+    CONTIKI_TARGET_SOURCEFILES += button-sensor.c adc-sensor.c
+
+    ### Configure make to clean the relevant files
+    CLEAN += *.<platform>
+
+    ### Include the base CC2538 platform makefile
+    include $(CONTIKI)/platform/cc2538/Makefile.cc2538
+
+
+Second, you must create a `platform.c` that holds platform specific
+initialization code. A good starting point is the `platform.c` in the
+cc2538dk platform.
+
+    platform.c must have these three functions:
+
+    /**
+     * \brief First init after the core CC2538 peripherals are initialized
+     */
+    void
+    platform_init_post_initial()
+    {
+    }
+
+    /**
+     * \brief Second init after the networking stack has been configured
+     */
+    void
+    platform_init_post_networking()
+    {
+    }
+
+    /**
+     * \brief Init function at the very end before the main loop
+     */
+    void
+    platform_init_end()
+    {
+    }
+
+
+Third, you need a `platform-conf.h` to set any platform specific defines.
+Here is a short example:
+
+    platform-conf.h:
+
+    #ifndef PLATFORM_CONF_H_
+    #define PLATFORM_CONF_H_
+
+    #define STARTUP_CONF_LEDS     1
+
+    #endif /* PLATFORM_CONF_H_ */
+
+
+Using the New Platform as a Target
+----------------------------------
+
+At this point the target should be usable like any other target/platform
+
+    make TARGET=<platform>

--- a/platform/cc2538/contiki-conf.h
+++ b/platform/cc2538/contiki-conf.h
@@ -1,9 +1,9 @@
 /**
- * \addtogroup cc2538dk
+ * \addtogroup cc2538
  * @{
  *
  * \file
- *  Configuration for the cc2538dk platform
+ *  Configuration for the base cc2538 platform
  */
 #ifndef CONTIKI_CONF_H_
 #define CONTIKI_CONF_H_
@@ -15,6 +15,8 @@
 #ifdef PROJECT_CONF_H
 #include PROJECT_CONF_H
 #endif /* PROJECT_CONF_H */
+/* Include target/platform specific conf */
+#include "platform-conf.h"
 /*---------------------------------------------------------------------------*/
 /**
  * \name Compiler configuration and platform-specific type definitions
@@ -113,6 +115,10 @@ typedef uint32_t rtimer_clock_t;
 
 #ifndef STARTUP_CONF_VERBOSE
 #define STARTUP_CONF_VERBOSE        1 /**< Set to 0 to decrease startup verbosity */
+#endif
+
+#ifndef STARTUP_CONF_LEDS
+#define STARTUP_CONF_LEDS           1 /**< Set to 0 to not fade LEDs at startup */
 #endif
 /** @} */
 /*---------------------------------------------------------------------------*/

--- a/platform/cc2538/contiki-main.c
+++ b/platform/cc2538/contiki-main.c
@@ -32,17 +32,18 @@
  * \addtogroup cc2538-platforms
  * @{
  *
- * \defgroup cc2538dk The cc2538 Development Kit platform
+ * \defgroup cc2538 The cc2538 SoC platform
  *
- * The cc2538DK is a platform by Texas Instruments, based on the
- * cc2538 SoC with an ARM Cortex-M3 core.
+ * SoC from Texas Instruments with an ARM Cortex-M3 core.
+ *
  * @{
  *
  * \file
- *   Main module for the cc2538dk platform
+ *   Main module for the cc2538 platform
  */
 /*---------------------------------------------------------------------------*/
 #include "contiki.h"
+#include "platform.h"
 #include "dev/adc.h"
 #include "dev/leds.h"
 #include "dev/sys-ctrl.h"
@@ -51,7 +52,6 @@
 #include "dev/uart.h"
 #include "dev/watchdog.h"
 #include "dev/ioc.h"
-#include "dev/button-sensor.h"
 #include "dev/serial-line.h"
 #include "dev/slip.h"
 #include "dev/cc2538-rf.h"
@@ -72,10 +72,21 @@
 #include <string.h>
 #include <stdio.h>
 /*---------------------------------------------------------------------------*/
+/* Define main() as a weak reference in case a sub-platform wishes to
+ * define a custom main function. */
+#pragma weak main
+int main(void) __attribute__((weak));
+/*---------------------------------------------------------------------------*/
 #if STARTUP_CONF_VERBOSE
 #define PRINTF(...) printf(__VA_ARGS__)
 #else
 #define PRINTF(...)
+#endif
+
+#if STARTUP_CONF_LEDS
+#define FADE(l) fade(l)
+#else
+#define FADE(l)
 #endif
 
 #if UART_CONF_ENABLE
@@ -149,12 +160,13 @@ main(void)
   gpio_init();
 
   leds_init();
-  fade(LEDS_YELLOW);
+  FADE(LEDS_YELLOW);
 
   process_init();
 
   watchdog_init();
-  button_sensor_init();
+
+  platform_init_post_initial();
 
   /*
    * Character I/O Initialisation.
@@ -180,7 +192,7 @@ main(void)
   serial_line_init();
 
   INTERRUPTS_ENABLE();
-  fade(LEDS_GREEN);
+  FADE(LEDS_GREEN);
 
   PUTS(CONTIKI_VERSION_STRING);
   PUTS(BOARD_STRING);
@@ -211,7 +223,7 @@ main(void)
 
   adc_init();
 
-  process_start(&sensors_process, NULL);
+  platform_init_post_networking();
 
   energest_init();
   ENERGEST_ON(ENERGEST_TYPE_CPU);
@@ -219,7 +231,9 @@ main(void)
   autostart_start(autostart_processes);
 
   watchdog_start();
-  fade(LEDS_ORANGE);
+  FADE(LEDS_ORANGE);
+
+  platform_init_end();
 
   while(1) {
     uint8_t r;

--- a/platform/cc2538/platform.h
+++ b/platform/cc2538/platform.h
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2014, University of Michigan.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+/**
+ * \addtogroup cc2538
+ * @{
+ *
+ * Platform and hardware specific functions for the CC2538 series of platforms.
+ * @{
+ */
+/**
+ * \file
+ * Header file for the cc2538 platform init functions
+ */
+#ifndef PLATFORM_H_
+#define PLATFORM_H_
+
+/**
+ * \brief First platform specific initialization function
+ *
+ * Typically this contains init() functions for other hardware chips on the
+ * platform.
+ */
+void platform_init_post_initial();
+
+/**
+ * \brief Second platform init function after networking is configured
+ */
+void platform_init_post_networking();
+
+/**
+ * \brief Last platform init function that occurs just before the main
+ * while() loop.
+ */
+void platform_init_end();
+
+/** @} */
+
+#endif
+
+/**
+ * @}
+ * @}
+ */

--- a/platform/cc2538dk/Makefile.cc2538dk
+++ b/platform/cc2538dk/Makefile.cc2538dk
@@ -4,35 +4,16 @@ ifndef CONTIKI
   $(error CONTIKI not defined! You must specify where CONTIKI resides!)
 endif
 
-CONTIKI_TARGET_DIRS = . dev
+### Include the files from the base platform (cc2538)
+CONTIKI_TARGET_DIRS =  ../cc2538
 
-CONTIKI_TARGET_SOURCEFILES += leds.c leds-arch.c
-CONTIKI_TARGET_SOURCEFILES += contiki-main.c
+### Also include this platform
+CONTIKI_TARGET_DIRS += . dev
+
 CONTIKI_TARGET_SOURCEFILES += sensors.c smartrf-sensors.c
 CONTIKI_TARGET_SOURCEFILES += button-sensor.c als-sensor.c
 
-CONTIKI_SOURCEFILES += $(CONTIKI_TARGET_SOURCEFILES)
-
 CLEAN += *.cc2538dk
 
-### Unless the example dictates otherwise, build with code size optimisations
-ifndef SMALL
-  SMALL = 1
-endif
-
-### Define the CPU directory
-CONTIKI_CPU=$(CONTIKI)/cpu/cc2538
-include $(CONTIKI_CPU)/Makefile.cc2538
-
-MODULES += core/net core/net/mac \
-           core/net/mac/contikimac \
-           core/net/llsec
-
-BSL = $(CONTIKI)/tools/cc2538-bsl/cc2538-bsl.py
-
-%.upload: %.bin
-ifeq ($(wildcard $(BSL)), )
-	@echo "ERROR: Could not find the cc2538-bsl script. Did you run 'git submodule update --init' ?"
-else
-	python $(BSL) -e -w -v $<
-endif
+### Include the base CC2538 platform makefile
+include $(CONTIKI)/platform/cc2538/Makefile.cc2538

--- a/platform/cc2538dk/platform-conf.h
+++ b/platform/cc2538dk/platform-conf.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2014, University of Michigan.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+/**
+ * \addtogroup cc2538dk
+ * @{
+ *
+ * \file
+ * Platform specific configuration defines for the cc2538dk
+ */
+#ifndef PLATFORM_CONF_H_
+#define PLATFORM_CONF_H_
+
+#define STARTUP_CONF_LEDS     1
+
+#endif /* PLATFORM_CONF_H_ */
+
+/** @} */

--- a/platform/cc2538dk/platform.c
+++ b/platform/cc2538dk/platform.c
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2014, University of Michigan.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+/**
+ * \addtogroup cc2538dk
+ * @{
+ *
+ * \file
+ * Implementation of the cc2538dk specific functions
+ */
+#include "contiki.h"
+#include "platform.h"
+#include "button-sensor.h"
+
+/**
+ * \brief Initialize the CC2538dk buttons.
+ */
+void
+platform_init_post_initial()
+{
+  button_sensor_init();
+}
+
+/**
+ * \brief Run the sensors process for the CC2538dk
+ */
+void
+platform_init_post_networking()
+{
+  process_start(&sensors_process, NULL);
+}
+
+/**
+ * \brief Not needed for cc2538dk
+ */
+void
+platform_init_end()
+{
+}
+
+/** @} */


### PR DESCRIPTION
The better the Contiki support for the CC2538 gets, the more CC2538 based hardware platforms that will be created. Right now, this is a bit tricky as one must copy the cc2538dk platform and make a few changes for the difference in hardware and then compile against the cpu/cc2538 folder. This works until the cpu/cc2538 changes at which point platform/cc2538dk gets updated but not the platforms sitting in other repositories and compilation fails.

Because the changes to the cc2538dk platform to create a new platform are usually small (typically initializing different hardware), we can create a "base" cc2538 platform and build specific hardware platforms off of that. This commit does just that. It spins most of the cc2538dk platform into just a "cc2538" platform and uses the cc2538dk platform for the /dev folder code and a couple of `init()` functions.

`contiki-main.c` now calls two new functions

- `platform_init()`
- `platform_process_init()`

in the `main()` function. The first `platform_init()` function calls any platform specific hardware functions that need to be initalized (like the smartrf06 buttons). The `platform_process_init()` is there to start and platform specific processes (like the sensors process). Both init functions are defined in `platform.c`.

This commit also adds a `platform-conf.h` file that can be used to override any of the defaults in `contiki-conf.h`.

Finally, this commit adds support for disabling the LEDs during boot.