### PR TITLE
examples/rpl-border-router: Fix two minor warnings.

### DIFF
--- a/examples/ipv6/rpl-border-router/border-router.c
+++ b/examples/ipv6/rpl-border-router/border-router.c
@@ -99,7 +99,7 @@ PROCESS_THREAD(webserver_nogui_process, ev, data)
     PROCESS_WAIT_EVENT_UNTIL(ev == tcpip_event);
     httpd_appcall(data);
   }
-  
+
   PROCESS_END();
 }
 AUTOSTART_PROCESSES(&border_router_process,&webserver_nogui_process);
@@ -143,7 +143,6 @@ ipaddr_add(const uip_ipaddr_t *addr)
 static
 PT_THREAD(generate_routes(struct httpd_state *s))
 {
-  static int i;
   static uip_ds6_route_t *r;
   static uip_ds6_nbr_t *nbr;
 #if BUF_USES_STACK
@@ -176,7 +175,7 @@ PT_THREAD(generate_routes(struct httpd_state *s))
       switch (nbr->state) {
       case NBR_INCOMPLETE: ADD(" INCOMPLETE");break;
       case NBR_REACHABLE: ADD(" REACHABLE");break;
-      case NBR_STALE: ADD(" STALE");break;      
+      case NBR_STALE: ADD(" STALE");break;
       case NBR_DELAY: ADD(" DELAY");break;
       case NBR_PROBE: ADD(" NBR_PROBE");break;
       }
@@ -188,7 +187,7 @@ PT_THREAD(generate_routes(struct httpd_state *s))
       switch (nbr->state) {
       case NBR_INCOMPLETE: ADD(" INCOMPLETE");break;
       case NBR_REACHABLE: ADD(" REACHABLE");break;
-      case NBR_STALE: ADD(" STALE");break;      
+      case NBR_STALE: ADD(" STALE");break;
       case NBR_DELAY: ADD(" DELAY");break;
       case NBR_PROBE: ADD(" NBR_PROBE");break;
       }
@@ -247,7 +246,7 @@ PT_THREAD(generate_routes(struct httpd_state *s))
     ADD("/%u (via ", r->length);
     ipaddr_add(uip_ds6_route_nexthop(r));
     if(1 || (r->state.lifetime < 600)) {
-      ADD(") %lus\n", r->state.lifetime);
+      ADD(") %lus\n", (unsigned long)r->state.lifetime);
     } else {
       ADD(")\n");
     }
@@ -340,7 +339,7 @@ PROCESS_THREAD(border_router_process, ev, data)
   PROCESS_BEGIN();
 
 /* While waiting for the prefix to be sent through the SLIP connection, the future
- * border router can join an existing DAG as a parent or child, or acquire a default 
+ * border router can join an existing DAG as a parent or child, or acquire a default
  * router that will later take precedence over the SLIP fallback interface.
  * Prevent that by turning the radio off until we are initialized as a DAG root.
  */
@@ -359,7 +358,7 @@ PROCESS_THREAD(border_router_process, ev, data)
      cpu will interfere with establishing the SLIP connection */
   NETSTACK_MAC.off(1);
 #endif
- 
+
   /* Request prefix until it has been received */
   while(!prefix_set) {
     etimer_set(&et, CLOCK_SECOND);
@@ -371,7 +370,7 @@ PROCESS_THREAD(border_router_process, ev, data)
    * Since we are the DAG root, reception delays would constrain mesh throughbut.
    */
   NETSTACK_MAC.off(1);
-  
+
 #if DEBUG || 1
   print_local_addresses();
 #endif


### PR DESCRIPTION
Fix some insignificant warnings in the rpl-border-router example.
- Remove unused variable i in generate_routes.
- Add cast to unsigned long for printf(..%lu..) in generate_routes.

The patch also removes trailing whitespace in border-router.c

Clang gave the following warnings:

```
border-router.c:250:23: warning: format specifies type 'unsigned long' but the argument has type 'uint32_t' (aka 'unsigned int') [-Wformat]
      ADD(") %lus\n", r->state.lifetime);
             ~~~      ^~~~~~~~~~~~~~~~~
             %u
border-router.c:118:54: note: expanded from macro 'ADD'
    blen += snprintf(&buf[blen], sizeof(buf) - blen, __VA_ARGS__);      \
                                                     ^
border-router.c:146:14: warning: unused variable 'i' [-Wunused-variable]
  static int i;
             ^
```
