### PR TITLE
Add new multicast RPL forwarding engine: BMRF

### DIFF
--- a/core/net/ipv6/multicast/bmrf.c
+++ b/core/net/ipv6/multicast/bmrf.c
@@ -1,0 +1,424 @@
+/*
+ * Copyright (c) 2014, VUB - ETRO
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * This file is part of the Contiki operating system.
+ */
+
+/**
+ *         Original code for calculating delays by
+ *         George Oikonomou - <oikonomou@users.sourceforge.net>
+ *         from smrf.c
+ */
+
+/**
+ * \file
+ *         This file implements 'Bidirectional Multicast RPL Forwarding' (BMRF)
+ *
+ *         It will only work in RPL networks in MOP 3 "Storing with Multicast"
+ *
+ * \author
+ *         Guillermo Gastón Lorente
+ */
+
+#include "contiki.h"
+#include "contiki-net.h"
+#include "net/ipv6/multicast/uip-mcast6.h"
+#include "net/ipv6/multicast/uip-mcast6-route.h"
+#include "net/ipv6/multicast/uip-mcast6-stats.h"
+#include "net/ipv6/multicast/bmrf.h"
+#include "net/rpl/rpl.h"
+#include "net/rpl/rpl-private.h"
+#include "net/netstack.h"
+#include "lib/list.h"
+#include <string.h>
+
+#define DEBUG DEBUG_NONE
+#include "net/ip/uip-debug.h"
+
+#if UIP_CONF_IPV6
+#if UIP_MCAST6_ENGINE == UIP_MCAST6_ENGINE_BMRF
+/*---------------------------------------------------------------------------*/
+/* Macros */
+/*---------------------------------------------------------------------------*/
+/* CCI */
+#define BMRF_FWD_DELAY()  NETSTACK_RDC.channel_check_interval()
+/* Number of slots in the next 500ms */
+#define BMRF_INTERVAL_COUNT  ((CLOCK_SECOND >> 2) / fwd_delay)
+/* uip_lladdr comparison */
+#define uip_lladdr_cmp(addr1, addr2) (memcmp(addr1, addr2, UIP_LLADDR_LEN) == 0)
+/* uip_ipaddr partial comparison */
+#define uip_partial_cmp(addr1, addr2, len) (memcmp(addr1, addr2, len) == 0)
+/*---------------------------------------------------------------------------*/
+/* Maintain Stats */
+/*---------------------------------------------------------------------------*/
+#if UIP_MCAST6_STATS
+static struct bmrf_stats stats;
+#define BMRF_STATS_ADD(x) stats.x++
+#define BMRF_STATS_INIT() do { memset(&stats, 0, sizeof(stats)); } while(0)
+#else /* UIP_MCAST6_STATS */
+#define BMRF_STATS_ADD(x)
+#define BMRF_STATS_INIT()
+#endif
+/*---------------------------------------------------------------------------*/
+/* Internal Data */
+/*---------------------------------------------------------------------------*/
+static struct ctimer mcast_periodic;
+static uint8_t mcast_len;
+static uip_buf_t mcast_buf;
+static uint8_t fwd_delay;
+static uint8_t fwd_spread;
+/*---------------------------------------------------------------------------*/
+/* uIPv6 Pointers */
+/*---------------------------------------------------------------------------*/
+#define UIP_IP_BUF                ((struct uip_ip_hdr *)&uip_buf[UIP_LLH_LEN])
+#define UIP_HBHO_BUF              ((struct uip_hbho_hdr *)&uip_buf[uip_l2_l3_hdr_len])
+#define UIP_EXT_HDR_OPT_RPL_BUF   ((struct uip_ext_hdr_opt_rpl *)&uip_buf[uip_l2_l3_hdr_len + 2])
+/*---------------------------------------------------------------------------*/
+static void
+mcast_fwd_with_broadcast(void)
+{
+  tcpip_output(NULL);
+  PRINTF("BMRF: Forwarded with LL-broadcast\n");
+}
+/*---------------------------------------------------------------------------*/
+static void
+mcast_fwd_with_unicast(void)
+{
+  uip_mcast6_route_t *mcast_entries;
+  for(mcast_entries = uip_mcast6_route_list_head();
+      mcast_entries != NULL;
+      mcast_entries = list_item_next(mcast_entries)) {
+    if(uip_ipaddr_cmp(&mcast_entries->group, &UIP_IP_BUF->destipaddr)) {
+      tcpip_output(&mcast_entries->subscribed_child);
+      PRINTF("BMRF: Forwarded with LL-unicast to ");
+      PRINTLLADDR(&mcast_entries->subscribed_child);
+      PRINTF("\n");
+    }
+  }
+  PRINTF("BMRF: Ended forwarding with LL-unicast\n");
+}
+/*---------------------------------------------------------------------------*/
+static void
+mcast_fwd_with_unicast_up_down(const uip_lladdr_t *preferred_parent)
+{
+  uip_mcast6_route_t *mcast_entries;
+  uip_lladdr_t sender;
+  memcpy(&sender, (uip_lladdr_t *)packetbuf_addr(PACKETBUF_ADDR_SENDER), UIP_LLADDR_LEN);
+  UIP_IP_BUF->ttl--;    /* Decrease TTL before forwarding */
+  for(mcast_entries = uip_mcast6_route_list_head();
+      mcast_entries != NULL;
+      mcast_entries = list_item_next(mcast_entries)) {
+    /* Only send if it is not the origin */
+    if(uip_ipaddr_cmp(&mcast_entries->group, &UIP_IP_BUF->destipaddr)
+       && !uip_lladdr_cmp(&mcast_entries->subscribed_child, &sender)) {
+      tcpip_output(&mcast_entries->subscribed_child);
+      PRINTF("BMRF: Forwarded with LL-unicast to ");
+      PRINTLLADDR(&mcast_entries->subscribed_child);
+      PRINTF("\n");
+    }
+  }
+  /* If preferred_parent == NULL, we are the DODAG root */
+  if(preferred_parent != NULL) {
+    tcpip_output(preferred_parent);
+    PRINTF("BMRF: Forwarded with LL-unicast up and down\n");
+    PRINTF("BMRF: Preferred parent LL: ");
+    PRINTLLADDR(preferred_parent);
+    PRINTF("\n");
+  }
+  UIP_IP_BUF->ttl++;   /* Restore before potential upstack delivery */
+}
+/*---------------------------------------------------------------------------*/
+static void
+mcast_fwd_down(void)
+{
+  UIP_IP_BUF->ttl--;    /* Decrease TTL before forwarding */
+#if BMRF_MODE == BMRF_UNICAST_MODE
+  BMRF_STATS_ADD(bmrf_fwd_uncst);
+  mcast_fwd_with_unicast();
+#elif BMRF_MODE == BMRF_BROADCAST_MODE
+  BMRF_STATS_ADD(bmrf_fwd_brdcst);
+  mcast_fwd_with_broadcast();
+#elif BMRF_MODE == BMRF_MIXED_MODE
+  uip_mcast6_route_t *locmcastrt;
+  uint8_t entries_number;
+  entries_number = 0;
+  for(locmcastrt = uip_mcast6_route_list_head();
+      locmcastrt != NULL;
+      locmcastrt = list_item_next(locmcastrt)) {
+    if(uip_ipaddr_cmp(&locmcastrt->group, &UIP_IP_BUF->destipaddr) && ++entries_number > BMRF_BROADCAST_THRESHOLD) {
+      BMRF_STATS_ADD(bmrf_fwd_brdcst);
+      mcast_fwd_with_broadcast();
+      UIP_IP_BUF->ttl++;   /* Restore before potential upstack delivery */
+      return;
+    }
+  }
+  BMRF_STATS_ADD(bmrf_fwd_uncst);
+  mcast_fwd_with_unicast();
+#endif /* BMRF_MODE */
+  UIP_IP_BUF->ttl++;   /* Restore before potential upstack delivery */
+}
+/*---------------------------------------------------------------------------*/
+static void
+mcast_fwd_down_delayed(void *p)
+{
+  memcpy(uip_buf, &mcast_buf, mcast_len);
+  uip_len = mcast_len;
+  mcast_fwd_down();
+  uip_len = 0;
+}
+/*---------------------------------------------------------------------------*/
+/* Comparing uip_ipaddr without the first 16 prefix bits */
+uip_ds6_route_t *
+uip_ds6_route_lookup_from_nbr_ip(uip_ipaddr_t *addr)
+{
+  uip_ds6_route_t *r;
+  uip_ds6_route_t *found_route;
+  uint8_t longestmatch;
+
+  found_route = NULL;
+  longestmatch = 0;
+  for(r = uip_ds6_route_head();
+      r != NULL;
+      r = uip_ds6_route_next(r)) {
+    if(r->length >= longestmatch &&
+       uip_partial_cmp(&(((uint16_t *)addr)[1]), &(((uint16_t *)(&r->ipaddr))[1]), ((r->length >> 3) - 2))) {
+      longestmatch = r->length;
+      found_route = r;
+    }
+  }
+
+  return found_route;
+}
+/*---------------------------------------------------------------------------*/
+static uint8_t
+in()
+{
+  rpl_dag_t *d;                       /* Our DODAG */
+  uip_ipaddr_t *aux_ipaddr;
+  const uip_lladdr_t *parent_lladdr;  /* Our pref. parent's LL address */
+
+  /*
+   * Fetch a pointer to the LL address of our preferred parent
+   */
+  /* RPL HBHO present */
+  if(UIP_IP_BUF->proto == UIP_PROTO_HBHO && UIP_HBHO_BUF->len == RPL_HOP_BY_HOP_LEN - 8) {
+    d = ((rpl_instance_t *)rpl_get_instance(UIP_EXT_HDR_OPT_RPL_BUF->instance))->current_dag;
+  } else {
+    d = rpl_get_any_dag();
+  }
+
+  if(!d) {
+    PRINTF("BMRF: Dropped, no DODAG\n");
+    UIP_MCAST6_STATS_ADD(mcast_dropped);
+    return UIP_MCAST6_DROP;
+  }
+
+  if(UIP_IP_BUF->ttl < 1) {
+    PRINTF("BMRF: Dropped because ttl=0\n");
+    UIP_MCAST6_STATS_ADD(mcast_dropped);
+    return UIP_MCAST6_DROP;
+  } else if(UIP_IP_BUF->ttl == 1) {
+    PRINTF("BMRF: Not forwarded because ttl=0\n");
+    goto check_membership;  /* Check if we are a member of the multicast group before dropping */
+  }
+
+  /* We are not the root */
+  if(d->rank != ROOT_RANK(default_instance)) {
+    /* Retrieve our preferred parent's LL address */
+    aux_ipaddr = rpl_get_parent_ipaddr(d->preferred_parent);
+    parent_lladdr = uip_ds6_nbr_lladdr_from_ipaddr(aux_ipaddr);
+  } else {
+    parent_lladdr = NULL;
+    if(uip_lladdr_cmp(packetbuf_addr(PACKETBUF_ADDR_RECEIVER), &linkaddr_null)) {
+      PRINTF("BMRF: Dropped, broadcast from a child\n");
+      UIP_MCAST6_STATS_ADD(mcast_dropped);
+      return UIP_MCAST6_DROP;
+    } else {
+      goto packet_from_bellow;
+    }
+  }
+
+  if(parent_lladdr == NULL) {
+    PRINTF("BMRF: Dropped, no preferred parent\n");
+    UIP_MCAST6_STATS_ADD(mcast_dropped);
+    return UIP_MCAST6_DROP;
+  }
+
+  /* LL Broadcast */
+  if(uip_lladdr_cmp(packetbuf_addr(PACKETBUF_ADDR_RECEIVER), &linkaddr_null)) {
+    /*
+     * We accept a datagram if it arrived from our preferred parent, discard
+     * otherwise.
+     */
+    if(!uip_lladdr_cmp(parent_lladdr, packetbuf_addr(PACKETBUF_ADDR_SENDER))) {
+      PRINTF("BMRF: Routable in but BMRF ignored it\n");
+      UIP_MCAST6_STATS_ADD(mcast_dropped);
+      return UIP_MCAST6_DROP;
+    }
+    PRINTF("BMRF: Broadcast packet. LL-sender: ");
+    PRINTLLADDR(packetbuf_addr(PACKETBUF_ADDR_SENDER));
+    PRINTF("\n");
+    /* If we have an entry in the mcast routing table, something with
+     * a higher RPL rank (somewhere down the tree) is a group member */
+    if(uip_mcast6_route_lookup(&UIP_IP_BUF->destipaddr)) {
+      UIP_MCAST6_STATS_ADD(mcast_fwd);
+
+      /*
+       * Add a delay (D) of at least BMRF_FWD_DELAY() to compensate for how
+       * contikimac handles broadcasts. We can't start our TX before the sender
+       * has finished its own.
+       */
+      fwd_delay = BMRF_FWD_DELAY();
+
+      /* Finalise D: D = max(BMRF_FWD_DELAY(), BMRF_MIN_FWD_DELAY) */
+#if BMRF_MIN_FWD_DELAY
+      if(fwd_delay < BMRF_MIN_FWD_DELAY) {
+        fwd_delay = BMRF_MIN_FWD_DELAY;
+      }
+#endif
+
+      if(fwd_delay == 0) {
+        /* No delay required, send it, do it now, why wait? */
+        mcast_fwd_down();
+      } else {
+        /* Randomise final delay in [D , D*Spread], step D */
+        fwd_spread = BMRF_INTERVAL_COUNT;
+        if(fwd_spread > BMRF_MAX_SPREAD) {
+          fwd_spread = BMRF_MAX_SPREAD;
+        }
+        if(fwd_spread) {
+          fwd_delay = fwd_delay * (1 + ((random_rand() >> 11) % fwd_spread));
+        }
+
+        memcpy(&mcast_buf, uip_buf, uip_len);
+        mcast_len = uip_len;
+        ctimer_set(&mcast_periodic, fwd_delay, mcast_fwd_down_delayed, NULL);
+      }
+      PRINTF("BMRF: %u bytes: fwd in %u [%u]\n",
+             uip_len, fwd_delay, fwd_spread);
+
+    } else {
+      PRINTF("BMRF: No entries for this group\n");
+    }
+  /* LL Unicast from above us */
+  } else if(uip_lladdr_cmp(parent_lladdr, packetbuf_addr(PACKETBUF_ADDR_SENDER))) {
+    /* If we have an entry in the mcast routing table, something with
+     * a higher RPL rank (somewhere down the tree) is a group member */
+    if(uip_mcast6_route_lookup(&UIP_IP_BUF->destipaddr)) {
+      UIP_MCAST6_STATS_ADD(mcast_fwd);
+      mcast_fwd_down();
+    } else {
+      PRINTF("BMRF: No entries for this group\n");
+    }
+  } else {
+packet_from_bellow:
+    aux_ipaddr = uip_ds6_nbr_ipaddr_from_lladdr((uip_lladdr_t *)packetbuf_addr(PACKETBUF_ADDR_SENDER));
+    PRINTF("BMRF: Should be a packet from bellow. ll_src: ");
+    PRINTLLADDR((uip_lladdr_t *)packetbuf_addr(PACKETBUF_ADDR_SENDER));
+    PRINTF("\n");
+    /* Unicast from below */
+    if(aux_ipaddr != NULL && uip_ds6_route_lookup_from_nbr_ip(aux_ipaddr) != NULL) {
+      /* If we enter here, we will definitely forward */
+      UIP_MCAST6_STATS_ADD(mcast_fwd);
+      BMRF_STATS_ADD(bmrf_fwd_uncst);
+      mcast_fwd_with_unicast_up_down(parent_lladdr);
+    } else {
+      PRINTF("BMRF: Not a packet from bellow, drop\n");
+      UIP_MCAST6_STATS_ADD(mcast_dropped);
+      return UIP_MCAST6_DROP;
+    }
+  }
+
+  UIP_MCAST6_STATS_ADD(mcast_in_all);
+  UIP_MCAST6_STATS_ADD(mcast_in_unique);
+
+check_membership:
+  /* Done with this packet unless we are a member of the mcast group */
+  if(!uip_ds6_is_my_maddr(&UIP_IP_BUF->destipaddr)) {
+    PRINTF("BMRF: Not a group member. No further processing\n");
+    return UIP_MCAST6_DROP;
+  } else {
+    PRINTF("BMRF: Ours. Deliver to upper layers\n");
+    UIP_MCAST6_STATS_ADD(mcast_in_ours);
+    return UIP_MCAST6_ACCEPT;
+  }
+}
+/*---------------------------------------------------------------------------*/
+static void
+init()
+{
+  BMRF_STATS_INIT();
+  UIP_MCAST6_STATS_INIT(&stats);
+
+  uip_mcast6_route_init();
+}
+/*---------------------------------------------------------------------------*/
+static void
+out()
+{
+  rpl_dag_t *dag;                       /* Our DODAG */
+  const uip_lladdr_t *parent_lladdr;  /* Our pref. parent's LL address */
+  dag = rpl_get_any_dag();
+  UIP_MCAST6_STATS_ADD(mcast_out);
+  if(dag->rank != ROOT_RANK(default_instance)) {
+    /* Retrieve our preferred parent's LL address */
+    parent_lladdr = uip_ds6_nbr_lladdr_from_ipaddr(rpl_get_parent_ipaddr(dag->preferred_parent));
+
+    if(parent_lladdr != NULL) {
+      /* Send to our preferred parent LL-address */
+      PRINTF("BMRF: Seed, send to our preferred parent with address: ");
+      PRINTLLADDR(parent_lladdr);
+      PRINTF("\n");
+      tcpip_output(parent_lladdr);
+    } else {
+      PRINTF("BMRF: We are the seed but not preferred parent found\n");
+    }
+  }
+
+  if(uip_mcast6_route_lookup(&UIP_IP_BUF->destipaddr)) {
+    UIP_IP_BUF->ttl++;   /* Dirty: increment TTL since it is going to be decremented before tcpip_output */
+    mcast_fwd_down();
+  } else {
+    PRINTF("BMRF: No entries for this group\n");
+  }
+
+  /* Set uip_len = 0 to stop the core from re-sending it. */
+  uip_len = 0;
+  return;
+}
+/*---------------------------------------------------------------------------*/
+const struct uip_mcast6_driver bmrf_driver = {
+  "BMRF",
+  init,
+  out,
+  in,
+};
+/*---------------------------------------------------------------------------*/
+
+#endif /* UIP_MCAST6_ENGINE */
+#endif /* UIP_CONF_IPV6 */

