### PR TITLE
Added battery capability to Z1 platform

### DIFF
--- a/platform/z1/platform-conf.h
+++ b/platform/z1/platform-conf.h
@@ -43,9 +43,10 @@
  */
 #define ZOLERTIA_Z1 1  /* Enric */
 
-#define PLATFORM_HAS_LEDS   1
-#define PLATFORM_HAS_BUTTON 1
-#define PLATFORM_HAS_RADIO  1
+#define PLATFORM_HAS_LEDS    1
+#define PLATFORM_HAS_BUTTON  1
+#define PLATFORM_HAS_RADIO   1
+#define PLATFORM_HAS_BATTERY 1
 
 /* CPU target speed in Hz */
 #define F_CPU 8000000uL /* 8MHz by default */


### PR DESCRIPTION
Added missing define to make available the built-in battery sensor
