### PR TITLE
Allow user configuration of RPL hop-by-hop option

### DIFF
--- a/core/net/rpl/rpl-conf.h
+++ b/core/net/rpl/rpl-conf.h
@@ -195,4 +195,16 @@
 #define RPL_PREFERENCE              0
 #endif
 
+/*
+ * Hop-by-hop option
+ * This option control the insertion of the RPL Hop-by-Hop extension header
+ * into packets originating from this node. Incoming Hop-by-hop extension
+ * header are still processed and forwarded.
+ */
+#ifdef RPL_CONF_INSERT_HBH_OPTION
+#define RPL_INSERT_HBH_OPTION       RPL_CONF_INSERT_HBH_OPTION
+#else
+#define RPL_INSERT_HBH_OPTION       1
+#endif
+
 #endif /* RPL_CONF_H */

--- a/core/net/rpl/rpl-ext-header.c
+++ b/core/net/rpl/rpl-ext-header.c
@@ -213,6 +213,7 @@ rpl_update_header_empty(void)
     }
     break;
   default:
+#if RPL_INSERT_HBH_OPTION
     PRINTF("RPL: No hop-by-hop option found, creating it\n");
     if(uip_len + RPL_HOP_BY_HOP_LEN > UIP_BUFSIZE) {
       PRINTF("RPL: Packet too long: impossible to add hop-by-hop option\n");
@@ -221,6 +222,7 @@ rpl_update_header_empty(void)
     }
     set_rpl_opt(uip_ext_opt_offset);
     uip_ext_len = last_uip_ext_len + RPL_HOP_BY_HOP_LEN;
+#endif
     return 0;
   }
 
@@ -372,9 +374,11 @@ rpl_invert_header(void)
 void
 rpl_insert_header(void)
 {
+#if RPL_INSERT_HBH_OPTION
   if(default_instance != NULL && !uip_is_addr_mcast(&UIP_IP_BUF->destipaddr)) {
     rpl_update_header_empty();
   }
+#endif
 }
 /*---------------------------------------------------------------------------*/
 


### PR DESCRIPTION
Although Hop-by-hop option is extremely useful, it is not mandatory in RPL. This PR allows to deactivate properly RPL HBH