--- a/core/net/ipv6/multicast/bmrf.h
+++ b/core/net/ipv6/multicast/bmrf.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, Loughborough University - Computer Science
+ * Copyright (c) 2014, VUB - ETRO
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -31,21 +31,61 @@
 
 /**
  * \file
- *         Header file with definition of multicast engine constants
- *
- *         When writing a new engine, add it here with a unique number and
- *         then modify uip-mcast6.h accordingly
+ *         Header file for 'Bidirectional Multicast RPL Forwarding' (BMRF)
  *
  * \author
- *         George Oikonomou - <oikonomou@users.sourceforge.net>
+ *         Guillermo Gastón Lorente
  */
 
-#ifndef UIP_MCAST6_ENGINES_H_
-#define UIP_MCAST6_ENGINES_H_
+#ifndef BMRF_H_
+#define BMRF_H_
 
-#define UIP_MCAST6_ENGINE_NONE        0 /* Selecting this disables mcast */
-#define UIP_MCAST6_ENGINE_SMRF        1
-#define UIP_MCAST6_ENGINE_ROLL_TM     2
-#define UIP_MCAST6_ENGINE_BMRF        3
+#include "contiki-conf.h"
 
-#endif /* UIP_MCAST6_ENGINES_H_ */
+#include <stdint.h>
+
+#define BMRF_UNICAST_MODE      0
+#define BMRF_BROADCAST_MODE    1
+#define BMRF_MIXED_MODE        2
+
+/*---------------------------------------------------------------------------*/
+/* Configuration */
+/*---------------------------------------------------------------------------*/
+/* LL forwarding mode */
+#ifdef BMRF_CONF_MODE
+#define BMRF_MODE              BMRF_CONF_MODE
+#else
+#define BMRF_MODE              BMRF_MIXED_MODE
+#endif /* BMRF_CONF_MODE */
+
+#if BMRF_MODE == BMRF_MIXED_MODE
+#ifdef BMRF_CONF_BROADCAST_THRESHOLD
+#define BMRF_BROADCAST_THRESHOLD    BMRF_CONF_BROADCAST_THRESHOLD
+#else
+#define BMRF_BROADCAST_THRESHOLD    3
+#endif /* BMRF_CONF_BROADCAST_THRESHOLD */
+#endif /* BMRF_MODE */
+
+/* Fmin */
+#ifdef BMRF_CONF_MIN_FWD_DELAY
+#define BMRF_MIN_FWD_DELAY BMRF_CONF_MIN_FWD_DELAY
+#else
+#define BMRF_MIN_FWD_DELAY 4
+#endif
+
+/* Max Spread */
+#ifdef BMRF_CONF_MAX_SPREAD
+#define BMRF_MAX_SPREAD BMRF_CONF_MAX_SPREAD
+#else
+#define BMRF_MAX_SPREAD 4
+#endif
+
+/*---------------------------------------------------------------------------*/
+/* Stats datatype */
+/*---------------------------------------------------------------------------*/
+struct bmrf_stats {
+  UIP_MCAST6_STATS_DATATYPE bmrf_fwd_brdcst; /* Forwarded by us with LL Broadcast*/
+  UIP_MCAST6_STATS_DATATYPE bmrf_fwd_uncst;  /* Forwarded by us with LL Unicast*/
+};
+
+#endif /* BMRF_H_ */

