### PR TITLE
Allow disabling of DIO suppression as required by RFC

### DIFF
--- a/core/net/rpl/rpl-timers.c
+++ b/core/net/rpl/rpl-timers.c
@@ -145,7 +145,7 @@ handle_dio_timer(void *ptr)
 
   if(instance->dio_send) {
     /* send DIO if counter is less than desired redundancy */
-    if(instance->dio_counter < instance->dio_redundancy) {
+    if(instance->dio_redundancy != 0 && instance->dio_counter < instance->dio_redundancy) {
 #if RPL_CONF_STATS
       instance->dio_totsend++;
 #endif /* RPL_CONF_STATS */


### PR DESCRIPTION
The special value 0 of DIO Redundancy means that DIO suppression mechanism is disabled instead of triggered immediately as currently done.

<pre>
         In RPL, when k has the value
         of 0x00, this is to be treated as a redundancy constant of
         infinity in RPL, i.e., Trickle never suppresses messages.
</pre>
