### PR TITLE
core: Don't default UIP_CONF_BUFFER_SIZE to just 128 bytes.

### DIFF
--- a/core/contiki-default-conf.h
+++ b/core/contiki-default-conf.h
@@ -117,13 +117,6 @@
 #define UIP_CONF_IPV6 0
 #endif /* UIP_CONF_IPV6 */
 
-/* UIP_CONF_BUFFER_SIZE specifies how much memory should be reserved
-   for the uIP packet buffer. This sets an upper bound on the largest
-   IP packet that can be received by the system. */
-#ifndef UIP_CONF_BUFFER_SIZE
-#define UIP_CONF_BUFFER_SIZE 128
-#endif /* UIP_CONF_BUFFER_SIZE */
-
 /* UIP_CONF_ROUTER specifies if the IPv6 node should be a router or
    not. By default, all Contiki nodes are routers. */
 #ifndef UIP_CONF_ROUTER


### PR DESCRIPTION
Setting the uIP buffer size to 128 bytes is rather unreasonable,
especially for IPv6. uIP already manages default values for
macros like these. If a platform is really so constrained,
it can set this parameter itself in it's own `contiki-config.h`.