### PR TITLE
[avr] Add mcu parameter to ASFLAGS

### DIFF
--- a/cpu/avr/Makefile.avr
+++ b/cpu/avr/Makefile.avr
@@ -99,6 +99,7 @@ CFLAGSNO = -Wall -mmcu=$(MCU) -gdwarf-2 -fno-strict-aliasing \
             -I. -I$(CONTIKI)/core -I$(CONTIKI_CPU) $(USB_INCLUDES) \
             $(CONTIKI_PLAT_DEFS)
 CFLAGS   += $(CFLAGSNO) -O$(OPTI)
+ASFLAGS  += -mmcu=$(MCU)
 ifndef BOOTLOADER_START
   BOOTLOADER_START = 0x1F800
 endif


### PR DESCRIPTION
Allows compiling assembler code for target platform.
