### PR TITLE
Added support for SPI slave and SPI-accel drivers

### DIFF
--- a/cpu/cc2538/spi-arch.h
+++ b/cpu/cc2538/spi-arch.h
@@ -63,11 +63,11 @@
 #error "You must include spi-arch.h before spi.h for the CC2538."
 #endif
 #define SPI_FLUSH() do { \
-  SPI_WAITFOREORx(); \
   while (REG(SSI0_BASE + SSI_SR) & SSI_SR_RNE) { \
     SPI_RXBUF; \
   } \
 } while(0)
+
 
 #define SPI_CS_CLR(port, pin) do { \
   GPIO_CLR_PIN(GPIO_PORT_TO_BASE(port), GPIO_PIN_MASK(pin)); \
@@ -84,7 +84,7 @@
 /**
  * \brief Configure a GPIO to be the chip select pin
  */
-void spi_cs_init(uint8_t port, uint8_t pin);
+void spi_cs_init(uint8_t port, uint8_t pin, uint8_t soft_control);
 
 /** \brief Enables the SPI peripheral
  */
@@ -115,6 +115,13 @@ void spi_disable(void);
  */
 void spi_set_mode(uint32_t frame_format, uint32_t clock_polarity,
                   uint32_t clock_phase, uint32_t data_size);
+
+/** \interrupt called functions
+ * \note input is called when buffer is receiving and reset when transmission is terminated.
+ */
+#if SSI_MODE_SLAVE
+void ssi_set_input(int(* input)(void));
+#endif
 
 /** @} */
 

--- a/examples/cc2538dk/accel/Makefile
+++ b/examples/cc2538dk/accel/Makefile
@@ -1,0 +1,9 @@
+DEFINES+=PROJECT_CONF_H=\"project-conf.h\"
+
+CONTIKI_PROJECT = accelerometer
+
+all: $(CONTIKI_PROJECT)
+
+CONTIKI = ../../..
+
+include $(CONTIKI)/Makefile.include

--- a/examples/cc2538dk/accel/accelerometer.c
+++ b/examples/cc2538dk/accel/accelerometer.c
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2013, Loughborough University.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+/**
+ * \addtogroup cc2538-examples
+ * @{
+ *
+ *
+ * \defgroup cc2538-spi cc2538dk accelerometer Project
+ *
+ *    This example tests the correct functionality of RF06 accelerometer
+ *
+ * @{
+ *
+ * \file
+ *         Tests related accelerometer
+ *
+ *
+ * \author
+ *         Vasilis Michopoulos <basilismicho@gmail.com>
+ */
+
+#include "contiki.h"
+#include "contiki-lib.h"
+#include "sys/clock.h"
+#include "sys/rtimer.h"
+#include "dev/accel-sensor.h"
+#include "dev/leds.h"
+
+/*---------------------------------------------------------------------------*/
+
+#define DEBUG DEBUG_PRINT
+#include "net/ip/uip-debug.h"
+#include "dev/watchdog.h"
+
+/*---------------------------------------------------------------------------*/
+PROCESS(accelerometer_process, "accelerometer process");
+AUTOSTART_PROCESSES(&accelerometer_process);
+/*---------------------------------------------------------------------------*/
+PROCESS_THREAD(accelerometer_process, ev, data) {
+
+  static struct etimer et;
+  PROCESS_BEGIN();
+
+  etimer_set(&et, CLOCK_SECOND);
+  accel_sensor.configure(SENSORS_HW_INIT, 1);
+
+  while(1) {
+    PROCESS_YIELD();
+    if(etimer_expired(&et)) {
+      etimer_restart(&et);
+
+      PRINTF("(X,Y,Z): (%d,%d,%d)\n", accel_sensor.value(ACC_X_AXIS),
+             accel_sensor.value(ACC_Y_AXIS),
+             accel_sensor.value(ACC_Z_AXIS));
+
+      PRINTF("tmp: (%x)\n", accel_sensor.value(ACC_TMP));
+
+      leds_toggle(LEDS_RED);
+    }
+  }
+
+  PROCESS_END();
+}
+/*---------------------------------------------------------------------------*/
+/**
+ * @}
+ * @}
+ */

--- a/examples/cc2538dk/accel/project-conf.h
+++ b/examples/cc2538dk/accel/project-conf.h
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2013, Loughborough University
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+/**
+ * \addtogroup cc2538-examples
+ * @{
+ *
+ * \file
+ * Project specific configuration defines for SPI examples
+ * \author
+ *         Vasilis Michopoulos <basilismicho@gmail.com>
+ */
+
+#ifndef PROJECT_CONF_H_
+#define PROJECT_CONF_H_
+
+#define NETSTACK_CONF_RDC     nullrdc_driver
+
+/*---------------------------------------------------------------------------*/
+/*
+ * set SPI to master
+ */
+#ifndef SSI_MODE_SLAVE
+#define SSI_MODE_SLAVE  0
+#else
+#undef SSI_MODE_SLAVE
+#define SSI_MODE_SLAVE  0
+#endif
+
+#define SLIP_ARCH_CONF_USB          0 /**< SLIP over UART by default */
+#define DBG_CONF_USB                0 /**< All debugging over UART by default */
+
+#endif /* PROJECT_CONF_H_ */
+
+/** @} */

