### PR TITLE
Add DODAG lifetime, update of parent rank when switching dag and multi dodag non-regression test

### DIFF
--- a/core/net/rpl/rpl-conf.h
+++ b/core/net/rpl/rpl-conf.h
@@ -122,6 +122,18 @@
 #endif /* RPL_CONF_DEFAULT_ROUTE_INFINITE_LIFETIME */
 
 /*
+ * Maximum lifetime of a DAG
+ * When a DODAG is not updated since RPL_CONF_DAG_LIFETIME times the DODAG
+ * maximum DIO interval the DODAG is removed from the list of DODAGS of the
+ * related instance, except if it is the currently joined DODAG.
+ */
+#ifdef RPL_CONF_DAG_LIFETIME
+#define RPL_DAG_LIFETIME                    RPL_CONF_DAG_LIFETIME
+#else
+#define RPL_DAG_LIFETIME                    3
+#endif /* RPL_CONF_DAG_LIFETIME */
+
+/*
  * 
  */
 #ifndef RPL_CONF_DAO_SPECIFY_DAG

--- a/core/net/rpl/rpl-dag.c
+++ b/core/net/rpl/rpl-dag.c
@@ -1060,6 +1060,7 @@ rpl_add_dag(uip_ipaddr_t *from, rpl_dio_t *dio)
       rpl_move_parent(previous_dag, dag, p);
     }
   }
+  p->rank = dio->rank;
 
   /* Determine the objective function by using the
      objective code point of the DIO. */
@@ -1374,10 +1375,9 @@ rpl_process_dio(uip_ipaddr_t *from, rpl_dio_t *dio)
       if(dag->joined) {
         instance->dio_counter++;
       }
-    } else {
-      p->rank=dio->rank;
     }
   }
+  p->rank = dio->rank;
 
   /* Parent info has been updated, trigger rank recalculation */
   p->flags |= RPL_PARENT_FLAG_UPDATED;

--- a/core/net/rpl/rpl-dag.c
+++ b/core/net/rpl/rpl-dag.c
@@ -1334,6 +1334,12 @@ rpl_process_dio(uip_ipaddr_t *from, rpl_dio_t *dio)
     return;
   }
 
+  /* The DIO comes from a valid DAG, we can refresh its lifetime */
+  dag->lifetime = (1UL << (instance->dio_intmin + instance->dio_intdoubl)) / 1000;
+  PRINTF("Set dag ");
+  PRINT6ADDR(&dag->dag_id);
+  PRINTF(" lifetime to %ld\n", dag->lifetime);
+
   /*
    * At this point, we know that this DIO pertains to a DAG that
    * we are already part of. We consider the sender of the DIO to be

--- a/core/net/rpl/rpl-private.h
+++ b/core/net/rpl/rpl-private.h
@@ -284,6 +284,7 @@ rpl_dag_t *rpl_alloc_dag(uint8_t, uip_ipaddr_t *);
 rpl_instance_t *rpl_alloc_instance(uint8_t);
 void rpl_free_dag(rpl_dag_t *);
 void rpl_free_instance(rpl_instance_t *);
+void rpl_purge_dags(void);
 
 /* DAG parent management function. */
 rpl_parent_t *rpl_add_parent(rpl_dag_t *, rpl_dio_t *dio, uip_ipaddr_t *);

--- a/core/net/rpl/rpl-timers.c
+++ b/core/net/rpl/rpl-timers.c
@@ -66,6 +66,7 @@ static uint8_t dio_send_ok;
 static void
 handle_periodic_timer(void *ptr)
 {
+  rpl_purge_dags();
   rpl_purge_routes();
   rpl_recalculate_ranks();
 

--- a/core/net/rpl/rpl.c
+++ b/core/net/rpl/rpl.c
@@ -300,6 +300,34 @@ rpl_ipv6_neighbor_callback(uip_ds6_nbr_t *nbr)
 }
 /*---------------------------------------------------------------------------*/
 void
