### PR TITLE
[avr] Removed usage of deprecated MCUSR

### DIFF
--- a/cpu/avr/bootloader.c
+++ b/cpu/avr/bootloader.c
@@ -9,10 +9,12 @@
 #include <avr/interrupt.h>
 #include <avr/eeprom.h>
 
-/* Not all AVR toolchains alias MCUSR to the older MSUSCR name */
-#if !defined (MCUSR) && defined (MCUCSR)
-#warning *** MCUSR not defined, using MCUCSR instead ***
-#define MCUSR MCUCSR
+/* MCUSR is a deprecated name but older avr-libc versions may define it */
+#if !defined (MCUCSR)
+# if defined (MCUSR)
+#  warning *** MCUCSR not defined, using MCUSR instead ***
+#  define MCUCSR MCUSR
+# endif
 #endif
 
 #ifndef EEPROM_MAGIC_BYTE_ADDR
@@ -69,8 +71,8 @@ Bootloader_Jump_Check(void)
   /* If the reset source was the bootloader and the key is correct,
    * clear it and jump to the bootloader
    */
-  if(MCUSR & (1 << WDRF)) {
-    MCUSR = 0;
+  if(MCUCSR & (1 << WDRF)) {
+    MCUCSR = 0;
     if(Boot_Key == MAGIC_BOOT_KEY) {
       Boot_Key = 0;
       wdt_disable();

--- a/cpu/avr/watchdog.c
+++ b/cpu/avr/watchdog.c
@@ -64,11 +64,12 @@
 #include <avr/wdt.h>
 #include <avr/interrupt.h>
 
-//Not all AVR toolchains alias MCUSR to the older MSUSCR name
-//#if defined (__AVR_ATmega8__) || defined (__AVR_ATmega8515__) || defined (__AVR_ATmega16__)
-#if !defined (MCUSR) && defined (MCUCSR)
-#warning *** MCUSR not defined, using MCUCSR instead ***
-#define MCUSR MCUCSR
+/* MCUSR is a deprecated name but older avr-libc versions may define it */
+#if !defined (MCUCSR)
+# if defined (MCUSR)
+#  warning *** MCUCSR not defined, using MCUSR instead ***
+#  define MCUCSR MCUSR
+# endif
 #endif
 
 #if WATCHDOG_CONF_BALANCE && WATCHDOG_CONF_TIMEOUT >= 0
@@ -82,7 +83,7 @@ watchdog_init(void)
 /*  Clear startup bit and disable the wdt, whether or not it will be used.
     Random code may have caused the last reset.
  */
-	MCUSR&=~(1<<WDRF);
+	MCUCSR&=~(1<<WDRF);
     wdt_disable();
 #if WATCHDOG_CONF_BALANCE && WATCHDOG_CONF_TIMEOUT >= 0
 	stopped = 1;


### PR DESCRIPTION
Since avr-libc 1.8.0 MCUSR is marked as poison [1] as it was replaced by the
correct name MCUCSR [2].
Thus code still using the old MCUSR name does not compile anymore.

This commit replaces usages of former MCUSR by its new name MCUCSR and
modifies the alias fallback accordingly.

[1] http://svn.savannah.nongnu.org/viewvc/trunk/avr-libc/include/avr/iom128.h?root=avr-libc&r1=2225&r2=2226
[2] http://svn.savannah.nongnu.org/viewvc/trunk/avr-libc/include/avr/iom128.h?root=avr-libc&r1=2&r2=61&pathrev=2226
