### PR TITLE
Fix too short 6LoWPAN reassembly timeout

### DIFF
--- a/core/net/ipv6/sicslowpan.c
+++ b/core/net/ipv6/sicslowpan.c
@@ -1705,7 +1705,7 @@ input(void)
 
       sicslowpan_len = frag_size;
       reass_tag = frag_tag;
-      timer_set(&reass_timer, SICSLOWPAN_REASS_MAXAGE * CLOCK_SECOND / 16);
+      timer_set(&reass_timer, SICSLOWPAN_REASS_MAXAGE * CLOCK_SECOND);
       PRINTFI("sicslowpan input: INIT FRAGMENTATION (len %d, tag %d)\n",
              sicslowpan_len, reass_tag);
       linkaddr_copy(&frag_sender, packetbuf_addr(PACKETBUF_ADDR_SENDER));


### PR DESCRIPTION
The 6LoWPAN fragments reassembly timer is started when a first fragmented 6LoWPAN frame is received, all the other fragments must be received before it expires. In Contiki, this timeout is defined in SICSLOWPAN_CONF_MAXAGE and is expressed in seconds.

For unknown reasons, when the timer is started, this timeout value is however divided by 16. WIth the default value of 20, it means the actual timeout is just a bit more than one second. When there are more than a few fragments the reassembly always fails as the timeout is always triggered.

This division by 16 has been introduced in 5c5545ba7dc1a381d4460131785da03de8d669a0 with no really clear reason :) This pull request remove this modification.
