### PR TITLE
Stop the DAO lifetime timer in RPL instances when released.

### DIFF
--- a/core/net/rpl/rpl-dag.c
+++ b/core/net/rpl/rpl-dag.c
@@ -513,6 +513,7 @@ rpl_free_instance(rpl_instance_t *instance)
 
   ctimer_stop(&instance->dio_timer);
   ctimer_stop(&instance->dao_timer);
+  ctimer_stop(&instance->dao_lifetime_timer);
 
   if(default_instance == instance) {
     default_instance = NULL;


### PR DESCRIPTION
Clearing the memory for an active etimer/ctimer might corrupt the timer list and cause other timers to be lost or infinite loops. The DAO lifetime timer is only used when RPL route lifetime is not infinite but then the timer will cause problems if not stopped.
