### PR TITLE
usb/rndis: Add parentheses to an unsafe macro

### DIFF
--- a/cpu/avr/dev/usb/rndis/rndis_task.h
+++ b/cpu/avr/dev/usb/rndis/rndis_task.h
@@ -56,7 +56,7 @@
 
 //_____ M A C R O S ________________________________________________________
 
-#define USB_ETH_MTU	UIP_BUFSIZE+4
+#define USB_ETH_MTU (UIP_BUFSIZE + 4)
 
 
 /*! Hook Documentation


### PR DESCRIPTION
Using this macro with other operators such as `*` or `/` can lead to unexpected results.
