### PR TITLE
[MSP430] Add gstabs debug information (dwarf is broken)

### DIFF
--- a/cpu/msp430/Makefile.msp430
+++ b/cpu/msp430/Makefile.msp430
@@ -4,6 +4,8 @@ ifdef nodeid
 CFLAGS += -DNODEID=$(nodeid)
 endif
 
+CFLAGS += -gstabs+
+
 .SUFFIXES:
 
 ### Define the CPU directory


### PR DESCRIPTION
Currently there is an linker error when compiling with debug information.
This is only the case for dwarf (the default). Everything is fine with
stabs, thus allowing to debug and use all the other nice tools like
"objdump -S".