--- a/core/net/ipv6/multicast/uip-mcast6-route.c
+++ b/core/net/ipv6/multicast/uip-mcast6-route.c
@@ -74,6 +74,29 @@ uip_mcast6_route_lookup(uip_ipaddr_t *group)
   return NULL;
 }
 /*---------------------------------------------------------------------------*/
+#if UIP_MCAST6_CONF_ENGINE == UIP_MCAST6_ENGINE_BMRF
+uip_mcast6_route_t *
+uip_mcast6_route_add(uip_ipaddr_t *group, uip_lladdr_t *subscriber)
+{
+  locmcastrt = NULL;
+  for(locmcastrt = list_head(mcast_route_list);
+      locmcastrt != NULL;
+      locmcastrt = list_item_next(locmcastrt)) {
+    if(uip_ipaddr_cmp(&locmcastrt->group, group) && !memcmp(&locmcastrt->subscribed_child, subscriber, UIP_LLADDR_LEN)) {
+      /* The entry already exists */
+      return locmcastrt;
+    }
+  }
+  locmcastrt = memb_alloc(&mcast_route_memb);
+  if(locmcastrt == NULL) {
+    return NULL;
+  }
+  list_add(mcast_route_list, locmcastrt);
+  uip_ipaddr_copy(&(locmcastrt->group), group);
+  memcpy(&(locmcastrt->subscribed_child), subscriber, UIP_LLADDR_LEN);
+  return locmcastrt;
+}
+#else
 uip_mcast6_route_t *
 uip_mcast6_route_add(uip_ipaddr_t *group)
 {
@@ -94,6 +117,7 @@ uip_mcast6_route_add(uip_ipaddr_t *group)
 
   return locmcastrt;
 }
