### PR TITLE
Send no-path DAO only when the dag has a preferred parent

### DIFF
--- a/core/net/rpl/rpl-dag.c
+++ b/core/net/rpl/rpl-dag.c
@@ -765,7 +765,6 @@ rpl_nullify_parent(rpl_parent_t *parent)
   /* This function can be called when the preferred parent is NULL, so we
      need to handle this condition in order to trigger uip_ds6_defrt_rm. */
   if(parent == dag->preferred_parent || dag->preferred_parent == NULL) {
-    rpl_set_preferred_parent(dag, NULL);
     dag->rank = INFINITE_RANK;
     if(dag->joined) {
       if(dag->instance->def_route != NULL) {
@@ -775,7 +774,11 @@ rpl_nullify_parent(rpl_parent_t *parent)
         uip_ds6_defrt_rm(dag->instance->def_route);
         dag->instance->def_route = NULL;
       }
-      dao_output(parent, RPL_ZERO_LIFETIME);
+      /* Send no-path DAO only to preferred parent, if any */
+      if(parent == dag->preferred_parent) {
+        dao_output(parent, RPL_ZERO_LIFETIME);
+        rpl_set_preferred_parent(dag, NULL);
+      }
     }
   }
 


### PR DESCRIPTION
In the current code, the No-Path DAO is send, even when the the node has no preferred parent (which happens when it first joins a DODAG), this cause a malformed DAO to be send.

Updated 3/3: The previous PR comment was completely wrong (but the title was right)