--- a/examples/cc2538dk/spi-slave/Makefile
+++ b/examples/cc2538dk/spi-slave/Makefile
@@ -1,0 +1,10 @@
+DEFINES+=PROJECT_CONF_H=\"project-conf.h\"
+UIP_CONF_IPV6=1
+UIP_CONF_RPL=1
+CONTIKI_PROJECT = spi-srv
+
+all: $(CONTIKI_PROJECT)
+
+CONTIKI = ../../..
+
+include $(CONTIKI)/Makefile.include

--- a/examples/cc2538dk/spi-slave/project-conf.h
+++ b/examples/cc2538dk/spi-slave/project-conf.h
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2013, Loughborough University
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+/**
+ * \addtogroup cc2538-examples
+ * @{
+ *
+ * \file
+ * Project specific configuration defines for SPI examples
+ * \author
+ *         Vasilis Michopoulos <basilismicho@gmail.com>
+ */
+
+#ifndef PROJECT_CONF_H_
+#define PROJECT_CONF_H_
+
+#define NETSTACK_CONF_RDC     nullrdc_driver
+
+/*---------------------------------------------------------------------------*/
+/*
+ * Define SPI master or SLAVE
+ */
+#ifndef SSI_MODE_SLAVE
+#define SSI_MODE_SLAVE  1
+#endif
+
+/*
+ * Enable or disable interrupts
+ */
+#if   SSI_MODE_SLAVE
+
+/*transmission over ipv6*/
+#define SPI_FW            1
+
+#if LPM_CONF_ENABLE
+#undef LPM_CONF_ENABLE
+#define LPM_CONF_ENABLE 0
+#else
+#define LPM_CONF_ENABLE 0
+#endif
+#endif
+
+#define SLIP_ARCH_CONF_USB          0 /**< SLIP over UART by default */
+#define DBG_CONF_USB                0 /**< All debugging over UART by default */
+
+#endif /* PROJECT_CONF_H_ */
+
+/** @} */

