### PR TITLE
Avoid compilation warnings in Antelope.

### DIFF
--- a/apps/antelope/lvm.c
+++ b/apps/antelope/lvm.c
@@ -586,7 +586,6 @@ derive_relation(lvm_instance_t *p, derivation_t *local_derivations)
   node_type_t type;
   operand_t operand[2];
   int i;
-  int var;
   int variable_id;
   operand_value_t *value;
   derivation_t *derivation;
@@ -640,11 +639,9 @@ derive_relation(lvm_instance_t *p, derivation_t *local_derivations)
     if(operand[1].type == LVM_VARIABLE) {
       return DERIVATION_ERROR;
     }
-    var = 0;
     variable_id = operand[0].value.id;
     value = &operand[1].value;
   } else {
-    var = 1;
     variable_id = operand[1].value.id;
     value = &operand[0].value;
   }

--- a/examples/antelope/netdb/netdb-server.c
+++ b/examples/antelope/netdb/netdb-server.c
@@ -36,6 +36,7 @@
 
 #include <stdarg.h>
 #include <stdio.h>
+#include <string.h>
 
 #include "contiki.h"
 #include "dev/serial-line.h"
@@ -110,6 +111,7 @@ buffer_db_data(const char *format, ...)
   return len;
 }
 /*---------------------------------------------------------------------------*/
+#if !PREPARE_DB
 static void
 take_sample(void)
 {
@@ -123,6 +125,7 @@ take_sample(void)
     printf("DB insertion failed\n");
   }
 }
+#endif /* !PREPARE_DB */
 /*---------------------------------------------------------------------------*/
 static void
 stop_handler(void *ptr)


### PR DESCRIPTION
This PR removes some compilation warnings for Antelope's LVM module and the NetDB server example.
