### PR TITLE
Now uses the declared variable for the print line rather than 'v' which ...

### DIFF
--- a/examples/z1sp/test-potentiometer.c
+++ b/examples/z1sp/test-potentiometer.c
@@ -56,7 +56,7 @@ PROCESS_THREAD(test_potent_process, ev, data)
   while(1) {
     uint16_t value = potentiometer_sensor.value(0);
 
-    printf("Potentiometer Value: %i\n", value);
+    printf("Potentiometer Value: %u\n", (uint)value);
   }
 
   SENSORS_DEACTIVATE(potentiometer_sensor);


### PR DESCRIPTION
...was causing it to fail at the compilation stage
