### PR TITLE
frame802154_t: make sure dest_addr and src_addr are aligned

### DIFF
--- a/core/net/mac/frame802154.c
+++ b/core/net/mac/frame802154.c
@@ -64,6 +64,7 @@
 #include "sys/cc.h"
 #include "net/mac/frame802154.h"
 #include "net/llsec/llsec802154.h"
+#include "net/linkaddr.h"
 #include <string.h>
 
 /**

--- a/core/net/mac/frame802154.h
+++ b/core/net/mac/frame802154.h
@@ -62,7 +62,6 @@
 #define FRAME_802154_H
 
 #include "contiki-conf.h"
-#include "net/linkaddr.h"
 
 #ifdef IEEE802154_CONF_PANID
 #define IEEE802154_PANID           IEEE802154_CONF_PANID

--- a/platform/micaz/init-net.c
+++ b/platform/micaz/init-net.c
@@ -49,6 +49,7 @@
 #include "dev/leds.h"
 #include "net/netstack.h"
 #include "net/mac/frame802154.h"
+#include "net/linkaddr.h"
 
 #include "dev/ds2401.h"
 #include "sys/node-id.h"


### PR DESCRIPTION
This PR makes sure `dest_addr` and `src_addr` are aligned to CPU word size.
Needed as they are accessed directly as `linkaddr_t*`.
Note we cannot use the type `linkaddr_t` directly here, as we always need 8 bytes, not `LINKADDR_SIZE` bytes.