+#endif /* UIP_MCAST6_ENGINE */
 /*---------------------------------------------------------------------------*/
 void
 uip_mcast6_route_rm(uip_mcast6_route_t *route)

--- a/core/net/ipv6/multicast/uip-mcast6-route.h
+++ b/core/net/ipv6/multicast/uip-mcast6-route.h
@@ -49,12 +49,19 @@ typedef struct uip_mcast6_route {
   uip_ipaddr_t group;
   uint32_t lifetime; /* seconds */
   void *dag; /* Pointer to an rpl_dag_t struct */
+#if UIP_MCAST6_CONF_ENGINE == UIP_MCAST6_ENGINE_BMRF
+  uip_lladdr_t subscribed_child;
+#endif
 } uip_mcast6_route_t;
 /*---------------------------------------------------------------------------*/
 /** \name Multicast Routing Table Manipulation */
 /** @{ */
 uip_mcast6_route_t *uip_mcast6_route_lookup(uip_ipaddr_t *group);
+#if UIP_MCAST6_CONF_ENGINE == UIP_MCAST6_ENGINE_BMRF
+uip_mcast6_route_t *uip_mcast6_route_add(uip_ipaddr_t *group, uip_lladdr_t *subscriber);
+#else
 uip_mcast6_route_t *uip_mcast6_route_add(uip_ipaddr_t *group);
