### PR TITLE
Change the default IPv6 prefix from aaaa::0/? to fc00::0/7

### DIFF
--- a/apps/rest-common/static-routing.c
+++ b/apps/rest-common/static-routing.c
@@ -30,7 +30,7 @@ void set_global_address(void)
 {
   uip_ipaddr_t ipaddr;
 
-  uip_ip6addr(&ipaddr, 0xaaaa, 0, 0, 0, 0, 0, 0, 0);
+  uip_ip6addr(&ipaddr, 0xfc00, 0, 0, 0, 0, 0, 0, 0);
   uip_ds6_set_addr_iid(&ipaddr, &uip_lladdr);
   uip_ds6_addr_add(&ipaddr, 0, ADDR_AUTOCONF);
 }

--- a/apps/rest-common/static-routing.h
+++ b/apps/rest-common/static-routing.h
@@ -13,37 +13,37 @@
 
 /*desktop machine*/
 #define DESKTOP_MACHINE_ID 0
-#define NODE_0_GLOBAL(ipaddr) uip_ip6addr(ipaddr, 0xaaaa, 0, 0, 0, 0, 0, 0, 0x0001)
+#define NODE_0_GLOBAL(ipaddr) uip_ip6addr(ipaddr, 0xfc00, 0, 0, 0, 0, 0, 0, 0x0001)
 
 /*Cooja Nodes*/
 #define COOJA_BORDER_ROUTER_ID 1
-#define NODE_1_GLOBAL(ipaddr)   uip_ip6addr(ipaddr, 0xaaaa, 0, 0, 0, 0x0212, 0x7401, 0x0001, 0x0101)
+#define NODE_1_GLOBAL(ipaddr)   uip_ip6addr(ipaddr, 0xfc00, 0, 0, 0, 0x0212, 0x7401, 0x0001, 0x0101)
 #define NODE_1_LOCAL(ipaddr)    uip_ip6addr(ipaddr, 0xfe80, 0, 0, 0, 0x0212, 0x7401, 0x0001, 0x0101)
 
-#define NODE_2_GLOBAL(ipaddr)   uip_ip6addr(ipaddr, 0xaaaa, 0, 0, 0, 0x0212, 0x7402, 0x0002, 0x0202)
+#define NODE_2_GLOBAL(ipaddr)   uip_ip6addr(ipaddr, 0xfc00, 0, 0, 0, 0x0212, 0x7402, 0x0002, 0x0202)
 #define NODE_2_LOCAL(ipaddr)    uip_ip6addr(ipaddr, 0xfe80, 0, 0, 0, 0x0212, 0x7402, 0x0002, 0x0202)
 
-#define NODE_3_GLOBAL(ipaddr)   uip_ip6addr(ipaddr, 0xaaaa, 0, 0, 0, 0x0212, 0x7403, 0x0003, 0x0303)
+#define NODE_3_GLOBAL(ipaddr)   uip_ip6addr(ipaddr, 0xfc00, 0, 0, 0, 0x0212, 0x7403, 0x0003, 0x0303)
 #define NODE_3_LOCAL(ipaddr)    uip_ip6addr(ipaddr, 0xfe80, 0, 0, 0, 0x0212, 0x7403, 0x0003, 0x0303)
 
-#define NODE_6_GLOBAL(ipaddr)   uip_ip6addr(ipaddr, 0xaaaa, 0, 0, 0, 0x0212, 0x7406, 0x0006, 0x0606)
+#define NODE_6_GLOBAL(ipaddr)   uip_ip6addr(ipaddr, 0xfc00, 0, 0, 0, 0x0212, 0x7406, 0x0006, 0x0606)
 #define NODE_6_LOCAL(ipaddr)    uip_ip6addr(ipaddr, 0xfe80, 0, 0, 0, 0x0212, 0x7406, 0x0006, 0x0606)
 
 /*real nodes*/
 #define BORDER_ROUTER_ID 11
-#define NODE_11_GLOBAL(ipaddr)  uip_ip6addr(ipaddr, 0xaaaa, 0, 0, 0, 0x0212, 0x7400, 0x116e, 0xd5f1)
+#define NODE_11_GLOBAL(ipaddr)  uip_ip6addr(ipaddr, 0xfc00, 0, 0, 0, 0x0212, 0x7400, 0x116e, 0xd5f1)
 #define NODE_11_LOCAL(ipaddr)   uip_ip6addr(ipaddr, 0xfe80, 0, 0, 0, 0x0212, 0x7400, 0x116e, 0xd5f1)
 
-#define NODE_12_GLOBAL(ipaddr)  uip_ip6addr(ipaddr, 0xaaaa, 0, 0, 0, 0x0212, 0x7400, 0x1160, 0xf95a)
+#define NODE_12_GLOBAL(ipaddr)  uip_ip6addr(ipaddr, 0xfc00, 0, 0, 0, 0x0212, 0x7400, 0x1160, 0xf95a)
 #define NODE_12_LOCAL(ipaddr)   uip_ip6addr(ipaddr, 0xfe80, 0, 0, 0, 0x0212, 0x7400, 0x1160, 0xf95a)
 
-#define NODE_13_GLOBAL(ipaddr)  uip_ip6addr(ipaddr, 0xaaaa, 0, 0, 0, 0x0212, 0x7400, 0x117d, 0x3575)
+#define NODE_13_GLOBAL(ipaddr)  uip_ip6addr(ipaddr, 0xfc00, 0, 0, 0, 0x0212, 0x7400, 0x117d, 0x3575)
 #define NODE_13_LOCAL(ipaddr)   uip_ip6addr(ipaddr, 0xfe80, 0, 0, 0, 0x0212, 0x7400, 0x117d, 0x3575)
 
-#define NODE_22_GLOBAL(ipaddr)  uip_ip6addr(ipaddr, 0xaaaa, 0, 0, 0, 0x0212, 0x7400, 0x116e, 0xc0f6)
+#define NODE_22_GLOBAL(ipaddr)  uip_ip6addr(ipaddr, 0xfc00, 0, 0, 0, 0x0212, 0x7400, 0x116e, 0xc0f6)
 #define NODE_22_LOCAL(ipaddr)   uip_ip6addr(ipaddr, 0xfe80, 0, 0, 0, 0x0212, 0x7400, 0x116e, 0xc0f6)
 
-#define NODE_23_GLOBAL(ipaddr)  uip_ip6addr(ipaddr, 0xaaaa, 0, 0, 0, 0x0212, 0x7400, 0x117d, 0x0d5a)
+#define NODE_23_GLOBAL(ipaddr)  uip_ip6addr(ipaddr, 0xfc00, 0, 0, 0, 0x0212, 0x7400, 0x117d, 0x0d5a)
 #define NODE_23_LOCAL(ipaddr)   uip_ip6addr(ipaddr, 0xfe80, 0, 0, 0, 0x0212, 0x7400, 0x117d, 0x0d5a)
 
 #define ADD_ROUTE(node_global,node_local)\

