### PR TITLE
Add PLATFORM_HAS_RADIO in Sky Platform

### DIFF
--- a/platform/sky/platform-conf.h
+++ b/platform/sky/platform-conf.h
@@ -51,6 +51,7 @@
 #define PLATFORM_HAS_LIGHT   1
 #define PLATFORM_HAS_BATTERY 1
 #define PLATFORM_HAS_SHT11   1
+#define PLATFORM_HAS_RADIO   1
 
 /* CPU target speed in Hz */
 #define F_CPU 3900000uL /*2457600uL*/


### PR DESCRIPTION
In order to use the er-server-example Radio resource it is required that the platform defines that it has a radio. This line might be required in other platforms.
