### PR TITLE
[Cooja/MSPSim] Msp802154Radio: Fix maximum power indicator

### DIFF
--- a/tools/cooja/apps/mspsim/src/org/contikios/cooja/mspmote/interfaces/Msp802154Radio.java
+++ b/tools/cooja/apps/mspsim/src/org/contikios/cooja/mspmote/interfaces/Msp802154Radio.java
@@ -332,7 +332,7 @@ public class Msp802154Radio extends Radio implements CustomDataRadio {
   }
 
   public int getOutputPowerIndicatorMax() {
-    return 31;
+    return radio.getOutputPowerIndicatorMax();
   }
 
   /**


### PR DESCRIPTION
Previously getOutputPowerIndicatorMax() returned the fixed value 31.
This is valid for e.g. the mspsim CC2420 radio implementation but not for the CC2520 implementation where the maximum returned value is 9.

Thus to fix transmission range issues (for example for Wismote node) the maxium value provided by the radio implementaiton must be used.
