### PR TITLE
Assert that the ringbuf has the right size / Add compile time assert

### DIFF
--- a/core/dev/serial-line.c
+++ b/core/dev/serial-line.c
@@ -131,7 +131,7 @@ PROCESS_THREAD(serial_line_process, ev, data)
 void
 serial_line_init(void)
 {
-  ringbuf_init(&rxbuf, rxbuf_data, sizeof(rxbuf_data));
+  RINGBUF_INIT(&rxbuf, rxbuf_data);
   process_start(&serial_line_process, NULL);
 }
 /*---------------------------------------------------------------------------*/

--- a/core/lib/assert.h
+++ b/core/lib/assert.h
@@ -42,7 +42,13 @@ void _xassert(const char *, int);
 #ifndef CTASSERT                /* Allow lint to override */
 #define CTASSERT(x)             _CTASSERT(x, __LINE__)
 #define _CTASSERT(x, y)         __CTASSERT(x, y)
+
+#ifdef __CC65__
+/* CC65 can't cope with compile time assert -> Fall back to run time */
+#define __CTASSERT(x, y)        assert(x)
+#else
 #define __CTASSERT(x, y)        typedef char __assert ## y[(x) ? 1 : -1]
+#endif
 #endif
 
 #endif /* ASSERT_H_ */

--- a/core/lib/assert.h
+++ b/core/lib/assert.h
@@ -28,21 +28,30 @@
  *
  */
 
-#ifndef ASSERT_H_
-#define ASSERT_H_
+
+
+#ifndef CONTIKI_ASSERT_H_
+#define CONTIKI_ASSERT_H_
 
 #undef assert
+// Include library-assert if available
+#include <assert.h>
+
+#ifndef assert
 #ifdef NDEBUG
 #define assert(e) ((void)0)
 #else
 #define assert(e) ((e) ? (void)0 : _xassert(__FILE__, __LINE__))
 void _xassert(const char *, int);
 #endif
+#endif
 
 #ifndef CTASSERT                /* Allow lint to override */
 #define CTASSERT(x)             _CTASSERT(x, __LINE__)
-#define _CTASSERT(x, y)         __CTASSERT(x, y)
+#endif
 
+#ifndef _CTASSERT
+#define _CTASSERT(x, y)         __CTASSERT(x, y)
 #ifdef __CC65__
 /* CC65 can't cope with compile time assert -> Fall back to run time */
 #define __CTASSERT(x, y)        assert(x)

--- a/core/lib/ringbuf.h
+++ b/core/lib/ringbuf.h
@@ -55,6 +55,7 @@
 #define RINGBUF_H_
 
 #include "contiki-conf.h"
+#include "assert.h"
 
 /**
  * \brief      Structure that holds the state of a ring buffer.
@@ -78,16 +79,34 @@ struct ringbuf {
  * \param r    A pointer to a struct ringbuf to hold the state of the ring buffer
  * \param a    A pointer to an array to hold the data in the buffer
  * \param size_power_of_two The size of the ring buffer, which must be a power of two
+ * \sa RINGBUF_INIT
  *
  *             This function initiates a ring buffer. The data in the
  *             buffer is stored in an external array, to which a
  *             pointer must be supplied. The size of the ring buffer
  *             must be a power of two and cannot be larger than 128
- *             bytes.
+ *             bytes. If possible use the \ref RINGBUF_INIT macro.
  *
  */
 void    ringbuf_init(struct ringbuf *r, uint8_t *a,
 		     uint8_t size_power_of_two);