--- a/examples/cc2538dk/spi-slave/spi-srv.c
+++ b/examples/cc2538dk/spi-slave/spi-srv.c
@@ -1,0 +1,280 @@
+/*
+ * Copyright (c) 2013, Loughborough University.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+/**
+ * \addtogroup cc2538-examples
+ * @{
+ *
+ * @{
+ *
+ * \defgroup cc2538-spi cc2538dk SPI Test Project
+ *
+ *    This example tests the correct functionality of SPI interface in both Master
+ *    and Slave mode.
+ *
+ *    More specifically, it is a very basic example testing
+ *     SPI in master and slave modes as well as
+ *    their ISR functionality
+ *
+ *    This example will not work as it is if multiple SPI devices are connected at the same time.
+ *    its ment to work with 2 devices master and slave
+ *
+ * @{
+ *
+ * \file
+ *         Tests related to SPI interface
+ *
+ *
+ * \author
+ *         Vasilis Michopoulos <basilismicho@gmail.com>
+ */
+
+#include "contiki.h"
+#include "contiki-lib.h"
+#include "contiki-net.h"
+#include "sys/clock.h"
+#include "sys/rtimer.h"
+#include "dev/leds.h"
+#include "spi-arch.h"
+#include "dev/spi.h"
+#include "dev/gpio.h"
+
+#include <string.h>
+/*---------------------------------------------------------------------------*/
+#define SIZE 30
+#define FIFO 4		// This can either be set to 4(half FIFO interrupt trigger or fully pre-load FIFO by setting this to 8)
+#define DEBUG DEBUG_PRINT
+#include "net/ip/uip-debug.h"
+#include "dev/watchdog.h"
+#include "net/rpl/rpl.h"
+/*---------------------------------------------------------------------------*/
+#if SPI_FW
+#define MAX_PAYLOAD_LEN 120
+#define UDP_SERVER_PORT 60000
+#define UDP_CLIENT_PORT 60001
+#define UIP_IP_BUF   ((struct uip_ip_hdr *)&uip_buf[UIP_LLH_LEN])
+#define UIP_UDP_BUF  ((struct uip_udp_hdr *)&uip_buf[uip_l2_l3_hdr_len])
+/*---------------------------------------------------------------------------*/
+static struct uip_udp_conn *client_conn;
+static uip_ipaddr_t server_ipaddr;
+static void send_packet(void);
+/*---------------------------------------------------------------------------*/
+#endif
+
+#if SSI_MODE_SLAVE
+static uint16_t spi_len= 0;
+static uint16_t udp_len= 0;
+static uint8_t data_received = 1;
+#endif
+
+static uint8_t tx_data[SIZE];
+static uint8_t rx_data[SIZE];
+
+
+/*---------------------------------------------------------------------------*/
+PROCESS(spi_test_process, "SPI test process");
+AUTOSTART_PROCESSES(&spi_test_process);
+
+#if SSI_MODE_SLAVE
+/*---------------------------------------------------------------------------*/
+int
+ssi_input(void)
+{
+	spi_len = 0;
+  while(spi_len < SIZE){
+	while(!(REG(SSI0_BASE + SSI_SR) & SSI_SR_RNE));
+    rx_data[spi_len] = SPI_RXBUF;
+
+    /*buffer has been pre-loaded since interrupt doesn't trigger from byte 1
+     * Wait until you have transmitted the pre-loaded values before u add extra data
+     *
+     ***This (len + FIFO) < SIZE is to ensure we wont write more data
+     ***Than we want to transmit as slave (since we pre-load 4 bytes)
+     * Additionally, it will only work as long as the data transmitted from Slave
+     * are <= bytes than the data to be transmitted by the master
+     * Since slave will only transmit upon reception this is a
+     * realistic assumption (if you want to transmit more data than masters
+     * transmission it has to be done over multiple master transmissions)*/
+    if((spi_len + FIFO) < SIZE) {
+      SPI_TXBUF = tx_data[spi_len + FIFO];
+    }
+    spi_len++;
+  }
+  data_received = 1;
+  return 0;
+}
+/*---------------------------------------------------------------------------*/
+void
+ssi_reset(void)
+{
+  data_received = 0;
+  udp_len = 0;
+
+#if SPI_FW
+  send_packet();
+#endif
+  int i;
+  PRINTF("receiving");
+  for(i = 0; i < SIZE; i++) {
+    PRINTF("%x:", rx_data[i]);
+  }
+  PRINTF("\n");
+
+	memset(tx_data, 0, SIZE);
+	memset(rx_data, 0, SIZE);
+  /*reset TX/RX FIFO*/
+  SPI_FLUSH();
+
+}
+/*---------------------------------------------------------------------------*/
+#endif
+
+#if SPI_FW
+/*---------------------------------------------------------------------------*/
+static void
+send_packet(void)
+{
+  char buf[spi_len + 1];
+  memset(buf, 0, sizeof(buf));
+  memcpy(buf, rx_data, spi_len);
+  uip_udp_packet_sendto(client_conn, buf, sizeof(buf),
+                        &server_ipaddr, UIP_HTONS(UDP_SERVER_PORT));
+}
+/*---------------------------------------------------------------------------*/
+static void
+tcpip_handler(void)
+{
+	char * rep = "OK";
+	uint8_t i;
+	if(uip_newdata()) {
+		udp_len = uip_datalen();
+		memcpy(tx_data, uip_appdata, udp_len);
+
+		PRINTF("received %u bytes:", udp_len);
+		  for(i = 0; i < udp_len; i++) {
+			PRINTF("%x :", tx_data[i]);
+		  }
+		PRINTF("\n");
+
+
+		  /*pre-load transmission buffer since interrupt is triggered at 4 bytes*/
+		  for(i = 0; i < FIFO; i++) {
+		    SPI_TXBUF = tx_data[i];
+		  }
+
+		/*reply*/
+		uip_udp_packet_sendto(client_conn, rep , strlen(rep),
+				&UIP_IP_BUF->srcipaddr, UIP_UDP_BUF->srcport);
+	}
+	return;
+}
+/*---------------------------------------------------------------------------*/
+#endif
+
+PROCESS_THREAD(spi_test_process, ev, data) {
+  static struct etimer et;
+  PROCESS_BEGIN();
+
+#if SPI_FW
+  /* new connection with remote host */
+  client_conn = udp_new(NULL, UIP_HTONS(0), NULL);
+  if(client_conn == NULL) {
+    PRINTF("No UDP connection available, exiting the process!\n");
+    PROCESS_EXIT();
+  }
+  udp_bind(client_conn, UIP_HTONS(UDP_CLIENT_PORT));
+
+  uip_ip6addr(&server_ipaddr, 0xaaaa, 0, 0, 0, 0, 0, 0, 1);
+#endif
+
+#if SSI_MODE_SLAVE
+  ssi_set_input(ssi_input);
+  /*If slave clock is slower than master
+   * rx buffer will be over-written*/
+  etimer_set(&et, CLOCK_SECOND / 5);
+#else
+  etimer_set(&et, 3 * CLOCK_SECOND);
+  int8_t i = 0;
+#endif
+
+  memset(tx_data, 0, sizeof(tx_data));
+  memset(rx_data, 0, sizeof(rx_data));
+
+  spi_init();
+  /*GPIO_B= 1 PIN = 5 RF06 = RF1.17*/
+  spi_cs_init(1, 5, 1);
+
+  while(1) {
+    PROCESS_YIELD();
+#if SPI_FW
+    if(ev == tcpip_event) {
+      tcpip_handler();
+    }
+#endif
+
+    if(etimer_expired(&et)) {
+      etimer_reset(&et);
+
+#if SSI_MODE_SLAVE
+      if(data_received) {
+        /*Prepare for next SSI TX/RX*/
+        ssi_reset();
+      }
+#else
+      GPIO_CLR_PIN(GPIO_PORT_TO_BASE(1), GPIO_PIN_MASK(5));
+      for(i = 0; i < SIZE; i++) {
+        tx_data[i] = i;
+        SPI_WRITE(tx_data[i]);
+        rx_data[i] = SPI_RXBUF;
+      }
+      GPIO_SET_PIN(GPIO_PORT_TO_BASE(1), GPIO_PIN_MASK(5));
+
+      PRINTF("Sending:");
+      for(i = 0; i < SIZE; i++) {
+        PRINTF("%x", tx_data[i]);
+      }
+      PRINTF("\n");
+
+      PRINTF("Received:");
+      for(i = 0; i < SIZE; i++) {
+        PRINTF("%x", rx_data[i]);
+      }
+      PRINTF("\n");
+#endif
+
+      leds_toggle(LEDS_RED);
+    }
+  }
+
+  PROCESS_END();
+}
+/*---------------------------------------------------------------------------*/
+/**
+ * @}
+ * @}
+ */

