### PR TITLE
Fix and add more RPL stats

### DIFF
--- a/core/net/rpl/rpl-dag.c
+++ b/core/net/rpl/rpl-dag.c
@@ -332,6 +332,7 @@ rpl_repair_root(uint8_t instance_id)
     PRINTF("RPL: rpl_repair_root triggered but not root\n");
     return 0;
   }
+  RPL_STAT(rpl_stats.root_repairs++);
 
   RPL_LOLLIPOP_INCREMENT(instance->current_dag->version);
   RPL_LOLLIPOP_INCREMENT(instance->dtsn_out);

--- a/core/net/rpl/rpl-ext-header.c
+++ b/core/net/rpl/rpl-ext-header.c
@@ -137,12 +137,14 @@ rpl_verify_header(int uip_ext_opt_offset)
 	   sender_rank, instance->current_dag->rank,
 	   sender_closer);
     if(UIP_EXT_HDR_OPT_RPL_BUF->flags & RPL_HDR_OPT_RANK_ERR) {
+      RPL_STAT(rpl_stats.loop_errors++);
       PRINTF("RPL: Rank error signalled in RPL option!\n");
       /* Packet must be dropped and dio trickle timer reset, see RFC6550 - 11.2.2.2 */
       rpl_reset_dio_timer(instance);
       return 1;
     }
     PRINTF("RPL: Single error tolerated\n");
+    RPL_STAT(rpl_stats.loop_warnings++);
     UIP_EXT_HDR_OPT_RPL_BUF->flags |= RPL_HDR_OPT_RANK_ERR;
     return 0;
   }

--- a/core/net/rpl/rpl-private.h
+++ b/core/net/rpl/rpl-private.h
@@ -242,6 +242,10 @@ struct rpl_stats {
   uint16_t malformed_msgs;
   uint16_t resets;
   uint16_t parent_switch;
+  uint16_t forward_errors;
+  uint16_t loop_errors;
+  uint16_t loop_warnings;
+  uint16_t root_repairs;
 };
 typedef struct rpl_stats rpl_stats_t;
 


### PR DESCRIPTION
This add loop errors, loop warning and root repairs statistics in rpl_stats and also add the missing entry for forward_errors which caused a compilation error when RPL_STAT was enabled
