### PR TITLE
Align packetbuf on an even 32-bit boundary

### DIFF
--- a/core/net/packetbuf.c
+++ b/core/net/packetbuf.c
@@ -56,10 +56,10 @@ static uint16_t buflen, bufptr;
 static uint8_t hdrptr;
 
 /* The declarations below ensure that the packet buffer is aligned on
-   an even 16-bit boundary. On some platforms (most notably the
-   msp430), having apotentially misaligned packet buffer may lead to
-   problems when accessing 16-bit values. */
-static uint16_t packetbuf_aligned[(PACKETBUF_SIZE + PACKETBUF_HDR_SIZE) / 2 + 1];
+   an even 32-bit boundary. On some platforms (most notably the
+   msp430 or OpenRISC), having a potentially misaligned packet buffer may lead to
+   problems when accessing words. */
+static uint32_t packetbuf_aligned[(PACKETBUF_SIZE + PACKETBUF_HDR_SIZE + 3) / 4];
 static uint8_t *packetbuf = (uint8_t *)packetbuf_aligned;
 
 static uint8_t *packetbufptr;


### PR DESCRIPTION
This PR aligns packetbuf on 32-bit rather than 16-bit, which is required for platforms such as the OpenRISC that does not support non-aligned 32-bit word access.
I would also expect this to make memcpy and memcmp potentially faster on Cortex-M3 and other 32-bit CPUs.