--- a/platform/cc2538dk/Makefile.cc2538dk
+++ b/platform/cc2538dk/Makefile.cc2538dk
@@ -9,7 +9,7 @@ CONTIKI_TARGET_DIRS = . dev
 CONTIKI_TARGET_SOURCEFILES += leds.c leds-arch.c
 CONTIKI_TARGET_SOURCEFILES += contiki-main.c
 CONTIKI_TARGET_SOURCEFILES += sensors.c smartrf-sensors.c
-CONTIKI_TARGET_SOURCEFILES += button-sensor.c adc-sensor.c
+CONTIKI_TARGET_SOURCEFILES += button-sensor.c adc-sensor.c accel-sensor.c
 
 TARGET_START_SOURCEFILES += startup-gcc.c
 TARGET_STARTFILES = ${addprefix $(OBJECTDIR)/,${call oname, $(TARGET_START_SOURCEFILES)}}

--- a/platform/cc2538dk/dev/accel-sensor.c
+++ b/platform/cc2538dk/dev/accel-sensor.c
@@ -1,0 +1,241 @@
+/*
+ * Copyright (c) 2013, Loughborough University.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+/**
+ * \addtogroup cc2538dk-accelerometer
+ * @{
+ *
+ * \file
+ *         TDriver for the SmartRF06EB accelerometer
+ *
+ *
+ * \author
+ *         Vasilis Michopoulos <basilismicho@gmail.com>
+ */
+
+#include "contiki.h"
+#include "dev/accel-sensor.h"
+#include "sys/clock.h"
+#include "dev/ioc.h"
+#include "dev/gpio.h"
+#include "spi-arch.h"
+#include "dev/spi.h"
+
+#include <stdint.h>
+#include <stdio.h>
+/*---------------------------------------------------------------------------*/
+/**
+ * \brief read bytes function for the accelerometer.
+ *
+ * reads multiple bytes.
+ *
+ * TBD
+ */
+/*---------------------------------------------------------------------------*/
+/**
+ * \brief read byte function for the accelerometer.
+ *
+ * reads 1 bytes.
+ */
+void
+read_reg(uint8_t reg_addr, uint8_t * value)
+{
+  uint16_t tx_buf, rx_buf;
+  /*use type as ur read address and add the read mask*/
+  reg_addr |= ACC_READ_M;
+
+  tx_buf = (uint16_t)(reg_addr << 8);
+
+  /*wait for end of transmissions if any
+   * and empty RX FIFO*/
+  SPI_WAITFOREOTx();
+  SPI_FLUSH();
+
+#if SOFT_CS
+  GPIO_CLR_PIN(GPIO_PORT_TO_BASE(ACC_PORT), GPIO_PIN_MASK(ACC_CS_PIN));
+#endif
+  /*initiate communication with accelerometer*/
+	SPI_WRITE(tx_buf);
+	rx_buf = SPI_RXBUF;
+#if SOFT_CS
+  GPIO_SET_PIN(GPIO_PORT_TO_BASE(ACC_PORT), GPIO_PIN_MASK(ACC_CS_PIN));
+#endif
+
+  *value = (uint8_t) (rx_buf & 0xff);
+
+}
+/*---------------------------------------------------------------------------*/
+/**
+ * \brief read value function for the accelerometer.
+ *
+ * returns 1 reading
+ */
+static int
+value(int type)
+{
+  int ret = 0;
+  uint8_t tmp_buffer[2] = {0};
+  uint8_t reg_addr;
+  uint8_t tmp=0;
+
+  switch(type) {
+  case ACC_X_AXIS:
+    reg_addr = ACC_X_LSB;
+    break;
+  case ACC_Y_AXIS:
+    reg_addr = ACC_Y_LSB;
+    break;
+  case ACC_Z_AXIS:
+    reg_addr = ACC_Z_LSB;
+    break;
+  case ACC_TMP:
+    reg_addr = ACC_TEMP;
+    tmp = 1;
+    break;
+  default:
+    return 0;
+  }
+
+  if(!tmp){
+	  /*LSB and MSB bytes*/
+	  read_reg(reg_addr, &tmp_buffer[0]);
+	  /*wait for accel idle*/
+	  clock_delay_usec(6);
+	  read_reg((reg_addr + 1), &tmp_buffer[1]);
+
+	  /*after you read with read_bytes all the register values you want
+	   * ..Process them here...*/
+	  ret = (((int)(tmp_buffer[1]) << 2) | ((tmp_buffer[0] >> 6) & 0x03));
+  }else{
+	  read_reg(reg_addr, tmp_buffer);
+	  ret = (int) tmp_buffer[0];
+  }
+  return ret;
+}
+/*---------------------------------------------------------------------------*/
+/**
+ * \brief write byte function for the accelerometer.
+ *
+ * write 1 byte
+ */
+void
+write_reg(uint8_t reg_addr, uint8_t value)
+{
+  uint16_t tx_buf;
+  /*add the write mask*/
+  reg_addr |= ACC_WRITE_M;
+
+  tx_buf = (uint16_t)(reg_addr << 8) | value;
+
+  /*wait for end of transmissions if anny
+   * and empty RX FIFO*/
+  SPI_WAITFOREOTx();
+  SPI_FLUSH();
+
+#if SOFT_CS
+  GPIO_CLR_PIN(GPIO_PORT_TO_BASE(ACC_PORT), GPIO_PIN_MASK(ACC_CS_PIN));
+#endif
+  /*write byte to accelerometer*/
+  SPI_WRITE(tx_buf);
+#if SOFT_CS
+  GPIO_SET_PIN(GPIO_PORT_TO_BASE(ACC_PORT), GPIO_PIN_MASK(ACC_CS_PIN));
+#endif
+}
+/*---------------------------------------------------------------------------*/
+/**
+ * \brief on function for the accelerometer.
+ *
+ * power VDD
+ */
+void
+accel_on(void)
+{
+  GPIO_SET_PIN(GPIO_PORT_TO_BASE(ACC_PORT), GPIO_PIN_MASK(ACC_PWD_PIN));
+  /*wait 2ms in order to enable accelerometer*/
+  clock_delay_usec(2);
+}
+/*---------------------------------------------------------------------------*/
+/**
+ * \brief on function for the accelerometer.
+ *
+ * power off VDD
+ */
+void
+accel_off(void)
+{
+  GPIO_CLR_PIN(GPIO_PORT_TO_BASE(ACC_PORT), GPIO_PIN_MASK(ACC_PWD_PIN));
+}
+/*---------------------------------------------------------------------------*/
+static int
+configure(int type, int value)
+{
+  switch(type) {
+  case SENSORS_HW_INIT:
+    /*prepare PINS and SPI*/
+    spi_init();
+    spi_cs_init(ACC_PORT, ACC_CS_PIN, SOFT_CS);
+    /*with 8 bit data there were some complications
+     * 16 bit transmissions mode*/
+    spi_set_mode(0, 0x80,0x40, 16);
+
+    /*Configure PWD PIN*/
+    GPIO_SOFTWARE_CONTROL(GPIO_PORT_TO_BASE(ACC_PORT),
+                          GPIO_PIN_MASK(ACC_PWD_PIN));
+    ioc_set_over(ACC_PORT, ACC_PWD_PIN, IOC_OVERRIDE_DIS);
+    GPIO_SET_OUTPUT(GPIO_PORT_TO_BASE(ACC_PORT),
+                    GPIO_PIN_MASK(ACC_PWD_PIN));
+    accel_on();
+
+    /*set Range*/
+    write_reg(ACC_RANGE, ACC_RANGE_2G);
+    /*set filter detection bandwidth*/
+    write_reg(ACC_BW, ACC_BW_250HZ);
+
+    if(!value)
+      accel_off();
+    break;
+  case SENSORS_ACTIVE:
+    if(value) {
+      accel_on();
+    } else {
+      accel_off();
+    } break;
+  case SENSORS_INT:
+    /*TBD use write_reg to configure registers and GPIO to
+     * set the PINs to appropriate mode*/
+    break;
+  default:
+    return 0;
+  }
+  return 1;
+}
+/*---------------------------------------------------------------------------*/
+
+SENSORS_SENSOR(accel_sensor, ACCEL_SENSOR, value, configure, NULL);
+
+/** @} */

