### PR TITLE
avoid updating routes that already are correct

### DIFF
--- a/core/net/ipv6/uip-ds6-route.c
+++ b/core/net/ipv6/uip-ds6-route.c
@@ -269,9 +269,16 @@ uip_ds6_route_add(uip_ipaddr_t *ipaddr, uint8_t length,
      one first. */
   r = uip_ds6_route_lookup(ipaddr);
   if(r != NULL) {
+    uip_ipaddr_t *current_nexthop;
+    current_nexthop = uip_ds6_route_nexthop(r);
+    if(uip_ipaddr_cmp(nexthop, current_nexthop)) {
+      /* no need to update route - already correct! */
+      return r;
+    }
     PRINTF("uip_ds6_route_add: old route for ");
     PRINT6ADDR(ipaddr);
     PRINTF(" found, deleting it\n");
+
     uip_ds6_route_rm(r);
   }
   {


### PR DESCRIPTION
This PR make the routing table check that the nexthop we are trying to add is different than the nexthop already   in the routing table for the specific route entry. If that is the case it skips doing both a remove and an add.
