### PR TITLE
rl78: Change RIMEADDR_CONF_SIZE to LINKADDR_CONF_SIZE

### DIFF
--- a/platform/eval-adf7xxxmb4z/contiki-conf.h
+++ b/platform/eval-adf7xxxmb4z/contiki-conf.h
@@ -56,7 +56,7 @@
 #define PLATFORM_HAS_LEDS   0 /* TODO */
 #define PLATFORM_HAS_BUTTON 1
 
-#define RIMEADDR_CONF_SIZE              8
+#define LINKADDR_CONF_SIZE              8
 
 #if WITH_UIP6
 /* Network setup for IPv6 */
@@ -121,7 +121,7 @@
 
 #ifdef WITH_UIP6
 
-#define RIMEADDR_CONF_SIZE              8
+#define LINKADDR_CONF_SIZE              8
 
 #define UIP_CONF_LL_802154              1
 #define UIP_CONF_LLH_LEN                0


### PR DESCRIPTION
Because the rimeaddr module was renamed to linkaddr.
