### PR TITLE
fixed so that trickle timer and route lifetime rpl config is updated at global repair

### DIFF
--- a/core/net/rpl/rpl-dag.c
+++ b/core/net/rpl/rpl-dag.c
@@ -1037,6 +1037,14 @@ global_repair(uip_ipaddr_t *from, rpl_dag_t *dag, rpl_dio_t *dio)
 
   remove_parents(dag, 0);
   dag->version = dio->version;
+
+  /* copy parts of the configuration so that it propagates in the network */
+  dag->instance->dio_intdoubl = dio->dag_intdoubl;
+  dag->instance->dio_intmin = dio->dag_intmin;
+  dag->instance->dio_redundancy = dio->dag_redund;
+  dag->instance->default_lifetime = dio->default_lifetime;
+  dag->instance->lifetime_unit = dio->lifetime_unit;
+
   dag->instance->of->reset(dag);
   dag->min_rank = INFINITE_RANK;
   RPL_LOLLIPOP_INCREMENT(dag->instance->dtsn_out);


### PR DESCRIPTION
This PR makes sure that nodes in the RPL network pick up new configuration of trickle timers and route default lifetime at a global repair. This makes the whole network run the same settings as the RPL Root when it is changing the configuration (I have had problems getting all the nodes in a network to update timers and route-lifetime when updating the RPL Root with new config in a already deployed network).