### PR TITLE
Allow rpl default route lifetime to be infinite

### DIFF
--- a/core/net/rpl/rpl-conf.h
+++ b/core/net/rpl/rpl-conf.h
@@ -106,6 +106,22 @@
 #endif /* RPL_CONF_MAX_DAG_PER_INSTANCE */
 
 /*
+ * RPL Default route lifetime
+ * The RPL route lifetime is used for the downward routes and for the default
+ * route. In a high density network with DIO suppression activated it may happen
+ * that a node will never send a DIO once the DIO interval becomes high as it
+ * has heard DIO from many neighbors already. As the default route to the
+ * preferred parent has a lifetime reset by receiving DIO from the parent, it
+ * means that the default route can be destroyed after a while. Setting the
+ * default route with infinite lifetime secures the upstream route.
+ */
+#ifdef RPL_CONF_DEFAULT_ROUTE_INFINITE_LIFETIME
+#define RPL_DEFAULT_ROUTE_INFINITE_LIFETIME                    RPL_CONF_DEFAULT_ROUTE_INFINITE_LIFETIME
+#else
+#define RPL_DEFAULT_ROUTE_INFINITE_LIFETIME                    0
+#endif /* RPL_CONF_DEFAULT_ROUTE_INFINITE_LIFETIME */
+
+/*
  * 
  */
 #ifndef RPL_CONF_DAO_SPECIFY_DAG

--- a/core/net/rpl/rpl-dag.c
+++ b/core/net/rpl/rpl-dag.c
@@ -481,8 +481,7 @@ rpl_set_default_route(rpl_instance_t *instance, uip_ipaddr_t *from)
     PRINT6ADDR(from);
     PRINTF("\n");
     instance->def_route = uip_ds6_defrt_add(from,
-        RPL_LIFETIME(instance,
-            instance->default_lifetime));
+        RPL_DEFAULT_ROUTE_INFINITE_LIFETIME ? 0 : RPL_LIFETIME(instance, instance->default_lifetime));
     if(instance->def_route == NULL) {
       return 0;
     }
@@ -1398,7 +1397,7 @@ rpl_process_dio(uip_ipaddr_t *from, rpl_dio_t *dio)
     }
     /* We received a new DIO from our preferred parent.
      * Call uip_ds6_defrt_add to set a fresh value for the lifetime counter */
-    uip_ds6_defrt_add(from, RPL_LIFETIME(instance, instance->default_lifetime));
+    uip_ds6_defrt_add(from, RPL_DEFAULT_ROUTE_INFINITE_LIFETIME ? 0 : RPL_LIFETIME(instance, instance->default_lifetime));
   }
   p->dtsn = dio->dtsn;
 }


### PR DESCRIPTION
In high density network with DIO suppression activated it may happens that a node will never sent a DIO once the DIO interval becomes high as it has heard DIO from many neighbors already. As the default route to the preferred parent has a lifetime reset by receiving DIO from the parent, it means that the default route can be destroyed after a while.
This PR add the possibility to create default route with infinite lifetime, thus securing the upstream route. The default value is to not enable it though.
(It should be noted that TinyOS uses infinite lifetime for upstream routes in RPL)