### PR TITLE
Seedeye platform: add the explicit list of modules

### DIFF
--- a/platform/seedeye/Makefile.seedeye
+++ b/platform/seedeye/Makefile.seedeye
@@ -63,3 +63,6 @@ CONTIKI_TARGET_SOURCEFILES += $(CONTIKI_CORE_SOURCEFILES)
 CONTIKI_SOURCEFILES += $(CONTIKI_TARGET_SOURCEFILES)
 
 include $(CONTIKI)/cpu/pic32/Makefile.pic32
+
+MODULES += core/net core/net/mac core/net/rime core/net/llsec \
+           core/net/ipv6 core/net/rpl core/net/ip


### PR DESCRIPTION
Examples for Seedeye board won't compile without the explicit list of modules.
