### PR TITLE
IP64: randomize source ports for all outgoing connections

### DIFF
--- a/core/net/ip64/ip64-addrmap.c
+++ b/core/net/ip64/ip64-addrmap.c
@@ -35,6 +35,8 @@
 
 #include "ip64-conf.h"
 
+#include "lib/random.h"
+
 #include <string.h>
 
 #ifdef IP64_ADDRMAP_CONF_ENTRIES
@@ -173,10 +175,8 @@ ip64_addrmap_lookup_port(uint16_t mapped_port, uint8_t protocol)
 static void
 increase_mapped_port(void)
 {
-  mapped_port++;
-  if(mapped_port >= LAST_MAPPED_PORT) {
-    mapped_port = FIRST_MAPPED_PORT;
-  }
+  mapped_port = (random_rand() % (LAST_MAPPED_PORT - FIRST_MAPPED_PORT)) +
+    FIRST_MAPPED_PORT;
 }
 /*---------------------------------------------------------------------------*/
 struct ip64_addrmap_entry *


### PR DESCRIPTION
This is another fix for http://www.kb.cert.org/vuls/id/210620.

It also makes life easier when running repeated development/testing, as new TCP and UDP ports will be chosen with each test run.
