### PR TITLE
Fix a bug with sdcc and icmpv6 handler

### DIFF
--- a/core/net/ipv6/multicast/roll-tm.c
+++ b/core/net/ipv6/multicast/roll-tm.c
@@ -482,7 +482,7 @@ static void handle_timer(void *);
 /*---------------------------------------------------------------------------*/
 /* ROLL TM ICMPv6 handler declaration */
 UIP_ICMP6_HANDLER(roll_tm_icmp_handler, ICMP6_ROLL_TM,
-                  UIP_ICMP6_HANDLER_CODE_ANY, icmp_input);
+                  UIP_ICMP6_HANDLER_CODE_ANY, &icmp_input);
 /*---------------------------------------------------------------------------*/
 /* Return a random number in [I/2, I), for a timer with Imin when the timer's
  * current number of doublings is d */

--- a/core/net/ipv6/uip-icmp6.c
+++ b/core/net/ipv6/uip-icmp6.c
@@ -408,9 +408,9 @@ uip_icmp6_echo_reply_callback_rm(struct uip_icmp6_echo_reply_notification *n)
 }
 /*---------------------------------------------------------------------------*/
 UIP_ICMP6_HANDLER(echo_request_handler, ICMP6_ECHO_REQUEST,
-                  UIP_ICMP6_HANDLER_CODE_ANY, echo_request_input);
+                  UIP_ICMP6_HANDLER_CODE_ANY, &echo_request_input);
 UIP_ICMP6_HANDLER(echo_reply_handler, ICMP6_ECHO_REPLY,
-                  UIP_ICMP6_HANDLER_CODE_ANY, echo_reply_input);
+                  UIP_ICMP6_HANDLER_CODE_ANY, &echo_reply_input);
 /*---------------------------------------------------------------------------*/
 void
 uip_icmp6_init()

--- a/core/net/ipv6/uip-nd6.c
+++ b/core/net/ipv6/uip-nd6.c
@@ -992,19 +992,19 @@ discard:
 /* ICMPv6 input handlers */
 #if UIP_ND6_SEND_NA
 UIP_ICMP6_HANDLER(ns_input_handler, ICMP6_NS, UIP_ICMP6_HANDLER_CODE_ANY,
-                  ns_input);
+                  &ns_input);
 UIP_ICMP6_HANDLER(na_input_handler, ICMP6_NA, UIP_ICMP6_HANDLER_CODE_ANY,
-                  na_input);
+                  &na_input);
 #endif
 
 #if UIP_CONF_ROUTER && UIP_ND6_SEND_RA
 UIP_ICMP6_HANDLER(rs_input_handler, ICMP6_RS, UIP_ICMP6_HANDLER_CODE_ANY,
-                  rs_input);
+                  &rs_input);
 #endif
 
 #if !UIP_CONF_ROUTER
 UIP_ICMP6_HANDLER(ra_input_handler, ICMP6_RA, UIP_ICMP6_HANDLER_CODE_ANY,
-                  ra_input);
+                  &ra_input);
 #endif
 /*---------------------------------------------------------------------------*/
 void

--- a/core/net/rpl/rpl-icmp6.c
+++ b/core/net/rpl/rpl-icmp6.c
@@ -93,10 +93,10 @@ static uip_mcast6_route_t *mcast_group;
 #endif
 /*---------------------------------------------------------------------------*/
 /* Initialise RPL ICMPv6 message handlers */
-UIP_ICMP6_HANDLER(dis_handler, ICMP6_RPL, RPL_CODE_DIS, dis_input);
-UIP_ICMP6_HANDLER(dio_handler, ICMP6_RPL, RPL_CODE_DIO, dio_input);
-UIP_ICMP6_HANDLER(dao_handler, ICMP6_RPL, RPL_CODE_DAO, dao_input);
-UIP_ICMP6_HANDLER(dao_ack_handler, ICMP6_RPL, RPL_CODE_DAO_ACK, dao_ack_input);
+UIP_ICMP6_HANDLER(dis_handler, ICMP6_RPL, RPL_CODE_DIS, &dis_input);
+UIP_ICMP6_HANDLER(dio_handler, ICMP6_RPL, RPL_CODE_DIO, &dio_input);
+UIP_ICMP6_HANDLER(dao_handler, ICMP6_RPL, RPL_CODE_DAO, &dao_input);
+UIP_ICMP6_HANDLER(dao_ack_handler, ICMP6_RPL, RPL_CODE_DAO_ACK, &dao_ack_input);
 /*---------------------------------------------------------------------------*/
 static int
 get_global_addr(uip_ipaddr_t *addr)


### PR DESCRIPTION
When passing function pointer without '&' code generated jumps to an invalid address when handler function is called dynamically.
I fond this issue on CC2530 with head revision of contiki an dcc2530dk plateform. I was first tracking stack issues, but finally i found that problem. Following the C norm, using '&' or not when assigning a function address to a pointer function should be the same , but it seems that with sdd it's not the case, and the code jumps to an invalid address.
