### PR TITLE
Makefile.include: Reduce I/O load (and build time) by assigning git description variable once.

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -153,7 +153,7 @@ CFLAGS += ${addprefix -I,$(SOURCEDIRS) $(CONTIKI)}
 ### Check for a git repo and pass version if found
 ### git.exe in Windows cmd shells may require no stderr redirection
 #RELSTR=${shell git describe --tags}
-RELSTR=${shell git --git-dir ${CONTIKI}/.git describe --tags 2>/dev/null}
+RELSTR:=${shell git --git-dir ${CONTIKI}/.git describe --tags 2>/dev/null}
 ifneq ($(RELSTR),)
 CFLAGS += -DCONTIKI_VERSION_STRING=\"Contiki-$(RELSTR)\"
 endif


### PR DESCRIPTION
By changing RELSTR= into RELSTR:= we force Make to evaluate the Git
version string only during Makefile read, and not on every single build
command execution.

The reduction in file system I/O cut the time to build
examples/er-rest-example on my development machine by a significant
amount, see below.

Core i7 notebook with ext4 file system on an SSD (building for TARGET=mulle):
"RELSTR="  make  19.70s user 1.07s system 82% cpu 25.291 total
"RELSTR:=" make  11.81s user 1.27s system 79% cpu 16.499 total

Signed-off-by: Joakim Gebart joakim.gebart@eistec.se