+rpl_purge_dags(void)
+{
+  rpl_instance_t *instance;
+  rpl_instance_t *end;
+  int i;
+
+  for(instance = &instance_table[0], end = instance + RPL_MAX_INSTANCES;
+      instance < end; ++instance) {
+    if(instance->used) {
+      for(i = 0; i < RPL_MAX_DAG_PER_INSTANCE; i++) {
+        if(instance->dag_table[i].used) {
+          if(instance->dag_table[i].lifetime == 0) {
+            if(!instance->dag_table[i].joined) {
+              PRINTF("Removing dag ");
+              PRINT6ADDR(&instance->dag_table[i].dag_id);
+              PRINTF("\n");
+              rpl_free_dag(&instance->dag_table[i]);
+            }
+          } else {
+            instance->dag_table[i].lifetime--;
+          }
+        }
+      }
+    }
+  }
+}
+/*---------------------------------------------------------------------------*/
+void
 rpl_init(void)
 {
   uip_ipaddr_t rplmaddr;

--- a/core/net/rpl/rpl.h
+++ b/core/net/rpl/rpl.h
@@ -142,6 +142,7 @@ struct rpl_dag {
   rpl_rank_t rank;
   struct rpl_instance *instance;
   rpl_prefix_t prefix_info;
+  uint32_t lifetime;
 };
 typedef struct rpl_dag rpl_dag_t;
 typedef struct rpl_instance rpl_instance_t;

--- a/regression-tests/12-rpl/10-rpl-multi-dodag.csc
+++ b/regression-tests/12-rpl/10-rpl-multi-dodag.csc
@@ -1,0 +1,391 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<simconf>
+  <project EXPORT="discard">[APPS_DIR]/mrm</project>
+  <project EXPORT="discard">[APPS_DIR]/mspsim</project>
+  <project EXPORT="discard">[APPS_DIR]/avrora</project>
+  <project EXPORT="discard">[APPS_DIR]/serial_socket</project>
+  <project EXPORT="discard">[APPS_DIR]/collect-view</project>
+  <project EXPORT="discard">[APPS_DIR]/powertracker</project>
+  <project EXPORT="discard">[APPS_DIR]/serial2pty</project>
+  <project EXPORT="discard">[APPS_DIR]/radiologger-headless</project>
+  <simulation>
+    <title>My simulation</title>
+    <randomseed>123456</randomseed>
+    <motedelay_us>1000000</motedelay_us>
+    <radiomedium>
+      org.contikios.cooja.radiomediums.UDGM
+      <transmitting_range>50.0</transmitting_range>
+      <interference_range>50.0</interference_range>
+      <success_ratio_tx>1.0</success_ratio_tx>
+      <success_ratio_rx>1.0</success_ratio_rx>
+    </radiomedium>
+    <events>
+      <logoutput>40000</logoutput>
+    </events>
+    <motetype>
+      org.contikios.cooja.contikimote.ContikiMoteType
+      <identifier>mtype301</identifier>
+      <description>Sender</description>
+      <source>[CONTIKI_DIR]/regression-tests/12-rpl/code/sender-node.c</source>
+      <commands>make sender-node.cooja TARGET=cooja</commands>
+      <moteinterface>org.contikios.cooja.interfaces.Position</moteinterface>
+      <moteinterface>org.contikios.cooja.interfaces.Battery</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiVib</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiMoteID</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiRS232</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiBeeper</moteinterface>
+      <moteinterface>org.contikios.cooja.interfaces.RimeAddress</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiIPAddress</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiRadio</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiButton</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiPIR</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiClock</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiLED</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiCFS</moteinterface>
+      <moteinterface>org.contikios.cooja.interfaces.Mote2MoteRelations</moteinterface>
+      <moteinterface>org.contikios.cooja.interfaces.MoteAttributes</moteinterface>
+      <symbols>false</symbols>
+    </motetype>
+    <motetype>
+      org.contikios.cooja.contikimote.ContikiMoteType
+      <identifier>mtype820</identifier>
+      <description>RPL root</description>
+      <source>[CONTIKI_DIR]/regression-tests/12-rpl/code/root-node.c</source>
+      <commands>make root-node.cooja TARGET=cooja</commands>
+      <moteinterface>org.contikios.cooja.interfaces.Position</moteinterface>
+      <moteinterface>org.contikios.cooja.interfaces.Battery</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiVib</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiMoteID</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiRS232</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiBeeper</moteinterface>
+      <moteinterface>org.contikios.cooja.interfaces.RimeAddress</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiIPAddress</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiRadio</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiButton</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiPIR</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiClock</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiLED</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiCFS</moteinterface>
+      <moteinterface>org.contikios.cooja.interfaces.Mote2MoteRelations</moteinterface>
+      <moteinterface>org.contikios.cooja.interfaces.MoteAttributes</moteinterface>
+      <symbols>false</symbols>
+    </motetype>
+    <motetype>
+      org.contikios.cooja.contikimote.ContikiMoteType
+      <identifier>mtype306</identifier>
+      <description>Receiver</description>
+      <source>[CONTIKI_DIR]/regression-tests/12-rpl/code/receiver-node.c</source>
+      <commands>make receiver-node.cooja TARGET=cooja</commands>
+      <moteinterface>org.contikios.cooja.interfaces.Position</moteinterface>
+      <moteinterface>org.contikios.cooja.interfaces.Battery</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiVib</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiMoteID</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiRS232</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiBeeper</moteinterface>
+      <moteinterface>org.contikios.cooja.interfaces.RimeAddress</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiIPAddress</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiRadio</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiButton</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiPIR</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiClock</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiLED</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiCFS</moteinterface>
+      <moteinterface>org.contikios.cooja.interfaces.Mote2MoteRelations</moteinterface>
+      <moteinterface>org.contikios.cooja.interfaces.MoteAttributes</moteinterface>
+      <symbols>false</symbols>
+    </motetype>
+    <mote>
+      <interface_config>
+        org.contikios.cooja.interfaces.Position
+        <x>9.767954940345236</x>
+        <y>88.75813939592845</y>
+        <z>0.0</z>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.contikimote.interfaces.ContikiMoteID
+        <id>1</id>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.contikimote.interfaces.ContikiRadio
+        <bitrate>250.0</bitrate>
+      </interface_config>
+      <motetype_identifier>mtype306</motetype_identifier>
+    </mote>
+    <mote>
+      <interface_config>
+        org.contikios.cooja.interfaces.Position
+        <x>63.36720084537501</x>
+        <y>75.88456991067605</y>
+        <z>0.0</z>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.contikimote.interfaces.ContikiMoteID
+        <id>2</id>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.contikimote.interfaces.ContikiRadio
+        <bitrate>250.0</bitrate>
+      </interface_config>
+      <motetype_identifier>mtype301</motetype_identifier>
+    </mote>
+    <mote>
+      <interface_config>
+        org.contikios.cooja.interfaces.Position
+        <x>-20.684049350551753</x>
+        <y>60.49767834794315</y>
+        <z>0.0</z>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.contikimote.interfaces.ContikiMoteID
+        <id>6</id>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.contikimote.interfaces.ContikiRadio
+        <bitrate>250.0</bitrate>
+      </interface_config>
+      <motetype_identifier>mtype306</motetype_identifier>
+    </mote>
+    <mote>
+      <interface_config>
+        org.contikios.cooja.interfaces.Position
+        <x>64.61229064867878</x>
+        <y>39.88729002781773</y>
+        <z>0.0</z>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.contikimote.interfaces.ContikiMoteID
+        <id>3</id>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.contikimote.interfaces.ContikiRadio
+        <bitrate>250.0</bitrate>
+      </interface_config>
+      <motetype_identifier>mtype306</motetype_identifier>
+    </mote>
+    <mote>
+      <interface_config>
+        org.contikios.cooja.interfaces.Position
+        <x>37.157272454309606</x>
+        <y>19.60335867526139</y>
+        <z>0.0</z>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.contikimote.interfaces.ContikiMoteID
+        <id>4</id>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.contikimote.interfaces.ContikiRadio
+        <bitrate>250.0</bitrate>
+      </interface_config>
+      <motetype_identifier>mtype306</motetype_identifier>
+    </mote>
+    <mote>
+      <interface_config>
+        org.contikios.cooja.interfaces.Position
+        <x>-21.976612887408603</x>
+        <y>30.69884249204435</y>
+        <z>0.0</z>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.contikimote.interfaces.ContikiMoteID
+        <id>5</id>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.contikimote.interfaces.ContikiRadio
+        <bitrate>250.0</bitrate>
+      </interface_config>
+      <motetype_identifier>mtype306</motetype_identifier>
+    </mote>
+    <mote>
+      <interface_config>
+        org.contikios.cooja.interfaces.Position
+        <x>43</x>
+        <y>98</y>
+        <z>0.0</z>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.contikimote.interfaces.ContikiMoteID
+        <id>7</id>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.contikimote.interfaces.ContikiRadio
+        <bitrate>250.0</bitrate>
+      </interface_config>
+      <motetype_identifier>mtype820</motetype_identifier>
+    </mote>
+    <mote>
+      <interface_config>
+        org.contikios.cooja.interfaces.Position
+        <x>0.0</x>
+        <y>0.0</y>
+        <z>0.0</z>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.contikimote.interfaces.ContikiMoteID
+        <id>8</id>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.contikimote.interfaces.ContikiRadio
+        <bitrate>250.0</bitrate>
+      </interface_config>
+      <motetype_identifier>mtype820</motetype_identifier>
+    </mote>
+  </simulation>
+  <plugin>
+    org.contikios.cooja.plugins.SimControl
+    <width>280</width>
+    <z>3</z>
+    <height>160</height>
+    <location_x>400</location_x>
+    <location_y>0</location_y>
+  </plugin>
+  <plugin>
+    org.contikios.cooja.plugins.Visualizer
+    <plugin_config>
+      <skin>org.contikios.cooja.plugins.skins.IDVisualizerSkin</skin>
+      <skin>org.contikios.cooja.plugins.skins.UDGMVisualizerSkin</skin>
+      <skin>org.contikios.cooja.plugins.skins.GridVisualizerSkin</skin>
+      <skin>org.contikios.cooja.plugins.skins.MoteTypeVisualizerSkin</skin>
+      <viewport>1.7624788498159916 0.0 0.0 1.7624788498159916 97.6893062637241 8.72727272727273</viewport>
+    </plugin_config>
+    <width>400</width>
+    <z>0</z>
+    <height>400</height>
+    <location_x>1</location_x>
+    <location_y>1</location_y>
+  </plugin>
+  <plugin>
+    org.contikios.cooja.plugins.LogListener
+    <plugin_config>
+      <filter />
+      <formatted_time />
+      <coloring />
+    </plugin_config>
+    <width>1184</width>
+    <z>2</z>
+    <height>240</height>
+    <location_x>402</location_x>
+    <location_y>162</location_y>
+  </plugin>
+  <plugin>
+    org.contikios.cooja.plugins.Notes
+    <plugin_config>
+      <notes>Enter notes here</notes>
+      <decorations>true</decorations>
+    </plugin_config>
+    <width>904</width>
+    <z>4</z>
+    <height>160</height>
+    <location_x>680</location_x>
+    <location_y>0</location_y>
+  </plugin>
+  <plugin>
+    org.contikios.cooja.plugins.ScriptRunner
+    <plugin_config>
+      <script>GENERATE_MSG(0000000, "add-sink-1");&#xD;
+GENERATE_MSG(0000000, "add-sink-2");&#xD;
+GENERATE_MSG(0000000, "remove-sink-3");&#xD;
+&#xD;
+GENERATE_MSG(2000000, "remove-sink-1");&#xD;
+GENERATE_MSG(4000000, "remove-sink-2");&#xD;
+GENERATE_MSG(4000000, "add-sink-3");&#xD;
+&#xD;
+lostMsgs = 0;&#xD;
+newDagOk = 0;&#xD;
+&#xD;
+TIMEOUT(6000000, if(newDagOk == 2) { log.testOK(); } );&#xD;
+&#xD;
+lastMsg = -1;&#xD;
+newSink = 0;&#xD;
+packets = "_________";&#xD;
+hops = 0;&#xD;
+&#xD;
+while(true) {&#xD;
+    YIELD();&#xD;
+    if(msg.equals("remove-sink-1")) {&#xD;
+        m = sim.getMoteWithID(7);&#xD;
+        if(m) {&#xD;
+            sim.removeMote(m);&#xD;
+            log.log("removed sink 1\n");&#xD;
+        }&#xD;
+    } else if(msg.equals("remove-sink-2")) {&#xD;
+        m = sim.getMoteWithID(8);&#xD;
+        if(m) {&#xD;
+            sim.removeMote(m);&#xD;
+            log.log("removed sink 2\n");&#xD;
+        }&#xD;
+    } else if(msg.equals("remove-sink-3")) {&#xD;
+        m = sim.getMoteWithID(9);&#xD;
+        if(m) {&#xD;
+            sim.removeMote(m);&#xD;
+            log.log("removed sink 3\n");&#xD;
+        }&#xD;
+    } else if(msg.equals("add-sink-1")) {&#xD;
+        newSink = 1;&#xD;
+        if(!sim.getMoteWithID(7)) {&#xD;
+            m = sim.getMoteTypes()[1].generateMote(sim);&#xD;
+            m.getInterfaces().getMoteID().setMoteID(7);&#xD;
+            sim.addMote(m);&#xD;
+            m.getInterfaces().getPosition().setCoordinates(43, 98, 0);&#xD;
+            log.log("added sink 1\n");&#xD;
+         } else {&#xD;
+            log.log("did not add sink 1 as it was already there\n");      &#xD;
+         }&#xD;
+    } else if(msg.equals("add-sink-2")) {&#xD;
+        newSink = 1;&#xD;
+        if(!sim.getMoteWithID(8)) {&#xD;
+            m = sim.getMoteTypes()[1].generateMote(sim);&#xD;
+            m.getInterfaces().getMoteID().setMoteID(8);&#xD;
+            sim.addMote(m);&#xD;
+            log.log("added sink 2\n");&#xD;
+         } else {&#xD;
+            log.log("did not add sink 2 as it was already there\n");      &#xD;
+         }&#xD;
+    } else if(msg.equals("add-sink-3")) {&#xD;
+        newSink = 1;&#xD;
+        if(!sim.getMoteWithID(9)) {&#xD;
+            m = sim.getMoteTypes()[1].generateMote(sim);&#xD;
+            m.getInterfaces().getMoteID().setMoteID(9);&#xD;
+            sim.addMote(m);&#xD;
+            log.log("added sink 3\n");&#xD;
+         } else {&#xD;
+            log.log("did not add sink 3 as it was already there\n");      &#xD;
+         }&#xD;
+    } else if(msg.startsWith("Sending")) {&#xD;
+        hops = 0;&#xD;
+    } else if(msg.startsWith("#L") &amp;&amp; msg.endsWith("1; red")) {&#xD;
+        hops++;&#xD;
+    } else if(msg.startsWith("Data")) {&#xD;
+//        log.log("" + msg + "\n");    &#xD;
+        data = msg.split(" ");&#xD;
+        num = parseInt(data[14]);&#xD;
+        packets = packets.substr(0, num) + "*";&#xD;
+        log.log("" + hops + " " + packets + "\n");&#xD;
+//        log.log("Num " + num + "\n");&#xD;
+        if(newSink) {&#xD;
+          newDagOk++;&#xD;
+          newSink = 0;&#xD;
+        }&#xD;
+        if(lastMsg != -1) {&#xD;
+          if(num != lastMsg + 1) {&#xD;
+            numMissed = num - lastMsg - 1;&#xD;
+            lostMsgs += numMissed;&#xD;
+            log.log("Missed messages " + numMissed + " before " + num + "\n");            &#xD;
+            for(i = 0; i &lt; numMissed; i++) {&#xD;
+                packets = packets.substr(0, lastMsg + i) + "_";    &#xD;
+            }&#xD;
+          }    &#xD;
+        }&#xD;
+        lastMsg = num;&#xD;
+    }&#xD;
+}</script>
+      <active>true</active>
+    </plugin_config>
+    <width>962</width>
+    <z>1</z>
+    <height>596</height>
+    <location_x>603</location_x>
+    <location_y>43</location_y>
+  </plugin>
+</simconf>
+


### PR DESCRIPTION
Currently there is no automated way to remove obsolete DODAG in a node, if a node has seen MAX_DODAG_PER_INSTANCE DODAGS all new DODAG are ignored, the only way to remove the old DODAG is to reset the node.

This PR add a lifetime for each DODAG, the lifetime is reset each time a DIO advertising that DODAG is heard. When a DODAG is not updated since RPL_CONF_DAG_LIFETIME the DODAG is removed from the list. Note that the currently joined DODAG is immunized from this.