--- a/core/net/ipv6/sicslowpan.c
+++ b/core/net/ipv6/sicslowpan.c
@@ -1876,8 +1876,8 @@ sicslowpan_init(void)
 #ifdef SICSLOWPAN_CONF_ADDR_CONTEXT_0
 	SICSLOWPAN_CONF_ADDR_CONTEXT_0;
 #else
-  addr_contexts[0].prefix[0] = 0xaa; 
-  addr_contexts[0].prefix[1] = 0xaa;
+  addr_contexts[0].prefix[0] = 0xfc; 
+  addr_contexts[0].prefix[1] = 0x00;
 #endif
 #endif /* SICSLOWPAN_CONF_MAX_ADDR_CONTEXTS > 0 */
 

--- a/cpu/native/net/wpcap.c
+++ b/cpu/native/net/wpcap.c
@@ -525,7 +525,7 @@ wpcap_init(void)
 //	  }
 #else
       addr.s_addr = inet_addr("10.10.10.10");   //prefer ipv4 default for legacy compatibility
-//    uiplib_ipaddrconv("aaaa::1",(uip_ipaddr_t*) &addr6.s6_addr);
+//    uiplib_ipaddrconv("fc00::1",(uip_ipaddr_t*) &addr6.s6_addr);
 #endif
 
 #ifdef UIP_FALLBACK_INTERFACE

--- a/examples/cc2530dk/udp-ipv6/client.c
+++ b/examples/cc2530dk/udp-ipv6/client.c
@@ -130,7 +130,7 @@ PROCESS_THREAD(udp_client_process, ev, data)
   PRINTF(" local/remote port %u/%u\n",
          UIP_HTONS(l_conn->lport), UIP_HTONS(l_conn->rport));
 