--- a/platform/cc2538dk/dev/accel-sensor.h
+++ b/platform/cc2538dk/dev/accel-sensor.h
@@ -1,0 +1,242 @@
+/*
+ * Copyright (c) 2014, Loughborough University.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+/**
+ * \addtogroup cc2538dk-accelerometer
+ * @{
+ *
+ * \file
+ *         TDriver for the SmartRF06EB accelerometer
+ *
+ *      Definitions based on the Foundation Firmware from
+ *      Texas Instruments.
+ * \author
+ *         Vasilis Michopoulos <basilismicho@gmail.com>
+ */
+
+#ifndef ACCEL_SENSOR_H_
+#define ACCEL_SENSOR_H_
+
+#include "lib/sensors.h"
+
+/*---------------------------------------------------------------------------*/
+/** \name ADC sensors
+ * @{
+ */
+extern const struct sensors_sensor accel_sensor;
+#define ACCEL_SENSOR "ACCELEROMETER"
+/** @} */
+/*---------------------------------------------------------------------------*/
+/** \name SPI accelerometer PIN
+ * @{
+ */
+#define ACC_PORT      	3 /*GPIO_D_NUM*/
+#define ACC_CS_PIN      5
+#define ACC_PWD_PIN     4 /*VDD*/
+#define ACC_INT1_PIN    2
+#define ACC_INT2_PIN    1
+
+/** @} */
+
+/*---------------------------------------------------------------------------*/
+/** \name accelerometer addressing space
+ * @{
+ */
+#define ACC_CHIPID                  0x00    /**< Always 0x03 for BMA250 */
+#define ACC_X_LSB                   0x02    /**< ACC_X_LSB[7:6] = 2 LSb of X data */
+#define ACC_X_MSB                   0x03    /**< ACC_X_MSB[7:0] = 8 MSb of X data */
+#define ACC_Y_LSB                   0x04
+#define ACC_Y_MSB                   0x05
+#define ACC_Z_LSB                   0x06
+#define ACC_Z_MSB                   0x07
+#define ACC_TEMP                    0x08    /**< Temperature data*/
+#define ACC_INT_STATUS0             0x09    /**< Interrupt status register*/
+#define ACC_INT_STATUS1             0x0A
+#define ACC_TAP_SLOPE_INT_STATUS    0x0B    /**< Interrupt detailed status*/
+#define ACC_FLAT_ORIENT_STATUS      0x0C    /**< Interrupt detailed status*/
+#define ACC_RANGE                   0x0F    /**< Working range (2/4/8/16 g)*/
+#define ACC_BW                      0x10    /**< Filtered bandwidth*/
+#define ACC_PWR_MODE                0x11    /**< Power configuration*/
+#define ACC_DATA_CFG                0x12
+#define ACC_CONF_FILT_SHADOW        0x13
+#define ACC_SOFTRESET               0x14    /**< Write 0xB6 for soft reset*/
+#define ACC_INT_EN0                 0x16    /**< Interrupt enable register*/
+#define ACC_INT_EN1                 0x17
+#define ACC_INT1_MAP                0x19    /**< Interrupt - IO mapping*/
+#define ACC_INT_MAP                 0x1A
+#define ACC_INT2_MAP                0x1B
+#define ACC_INT_SRC                 0x1E
+#define ACC_INT_PIN_CFG             0x20
+#define ACC_TAP_INT_TIMING          0x2A
+#define ACC_TAP_INT_SAMP_TH         0x2B
+/** @} */
+
+/*---------------------------------------------------------------------------*/
+/** \name accelerometer Register Values
+ * @{
+ */
+#define ACC_INT_STATUS0_FLAT_INT    0x80
+#define ACC_INT_STATUS0_ORIENT_INT  0x40
+#define ACC_INT_STATUS0_S_TAP_INT   0x20
+#define ACC_INT_STATUS0_D_TAP_INT   0x10
+#define ACC_INT_STATUS0_SLOPE_INT   0x04
+#define ACC_INT_STATUS0_HIGH_INT    0x02
+#define ACC_INT_STATUS0_LOW_INT     0x01
+#define ACC_INT_STATUS1_DATA_INT    0x80
+#define ACC_RANGE_M                 0x0F
+#define ACC_RANGE_2G                0x03    /**<  3.91 mg/LSB*/
+#define ACC_RANGE_4G                0x05    /**<  7.81 mg/LSB*/
+#define ACC_RANGE_8G                0x08    /**< 15.62 mg/LSB*/
+#define ACC_RANGE_16G               0x0C    /**< 31.25 mg/LSB*/
+#define ACC_SUSPEND                 0x80    /**< Set in suspend mode (default 0)*/
+#define ACC_LOWPOWER_EN             0x40    /**< Enable low-power mode (default 0)*/
+#define ACC_SLEEP_DUR_M             0x1E    /**< sleep_dur bitmask*/
+#define ACC_SLEEP_DUR_0MS           0x00    /**< sleep_dur default value*/
+#define ACC_SLEEP_DUR_0_5MS         0x14
+#define ACC_SLEEP_DUR_1MS           0x18
+#define ACC_SLEEP_DUR_2MS           0x1C
+#define ACC_SLEEP_DUR_4MS           0x20
+#define ACC_SLEEP_DUR_6MS           0x24
+#define ACC_SLEEP_DUR_10MS          0x28
+#define ACC_SLEEP_DUR_25MS          0x2C
+#define ACC_SLEEP_DUR_50MS          0x30
+#define ACC_SLEEP_DUR_100MS         0x34
+#define ACC_SLEEP_DUR_500MS         0x38
+#define ACC_SLEEP_DUR_1000MS        0x3C
+
+#define ACC_DATA_UNFILTERED         0x80    /**< Select unfiltered acceleration
+                                               to be written into data regs.
+                                               Default is 0 (filtered data) */
+
+#define ACC_DATA_SHADOW_DIS         0x80    /**< Disable shadownig procedure.
+                                               Default is 0 (shadowing enabled)*/
+#define ACC_TAP_QUIET_M             0x80
+#define ACC_TAP_QUIET_30MS          0x00
+#define ACC_TAP_QUIET_20MS          0x80
+#define ACC_TAP_SHOCK_M             0x40
+#define ACC_TAP_SHOCK_50MS          0x00
+#define ACC_TAP_SHOCK_75MS          0x40
+#define ACC_TAP_DUR_M               0x07
+#define ACC_TAP_DUR_50MS            0x00
+#define ACC_TAP_DUR_100MS           0x01
+#define ACC_TAP_DUR_150MS           0x02
+#define ACC_TAP_DUR_200MS           0x03
+#define ACC_TAP_DUR_250MS           0x04
+#define ACC_TAP_DUR_375MS           0x05
+#define ACC_TAP_DUR_500MS           0x06
+#define ACC_TAP_DUR_700MS           0x07
+#define ACC_TAMP_SAMP_M             0xC0
+#define ACC_TAP_SAMP_2_SAMPLES      0x00    /**< The number of samples to be*/
+#define ACC_TAP_SAMP_4_SAMPLES      0x40    /**< processed after wakeup in*/
+#define ACC_TAP_SAMP_8_SAMPLES      0x80    /**< low-power mode.*/
+#define ACC_TAP_SAMP_16_SAMPLES     0xC0
+#define ACC_TAP_TH_M                0x1F    /**< Bitmask for tap_th subset of
+                                               register.
+                                               The LSb of tap_th
+                                               corresponds to the following
+                                               acceleration difference:
+                                               2g  range: 62.5mg
+                                               4g  range: 125mg
+                                               8g  range: 250mg
+                                               16g range: 500mg*/
+
+/**<delta_t = time between successive acc samples*/
+#define ACC_BW_7_81HZ               0x08    /**< delta_t = 64   ms*/
+#define ACC_BW_15_63HZ              0x09    /**< delta_t = 32   ms*/
+#define ACC_BW_31_25HZ              0x0A    /**< delta_t = 16   ms*/
+#define ACC_BW_62_5HZ               0x0B    /**< delta_t =  8   ms*/
+#define ACC_BW_125HZ                0x0C    /**< delta_t =  4   ms*/
+#define ACC_BW_250HZ                0x0D    /**< delta_t =  2   ms*/
+#define ACC_BW_500HZ                0x0E    /**< delta_t =  1   ms*/
+#define ACC_BW_1000HZ               0x0F    /**< delta_t =  0.5 ms*/
+#define ACC_INT_EN0_FLAT_EN         0x80
+#define ACC_INT_EN0_ORIENT_EN       0x40
+#define ACC_INT_EN0_S_TAP_EN        0x20
+#define ACC_INT_EN0_D_TAP_EN        0x10
+#define ACC_INT_EN0_SLOPE_Z_EN      0x04
+#define ACC_INT_EN0_SLOPE_Y_EN      0x02
+#define ACC_INT_EN0_SLOPE_X_EN      0x01
+#define ACC_INT_EN1_DATA_EN         0x10
+#define ACC_INT_EN1_LOW_EN          0x08
+#define ACC_INT_EN1_HIGH_Z_EN       0x04
+#define ACC_INT_EN1_HIGH_Y_EN       0x02
+#define ACC_INT_EN1_HIGH_X_EN       0x01
+#define ACC_INT_MAP_FLAT            0x80
+#define ACC_INT_MAP_ORIENT          0x40
+#define ACC_INT_MAP_S_TAP           0x20
+#define ACC_INT_MAP_D_TAP           0x10
+#define ACC_INT_MAP_SLOPE           0x04
+#define ACC_INT_MAP_HIGH            0x02
+#define ACC_INT_MAP_LOW             0x01
+#define ACC_INT_MAP_DATA_INT1       0x01    /**< New data IRQ to pin INT1*/
+#define ACC_INT_MAP_DATA_INT2       0x80    /**< New data IRQ to pin INT2*/
+#define ACC_INT_SRC_DATA_FILT       0x20
+#define ACC_INT_SRC_TAP_FILT        0x01
+#define ACC_INT_SRC_SLOPE_FILT      0x04
+#define ACC_INT_SRC_HIGH_FILT       0x02
+#define ACC_INT_SRC_LOW_FILT        0x01
+#define ACC_INT_CFG_INT2_OD         0x08    /**< Select open drive for INT2 pin*/
+#define ACC_INT_CFG_INT2_PUSH_PULL  0x00    /**< Select open drive for INT1 pin*/
+#define ACC_INT_CFG_INT2_ACTIVE_HI  0x04    /**< Select active high for INT2 pin*/
+#define ACC_INT_CFG_INT2_ACTIVE_LO  0x00    /**< Select active low for INT2 pin*/
+#define ACC_INT_CFG_INT1_OD         0x02    /**< Select open drive for INT1 pin*/
+#define ACC_INT_CFG_INT1_PUSH_PULL  0x00    /**< Select open drive for INT1 pin*/
+#define ACC_INT_CFG_INT1_ACTIVE_HI  0x01    /**< Select active high for INT1 pin*/
+#define ACC_INT_CFG_INT1_ACTIVE_LO  0x00    /**< Select active high for INT1 pin*/
+/** @} */
+
+/*---------------------------------------------------------------------------*/
+/** \name accelerometer Register masks
+ * @{
+ */
+/* Soft reset by writing 0xB6 to ACC_SOFTRESET*/
+#define ACC_SOFTRESET_EN            0xB6
+
+/* R/W Bitmask*/
+#define ACC_READ_M                  0x80    /**< Read action bitmask*/
+#define ACC_WRITE_M                 0x00    /**< Read action bitmask*/
+
+/** @} */
+
+/* The type values used in the value() function.*/
+#define ACC_X_AXIS          1
+#define ACC_Y_AXIS          2
+#define ACC_Z_AXIS          3
+#define ACC_TMP          	4
+
+/* The type values used in the configure() function
+ * and are not defined by sensors.h*/
+#define SENSORS_INT       131
+
+#define SOFT_CS         1
+
+#endif /* ACCEL_SENSOR_H_ */
+
+/**
+ * @}
+ */

