### PR TITLE
Added missing radio capability define to Z1 platform config

### DIFF
--- a/platform/z1/platform-conf.h
+++ b/platform/z1/platform-conf.h
@@ -45,6 +45,7 @@
 
 #define PLATFORM_HAS_LEDS   1
 #define PLATFORM_HAS_BUTTON 1
+#define PLATFORM_HAS_RADIO  1
 
 /* CPU target speed in Hz */
 #define F_CPU 8000000uL /* 8MHz by default */


### PR DESCRIPTION
This commit adds a missing radio capability indication used in er-rest example.
