### PR TITLE
Multi DODAG support

### DIFF
--- a/core/net/rpl/rpl-dag.c
+++ b/core/net/rpl/rpl-dag.c
@@ -741,6 +741,9 @@ rpl_select_parent(rpl_dag_t *dag)
 
   if(best != NULL) {
     rpl_set_preferred_parent(dag, best);
+    dag->rank = dag->instance->of->calculate_rank(dag->preferred_parent, 0);
+  } else {
+    dag->rank = INFINITE_RANK;
   }
 
   return best;

--- a/core/net/rpl/rpl-dag.c
+++ b/core/net/rpl/rpl-dag.c
@@ -1285,6 +1285,9 @@ rpl_process_dio(uip_ipaddr_t *from, rpl_dio_t *dio)
     }
   }
 
+  /* Parent info has been updated, trigger rank recalculation */
+  p->flags |= RPL_PARENT_FLAG_UPDATED;
+
   PRINTF("RPL: preferred DAG ");
   PRINT6ADDR(&instance->current_dag->dag_id);
   PRINTF(", rank %u, min_rank %u, ",


### PR DESCRIPTION
Currently Contiki only updates rank of parent belonging to the active DAG, parents belonging to other DAGs keep their initial rank even when receiving DIO from them.

This PR adds a mechanism to update the rank of these parents and also prevent the DODAG Root to join another DAG. With #912, a node can be part of MAX_DODAG_PER_INSTANCE DODAGs and drops dead ones.