### PR TITLE
Optimization: Get rid of PT_YIELD_FLAG

### DIFF
--- a/core/sys/lc-addrlabels.h
+++ b/core/sys/lc-addrlabels.h
@@ -75,6 +75,9 @@ typedef void * lc_t;
 #define LC_SET(s)                               \
   do { ({ __label__ resume; resume: (s) = &&resume; }); }while(0)
 
+#define LC_SET_YIELD(s,retval)                               \
+  do { ({ __label__ resume; (s) = &&resume; return retval; resume:;  }); }while(0)
+
 #define LC_END(s)
 
 #endif /* LC_ADDRLABELS_H_ */

--- a/core/sys/lc-switch.h
+++ b/core/sys/lc-switch.h
@@ -68,6 +68,8 @@ typedef unsigned short lc_t;
 
 #define LC_SET(s) s = __LINE__; case __LINE__:
 
+#define LC_SET_YIELD(s,retval) s = __LINE__; return retval; case __LINE__:
+
 #define LC_END(s) }
 
 #endif /* LC_SWITCH_H_ */

--- a/core/sys/lc.h
+++ b/core/sys/lc.h
@@ -83,6 +83,21 @@
 #define LC_SET(lc)
 
 /**
+ * Set a local continuation and yield.
+ *
+ * The set-yield operation saves the state of the function and yields
+ * it at the point where the operation is executed. The function is
+ * continued with the subsequent statement at next invocation. The function
+ * is yielded by returning retval. As far as the set operation is concerned,
+ * the state of the function does <b>not</b> include the call-stack or local
+ * (automatic) variables, but only the program counter and such CPU registers
+ * that needs to be saved.
+ *
+ * \hideinitializer
+ */
+#define LC_SET_YIELD(lc,retval)
+
+/**
  * Resume a local continuation.
  *
  * The resume operation resumes a previously set local continuation, thus

--- a/core/sys/pt.h
+++ b/core/sys/pt.h
@@ -111,7 +111,7 @@ struct pt {
  *
  * \hideinitializer
  */
-#define PT_BEGIN(pt) { char PT_YIELD_FLAG = 1; if (PT_YIELD_FLAG) {;} LC_RESUME((pt)->lc)
+#define PT_BEGIN(pt) { LC_RESUME((pt)->lc)
 
 /**
  * Declare the end of a protothread.
@@ -123,8 +123,8 @@ struct pt {
  *
  * \hideinitializer
  */
-#define PT_END(pt) LC_END((pt)->lc); PT_YIELD_FLAG = 0; \
-                   PT_INIT(pt); return PT_ENDED; }
+#define PT_END(pt) LC_END((pt)->lc); \
+    PT_INIT(pt); return PT_ENDED; }
 
 /** @} */
 
@@ -286,13 +286,10 @@ struct pt {
  *
  * \hideinitializer
  */
-#define PT_YIELD(pt)				\
-  do {						\
-    PT_YIELD_FLAG = 0;				\
-    LC_SET((pt)->lc);				\
-    if(PT_YIELD_FLAG == 0) {			\
-      return PT_YIELDED;			\
-    }						\
+#define PT_YIELD(pt)                        \
+  do {                                      \
+      LC_SET_YIELD((pt)->lc, PT_YIELDED);   \
+    }                                       \
   } while(0)
 
 /**
@@ -306,14 +303,10 @@ struct pt {
  *
  * \hideinitializer
  */
-#define PT_YIELD_UNTIL(pt, cond)		\
-  do {						\
-    PT_YIELD_FLAG = 0;				\
-    LC_SET((pt)->lc);				\
-    if((PT_YIELD_FLAG == 0) || !(cond)) {	\
-      return PT_YIELDED;			\
-    }						\
-  } while(0)
+#define PT_YIELD_UNTIL(pt, cond)            \
+  do {                                      \
+    LC_SET_YIELD((pt)->lc, PT_YIELDED);     \
+  } while(!(cond))
 
 /** @} */
 

--- a/core/sys/pt.h
+++ b/core/sys/pt.h
@@ -289,7 +289,6 @@ struct pt {
 #define PT_YIELD(pt)                        \
   do {                                      \
       LC_SET_YIELD((pt)->lc, PT_YIELDED);   \
-    }                                       \
   } while(0)
 
 /**

--- a/cpu/6502/sys/lc.h
+++ b/cpu/6502/sys/lc.h
@@ -44,8 +44,16 @@ void __fastcall__ lc_set(lc_t *lc);
 void __fastcall__ lc_resume(lc_t *lc);
 
 #define LC_SET(lc)    lc_set(&(lc))
-#define LC_RESUME(lc) lc_resume(&(lc))
-#define LC_INIT(lc)   (lc) = NULL
-#define LC_END(lc)
+
+#define LC_SET_YIELD(lc,retval)             \
+    do {                                    \
+        LC_YIELD_FLAG = 1;                  \
+        LC_SET(lc);                         \
+        if(LC_YIELD_FLAG) return retval;    \
+    }while(0)
+
+#define LC_RESUME(lc)   { char LC_YIELD_FLAG = 0; lc_resume(&(lc))
+#define LC_INIT(lc)     (lc) = NULL
+#define LC_END(lc)      }
 
 #endif /* LC_H_ */


### PR DESCRIPTION
This pull request replaces #798 

Cleaned up the pull request.

IAR-C compiler throws this warning in case of following and often used example

PROCESS_THREAD(test_process, ev, data)
{
  PROCESS_EXITHANDLER(goto exit);

  PROCESS_BEGIN();

  ....
  exit:
  doSomething();

  PROCESS_END();
}

as in case of "goto exit" , PROCESS_BEGIN() gets bypassed.

Following changes were made:

Added LC_SET_YIELD(lc,retval) to switch and addrlabels version of lc
Modified PT_BEGIN,PT_END,PT_YIELD and PT_YIELD_UNTIL to work with LC_SET_YIELD

This change makes the PT_YIELD_FLAG unnecessary, but delivers the same behaviour and might be more efficient than the PT_YIELD_FLAG version.

The 6502 uses its own optimized version for local continuations.
So I added the PT_YIELD_FLAG (LC_YIELD_FLAG in this case) to lc.h of the 6502 implementation.
Maybe someone else can write an optimized version of LC_SET_YIELD for 6502?
In case of 6502 the code execution time for the LC_YIELD_FLAG version should be nearly the same as for PT_YIELD_FLAG version.