### PR TITLE
uip.h missing #include <string.h>

### DIFF
--- a/core/net/ip/uip.h
+++ b/core/net/ip/uip.h
@@ -92,6 +92,9 @@
 
 #include "net/ip/uipopt.h"
 
+/* For memcmp */
+#include <string.h>
+
 /**
  * Representation of an IP address.
  *


### PR DESCRIPTION
This fixes a warning when building uaodv-rt.c about implicit definition of memcmp.
