### PR TITLE
Added missing memb_free in queuebuf.c

### DIFF
--- a/core/net/queuebuf.c
+++ b/core/net/queuebuf.c
@@ -390,9 +390,9 @@ queuebuf_new_from_packetbuf(void)
       PRINTF("queuebuf len %d\n", queuebuf_len);
       printf("#A q=%d\n", queuebuf_len);
       if(queuebuf_len == queuebuf_max_len + 1) {
-  memb_free(&bufmem, buf);
-  queuebuf_len--;
-  return NULL;
+        queuebuf_free(buf);
+        queuebuf_len--;
+        return NULL;
       }
 #endif /* QUEUEBUF_STATS */
 


### PR DESCRIPTION
This PR fixes a memory leak in the queuebuf module.
In `queuebuf_new_from_packetbuf`, with `WITH_SWAP` unset: `buf` was not freed before returning in case the allocation of `buf->ram_ptr` fails.
