### PR TITLE
examples/webserver-ipv6: Add UIP_CONF_TCP=1 to DEFINES.

### DIFF
--- a/examples/webserver-ipv6/Makefile
+++ b/examples/webserver-ipv6/Makefile
@@ -35,7 +35,7 @@ all : $(CONTIKI_PROJECT)
 endif
 
 UIP_CONF_IPV6=1
-DEFINES=WITH_UIP6
+DEFINES=WITH_UIP6,UIP_CONF_TCP=1
 
 # Make no RPL the default for minimal-net builds
 ifeq ($(TARGET),minimal-net)


### PR DESCRIPTION
TCP is mandatory for this HTTP server.

Fixes builds for platforms which have TCP turned off by default (e.g. mulle)

Signed-off-by: Joakim Gebart joakim.gebart@eistec.se
