### PR TITLE
ipolite: stop ctimer and reset queuebuf pointer when canceling old send

### DIFF
--- a/core/net/rime/ipolite.c
+++ b/core/net/rime/ipolite.c
@@ -148,6 +148,8 @@ ipolite_send(struct ipolite_conn *c, clock_time_t interval, uint8_t hdrsize)
     PRINTF("%d.%d: ipolite_send: cancel old send\n",
 	   linkaddr_node_addr.u8[0],linkaddr_node_addr.u8[1]);
     queuebuf_free(c->q);
+    c->q = NULL;
+    ctimer_stop(&c->t);
   }
   c->dups = 0;
   c->hdrsize = hdrsize;


### PR DESCRIPTION
Fixes #827 

Ipolite is used by netflood and route-discovery modules among others. If a route request is yet to be re-broadcasted and a local route discovery is started (interval == 0), the previous queuebuf used is freed but ctimer and queuebuf pointer is left unchanged. This causes corrupt route requests to be sent, invalid routing tables to be formed, memcmp() on NULL pointer on receive, and other undefined behavior.

Signed-off-by: Oskar Nordquist oskar.nordquist@crlsweden.com
