### PR TITLE
[CC2538] Fix SPI_FLUSH

### DIFF
--- a/cpu/cc2538/spi-arch.h
+++ b/cpu/cc2538/spi-arch.h
@@ -63,7 +63,6 @@
 #error "You must include spi-arch.h before spi.h for the CC2538."
 #endif
 #define SPI_FLUSH() do { \
-  SPI_WAITFOREORx(); \
   while (REG(SSI0_BASE + SSI_SR) & SSI_SR_RNE) { \
     SPI_RXBUF; \
   } \


### PR DESCRIPTION
The current SPI_FLUSH macro first waits for the SPI RX FIFO to fill with something. So if an application makes a SPI_FLUSH call and the RX FIFO happens to already be empty, the application stalls. 