+#endif /* UIP_MCAST6_ENGINE */
 void uip_mcast6_route_rm(uip_mcast6_route_t *defrt);
 int uip_mcast6_route_count(void);
 uip_mcast6_route_t *uip_mcast6_route_list_head(void);

--- a/core/net/ipv6/multicast/uip-mcast6.h
+++ b/core/net/ipv6/multicast/uip-mcast6.h
@@ -54,6 +54,7 @@
 #include "net/ipv6/multicast/uip-mcast6-route.h"
 #include "net/ipv6/multicast/smrf.h"
 #include "net/ipv6/multicast/roll-tm.h"
+#include "net/ipv6/multicast/bmrf.h"
 
 #include <string.h>
 /*---------------------------------------------------------------------------*/
@@ -143,6 +144,10 @@ struct uip_mcast6_driver {
 #define RPL_CONF_MULTICAST     1
 
 #define UIP_MCAST6             smrf_driver
+#elif UIP_MCAST6_ENGINE == UIP_MCAST6_ENGINE_BMRF
+#define RPL_CONF_MULTICAST     1
+
+#define UIP_MCAST6             bmrf_driver
 #else
 #error "Multicast Enabled with an Unknown Engine."
 #error "Check the value of UIP_MCAST6_CONF_ENGINE in conf files."

--- a/core/net/ipv6/uip-ds6.c
+++ b/core/net/ipv6/uip-ds6.c
@@ -53,6 +53,13 @@
 #define DEBUG DEBUG_NONE
 #include "net/ip/uip-debug.h"
 
+#if UIP_CONF_IPV6_RPL
+#include "net/ipv6/multicast/uip-mcast6.h"
+#if UIP_MCAST6_ENGINE == UIP_MCAST6_ENGINE_BMRF
+#include "net/rpl/rpl-private.h"
+#endif /* UIP_MCAST6_ENGINE */
+#endif /* UIP_CONF_IPV6_RPL */
+
 struct etimer uip_ds6_timer_periodic;                           /** \brief Timer for maintenance of data structures */
 
 #if UIP_CONF_ROUTER
@@ -424,6 +431,9 @@ uip_ds6_maddr_add(const uip_ipaddr_t *ipaddr)
       (uip_ds6_element_t **)&locmaddr) == FREESPACE) {
     locmaddr->isused = 1;
     uip_ipaddr_copy(&locmaddr->ipaddr, ipaddr);
+#if UIP_CONF_IPV6_RPL && UIP_MCAST6_ENGINE == UIP_MCAST6_ENGINE_BMRF
+    rpl_schedule_dao_immediately_default_instance();
+#endif
     return locmaddr;
   }
   return NULL;
