### PR TITLE
Enhancement : Moved thread states from module to header

### DIFF
--- a/core/sys/mt.c
+++ b/core/sys/mt.c
@@ -46,10 +46,6 @@
 #include "sys/mt.h"
 #include "sys/cc.h"
 
-#define MT_STATE_READY   1
-#define MT_STATE_RUNNING 2
-#define MT_STATE_EXITED  5
-
 static struct mt_thread *current;
 
 /*--------------------------------------------------------------------------*/

--- a/core/sys/mt.h
+++ b/core/sys/mt.h
@@ -84,6 +84,9 @@
 
 #include "contiki.h"
 
+#define MT_STATE_READY   1
+#define MT_STATE_RUNNING 2
+#define MT_STATE_EXITED  5
 
 /**
  * An opaque structure that is used for holding the state of a thread.


### PR DESCRIPTION
I think it is better if the state definitions are located in the header-file (mt.h). 
Especially if you want to write an mt scheduler contiki process that has to know about the states of the thread.
