### PR TITLE
[cpu/cc253x] Makefile.customrules-cc253x: Disabled parallel makefile execution

### DIFF
--- a/cpu/cc253x/Makefile.customrules-cc253x
+++ b/cpu/cc253x/Makefile.customrules-cc253x
@@ -1,4 +1,5 @@
 ### Compilation rules
+.NOTPARALLEL :
 
 SEGMENT_RULE_FILES = $(foreach dir, . $(CONTIKI_PLATFORM_DIRS) \
 	$(CONTIKI_CPU_DIRS_LIST), $(wildcard $(dir)/segment.rules) )


### PR DESCRIPTION
The makefile (especially the execution of bank-alloc.py) is not capable
of parallel execution. So I disabled it in general for this cpu.

This is the seperate PR as requested in #803 