### PR TITLE
Ensure that the data in ringbuff is accessed in the right order

### DIFF
--- a/core/sys/cc.h
+++ b/core/sys/cc.h
@@ -123,6 +123,17 @@
 #define CC_NO_VA_ARGS CC_CONF_VA_ARGS
 #endif
 
+/** \def CC_ACCESS_NOW(x)
+ * This macro ensures that the access to a non-volatile variable can
+ * not be reordered or optimized by the compiler.
+ * See also https://lwn.net/Articles/508991/ - In Linux the macro is
+ * called ACCESS_ONCE
+ * The type must be passed, because the typeof-operator is a gcc
+ * extension
+ */
+
+#define CC_ACCESS_NOW(type, variable) (*(volatile type *)&(variable))
+
 #ifndef NULL
 #define NULL 0
 #endif /* NULL */


### PR DESCRIPTION
This fixes a potential issue with concurrency and the compiler being allowed to reorder instructions in the ringbuff (The whole topic is quite interesting and caused quite some discussions in our working group). Unfortunately this causes msp430-gcc 4.7.0 to produce worse code (for some reason the optimizer does not detect, that a register isn't needed anymore and does not reuse it, therefore needing an additional instruction). Nonetheless the side effects caused by this in the future may become quite ugly.