@@ -433,8 +443,11 @@ uip_ds6_maddr_add(const uip_ipaddr_t *ipaddr)
 void
 uip_ds6_maddr_rm(uip_ds6_maddr_t *maddr)
 {
-  if(maddr != NULL) {
+  if(maddr != NULL && maddr->isused == 1) {
     maddr->isused = 0;
+#if UIP_CONF_IPV6_RPL && UIP_MCAST6_ENGINE == UIP_MCAST6_ENGINE_BMRF
+    rpl_schedule_dao_immediately_default_instance();
+#endif
   }
   return;
 }

--- a/core/net/rpl/rpl-icmp6.c
+++ b/core/net/rpl/rpl-icmp6.c
@@ -708,7 +708,15 @@ dao_input(void)
       mcast_group->dag = dag;
       mcast_group->lifetime = RPL_LIFETIME(instance, lifetime);
     }
+#if UIP_MCAST6_ENGINE == UIP_MCAST6_ENGINE_BMRF
+    if(lifetime == RPL_ZERO_LIFETIME) {
+      goto end_dao;
+    } else {
+      goto fwd_dao;
+    }
+#else
     goto fwd_dao;
+#endif /* UIP_MCAST6_ENGINE */
   }
 #endif
 
@@ -799,6 +807,9 @@ fwd_dao:
       dao_ack_output(instance, &dao_sender_addr, sequence);
     }
   }
