### PR TITLE
Travis fix: trigger failed tests correctly

### DIFF
--- a/regression-tests/Makefile.simulation-test
+++ b/regression-tests/Makefile.simulation-test
@@ -29,7 +29,7 @@
 TESTS=$(wildcard ??-*.csc)
 TESTLOGS=$(patsubst %.csc,%.testlog,$(TESTS))
 LOGS=$(patsubst %.csc,%.log,$(TESTS))
-FAILLOGS=$(patsubst %.csc,%.faillog,$(TESTS))
+FAILLOGS=$(patsubst %.csc,%.*.faillog,$(TESTS))
 #Set random seeds to create reproduceable results.
 RANDOMSEED=1 5
 


### PR DESCRIPTION
We noticed that, after some recent changes, the current regression test scripts don't correctly trigger failed tests: tests that fail are incorrectly reported as if they are ok. This means that we could potentially have merged bad patches, but fortunately all the tests seem to work still.
