### PR TITLE
Remove leading zeros from node id

### DIFF
--- a/platform/z1/Makefile.common
+++ b/platform/z1/Makefile.common
@@ -68,11 +68,11 @@ ifeq ($(HOST_OS),Darwin)
               cut -f 2 -d ,)
       CMOTES=$(MOTES)
       REFNUM = $(shell $(MOTELIST) -c 2>&- | \
-               cut -f 1 -d , | tail -c5)
+               cut -f 1 -d , | tail -c5 | sed 's/^0*//')
       ifneq (,$(REFNUM))
         # No device fo-und
         ifeq (,$(findstring und, $(REFNUM)))
-          CFLAGS += -DSERIALNUM=$(REFNUM)
+          CFLAGS += -DSERIALNUM=$(REFNUM:0%=%)
         endif
       endif
   endif
@@ -89,7 +89,7 @@ else
               perl -ne 'print $$1 . " " if(m-(/dev/\w+)-);')
       CMOTES=$(MOTES)
       REFNUM = $(shell $(MOTELIST) -c 2>&- | \
-               cut -f 1 -d , | tail -c5 )
+               cut -f 1 -d , | tail -c5 | sed 's/^0*//')
       ifneq (,$(REFNUM))
         # No device fo-und
         ifeq (,$(findstring und, $(REFNUM)))


### PR DESCRIPTION
Remove leading zeros to avoid node id being treated as octal