### PR TITLE
moved ETX storage variable from RPL to ds6-nbr

### DIFF
--- a/core/net/ipv6/uip-ds6-nbr.h
+++ b/core/net/ipv6/uip-ds6-nbr.h
@@ -74,6 +74,7 @@ typedef struct uip_ds6_nbr {
   uint8_t nscount;
   uint8_t isrouter;
   uint8_t state;
+  uint16_t link_metric;
 #if UIP_CONF_IPV6_QUEUE_PKT
   struct uip_packetqueue_handle packethandle;
 #define UIP_DS6_NBR_PACKET_LIFETIME CLOCK_SECOND * 4

--- a/core/net/rpl/rpl-dag.c
+++ b/core/net/rpl/rpl-dag.c
@@ -83,7 +83,8 @@ rpl_instance_t *default_instance;
 
 /*---------------------------------------------------------------------------*/
 uip_ds6_nbr_t *
-rpl_get_nbr(rpl_parent_t *parent) {
+rpl_get_nbr(rpl_parent_t *parent)
+{
   linkaddr_t *lladdr = NULL;
   lladdr = nbr_table_get_lladdr(rpl_parents, parent);
   if(lladdr != NULL) {
@@ -93,9 +94,7 @@ rpl_get_nbr(rpl_parent_t *parent) {
     return NULL;
   }
 }
-
 /*---------------------------------------------------------------------------*/
-
 static void
 nbr_callback(void *ptr)
 {

--- a/core/net/rpl/rpl-dag.c
+++ b/core/net/rpl/rpl-dag.c
@@ -90,7 +90,6 @@ rpl_get_nbr(rpl_parent_t *parent)
   if(lladdr != NULL) {
     return nbr_table_get_from_lladdr(ds6_neighbors, lladdr);
   } else {
-    /* do nothing... can not update ETX Since there is no nbr struct */
     return NULL;
   }
 }
@@ -591,7 +590,7 @@ rpl_add_parent(rpl_dag_t *dag, rpl_dio_t *dio, uip_ipaddr_t *addr)
       p->rank = dio->rank;
       p->dtsn = dio->dtsn;
       
-      /* check if we have a nbr and if we have no prev link_metric  value */
+      /* Check whether we have a neighbor that has not gotten a link metric yet */
       if(nbr != NULL && nbr->link_metric == 0) {
 	nbr->link_metric = RPL_INIT_LINK_METRIC * RPL_DAG_MC_ETX_DIVISOR;
       }

--- a/core/net/rpl/rpl-mrhof.c
+++ b/core/net/rpl/rpl-mrhof.c
@@ -90,16 +90,22 @@ typedef uint16_t rpl_path_metric_t;
 static rpl_path_metric_t
 calculate_path_metric(rpl_parent_t *p)
 {
+  uip_ds6_nbr_t *nbr;
   if(p == NULL) {
     return MAX_PATH_COST * RPL_DAG_MC_ETX_DIVISOR;
   }
-
+  nbr = rpl_get_nbr(p);
+  if(nbr == NULL) {
+    return MAX_PATH_COST * RPL_DAG_MC_ETX_DIVISOR;
+  }
 #if RPL_DAG_MC == RPL_DAG_MC_NONE
-  return p->rank + (uint16_t)p->link_metric;
+  {
+    return p->rank + (uint16_t)nbr->link_metric;
+  }
 #elif RPL_DAG_MC == RPL_DAG_MC_ETX
-  return p->mc.obj.etx + (uint16_t)p->link_metric;
+  return p->mc.obj.etx + (uint16_t)nbr->link_metric;
 #elif RPL_DAG_MC == RPL_DAG_MC_ENERGY
-  return p->mc.obj.energy.energy_est + (uint16_t)p->link_metric;
+  return p->mc.obj.energy.energy_est + (uint16_t)nbr->link_metric;
 #else
 #error "Unsupported RPL_DAG_MC configured. See rpl.h."
 #endif /* RPL_DAG_MC */
@@ -114,9 +120,17 @@ reset(rpl_dag_t *dag)
 static void
 neighbor_link_callback(rpl_parent_t *p, int status, int numtx)
 {
-  uint16_t recorded_etx = p->link_metric;
+  uint16_t recorded_etx = 0;
   uint16_t packet_etx = numtx * RPL_DAG_MC_ETX_DIVISOR;
   uint16_t new_etx;
+  uip_ds6_nbr_t *nbr = NULL;
+
+  nbr = rpl_get_nbr(p);
+  if(nbr == NULL) {
+    /* No neighbor for this parent - something bad has occured!??? */
+    return;
+  }
+  recorded_etx = nbr->link_metric;
 
   /* Do not penalize the ETX when collisions or transmission errors occur. */
   if(status == MAC_TX_OK || status == MAC_TX_NOACK) {
@@ -139,7 +153,8 @@ neighbor_link_callback(rpl_parent_t *p, int status, int numtx)
         (unsigned)(recorded_etx / RPL_DAG_MC_ETX_DIVISOR),
         (unsigned)(new_etx  / RPL_DAG_MC_ETX_DIVISOR),
         (unsigned)(packet_etx / RPL_DAG_MC_ETX_DIVISOR));
-    p->link_metric = new_etx;
+    /* update the link metric for this nbr */
+    nbr->link_metric = new_etx;
   }
 }
 
@@ -148,14 +163,15 @@ calculate_rank(rpl_parent_t *p, rpl_rank_t base_rank)
 {
   rpl_rank_t new_rank;
   rpl_rank_t rank_increase;
+  uip_ds6_nbr_t *nbr;
 
-  if(p == NULL) {
+  if(p == NULL || (nbr = rpl_get_nbr(p)) == NULL) {
     if(base_rank == 0) {
       return INFINITE_RANK;
     }
     rank_increase = RPL_INIT_LINK_METRIC * RPL_DAG_MC_ETX_DIVISOR;
   } else {
-    rank_increase = p->link_metric;
+    rank_increase = nbr->link_metric;
     if(base_rank == 0) {
       base_rank = p->rank;
     }

--- a/core/net/rpl/rpl-mrhof.c
+++ b/core/net/rpl/rpl-mrhof.c
@@ -127,9 +127,10 @@ neighbor_link_callback(rpl_parent_t *p, int status, int numtx)
 
   nbr = rpl_get_nbr(p);
   if(nbr == NULL) {
-    /* No neighbor for this parent - something bad has occured!??? */
+    /* No neighbor for this parent - something bad has occured */
     return;
   }
+
   recorded_etx = nbr->link_metric;
 
   /* Do not penalize the ETX when collisions or transmission errors occur. */

--- a/core/net/rpl/rpl-mrhof.c
+++ b/core/net/rpl/rpl-mrhof.c
@@ -127,7 +127,7 @@ neighbor_link_callback(rpl_parent_t *p, int status, int numtx)
 
   nbr = rpl_get_nbr(p);
   if(nbr == NULL) {
-    /* No neighbor for this parent - something bad has occured */
+    /* No neighbor for this parent - something bad has occurred */
     return;
   }
 

--- a/core/net/rpl/rpl-of0.c
+++ b/core/net/rpl/rpl-of0.c
@@ -126,26 +126,34 @@ static rpl_parent_t *
 best_parent(rpl_parent_t *p1, rpl_parent_t *p2)
 {
   rpl_rank_t r1, r2;
-  rpl_dag_t *dag;
+  rpl_dag_t *dag;  
+  uip_ds6_nbr_t *nbr1, *nbr2;
+  nbr1 = rpl_get_nbr(p1);
+  nbr2 = rpl_get_nbr(p2);
+
+  dag = (rpl_dag_t *)p1->dag; /* Both parents must be in the same DAG. */
+
+  if(nbr1 == NULL || nbr2 == NULL) {
+    return dag->preferred_parent;
+  }
 
   PRINTF("RPL: Comparing parent ");
   PRINT6ADDR(rpl_get_parent_ipaddr(p1));
   PRINTF(" (confidence %d, rank %d) with parent ",
-        p1->link_metric, p1->rank);
+        nbr1->link_metric, p1->rank);
   PRINT6ADDR(rpl_get_parent_ipaddr(p2));
   PRINTF(" (confidence %d, rank %d)\n",
-        p2->link_metric, p2->rank);
+        nbr2->link_metric, p2->rank);
 
 
   r1 = DAG_RANK(p1->rank, p1->dag->instance) * RPL_MIN_HOPRANKINC  +
-         p1->link_metric;
+    nbr1->link_metric;
   r2 = DAG_RANK(p2->rank, p1->dag->instance) * RPL_MIN_HOPRANKINC  +
-         p2->link_metric;
+    nbr2->link_metric;
   /* Compare two parents by looking both and their rank and at the ETX
      for that parent. We choose the parent that has the most
      favourable combination. */
 
-  dag = (rpl_dag_t *)p1->dag; /* Both parents must be in the same DAG. */
   if(r1 < r2 + MIN_DIFFERENCE &&
      r1 > r2 - MIN_DIFFERENCE) {
     return dag->preferred_parent;

--- a/core/net/rpl/rpl.h
+++ b/core/net/rpl/rpl.h
@@ -114,7 +114,6 @@ struct rpl_parent {
   rpl_metric_container_t mc;
 #endif /* RPL_DAG_MC != RPL_DAG_MC_NONE */
   rpl_rank_t rank;
-  uint16_t link_metric;
   uint8_t dtsn;
   uint8_t flags;
 };
@@ -251,7 +250,7 @@ rpl_parent_t *rpl_get_parent(uip_lladdr_t *addr);
 rpl_rank_t rpl_get_parent_rank(uip_lladdr_t *addr);
 uint16_t rpl_get_parent_link_metric(const uip_lladdr_t *addr);
 void rpl_dag_init(void);
-
+uip_ds6_nbr_t *rpl_get_nbr(rpl_parent_t *parent);
 
 /**
  * RPL modes


### PR DESCRIPTION
This PR is for moving where the ETX is stored. Today it is in the RPL parents which works well until a global repair is made - then the ETX is gone - which make the global repair do a very bad job at repairing and finding the best parent. By moving to ds6-nbr which is then stored as long as the neighbor is there - independent of RPL state - this information will be kept during the global repair and RPL can pick the best parent with up-to-date information on ETX.