--- a/platform/cc2538dk/startup-gcc.c
+++ b/platform/cc2538dk/startup-gcc.c
@@ -99,6 +99,17 @@ void uart1_isr(void);
 #define uart0_isr default_handler
 #define uart1_isr default_handler
 #endif /* UART_CONF_ENABLE */
+
+/* Likewise for the SSI ISRs */
+#if SSI_MODE_SLAVE
+void ssi_isr(void);
+
+#define ssi0_isr  ssi_isr
+#define ssi1_isr  default_handler
+#else
+#define ssi0_isr default_handler
+#define ssi1_isr default_handler
+#endif /* SSI ISRs */
 /*---------------------------------------------------------------------------*/
 /* Allocate stack space */
 static unsigned long stack[512];
@@ -144,7 +155,7 @@ void(*const vectors[])(void) =
   0,                          /* 20 none */
   uart0_isr,                  /* 21 UART0 Rx and Tx */
   uart1_isr,                  /* 22 UART1 Rx and Tx */
-  default_handler,            /* 23 SSI0 Rx and Tx */
+  ssi0_isr,                   /* 23 SSI0 Rx and Tx */
   default_handler,            /* 24 I2C Master and Slave */
   0,                          /* 25 Reserved */
   0,                          /* 26 Reserved */
