### PR TITLE
Note that timer_reset() must not be executed before timer expired

### DIFF
--- a/core/sys/timer.c
+++ b/core/sys/timer.c
@@ -76,8 +76,9 @@ timer_set(struct timer *t, clock_time_t interval)
  * function will cause the timer to be stable over time, unlike the
  * timer_restart() function.
  *
- * \param t A pointer to the timer.
+ * \note Must not be executed before timer expired
  *
+ * \param t A pointer to the timer.
  * \sa timer_restart()
  */
 void


### PR DESCRIPTION
I've seen several people (including me) having problems with the behavior of `timer_reset()` when it is invoked before the timer expired.

The problem was already discussed in #293 more detailed.

In my opinion adding a simple note should be the easiest solution so far as it does not introduce further computation overhead would but gives a hint for (doc-reading) users.

