### PR TITLE
er-coap (observe): fix possible duplicate value for observe option

### DIFF
--- a/apps/er-coap/er-coap-observe.c
+++ b/apps/er-coap/er-coap-observe.c
@@ -232,17 +232,18 @@ coap_observe_handler(resource_t *resource, void *request, void *response)
 {
   coap_packet_t *const coap_req = (coap_packet_t *)request;
   coap_packet_t *const coap_res = (coap_packet_t *)response;
+  coap_observer_t * obs;
 
   static char content[16];
 
   if(coap_req->code == COAP_GET && coap_res->code < 128) { /* GET request and response without error code */
     if(IS_OPTION(coap_req, COAP_OPTION_OBSERVE)) {
       if(coap_req->observe == 0) {
-
-        if(coap_add_observer(&UIP_IP_BUF->srcipaddr, UIP_UDP_BUF->srcport,
-                             coap_req->token, coap_req->token_len,
-                             resource->url)) {
-          coap_set_header_observe(coap_res, 0);
+        obs = coap_add_observer(&UIP_IP_BUF->srcipaddr, UIP_UDP_BUF->srcport,
+                                coap_req->token, coap_req->token_len,
+                                resource->url);
+       if(obs) {
+          coap_set_header_observe(coap_res, (obs->obs_counter)++);
           /*
            * Following payload is for demonstration purposes only.
            * A subscription should return the same representation as a normal GET.


### PR DESCRIPTION
Currently, the observe value of a response to a GET observe request is always set to zero. That may cause the subsequent notification to have the same observe value. In fact, that happens every time an observable resource is observed for the first time (since the obs_counter is implicitly initialized to zero).
This seems to me a violation of the IETF draft which mandates that the observe value be _"the 24 least-significant bits of a strictly increasing sequence number"_
This patch fixes such a problem by setting the observe option value of responses to obs_counter (and then incrementing it).