+
+
+/**
+ * \brief      Initialize a ring buffer with compile time checks
+ * @param r    A pointer to a struct ringbuf to hold the state of the ring buffer
+ * @param b    A pointer to an array to hold the data in the buffer - must be a power of two
+ * @sa ringbuf_init
+ *
+ *             This macro calls rinbuf_init(), but does some compile time checks whether your
+ *             buffer meets the criteria by \ref ringbuf_init. At least when using GCC.
+ */
+
+#define RINGBUF_INIT(r, b) do {\
+  CTASSERT( (sizeof(b) <= 128) && ((sizeof(b) & (sizeof(b) -1)) == 0)); \
+  ringbuf_init(r, b, sizeof(b));\
+} while(0)
+
 
 /**
  * \brief      Insert a byte into the ring buffer

--- a/core/lib/ringbuf.h
+++ b/core/lib/ringbuf.h
@@ -103,7 +103,7 @@ void    ringbuf_init(struct ringbuf *r, uint8_t *a,
  */
 
 #define RINGBUF_INIT(r, b) do {\
-  CTASSERT( (sizeof(b) <= 128) && ((sizeof(b) & (sizeof(b) -1)) == 0)); \
+  _CTASSERT( (sizeof(b) <= 128) && ((sizeof(b) & (sizeof(b) -1)) == 0), BUFFER_SIZE_NOT_VALID_); \
   ringbuf_init(r, b, sizeof(b));\
 } while(0)
 

--- a/core/lib/ringbuf.h
+++ b/core/lib/ringbuf.h
@@ -55,7 +55,7 @@
 #define RINGBUF_H_
 
 #include "contiki-conf.h"
-#include "assert.h"
+#include "lib/assert.h"
 
 /**
  * \brief      Structure that holds the state of a ring buffer.

--- a/cpu/msp430/f1xxx/uart1.c
+++ b/cpu/msp430/f1xxx/uart1.c
@@ -215,7 +215,7 @@ uart1_init(unsigned long ubr)
 
   IE2 |= URXIE1;                        /* Enable USART1 RX interrupt  */
 #if TX_WITH_INTERRUPT
-  ringbuf_init(&txbuf, txbuf_data, sizeof(txbuf_data));
+  RINGBUF_INIT(&txbuf, txbuf_data);
   IE2 |= UTXIE1;                        /* Enable USART1 TX interrupt  */
 #endif /* TX_WITH_INTERRUPT */
 

--- a/cpu/msp430/f2xxx/uart0.c
+++ b/cpu/msp430/f2xxx/uart0.c
@@ -132,7 +132,7 @@ uart0_init(unsigned long ubr)
   IE2 |= UCA0RXIE;                        /* Enable UCA0 RX interrupt */
   /* Enable USCI_A0 TX interrupts (if TX_WITH_INTERRUPT enabled) */
 #if TX_WITH_INTERRUPT
-  ringbuf_init(&txbuf, txbuf_data, sizeof(txbuf_data));
+  RINGBUF_INIT(&txbuf, txbuf_data);
   IE2 |= UCA0TXIE;                        /* Enable UCA0 TX interrupt */
 #endif /* TX_WITH_INTERRUPT */
 }

--- a/cpu/rl78/adf7023/ADF7023.c
+++ b/cpu/rl78/adf7023/ADF7023.c
@@ -33,7 +33,7 @@
  */
 
 #include <stdio.h>
-#include <assert.h>
+#include "lib/assert.h"
 #include <string.h>  /* for memcmp(). */
 #include <stdbool.h>
 

--- a/cpu/stm32w108/dev/uart1.c
+++ b/cpu/stm32w108/dev/uart1.c
@@ -159,7 +159,7 @@ uart1_init(unsigned long ubr)
   transmitting = 0;
 
 #if TX_WITH_INTERRUPT
-  ringbuf_init(&txbuf, txbuf_data, sizeof(txbuf_data));
+  RINGBUF_INIT(&txbuf, txbuf_data);
 #endif /* TX_WITH_INTERRUPT */
 
   INT_SC1FLAG = 0xFFFF;


### PR DESCRIPTION
This PR has to patches. The fist supports compile time asserts. The error itself is not really helpful, but as one still gets file name and line number its better than nothing.
The second uses the new compile-time assert-feature to ensure the the puffer passed the the ringbuf function fulfills the requirements.