### PR TITLE
rf230bb: Handle all IRQ flags in one ISR call. (Q: Is the current ISR valid?)

### DIFF
--- a/cpu/avr/radio/rf230bb/halbb.c
+++ b/cpu/avr/radio/rf230bb/halbb.c
@@ -751,7 +751,8 @@ HAL_RF230_ISR()
 #endif
 #endif
 
-    } else if (interrupt_source & HAL_TRX_END_MASK){
+    }
+    if (interrupt_source & HAL_TRX_END_MASK){
 	   INTERRUPTDEBUG(11);	    	    
         
        state = hal_subregister_read(SR_TRX_STATUS);
@@ -778,16 +779,20 @@ HAL_RF230_ISR()
 
        }
               
-    } else if (interrupt_source & HAL_TRX_UR_MASK){
+    }
+    if (interrupt_source & HAL_TRX_UR_MASK){
         INTERRUPTDEBUG(13);
         ;
-    } else if (interrupt_source & HAL_PLL_UNLOCK_MASK){
+    }
+    if (interrupt_source & HAL_PLL_UNLOCK_MASK){
         INTERRUPTDEBUG(14);
 	    ;
-    } else if (interrupt_source & HAL_PLL_LOCK_MASK){
+    }
+    if (interrupt_source & HAL_PLL_LOCK_MASK){
         INTERRUPTDEBUG(15);
         ;
-    } else if (interrupt_source & HAL_BAT_LOW_MASK){
+    }
+    if (interrupt_source & HAL_BAT_LOW_MASK){
         /*  Disable BAT_LOW interrupt to prevent endless interrupts. The interrupt */
         /*  will continously be asserted while the supply voltage is less than the */
         /*  user-defined voltage threshold. */
@@ -796,9 +801,6 @@ HAL_RF230_ISR()
         hal_register_write(RG_IRQ_MASK, trx_isr_mask);
         INTERRUPTDEBUG(16);
         ;
-     } else {
-        INTERRUPTDEBUG(99);
-	    ;
     }
 }
 #endif /* defined(__AVR_ATmega128RFA1__) */ 


### PR DESCRIPTION
I think the if statements in the ISR in rf230bb look weird. If the first flag is matched then no other IRQ flags will be checked. According to the data sheet, the IRQ signal is deasserted after reading the IRQ status register, which, as I understand it, would cause the other unhandled IRQ flags to be lost forever. See AT86RF212 data sheet, chapter 8.1 "Frame Receive Procedure".

If my understanding of the data sheet is correct, then this behaviour can possibly lead to missed TRX_END interrupts, because RX_START is checked first. The reason that these two flags would be set at the same time could be that the handling of the interrupt from the radio has been delayed by other code either disabling interrupts, or another ISR with a higher priority was executing during the time between RX_START and TRX_END.

I have attached an untested example solution for the problem described above.

The reason I discovered this is that I am looking over the rf230bb code in order to try to find the source of an issue I am seeing with dropped packets from time to time. I have not yet had time to evaluate if this change fixes the problem.