### PR TITLE
Quick travis fail fix: leds_toggle()

### DIFF
--- a/examples/er-rest-example/resources/res-toggle.c
+++ b/examples/er-rest-example/resources/res-toggle.c
@@ -58,6 +58,6 @@ RESOURCE(res_toggle,
 static void
 res_post_handler(void *request, void *response, uint8_t *buffer, uint16_t preferred_size, int32_t *offset)
 {
-  leds_invert(LEDS_RED);
+  leds_toggle(LEDS_RED);
 }
 #endif /* PLATFORM_HAS_LEDS */


### PR DESCRIPTION
Pull request https://github.com/contiki-os/contiki/pull/511 updated the `leds` API, but was based on an earlier version of the code than the current master, so the pull request didn't change all instances of `leds_invert()`. 

This pull request fixes the last remaining `leds_invert()` to `leds_toggle()` and should make travis happy again.
