### PR TITLE
core/net/ip: Prevent (tiny) buffer overflow in resolv_found()

### DIFF
--- a/core/net/ip/resolv.c
+++ b/core/net/ip/resolv.c
@@ -1455,7 +1455,7 @@ resolv_found(char *name, uip_ipaddr_t * ipaddr)
         val >>= 4;
         append_str[1] = (((val & 0xF) > 9) ? 'a' : '0') + (val & 0xF);
         strncat(resolv_hostname, append_str,
-                sizeof(resolv_hostname) - strlen(resolv_hostname));
+                sizeof(resolv_hostname) - strlen(resolv_hostname) - 1); /* -1 in order to fit the terminating null byte. */
       }
 
       /* Re-add the .local suffix */


### PR DESCRIPTION
An off-by-one error in resolv_found() could make an strncat() call overflow by the terminating null byte.

When building with Clang the following warning was shown:

```
../../../core/net/ip/resolv.c:1458:17: warning: the value of the size argument in 'strncat' is too large, might lead to a buffer overflow [-Wstrncat-size]
            sizeof(resolv_hostname) - strlen(resolv_hostname));
            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../../../core/net/ip/resolv.c:1458:17: note: change the argument to be the free space in the destination buffer minus the terminating null byte
            sizeof(resolv_hostname) - strlen(resolv_hostname));
            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
            sizeof(resolv_hostname) - strlen(resolv_hostname) - 1
```