-  uip_ip6addr(&ipaddr, 0xaaaa, 0, 0, 0, 0x0215, 0x2000, 0x0002, 0x2145);
+  uip_ip6addr(&ipaddr, 0xfc00, 0, 0, 0, 0x0215, 0x2000, 0x0002, 0x2145);
   g_conn = udp_new(&ipaddr, UIP_HTONS(3000), NULL);
   if(!g_conn) {
     PRINTF("udp_new g_conn error.\n");

--- a/examples/cc2530dk/udp-ipv6/ping6.c
+++ b/examples/cc2530dk/udp-ipv6/ping6.c
@@ -105,7 +105,7 @@ PROCESS_THREAD(ping6_process, ev, data)
   PRINTF("ping6 running.\n");
   PRINTF("Button 1: 5 pings 16 byte payload.\n");
 
-  uip_ip6addr(&dest_addr, 0xaaaa, 0, 0, 0, 0x0215, 0x2000, 0x0002, 0x2145);
+  uip_ip6addr(&dest_addr, 0xfc00, 0, 0, 0, 0x0215, 0x2000, 0x0002, 0x2145);
   count = 0;
 
   icmp6_new(NULL);

--- a/examples/cc2530dk/udp-ipv6/server.c
+++ b/examples/cc2530dk/udp-ipv6/server.c
@@ -126,7 +126,7 @@ create_dag()
 {
   rpl_dag_t *dag;
 
-  uip_ip6addr(&ipaddr, 0xaaaa, 0, 0, 0, 0, 0, 0, 0);
+  uip_ip6addr(&ipaddr, 0xfc00, 0, 0, 0, 0, 0, 0, 0);
   uip_ds6_set_addr_iid(&ipaddr, &uip_lladdr);
   uip_ds6_addr_add(&ipaddr, 0, ADDR_AUTOCONF);
 
@@ -135,7 +135,7 @@ create_dag()
   dag = rpl_set_root(RPL_DEFAULT_INSTANCE,
                      &uip_ds6_get_global(ADDR_PREFERRED)->ipaddr);
   if(dag != NULL) {
-    uip_ip6addr(&ipaddr, 0xaaaa, 0, 0, 0, 0, 0, 0, 0);
+    uip_ip6addr(&ipaddr, 0xfc00, 0, 0, 0, 0, 0, 0, 0);
     rpl_set_prefix(dag, &ipaddr, 64);
     PRINTF("Created a new RPL dag with ID: ");
     PRINT6ADDR(&dag->dag_id);

--- a/examples/ipv6/json-ws/json-ws.c
+++ b/examples/ipv6/json-ws/json-ws.c
@@ -78,7 +78,7 @@
 static const char http_content_type_json[] = "application/json";
 
 /* Maximum 40 chars in host name?: 5 x 8 */
-static char callback_host[40] = "[aaaa::1]";
+static char callback_host[40] = "[fc00::1]";
 static uint16_t callback_port = CALLBACK_PORT;
 static uint16_t callback_interval = SEND_INTERVAL;
 static char callback_path[80] = "/debug/";

--- a/examples/ipv6/multicast/root.c
+++ b/examples/ipv6/multicast/root.c
@@ -111,7 +111,7 @@ set_own_addresses(void)
   rpl_dag_t *dag;
   uip_ipaddr_t ipaddr;
 
-  uip_ip6addr(&ipaddr, 0xaaaa, 0, 0, 0, 0, 0, 0, 0);
+  uip_ip6addr(&ipaddr, 0xfc00, 0, 0, 0, 0, 0, 0, 0);
   uip_ds6_set_addr_iid(&ipaddr, &uip_lladdr);
   uip_ds6_addr_add(&ipaddr, 0, ADDR_AUTOCONF);
 

--- a/examples/ipv6/multicast/sink.c
+++ b/examples/ipv6/multicast/sink.c
@@ -84,7 +84,7 @@ join_mcast_group(void)
   uip_ds6_maddr_t *rv;
 
   /* First, set our v6 global */
-  uip_ip6addr(&addr, 0xaaaa, 0, 0, 0, 0, 0, 0, 0);
+  uip_ip6addr(&addr, 0xfc00, 0, 0, 0, 0, 0, 0, 0);
   uip_ds6_set_addr_iid(&addr, &uip_lladdr);
   uip_ds6_addr_add(&addr, 0, ADDR_AUTOCONF);
 

--- a/examples/ipv6/native-border-router/slip-config.c
+++ b/examples/ipv6/native-border-router/slip-config.c
@@ -125,7 +125,7 @@ slip_config_handle_arguments(int argc, char **argv)
     case 'h':
     default:
 fprintf(stderr,"usage:  %s [options] ipaddress\n", prog);
-fprintf(stderr,"example: border-router.native -L -v2 -s ttyUSB1 aaaa::1/64\n");
+fprintf(stderr,"example: border-router.native -L -v2 -s ttyUSB1 fc00::1/64\n");
 fprintf(stderr,"Options are:\n");
 #ifdef linux
 fprintf(stderr," -B baudrate    9600,19200,38400,57600,115200,921600 (default 115200)\n");

--- a/examples/ipv6/rpl-collect/udp-sender.c
+++ b/examples/ipv6/rpl-collect/udp-sender.c
@@ -195,12 +195,12 @@ set_global_address(void)
 {
   uip_ipaddr_t ipaddr;
 
-  uip_ip6addr(&ipaddr, 0xaaaa, 0, 0, 0, 0, 0, 0, 0);
+  uip_ip6addr(&ipaddr, 0xfc00, 0, 0, 0, 0, 0, 0, 0);
   uip_ds6_set_addr_iid(&ipaddr, &uip_lladdr);
   uip_ds6_addr_add(&ipaddr, 0, ADDR_AUTOCONF);
 
   /* set server address */
-  uip_ip6addr(&server_ipaddr, 0xaaaa, 0, 0, 0, 0, 0, 0, 1);
+  uip_ip6addr(&server_ipaddr, 0xfc00, 0, 0, 0, 0, 0, 0, 1);
 
 }
 /*---------------------------------------------------------------------------*/

--- a/examples/ipv6/rpl-collect/udp-sink.c
+++ b/examples/ipv6/rpl-collect/udp-sink.c
@@ -145,14 +145,14 @@ PROCESS_THREAD(udp_server_process, ev, data)
   PRINTF("UDP server started\n");
 
 #if UIP_CONF_ROUTER
-  uip_ip6addr(&ipaddr, 0xaaaa, 0, 0, 0, 0, 0, 0, 1);
+  uip_ip6addr(&ipaddr, 0xfc00, 0, 0, 0, 0, 0, 0, 1);
   /* uip_ds6_set_addr_iid(&ipaddr, &uip_lladdr); */
   uip_ds6_addr_add(&ipaddr, 0, ADDR_MANUAL);
   root_if = uip_ds6_addr_lookup(&ipaddr);
   if(root_if != NULL) {
     rpl_dag_t *dag;
     dag = rpl_set_root(RPL_DEFAULT_INSTANCE,(uip_ip6addr_t *)&ipaddr);
-    uip_ip6addr(&ipaddr, 0xaaaa, 0, 0, 0, 0, 0, 0, 0);
+    uip_ip6addr(&ipaddr, 0xfc00, 0, 0, 0, 0, 0, 0, 0);
     rpl_set_prefix(dag, &ipaddr, 64);
     PRINTF("created a new RPL dag\n");
   } else {

--- a/examples/ipv6/rpl-udp/udp-client.c
+++ b/examples/ipv6/rpl-udp/udp-client.c
@@ -116,7 +116,7 @@ set_global_address(void)
 {
   uip_ipaddr_t ipaddr;
 
-  uip_ip6addr(&ipaddr, 0xaaaa, 0, 0, 0, 0, 0, 0, 0);
+  uip_ip6addr(&ipaddr, 0xfc00, 0, 0, 0, 0, 0, 0, 0);
   uip_ds6_set_addr_iid(&ipaddr, &uip_lladdr);
   uip_ds6_addr_add(&ipaddr, 0, ADDR_AUTOCONF);
 
@@ -125,21 +125,21 @@ set_global_address(void)
  * Obviously the choice made here must also be selected in udp-server.c.
  *
  * For correct Wireshark decoding using a sniffer, add the /64 prefix to the 6LowPAN protocol preferences,
- * e.g. set Context 0 to aaaa::.  At present Wireshark copies Context/128 and then overwrites it.
- * (Setting Context 0 to aaaa::1111:2222:3333:4444 will report a 16 bit compressed address of aaaa::1111:22ff:fe33:xxxx)
+ * e.g. set Context 0 to fc00::.  At present Wireshark copies Context/128 and then overwrites it.
+ * (Setting Context 0 to fc00::1111:2222:3333:4444 will report a 16 bit compressed address of fc00::1111:22ff:fe33:xxxx)
  *
  * Note the IPCMV6 checksum verification depends on the correct uncompressed addresses.
  */
  
 #if 0
 /* Mode 1 - 64 bits inline */
-   uip_ip6addr(&server_ipaddr, 0xaaaa, 0, 0, 0, 0, 0, 0, 1);
+   uip_ip6addr(&server_ipaddr, 0xfc00, 0, 0, 0, 0, 0, 0, 1);
 #elif 1
 /* Mode 2 - 16 bits inline */
-  uip_ip6addr(&server_ipaddr, 0xaaaa, 0, 0, 0, 0, 0x00ff, 0xfe00, 1);
+  uip_ip6addr(&server_ipaddr, 0xfc00, 0, 0, 0, 0, 0x00ff, 0xfe00, 1);
 #else
 /* Mode 3 - derived from server link-local (MAC) address */
-  uip_ip6addr(&server_ipaddr, 0xaaaa, 0, 0, 0, 0x0250, 0xc2ff, 0xfea8, 0xcd1a); //redbee-econotag
+  uip_ip6addr(&server_ipaddr, 0xfc00, 0, 0, 0, 0x0250, 0xc2ff, 0xfea8, 0xcd1a); //redbee-econotag
 #endif
 }
 /*---------------------------------------------------------------------------*/

--- a/examples/ipv6/rpl-udp/udp-server.c
+++ b/examples/ipv6/rpl-udp/udp-server.c
@@ -114,20 +114,20 @@ PROCESS_THREAD(udp_server_process, ev, data)
  * Obviously the choice made here must also be selected in udp-client.c.
  *
  * For correct Wireshark decoding using a sniffer, add the /64 prefix to the 6LowPAN protocol preferences,
- * e.g. set Context 0 to aaaa::.  At present Wireshark copies Context/128 and then overwrites it.
- * (Setting Context 0 to aaaa::1111:2222:3333:4444 will report a 16 bit compressed address of aaaa::1111:22ff:fe33:xxxx)
+ * e.g. set Context 0 to fc00::.  At present Wireshark copies Context/128 and then overwrites it.
+ * (Setting Context 0 to fc00::1111:2222:3333:4444 will report a 16 bit compressed address of fc00::1111:22ff:fe33:xxxx)
  * Note Wireshark's IPCMV6 checksum verification depends on the correct uncompressed addresses.
  */
  
 #if 0
 /* Mode 1 - 64 bits inline */
-   uip_ip6addr(&ipaddr, 0xaaaa, 0, 0, 0, 0, 0, 0, 1);
+   uip_ip6addr(&ipaddr, 0xfc00, 0, 0, 0, 0, 0, 0, 1);
 #elif 1
 /* Mode 2 - 16 bits inline */
-  uip_ip6addr(&ipaddr, 0xaaaa, 0, 0, 0, 0, 0x00ff, 0xfe00, 1);
+  uip_ip6addr(&ipaddr, 0xfc00, 0, 0, 0, 0, 0x00ff, 0xfe00, 1);
 #else
 /* Mode 3 - derived from link local (MAC) address */
-  uip_ip6addr(&ipaddr, 0xaaaa, 0, 0, 0, 0, 0, 0, 0);
+  uip_ip6addr(&ipaddr, 0xfc00, 0, 0, 0, 0, 0, 0, 0);
   uip_ds6_set_addr_iid(&ipaddr, &uip_lladdr);
 #endif
 
@@ -136,7 +136,7 @@ PROCESS_THREAD(udp_server_process, ev, data)
   if(root_if != NULL) {
     rpl_dag_t *dag;
     dag = rpl_set_root(RPL_DEFAULT_INSTANCE,(uip_ip6addr_t *)&ipaddr);
-    uip_ip6addr(&ipaddr, 0xaaaa, 0, 0, 0, 0, 0, 0, 0);
+    uip_ip6addr(&ipaddr, 0xfc00, 0, 0, 0, 0, 0, 0, 0);
     rpl_set_prefix(dag, &ipaddr, 64);
     PRINTF("created a new RPL dag\n");
   } else {

--- a/examples/ipv6/simple-udp-rpl/unicast-receiver.c
+++ b/examples/ipv6/simple-udp-rpl/unicast-receiver.c
@@ -80,7 +80,7 @@ set_global_address(void)
   int i;
   uint8_t state;
 
-  uip_ip6addr(&ipaddr, 0xaaaa, 0, 0, 0, 0, 0, 0, 0);
+  uip_ip6addr(&ipaddr, 0xfc00, 0, 0, 0, 0, 0, 0, 0);
   uip_ds6_set_addr_iid(&ipaddr, &uip_lladdr);
   uip_ds6_addr_add(&ipaddr, 0, ADDR_AUTOCONF);
 
@@ -109,7 +109,7 @@ create_rpl_dag(uip_ipaddr_t *ipaddr)
     
     rpl_set_root(RPL_DEFAULT_INSTANCE, ipaddr);
     dag = rpl_get_any_dag();
-    uip_ip6addr(&prefix, 0xaaaa, 0, 0, 0, 0, 0, 0, 0);
+    uip_ip6addr(&prefix, 0xfc00, 0, 0, 0, 0, 0, 0, 0);
     rpl_set_prefix(dag, &prefix, 64);
     PRINTF("created a new RPL dag\n");
   } else {

--- a/examples/ipv6/simple-udp-rpl/unicast-sender.c
+++ b/examples/ipv6/simple-udp-rpl/unicast-sender.c
@@ -78,7 +78,7 @@ set_global_address(void)
   int i;
   uint8_t state;
 
-  uip_ip6addr(&ipaddr, 0xaaaa, 0, 0, 0, 0, 0, 0, 0);
+  uip_ip6addr(&ipaddr, 0xfc00, 0, 0, 0, 0, 0, 0, 0);
   uip_ds6_set_addr_iid(&ipaddr, &uip_lladdr);
   uip_ds6_addr_add(&ipaddr, 0, ADDR_AUTOCONF);
 

--- a/examples/ipv6/sky-websense/websense-remote.c
+++ b/examples/ipv6/sky-websense/websense-remote.c
@@ -44,13 +44,13 @@
 #include <stdio.h>
 
 /* The address of the server to register the services for this node */
-#define SERVER       "[aaaa::1]"
+#define SERVER       "[fc00::1]"
 
 /* This command registers two services (/0 and /1) to turn the leds on or off */
 #define REGISTER_COMMAND "/r?p=0&d=Turn%20off%20leds&p=1&d=Turn%20on%20leds"
 
 /* The address of the other node to control */
-#define OTHER_NODE   "[aaaa::1]"
+#define OTHER_NODE   "[fc00::1]"
 
 /* The commands to send to the other node */
 #define SET_LEDS_ON  "/1"

--- a/examples/mbxxx/udp-ipv6-sleep/udp-client.c
+++ b/examples/mbxxx/udp-ipv6-sleep/udp-client.c
@@ -107,7 +107,7 @@ set_global_address(void)
 {
   uip_ipaddr_t ipaddr;
 
-  uip_ip6addr(&ipaddr, 0xaaaa, 0, 0, 0, 0, 0, 0, 0);
+  uip_ip6addr(&ipaddr, 0xfc00, 0, 0, 0, 0, 0, 0, 0);
   uip_ds6_set_addr_iid(&ipaddr, &uip_lladdr);
   uip_ds6_addr_add(&ipaddr, 0, ADDR_AUTOCONF);
 }
@@ -123,7 +123,7 @@ set_connection_address(uip_ipaddr_t *ipaddr)
     PRINTF("UDP client failed to parse address '%s'\n", QUOTEME(UDP_CONNECTION_ADDR));
   }
 #elif UIP_CONF_ROUTER
-  uip_ip6addr(ipaddr,0xaaaa,0,0,0,0x0280,0xe102,0x0000,0x008a);
+  uip_ip6addr(ipaddr,0xfc00,0,0,0,0x0280,0xe102,0x0000,0x008a);
 #else
   uip_ip6addr(ipaddr,0xfe80,0,0,0,0x0280,0xe102,0x0000,0x008a);
 #endif /* UDP_CONNECTION_ADDR */

--- a/examples/mbxxx/udp-ipv6-sleep/udp-server.c
+++ b/examples/mbxxx/udp-ipv6-sleep/udp-server.c
@@ -95,7 +95,7 @@ PROCESS_THREAD(udp_server_process, ev, data)
   PRINTF("UDP server started\n");
 
 #if UIP_CONF_ROUTER
-  uip_ip6addr(&ipaddr, 0xaaaa, 0, 0, 0, 0, 0, 0, 0);
+  uip_ip6addr(&ipaddr, 0xfc00, 0, 0, 0, 0, 0, 0, 0);
   uip_ds6_set_addr_iid(&ipaddr, &uip_lladdr);
   uip_ds6_addr_add(&ipaddr, 0, ADDR_AUTOCONF);
 #endif /* UIP_CONF_ROUTER */

--- a/examples/servreg-hack/example-servreg-client.c
+++ b/examples/servreg-hack/example-servreg-client.c
@@ -54,7 +54,7 @@ set_global_address(void)
 {
   uip_ipaddr_t ipaddr;
 
-  uip_ip6addr(&ipaddr, 0xaaaa, 0, 0, 0, 0, 0, 0, 0);
+  uip_ip6addr(&ipaddr, 0xfc00, 0, 0, 0, 0, 0, 0, 0);
   uip_ds6_set_addr_iid(&ipaddr, &uip_lladdr);
   uip_ds6_addr_add(&ipaddr, 0, ADDR_AUTOCONF);
 }

--- a/examples/servreg-hack/example-servreg-server.c
+++ b/examples/servreg-hack/example-servreg-server.c
@@ -53,7 +53,7 @@ PROCESS_THREAD(example_servreg_server_process, ev, data)
   PROCESS_BEGIN();
 
   /* Set a global address. */
-  uip_ip6addr(&ipaddr, 0xaaaa, 0, 0, 0, 0, 0, 0, 0);
+  uip_ip6addr(&ipaddr, 0xfc00, 0, 0, 0, 0, 0, 0, 0);
   uip_ds6_set_addr_iid(&ipaddr, &uip_lladdr);
   uip_ds6_addr_add(&ipaddr, 0, ADDR_AUTOCONF);
 

--- a/examples/udp-ipv6/udp-client.c
+++ b/examples/udp-ipv6/udp-client.c
@@ -98,7 +98,7 @@ set_global_address(void)
 {
   uip_ipaddr_t ipaddr;
 
-  uip_ip6addr(&ipaddr, 0xaaaa, 0, 0, 0, 0, 0, 0, 0);
+  uip_ip6addr(&ipaddr, 0xfc00, 0, 0, 0, 0, 0, 0, 0);
   uip_ds6_set_addr_iid(&ipaddr, &uip_lladdr);
   uip_ds6_addr_add(&ipaddr, 0, ADDR_AUTOCONF);
 }
@@ -111,7 +111,7 @@ set_connection_address(uip_ipaddr_t *ipaddr)
 #if RESOLV_CONF_SUPPORTS_MDNS
 #define UDP_CONNECTION_ADDR       contiki-udp-server.local
 #elif UIP_CONF_ROUTER
-#define UDP_CONNECTION_ADDR       aaaa:0:0:0:0212:7404:0004:0404
+#define UDP_CONNECTION_ADDR       fc00:0:0:0:0212:7404:0004:0404
 #else
 #define UDP_CONNECTION_ADDR       fe80:0:0:0:6466:6666:6666:6666
 #endif

--- a/examples/udp-ipv6/udp-server.c
+++ b/examples/udp-ipv6/udp-server.c
@@ -99,7 +99,7 @@ PROCESS_THREAD(udp_server_process, ev, data)
 #endif
 
 #if UIP_CONF_ROUTER
-  uip_ip6addr(&ipaddr, 0xaaaa, 0, 0, 0, 0, 0, 0, 0);
+  uip_ip6addr(&ipaddr, 0xfc00, 0, 0, 0, 0, 0, 0, 0);
   uip_ds6_set_addr_iid(&ipaddr, &uip_lladdr);
   uip_ds6_addr_add(&ipaddr, 0, ADDR_AUTOCONF);
 #endif /* UIP_CONF_ROUTER */

--- a/examples/udp-stream/udp-stream.c
+++ b/examples/udp-stream/udp-stream.c
@@ -74,7 +74,7 @@ set_global_address(void)
   int i;
   uint8_t state;
 
-  uip_ip6addr(&ipaddr, 0xaaaa, 0, 0, 0, 0, 0, 0, 0);
+  uip_ip6addr(&ipaddr, 0xfc00, 0, 0, 0, 0, 0, 0, 0);
   uip_ds6_set_addr_iid(&ipaddr, &uip_lladdr);
   uip_ds6_addr_add(&ipaddr, 0, ADDR_AUTOCONF);
 
@@ -102,7 +102,7 @@ create_rpl_dag(uip_ipaddr_t *ipaddr)
 
     rpl_set_root(RPL_DEFAULT_INSTANCE, ipaddr);
     dag = rpl_get_any_dag();
-    uip_ip6addr(&prefix, 0xaaaa, 0, 0, 0, 0, 0, 0, 0);
+    uip_ip6addr(&prefix, 0xfc00, 0, 0, 0, 0, 0, 0, 0);
     rpl_set_prefix(dag, &prefix, 64);
     printf("created a new RPL dag\n");
   } else {

--- a/examples/z1/ipv6/z1-websense/websense-remote.c
+++ b/examples/z1/ipv6/z1-websense/websense-remote.c
@@ -45,13 +45,13 @@
 #include <stdio.h>
 
 /* The address of the server to register the services for this node */
-#define SERVER       "aaaa::1"
+#define SERVER       "fc00::1"
 
 /* This command registers two services (/0 and /1) to turn the leds on or off */
 #define REGISTER_COMMAND "/r?p=0&d=Turn%20off%20leds&p=1&d=Turn%20on%20leds"
 
 /* The address of the other node to control */
-#define OTHER_NODE   "aaaa::212:7403:3:303"
+#define OTHER_NODE   "fc00::212:7403:3:303"
 
 /* The commands to send to the other node */
 #define SET_LEDS_ON  "/1"

--- a/platform/avr-atmega128rfa1/apps/raven-ipso/raven-ipso.c
+++ b/platform/avr-atmega128rfa1/apps/raven-ipso/raven-ipso.c
@@ -97,7 +97,7 @@ raven_ping6(void)
   /* ping ipv6.google.com*/
   uip_ip6addr(&ping_addr,0x2001,0x420,0x5FFF,0x7D,0x2D0,0xB7FF,0xFE23,0xE6DB);
   //uip_ip6addr(&ping_addr, 0x2001, 0x4860, 0, 0x2001, 0, 0, 0, 0x68);
-  //uip_ip6addr(&ping_addr, 0xaaaa, 0, 0, 0, 0, 0, 0, 1);
+  //uip_ip6addr(&ping_addr, 0xfc00, 0, 0, 0, 0, 0, 0, 1);
   
   UIP_IP_BUF->vtc = 0x60;
   UIP_IP_BUF->tcflow = 1;

--- a/platform/avr-atmega128rfa1/contiki-conf.h
+++ b/platform/avr-atmega128rfa1/contiki-conf.h
@@ -159,7 +159,7 @@ typedef unsigned short uip_stats_t;
 #define UIP_CONF_LLH_LEN          0
 
 /* 10 bytes per stateful address context - see sicslowpan.c */
-/* Default is 1 context with prefix aaaa::/64 */
+/* Default is 1 context with prefix fc00::/64 */
 /* These must agree with all the other nodes or there will be a failure to communicate! */
 #define SICSLOWPAN_CONF_MAX_ADDR_CONTEXTS 1
 #define SICSLOWPAN_CONF_ADDR_CONTEXT_0 {addr_contexts[0].prefix[0]=0xaa;addr_contexts[0].prefix[1]=0xaa;}

--- a/platform/avr-atmega128rfa1/contiki-main.c
+++ b/platform/avr-atmega128rfa1/contiki-main.c
@@ -338,7 +338,7 @@ uint8_t i;
 #if 0
 {  
   uip_ip6addr_t ipaddr;
-  uip_ip6addr(&ipaddr, 0xaaaa, 0, 0, 0, 0, 0, 0, 0);
+  uip_ip6addr(&ipaddr, 0xfc00, 0, 0, 0, 0, 0, 0, 0);
   uip_ds6_addr_add(&ipaddr, 0, ADDR_AUTOCONF);
 //  uip_ds6_prefix_add(&ipaddr,64,0);
 }

--- a/platform/avr-raven/apps/raven-ipso/raven-ipso.c
+++ b/platform/avr-raven/apps/raven-ipso/raven-ipso.c
@@ -97,7 +97,7 @@ raven_ping6(void)
   /* ping ipv6.google.com*/
   uip_ip6addr(&ping_addr,0x2001,0x420,0x5FFF,0x7D,0x2D0,0xB7FF,0xFE23,0xE6DB);
   //uip_ip6addr(&ping_addr, 0x2001, 0x4860, 0, 0x2001, 0, 0, 0, 0x68);
-  //uip_ip6addr(&ping_addr, 0xaaaa, 0, 0, 0, 0, 0, 0, 1);
+  //uip_ip6addr(&ping_addr, 0xfc00, 0, 0, 0, 0, 0, 0, 1);
   
   UIP_IP_BUF->vtc = 0x60;
   UIP_IP_BUF->tcflow = 1;

--- a/platform/avr-raven/contiki-conf.h
+++ b/platform/avr-raven/contiki-conf.h
@@ -175,7 +175,7 @@ typedef unsigned short uip_stats_t;
 #define UIP_CONF_LLH_LEN         0
 
 /* 10 bytes per stateful address context - see sicslowpan.c */
-/* Default is 1 context with prefix aaaa::/64 */
+/* Default is 1 context with prefix fc00::/64 */
 /* These must agree with all the other nodes or there will be a failure to communicate! */
 #define SICSLOWPAN_CONF_MAX_ADDR_CONTEXTS 1
 #define SICSLOWPAN_CONF_ADDR_CONTEXT_0 {addr_contexts[0].prefix[0]=0xaa;addr_contexts[0].prefix[1]=0xaa;}

--- a/platform/avr-raven/contiki-raven-default-init-net.c
+++ b/platform/avr-raven/contiki-raven-default-init-net.c
@@ -44,7 +44,7 @@ init_net(void)
 
 /*  uip_ipaddr_t ipprefix;
 
-  uip_ip6addr(&ipprefix, 0xaaaa, 0, 0, 0, 0, 0, 0, 0);
+  uip_ip6addr(&ipprefix, 0xfc00, 0, 0, 0, 0, 0, 0, 0);
 
   uip_netif_addr_add(&ipprefix, UIP_DEFAULT_PREFIX_LEN, 0, AUTOCONF);
   uip_nd6_prefix_add(&ipprefix, UIP_DEFAULT_PREFIX_LEN, 0);

--- a/platform/avr-raven/contiki-raven-main.c
+++ b/platform/avr-raven/contiki-raven-main.c
@@ -353,7 +353,7 @@ uint8_t i;
 #if 0
 {  
   uip_ip6addr_t ipaddr;
-  uip_ip6addr(&ipaddr, 0xaaaa, 0, 0, 0, 0, 0, 0, 0);
+  uip_ip6addr(&ipaddr, 0xfc00, 0, 0, 0, 0, 0, 0, 0);
   uip_ds6_addr_add(&ipaddr, 0, ADDR_AUTOCONF);
 //  uip_ds6_prefix_add(&ipaddr,64,0);
 }

--- a/platform/avr-ravenusb/contiki-conf.h
+++ b/platform/avr-ravenusb/contiki-conf.h
@@ -245,7 +245,7 @@ extern void mac_log_802_15_4_rx(const uint8_t* buffer, size_t total_len);
 #define UIP_CONF_BUFSIZE		 UIP_LINK_MTU + UIP_LLH_LEN + 4   /* +4 for vlan on macosx */
 
 /* 10 bytes per stateful address context - see sicslowpan.c */
-/* Default is 1 context with prefix aaaa::/64 */
+/* Default is 1 context with prefix fc00::/64 */
 /* These must agree with all the other nodes or there will be a failure to communicate! */
 #//define SICSLOWPAN_CONF_MAX_ADDR_CONTEXTS 1
 #define SICSLOWPAN_CONF_ADDR_CONTEXT_0 {addr_contexts[0].prefix[0]=0xaa;addr_contexts[0].prefix[1]=0xaa;}

--- a/platform/cc2530dk/contiki-conf.h
+++ b/platform/cc2530dk/contiki-conf.h
@@ -256,10 +256,6 @@
 
 /* Define our IPv6 prefixes/contexts here */
 #define SICSLOWPAN_CONF_MAX_ADDR_CONTEXTS    1
-#define SICSLOWPAN_CONF_ADDR_CONTEXT_0 { \
-  addr_contexts[0].prefix[0] = 0xaa; \
-  addr_contexts[0].prefix[1] = 0xaa; \
-}
 
 #define MAC_CONF_CHANNEL_CHECK_RATE          8
 

--- a/platform/cc2538dk/contiki-conf.h
+++ b/platform/cc2538dk/contiki-conf.h
@@ -486,12 +486,6 @@ typedef uint32_t rtimer_clock_t;
 
 /* Define our IPv6 prefixes/contexts here */
 #define SICSLOWPAN_CONF_MAX_ADDR_CONTEXTS    1
-#ifndef SICSLOWPAN_CONF_ADDR_CONTEXT_0
-#define SICSLOWPAN_CONF_ADDR_CONTEXT_0 { \
-  addr_contexts[0].prefix[0] = 0xaa; \
-  addr_contexts[0].prefix[1] = 0xaa; \
-}
-#endif
 
 #define MAC_CONF_CHANNEL_CHECK_RATE          8
 

--- a/platform/cooja/contiki-cooja-main.c
+++ b/platform/cooja/contiki-cooja-main.c
@@ -307,7 +307,7 @@ contiki_init()
     if(1) {
       uip_ipaddr_t ipaddr;
       int i;
-      uip_ip6addr(&ipaddr, 0xaaaa, 0, 0, 0, 0, 0, 0, 0);
+      uip_ip6addr(&ipaddr, 0xfc00, 0, 0, 0, 0, 0, 0, 0);
       uip_ds6_set_addr_iid(&ipaddr, &uip_lladdr);
       uip_ds6_addr_add(&ipaddr, 0, ADDR_TENTATIVE);
       printf("Tentative global IPv6 address ");

--- a/platform/exp5438/contiki-exp5438-main.c
+++ b/platform/exp5438/contiki-exp5438-main.c
@@ -236,7 +236,7 @@ main(int argc, char **argv)
   if(!UIP_CONF_IPV6_RPL) {
     uip_ipaddr_t ipaddr;
     int i;
-    uip_ip6addr(&ipaddr, 0xaaaa, 0, 0, 0, 0, 0, 0, 0);
+    uip_ip6addr(&ipaddr, 0xfc00, 0, 0, 0, 0, 0, 0, 0);
     uip_ds6_set_addr_iid(&ipaddr, &uip_lladdr);
     uip_ds6_addr_add(&ipaddr, 0, ADDR_TENTATIVE);
     printf("Tentative global IPv6 address ");

--- a/platform/iris/init-net.c
+++ b/platform/iris/init-net.c
@@ -177,7 +177,7 @@ init_net(void)
   if(!UIP_CONF_IPV6_RPL) {
     uip_ipaddr_t ipaddr;
     int i;
-    uip_ip6addr(&ipaddr, 0xaaaa, 0, 0, 0, 0, 0, 0, 0);
+    uip_ip6addr(&ipaddr, 0xfc00, 0, 0, 0, 0, 0, 0, 0);
     uip_ds6_set_addr_iid(&ipaddr, &uip_lladdr);
     uip_ds6_addr_add(&ipaddr, 0, ADDR_TENTATIVE);
     printf_P(PSTR("Tentative global IPv6 address "));

--- a/platform/mbxxx/contiki-main.c
+++ b/platform/mbxxx/contiki-main.c
@@ -224,7 +224,7 @@ main(void)
   if(!UIP_CONF_IPV6_RPL) {
     uip_ipaddr_t ipaddr;
     int i;
-    uip_ip6addr(&ipaddr, 0xaaaa, 0, 0, 0, 0, 0, 0, 0);
+    uip_ip6addr(&ipaddr, 0xfc00, 0, 0, 0, 0, 0, 0, 0);
     uip_ds6_set_addr_iid(&ipaddr, &uip_lladdr);
     uip_ds6_addr_add(&ipaddr, 0, ADDR_TENTATIVE);
     printf("Tentative global IPv6 address ");

--- a/platform/micaz/init-net.c
+++ b/platform/micaz/init-net.c
@@ -175,7 +175,7 @@ init_net(void)
   if(!UIP_CONF_IPV6_RPL) {
     uip_ipaddr_t ipaddr;
     int i;
-    uip_ip6addr(&ipaddr, 0xaaaa, 0, 0, 0, 0, 0, 0, 0);
+    uip_ip6addr(&ipaddr, 0xfc00, 0, 0, 0, 0, 0, 0, 0);
     uip_ds6_set_addr_iid(&ipaddr, &uip_lladdr);
     uip_ds6_addr_add(&ipaddr, 0, ADDR_TENTATIVE);
     printf_P(PSTR("Tentative global IPv6 address "));

--- a/platform/minimal-net/contiki-main.c
+++ b/platform/minimal-net/contiki-main.c
@@ -281,7 +281,7 @@ main(int argc, char **argv)
 #ifdef HARD_CODED_ADDRESS
     uiplib_ipaddrconv(HARD_CODED_ADDRESS, &ipaddr);
 #else
-    uip_ip6addr(&ipaddr, 0xaaaa, 0, 0, 0, 0, 0, 0, 0);
+    uip_ip6addr(&ipaddr, 0xfc00, 0, 0, 0, 0, 0, 0, 0);
 #endif
     if((ipaddr.u16[0] != 0) ||
        (ipaddr.u16[1] != 0) ||

--- a/platform/sky/contiki-sky-main.c
+++ b/platform/sky/contiki-sky-main.c
@@ -316,7 +316,7 @@ main(int argc, char **argv)
   if(!UIP_CONF_IPV6_RPL) {
     uip_ipaddr_t ipaddr;
     int i;
-    uip_ip6addr(&ipaddr, 0xaaaa, 0, 0, 0, 0, 0, 0, 0);
+    uip_ip6addr(&ipaddr, 0xfc00, 0, 0, 0, 0, 0, 0, 0);
     uip_ds6_set_addr_iid(&ipaddr, &uip_lladdr);
     uip_ds6_addr_add(&ipaddr, 0, ADDR_TENTATIVE);
     printf("Tentative global IPv6 address ");

--- a/platform/wismote/contiki-wismote-main.c
+++ b/platform/wismote/contiki-wismote-main.c
@@ -321,7 +321,7 @@ main(int argc, char **argv)
   if(!UIP_CONF_IPV6_RPL) {
     uip_ipaddr_t ipaddr;
     int i;
-    uip_ip6addr(&ipaddr, 0xaaaa, 0, 0, 0, 0, 0, 0, 0);
+    uip_ip6addr(&ipaddr, 0xfc00, 0, 0, 0, 0, 0, 0, 0);
     uip_ds6_set_addr_iid(&ipaddr, &uip_lladdr);
     uip_ds6_addr_add(&ipaddr, 0, ADDR_TENTATIVE);
     printf("Tentative global IPv6 address ");

--- a/platform/z1/contiki-z1-main.c
+++ b/platform/z1/contiki-z1-main.c
@@ -331,7 +331,7 @@ main(int argc, char **argv)
   if(!UIP_CONF_IPV6_RPL) {
     uip_ipaddr_t ipaddr;
     int i;
-    uip_ip6addr(&ipaddr, 0xaaaa, 0, 0, 0, 0, 0, 0, 0);
+    uip_ip6addr(&ipaddr, 0xfc00, 0, 0, 0, 0, 0, 0, 0);
     uip_ds6_set_addr_iid(&ipaddr, &uip_lladdr);
     uip_ds6_addr_add(&ipaddr, 0, ADDR_TENTATIVE);
     printf("Tentative global IPv6 address ");

--- a/regression-tests/11-ipv6/code/receiver/udp-receiver.c
+++ b/regression-tests/11-ipv6/code/receiver/udp-receiver.c
@@ -39,7 +39,7 @@ PROCESS_THREAD(udp_process, ev, data)
 
   PROCESS_BEGIN();
 
-  uip_ip6addr(&addr, 0xaaaa, 0, 0, 0, 0, 0, 0, 2);
+  uip_ip6addr(&addr, 0xfc00, 0, 0, 0, 0, 0, 0, 2);
   uip_ds6_addr_add(&addr, 0, ADDR_AUTOCONF);
 
   simple_udp_register(&broadcast_connection, UDP_PORT,

--- a/regression-tests/11-ipv6/code/sender/unicast-sender.c
+++ b/regression-tests/11-ipv6/code/sender/unicast-sender.c
@@ -40,12 +40,12 @@ PROCESS_THREAD(udp_process, ev, data)
 
   PROCESS_BEGIN();
 
-  uip_ip6addr(&addr, 0xaaaa, 0, 0, 0, 0, 0, 0, 3);
+  uip_ip6addr(&addr, 0xfc00, 0, 0, 0, 0, 0, 0, 3);
   uip_ds6_addr_add(&addr, 0, ADDR_AUTOCONF);
 
   rpl_set_root(RPL_DEFAULT_INSTANCE, &addr);
   /*  dag = rpl_get_any_dag();
-  uip_ip6addr(&prefix, 0xaaaa, 0, 0, 0, 0, 0, 0, 0);
+  uip_ip6addr(&prefix, 0xfc00, 0, 0, 0, 0, 0, 0, 0);
   rpl_set_prefix(dag, &prefix, 64);*/
 
 
@@ -63,7 +63,7 @@ PROCESS_THREAD(udp_process, ev, data)
     etimer_reset(&periodic_timer);
 
     printf("Sending unicast\n");
-    uip_ip6addr(&addr, 0xaaaa, 0, 0, 0, 0, 0, 0, 2);
+    uip_ip6addr(&addr, 0xfc00, 0, 0, 0, 0, 0, 0, 2);
     simple_udp_sendto(&broadcast_connection, buf, sizeof(buf), &addr);
   }
 

--- a/regression-tests/12-rpl/code/receiver-node.c
+++ b/regression-tests/12-rpl/code/receiver-node.c
@@ -73,7 +73,7 @@ set_global_address(void)
   int i;
   uint8_t state;
 
-  uip_ip6addr(&ipaddr, 0xaaaa, 0, 0, 0, 0, 0, 0, 0);
+  uip_ip6addr(&ipaddr, 0xfc00, 0, 0, 0, 0, 0, 0, 0);
   uip_ds6_set_addr_iid(&ipaddr, &uip_lladdr);
   uip_ds6_addr_add(&ipaddr, 0, ADDR_AUTOCONF);
 

--- a/regression-tests/12-rpl/code/root-node.c
+++ b/regression-tests/12-rpl/code/root-node.c
@@ -77,7 +77,7 @@ set_global_address(void)
   int i;
   uint8_t state;
 
-  uip_ip6addr(&ipaddr, 0xaaaa, 0, 0, 0, 0, 0, 0, 0);
+  uip_ip6addr(&ipaddr, 0xfc00, 0, 0, 0, 0, 0, 0, 0);
   uip_ds6_set_addr_iid(&ipaddr, &uip_lladdr);
   uip_ds6_addr_add(&ipaddr, 0, ADDR_AUTOCONF);
 
@@ -106,7 +106,7 @@ create_rpl_dag(uip_ipaddr_t *ipaddr)
     
     rpl_set_root(RPL_DEFAULT_INSTANCE, ipaddr);
     dag = rpl_get_any_dag();
-    uip_ip6addr(&prefix, 0xaaaa, 0, 0, 0, 0, 0, 0, 0);
+    uip_ip6addr(&prefix, 0xfc00, 0, 0, 0, 0, 0, 0, 0);
     rpl_set_prefix(dag, &prefix, 64);
     PRINTF("created a new RPL dag\n");
   } else {

--- a/regression-tests/12-rpl/code/sender-node.c
+++ b/regression-tests/12-rpl/code/sender-node.c
@@ -72,7 +72,7 @@ set_global_address(void)
   int i;
   uint8_t state;
 
-  uip_ip6addr(&ipaddr, 0xaaaa, 0, 0, 0, 0, 0, 0, 0);
+  uip_ip6addr(&ipaddr, 0xfc00, 0, 0, 0, 0, 0, 0, 0);
   uip_ds6_set_addr_iid(&ipaddr, &uip_lladdr);
   uip_ds6_addr_add(&ipaddr, 0, ADDR_AUTOCONF);
 
@@ -109,7 +109,7 @@ PROCESS_THREAD(sender_node_process, ev, data)
 
     PROCESS_WAIT_EVENT_UNTIL(etimer_expired(&send_timer));
 
-    uip_ip6addr(&addr, 0xaaaa, 0, 0, 0, 0x0201, 0x001, 0x001, 0x001);
+    uip_ip6addr(&addr, 0xfc00, 0, 0, 0, 0x0201, 0x001, 0x001, 0x001);
 
     {
       static unsigned int message_number;

--- a/regression-tests/13-ipv6-apps/rest_rpl_coap.js
+++ b/regression-tests/13-ipv6-apps/rest_rpl_coap.js
@@ -1,8 +1,8 @@
 TIMEOUT(300000);
 
 /* conf */
-ADDRESS_ROUTER = "aaaa::212:7401:1:101";
-ADDRESS_SERVER = "aaaa::212:7402:2:202";
+ADDRESS_ROUTER = "fc00::212:7401:1:101";
+ADDRESS_SERVER = "fc00::212:7402:2:202";
 NR_PINGS = 10;
 CMD_PING_PREFIX = "ping6 -c " + NR_PINGS + " -I tun0 ";
 CMD_TUNNEL = "make connect-router-cooja";

--- a/regression-tests/13-ipv6-apps/x02-sky-coap.csc
+++ b/regression-tests/13-ipv6-apps/x02-sky-coap.csc
@@ -181,14 +181,14 @@ PROCESS_CONF_NO_PROCESS_NAMES=1
 
 The test script communicates with the REST server via the RPL border router using external commands.
 (* $ make connect-router-cooja)
-* $ ping6 -c 10 -I tun0 aaaa::212:7401:1:101
-* $ ping6 -c 10 -I tun0 aaaa::212:7402:2:202
-* $ wget -t 1 -T 10 -O - http://[aaaa::212:7402:2:202]
+* $ ping6 -c 10 -I tun0 fc00::212:7401:1:101
+* $ ping6 -c 10 -I tun0 fc00::212:7402:2:202
+* $ wget -t 1 -T 10 -O - http://[fc00::212:7402:2:202]
 
 The final test uses the CoAP Java implementation by Matthias Kovatsch, downloaded from:
 https://github.com/mkovatsc/Californium/blob/master/run/ExampleClient.jar
-* $ java -jar ExampleClient.jar DISCOVER coap://[aaaa::212:7402:2:202]
-* $ java -jar ExampleClient.jar GET coap://[aaaa::212:7402:2:202]/hello</notes>
+* $ java -jar ExampleClient.jar DISCOVER coap://[fc00::212:7402:2:202]
+* $ java -jar ExampleClient.jar GET coap://[fc00::212:7402:2:202]/hello</notes>
       <decorations>true</decorations>
     </plugin_config>
     <width>751</width>

--- a/tools/tunslip6.c
+++ b/tools/tunslip6.c
@@ -760,7 +760,7 @@ main(int argc, char **argv)
     case 'h':
     default:
 fprintf(stderr,"usage:  %s [options] ipaddress\n", prog);
-fprintf(stderr,"example: tunslip6 -L -v2 -s ttyUSB1 aaaa::1/64\n");
+fprintf(stderr,"example: tunslip6 -L -v2 -s ttyUSB1 fc00::1/64\n");
 fprintf(stderr,"Options are:\n");
 #ifndef __APPLE__
 fprintf(stderr," -B baudrate    9600,19200,38400,57600,115200 (default),230400,460800,921600\n");


### PR DESCRIPTION
Ever since 2008, the Contiki code has used an unauthorized IPv6 prefix `aaaa::0/?`, which at the time was picked for lack of a better prefix.

This pull request changes the default prefix to `fc00::0/7`, which is the unique local prefix as defined by RFC4193. Unique local addresses should not be globally routed, but may be used internally within a network or an organization, and makes a lot of sense to use as the default prefix in Contiki.