@@ -171,7 +182,7 @@ void(*const vectors[])(void) =
   default_handler,            /* 47 PKA (Alternate) */
   default_handler,            /* 48 SM Timer (Alternate) */
   default_handler,            /* 49 MacTimer (Alternate) */
-  default_handler,            /* 50 SSI1 Rx and Tx */
+  ssi0_isr,            /* 50 SSI1 Rx and Tx */
   default_handler,            /* 51 Timer 3 subtimer A */
   default_handler,            /* 52 Timer 3 subtimer B */
   0,                          /* 53 Reserved */


### PR DESCRIPTION
Added interupt support for slave SPI mode

Fixed minor bugs with PIN configuration:
When CS is configured with peripheral mode, SPI_WRITE will always terminate the transmission after each byte. This is expected since it waits for SPI not BSY.
for multiple byte transmissions use SPI_WRITE_FAST.

TI example software configures CS pins as software in accelerometer example. When i played with software controlled CS, SPI_WRITE_FAST() demonstrated a funny behaviour. In my oscilloscope the CS was changing values ... When CS is in software mode only use SPI_WRITE. SPI_WRITE works perfect in CS_Software mode.


Added check in SPI configuration of transmission size:
Now there is a max - min size check  in api driver (both init and configure function)

Removed wait time from SPI Flush, There is no point to use SPI_WAITFOREORx() before emptying the FIFO. 
it breaks when it is used since it waits for FIFO Not to be empty in order to empty it... if something a SSI_BSY
wait time should be added there to force the function to wait for end of transmission (if any) before erasing the FIFO

Added SPI master slave example. With 2 SMARTRF06 SPI master slave operation can be checked
Added smartrf06 accelerometer driver (not tested for calibrated)
added example with accelerometer