### PR TITLE
Changed code region to any

### DIFF
--- a/cpu/msp430/Makefile.msp430
+++ b/cpu/msp430/Makefile.msp430
@@ -151,7 +151,7 @@ ifneq (,$(findstring 4.7.,$(shell msp430-gcc -dumpversion)))
 ifdef CPU_HAS_MSP430X
   TARGET_MEMORY_MODEL ?= medium
   CFLAGS += -mmemory-model=$(TARGET_MEMORY_MODEL)
-  CFLAGS += -ffunction-sections -fdata-sections -mcode-region=far
+  CFLAGS += -ffunction-sections -fdata-sections -mcode-region=any
   LDFLAGS += -mmemory-model=$(TARGET_MEMORY_MODEL) -Wl,-gc-sections
 endif
 endif


### PR DESCRIPTION
Original discussion [Here](http://sourceforge.net/p/contiki/mailman/message/32628670/)

Tested with json-ws test application at examples/ipv6/json-ws.

Original:
> websense-z1.z1 section `.far.text' will not fit in region `far_rom'
> region `far_rom' overflowed by 376 bytes

Amended:
msp430-size websense-z1.z1 
>   text    data	    bss	    dec	    hex	filename
>  48260	    594	   5936	  54790	   d606	websense-z1.z1