+#if UIP_MCAST6_ENGINE == UIP_MCAST6_ENGINE_BMRF
+end_dao:
+#endif
   uip_len = 0;
 }
 /*---------------------------------------------------------------------------*/

--- a/core/net/rpl/rpl-icmp6.c
+++ b/core/net/rpl/rpl-icmp6.c
@@ -699,7 +699,11 @@ dao_input(void)
 
 #if RPL_CONF_MULTICAST
   if(uip_is_addr_mcast_global(&prefix)) {
+#if UIP_MCAST6_ENGINE == UIP_MCAST6_ENGINE_BMRF
+    mcast_group = uip_mcast6_route_add(&prefix, (uip_lladdr_t *)packetbuf_addr(PACKETBUF_ADDR_SENDER));
+#else
     mcast_group = uip_mcast6_route_add(&prefix);
+#endif /* UIP_MCAST6_ENGINE */
     if(mcast_group) {
       mcast_group->dag = dag;
       mcast_group->lifetime = RPL_LIFETIME(instance, lifetime);

--- a/core/net/rpl/rpl-private.h
+++ b/core/net/rpl/rpl-private.h
@@ -176,8 +176,8 @@
 #endif
 
 /*
- * The ETX in the metric container is expressed as a fixed-point value 
- * whose integer part can be obtained by dividing the value by 
+ * The ETX in the metric container is expressed as a fixed-point value
+ * whose integer part can be obtained by dividing the value by
  * RPL_DAG_MC_ETX_DIVISOR.
  */
 #define RPL_DAG_MC_ETX_DIVISOR		256
@@ -251,7 +251,7 @@ extern rpl_stats_t rpl_stats;
 /* RPL macros. */
 
 #if RPL_CONF_STATS
-#define RPL_STAT(code)	(code) 
+#define RPL_STAT(code)	(code)
 #else
 #define RPL_STAT(code)
 #endif /* RPL_CONF_STATS */
@@ -309,6 +309,9 @@ rpl_of_t *rpl_find_of(rpl_ocp_t);
 void rpl_schedule_dao(rpl_instance_t *);
 void rpl_schedule_dao_immediately(rpl_instance_t *);
 void rpl_cancel_dao(rpl_instance_t *instance);
+#if UIP_MCAST6_ENGINE == UIP_MCAST6_ENGINE_BMRF
+void rpl_schedule_dao_immediately_default_instance(void);
+#endif
 
 void rpl_reset_dio_timer(rpl_instance_t *);
 void rpl_reset_periodic_timer(void);

--- a/core/net/rpl/rpl-timers.c
+++ b/core/net/rpl/rpl-timers.c
@@ -346,6 +346,16 @@ rpl_schedule_dao_immediately(rpl_instance_t *instance)
   schedule_dao(instance, 0);
 }
 /*---------------------------------------------------------------------------*/
+#if UIP_MCAST6_ENGINE == UIP_MCAST6_ENGINE_BMRF
+void
+rpl_schedule_dao_immediately_default_instance(void)
+{
+  if(default_instance != NULL) {
+    rpl_schedule_dao_immediately(default_instance);
+  }
+}
+#endif /* UIP_MCAST6_ENGINE */
+/*---------------------------------------------------------------------------*/
 void
 rpl_cancel_dao(rpl_instance_t *instance)
 {

--- a/core/net/rpl/rpl-timers.c
+++ b/core/net/rpl/rpl-timers.c
@@ -253,6 +253,14 @@ handle_dao_timer(void *ptr)
           dao_output_target(instance->current_dag->preferred_parent,
               &uip_ds6_if.maddr_list[i].ipaddr, RPL_MCAST_LIFETIME);
         }
+#if UIP_MCAST6_ENGINE == UIP_MCAST6_ENGINE_BMRF
+        else if(!uip_ds6_if.maddr_list[i].isused
+                && uip_is_addr_mcast_global(&uip_ds6_if.maddr_list[i].ipaddr)
+                && !uip_mcast6_route_lookup(&uip_ds6_if.maddr_list[i].ipaddr)) {
+          dao_output_target(instance->current_dag->preferred_parent,
+                            &uip_ds6_if.maddr_list[i].ipaddr, RPL_ZERO_LIFETIME);
+        }
+#endif
       }
 
       /* Iterate over multicast routes and send DAOs */


### PR DESCRIPTION
This Pull Request adds an alternative multicast forwarding engine for RPL called BMRF. It is based on the ideas proposed by SMRF. It is documented here: https://www.dropbox.com/s/lx3ezdsmtye7w4x/BMRF.pdf

As a summary, these are the main news:
* Bidirectional: the multicast source is not restricted to the tree root. Multicast packets can go up and down in the tree.
* Dynamic groups: subscription and unsubscription can be done in any moment.
* Flexible LL forwarding: LL unicast or LL broadcast can be used. There are three modes: only unicast, only broadcast and mixed mode (it depends on the number of subscribed children).