### PR TITLE
Allow specifying a max outgoing segment size per TCP socket

### DIFF
--- a/core/net/ip/tcp-socket.c
+++ b/core/net/ip/tcp-socket.c
@@ -56,10 +56,10 @@ call_event(struct tcp_socket *s, tcp_socket_event_t event)
 static void
 senddata(struct tcp_socket *s)
 {
-  int len;
+  int len = MIN(s->output_data_max_seg, uip_mss());
 
   if(s->output_data_len > 0) {
-    len = MIN(s->output_data_len, uip_mss());
+    len = MIN(s->output_data_len, len);
     s->output_data_send_nxt = len;
     uip_send(s->output_data_ptr, len);
   }
@@ -255,6 +255,7 @@ tcp_socket_register(struct tcp_socket *s, void *ptr,
   s->input_data_maxlen = input_databuf_len;
   s->output_data_ptr = output_databuf;
   s->output_data_maxlen = output_databuf_len;
+  s->output_data_max_seg = uip_mss();
   s->input_callback = input_callback;
   s->event_callback = event_callback;
   list_add(socketlist, s);

--- a/core/net/ip/tcp-socket.h
+++ b/core/net/ip/tcp-socket.h
@@ -95,6 +95,7 @@ struct tcp_socket {
   uint16_t output_data_maxlen;
   uint16_t output_data_len;
   uint16_t output_data_send_nxt;
+  uint16_t output_data_max_seg;
 
   uint8_t flags;
   uint16_t listen_port;


### PR DESCRIPTION
I'm working on a TCP-heavy project which combines two things:
- An HTTPD
- A bespoke TCP client

I've found that the HTTPD benefits from long segments (and fragmentation at the 6LoWPAN layer), while the TCP client is a lot more stable with smaller segments and zero fragmentation. Thus, there is no single best value for `UIP_CONF_TCP_MSS` which would satisfy the requirements of both apps.

What I am proposing here is to add the ability to specify MSS on a per-socket basis. Naturally, the remote can still reduce it even further. This is not dis-similar to what one would do with `setsockopt` (`TCP_MAXSEG` option), but I've chosen not to disturb our TCP sockets API: The interested application will have to write directly to the relevant field in the TCP socket struct.

Default is set to `uip_mss()`
