### PR TITLE
Alignment of field `data` in queuebuf

### DIFF
--- a/core/net/queuebuf.c
+++ b/core/net/queuebuf.c
@@ -77,8 +77,8 @@ struct queuebuf {
 
 /* The actual queuebuf data */
 struct queuebuf_data {
-  uint16_t len;
   uint8_t data[PACKETBUF_SIZE];
+  uint16_t len;
   struct packetbuf_attr attrs[PACKETBUF_NUM_ATTRS];
   struct packetbuf_addr addrs[PACKETBUF_NUM_ADDRS];
 };


### PR DESCRIPTION
Minor improvement that makes sure the queuebuf payload is 32-bit aligned. Can not hurt 32-bit MCUs (memcpy and memcmp typically run faster with aligned addresses).
