### PR TITLE
rf230bb: Fix missing ')' and indentation.

### DIFF
--- a/cpu/avr/radio/rf230bb/rf230bb.c
+++ b/cpu/avr/radio/rf230bb/rf230bb.c
@@ -1679,7 +1679,7 @@ rf230_cca(void)
 
     /* Use ED register to determine result. 77dBm is poweron csma default.*/
 #ifdef RF230_CONF_CCA_THRES
-    if (hal_register_read(RG_PHY_ED_LEVEL)<(91+RF230_CONF_CCA_THRES) cca=0xff;
+    if (hal_register_read(RG_PHY_ED_LEVEL)<(91+RF230_CONF_CCA_THRES)) cca=0xff;
 #else
     if (hal_register_read(RG_PHY_ED_LEVEL)<(91-77)) cca=0xff;
 #endif
@@ -1701,9 +1701,9 @@ rf230_cca(void)
   /* If already in receive mode can read the current ED register without delay */
   /* CCA energy threshold = -91dB + 2*SR_CCA_ED_THRESH. Reset defaults to -77dB */
 #ifdef RF230_CONF_CCA_THRES
-    if (hal_register_read(RG_PHY_ED_LEVEL)<(91+RF230_CONF_CCA_THRES) cca=0xff;
+    if (hal_register_read(RG_PHY_ED_LEVEL)<(91+RF230_CONF_CCA_THRES)) cca=0xff;
 #else
-	if (hal_register_read(RG_PHY_ED_LEVEL)<(91-77)) cca=0xff;
+    if (hal_register_read(RG_PHY_ED_LEVEL)<(91-77)) cca=0xff;
 #endif
 #endif
 


### PR DESCRIPTION
When defining RF230_CONF_CCA_THRES the build fails.
Traced the cause to a missing parenthesis.
