### PR TITLE
Resolv fixes, including CERT VU #210620

### DIFF
--- a/core/net/ip/resolv.c
+++ b/core/net/ip/resolv.c
@@ -1380,7 +1380,8 @@ resolv_lookup(const char *name, uip_ipaddr_t ** ipaddr)
 
 #if VERBOSE_DEBUG
   switch (ret) {
-  case RESOLV_STATUS_CACHED:{
+  case RESOLV_STATUS_CACHED:
+    if(ipaddr) {
       PRINTF("resolver: Found \"%s\" in cache.\n", name);
       const uip_ipaddr_t *addr = *ipaddr;
 


### PR DESCRIPTION
This pull request fixes a few isseus in the `resolv` code:
- CERT vulnerability note VU#210620: http://www.kb.cert.org/vuls/id/210620 This pull request randomizes DNS request IDs to make them difficult to guess
- A few compiler warnings about unused variables
- Autostart the resolv process if it wasn't started by the `main()` code
- Fix a NULL bug if debugging is turned on
