### PR TITLE
Concept: mt scheduler with events

### DIFF
--- a/core/sys/mt.c
+++ b/core/sys/mt.c
@@ -46,9 +46,7 @@
 #include "sys/mt.h"
 #include "sys/cc.h"
 
-#define MT_STATE_READY   1
-#define MT_STATE_RUNNING 2
-#define MT_STATE_EXITED  5
+
 
 static struct mt_thread *current;
 
@@ -115,3 +113,9 @@ mt_stop(struct mt_thread *thread)
   mtarch_stop(&thread->thread);
 }
 /*--------------------------------------------------------------------------*/
+
+mt_thread*
+mt_current()
+{
+    return current;
+}

--- a/core/sys/mt.h
+++ b/core/sys/mt.h
@@ -84,6 +84,9 @@
 
 #include "contiki.h"
 
+#define MT_STATE_READY   1
+#define MT_STATE_RUNNING 2
+#define MT_STATE_EXITED  5
 
 /**
  * An opaque structure that is used for holding the state of a thread.
@@ -178,12 +181,14 @@ void mtarch_pstop(void);
 
 #include "mtarch.h"
 
+typedef struct mt_thread mt_thread;
+
 struct mt_thread {
-  int state;
-  process_event_t *evptr;
-  process_data_t *dataptr;
+  mt_thread *next;      /*!< pointer to the next thread in a thread list */
+  int state;            /*!< check if uint8_t is enough! */
   struct mtarch_thread thread;
 };
+
 
 /**
  * No error.
@@ -264,6 +269,17 @@ void mt_exit(void);
  *
  */
 void mt_stop(struct mt_thread *thread);
+
+/**
+ * Returns the currently running thread
+ *
+ * This function returns the currently running thread.
+ *
+ * \return  Either NULL if no thread is running or a pointer to the
+ *          mt_thread instance of the currently running thread is returned.
+ *
+ */
+mt_thread* mt_current();
 
 /** @} */
 /** @} */

--- a/cpu/native/mtarch.c
+++ b/cpu/native/mtarch.c
@@ -35,7 +35,7 @@
 #include "sys/mt.h"
 
 #ifndef MTARCH_STACKSIZE
-#define MTARCH_STACKSIZE 4096
+#define MTARCH_STACKSIZE (8192*2)
 #endif /* MTARCH_STACKSIZE */
 
 #if defined(_WIN32) || defined(__CYGWIN__)

--- a/examples/multi-threading/mt-scheduler/Makefile
+++ b/examples/multi-threading/mt-scheduler/Makefile
@@ -1,0 +1,7 @@
+CONTIKI_PROJECT = smt-sleep-test smt-event-test
+all: $(CONTIKI_PROJECT)
+
+PROJECT_SOURCEFILES += smt.c
+
+CONTIKI = ../../..
+include $(CONTIKI)/Makefile.include

--- a/examples/multi-threading/mt-scheduler/smt-event-test.c
+++ b/examples/multi-threading/mt-scheduler/smt-event-test.c
@@ -1,0 +1,194 @@
+/*
+ * Copyright (c) 2014, marcas756@gmail.com.
+ * All rights reserved. 
+ *
+ * Redistribution and use in source and binary forms, with or without 
+ * modification, are permitted provided that the following conditions 
+ * are met: 
+ * 1. Redistributions of source code must retain the above copyright 
+ *    notice, this list of conditions and the following disclaimer. 
+ * 2. Redistributions in binary form must reproduce the above copyright 
+ *    notice, this list of conditions and the following disclaimer in the 
+ *    documentation and/or other materials provided with the distribution. 
+ * 3. Neither the name of the Institute nor the names of its contributors 
+ *    may be used to endorse or promote products derived from this software 
+ *    without specific prior written permission. 
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND 
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE 
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL 
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS 
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) 
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY 
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
+ * SUCH DAMAGE. 
+ *
+ * This file is part of the Contiki operating system.
+ * 
+ * Author: marcas756 <marcas756@gmail.com>
+ *
+ */
+
+/**
+ * \file
+ *         Example implementation of an contiki event enabled  mt scheduler
+ *
+ *         2 processes(p3,p4), 2 mt_threads (t1,t2)
+ *
+ *         t1 -> smt_post     -> t2
+ *         t2 -> process_post -> p3
+ *         p3 -> process_post -> p4
+ *         p4 -> smt_post     -> t1
+ *
+ *         missing: test for post_sync
+ *
+ * \author
+ *         marcas756 <marcas756@gmail.com>
+ */
+
+
+
+#include "contiki.h"
+#include "smt.h"
+#include <stdint.h>
+
+#define DEBUG 1
+#if DEBUG
+#include <stdio.h>
+#define PRINTF(...) printf(__VA_ARGS__)
+#else
+#define PRINTF(...)
+#endif
+
+
+#define TEST_EVENT_ID 22
+
+uint8_t token = 0;
+
+mt_thread t1,t2;
+PROCESS(p3, "p3");
+PROCESS(p4, "p4");
+
+void t1_thread_func (void* data)
+{
+
+    while(1)
+    {
+        uint8_t* ev_data;
+
+        smt_wait_event_until(SMT_EVENT() == TEST_EVENT_ID);
+
+        ev_data = SMT_DATA();
+
+        PRINTF("t1 received %d\n", *ev_data);
+        (*ev_data)+=1;
+
+        smt_sleep(CLOCK_SECOND);
+
+        smt_post(&t2,TEST_EVENT_ID,ev_data);
+        PRINTF("t1 sent %d\n", *ev_data);
+    }
+}
+
+void t2_thread_func (void* data)
+{
+
+    while(1)
+    {
+        uint8_t* ev_data;
+
+        smt_wait_event_until(SMT_EVENT() == TEST_EVENT_ID);
+
+        ev_data = SMT_DATA();
+
+        PRINTF("t2 received %d\n", *ev_data);
+        (*ev_data)+=1;
+
+        smt_sleep(CLOCK_SECOND);
+
+        process_post(&p3,TEST_EVENT_ID,ev_data);
+        PRINTF("t2 sent %d\n", *ev_data);
+    }
+}
+
+PROCESS_THREAD(p3, ev, data)
+{
+    static struct etimer et;
+    static uint8_t *ev_data;
+
+    PROCESS_BEGIN();
+
+    while(1)
+    {
+        PROCESS_WAIT_EVENT_UNTIL(ev == TEST_EVENT_ID);
+
+        ev_data = data;
+
+        PRINTF("p3 received %d\n", *ev_data);
+        (*ev_data)+=1;
+
+        etimer_set(&et,CLOCK_SECOND);
+        PROCESS_WAIT_EVENT_UNTIL(etimer_expired(&et));
+
+        process_post(&p4,TEST_EVENT_ID,ev_data);
+        PRINTF("p3 sent %d\n", *ev_data);
+    }
+
+    PROCESS_END();
+}
+
+PROCESS_THREAD(p4, ev, data)
+{
+    static struct etimer et;
+    static uint8_t *ev_data;
+
+    PROCESS_BEGIN();
+
+    while(1)
+    {
+        PROCESS_WAIT_EVENT_UNTIL(ev == TEST_EVENT_ID);
+
+        ev_data = data;
+
+        PRINTF("p4 received %d\n", *ev_data);
+        (*ev_data)+=1;
+
+        etimer_set(&et,CLOCK_SECOND);
+        PROCESS_WAIT_EVENT_UNTIL(etimer_expired(&et));
+
+        smt_post(&t1,TEST_EVENT_ID,ev_data);
+        PRINTF("p4 sent %d\n", *ev_data);
+    }
+
+    PROCESS_END();
+}
+
+/*---------------------------------------------------------------------------*/
+PROCESS(smt_example, "smt example");
+AUTOSTART_PROCESSES(&smt_example);
+/*---------------------------------------------------------------------------*/
+PROCESS_THREAD(smt_example, ev, data)
+{
+
+  PROCESS_BEGIN();
+
+  mt_init();
+  smt_init();
+
+  smt_start(&t1,t1_thread_func,NULL);
+  smt_start(&t2,t2_thread_func,NULL);
+
+  process_start(&p3,NULL);
+  process_start(&p4,NULL);
+
+  // start the endless event loop
+  smt_post(&t1,TEST_EVENT_ID,&token);
+
+
+  PROCESS_END();
+}
+/*---------------------------------------------------------------------------*/
+

--- a/examples/multi-threading/mt-scheduler/smt-sleep-test.c
+++ b/examples/multi-threading/mt-scheduler/smt-sleep-test.c
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2014, marcas756@gmail.com.
+ * All rights reserved. 
+ *
+ * Redistribution and use in source and binary forms, with or without 
+ * modification, are permitted provided that the following conditions 
+ * are met: 
+ * 1. Redistributions of source code must retain the above copyright 
+ *    notice, this list of conditions and the following disclaimer. 
+ * 2. Redistributions in binary form must reproduce the above copyright 
+ *    notice, this list of conditions and the following disclaimer in the 
+ *    documentation and/or other materials provided with the distribution. 
+ * 3. Neither the name of the Institute nor the names of its contributors 
+ *    may be used to endorse or promote products derived from this software 
+ *    without specific prior written permission. 
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND 
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE 
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL 
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS 
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) 
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY 
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
+ * SUCH DAMAGE. 
+ *
+ * This file is part of the Contiki operating system.
+ * 
+ * Author: marcas756 <marcas756@gmail.com>
+ *
+ */
+
+/**
+ * \file
+ *         Testing mt sleep functionality
+ *         Example implementation of an contiki event enabled  mt scheduler
+ * \author
+ *         marcas756 <marcas756@gmail.com>
+ */
+
+
+
+#include "contiki.h"
+#include "smt.h"
+#include <stdint.h>
+
+#define DEBUG 1
+#if DEBUG
+#include <stdio.h>
+#define PRINTF(...) printf(__VA_ARGS__)
+#else
+#define PRINTF(...)
+#endif
+
+
+#define CNTDWN_THREAD_1     0
+#define CNTDWN_THREAD_2     1
+
+/*
+
+char is_prime(uint32_t number) {
+
+    uint32_t i;
+
+    if (number <= 1) return 0;
+
+    for (i=2; i*i<=number; i++) {
+        if (number % i == 0) return 0;
+    }
+    return 1;
+}
+
+typedef struct {
+    uint32_t from;
+    uint32_t to;
+}prime_thread_data_t ;
+
+void prime_thread(void *data)
+{
+    mt_thread *this_thread = mt_current();
+    PRINTF("%p : Starting\n",this_thread);
+}
+*/
+
+
+void cntdwn_thread(void *data)
+{
+    uint8_t* cntdwn = data;
+    mt_thread *this_thread = mt_current();
+    PRINTF("%p : Starting\n",this_thread);
+
+    while (*cntdwn)
+    {
+        PRINTF("%p : cntdwn = %d\n",this_thread, *cntdwn);
+        smt_sleep(CLOCK_SECOND);
+        (*cntdwn)--;
+    }
+
+    PRINTF("%p : Terminating\n",this_thread);
+
+    mt_exit();
+}
+
+
+uint8_t countdown1 = 10;
+uint8_t countdown2 = 20;
+
+static mt_thread threads[4];
+
+/*---------------------------------------------------------------------------*/
+PROCESS(smt_example, "smt example");
+AUTOSTART_PROCESSES(&smt_example);
+/*---------------------------------------------------------------------------*/
+PROCESS_THREAD(smt_example, ev, data)
+{
+      static struct etimer et;
+
+      PROCESS_BEGIN();
+
+      mt_init();
+      smt_init();
+
+      smt_start(&threads[CNTDWN_THREAD_1],cntdwn_thread,&countdown1);
+
+      /* Delay start of second thread for 0.5s */
+      etimer_set(&et,CLOCK_SECOND/2);
+      PROCESS_WAIT_EVENT();
+
+      smt_start(&threads[CNTDWN_THREAD_2],cntdwn_thread,&countdown2);
+
+
+      PROCESS_END();
+}
+/*---------------------------------------------------------------------------*/
+

--- a/examples/multi-threading/mt-scheduler/smt.c
+++ b/examples/multi-threading/mt-scheduler/smt.c
@@ -1,0 +1,199 @@
+/*
+ * Copyright (c) 2014, marcas756@gmail.com.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * This file is part of the Contiki operating system.
+ *
+ * Author: marcas756 <marcas756@gmail.com>
+ *
+ */
+
+/**
+ * \file
+ *         Scheduled multi threading library
+ * \author
+ *         marcas756 <marcas756@gmail.com>
+ */
+
+#include "smt.h"
+
+#define DEBUG 0
+#if DEBUG
+#include <stdio.h>
+#define PRINTF(...) printf(__VA_ARGS__)
+#else
+#define PRINTF(...)
+#endif
+
+
+struct mt_thread *smt_list = NULL;  /*!< list holding active mt_threads */
+struct mt_thread *current;  /*!< currently running mt_thread */
+process_event_t smt_ev;     /*!< Any mt_thread may access this event id */
+process_data_t smt_data;    /*!< Any mt_thread may access this event data */
+
+MEMB(memb_smt_event_ext,struct smt_event_ext_t,SMT_MAX_EVENTS); /*!< OOOUCH!  */
+
+PROCESS(mt_scheduler_process, "smt process");
+
+
+void smt_start(struct mt_thread *thread, void (* function)(void *), void *data)
+{
+    mt_thread *iter;
+
+    if(!thread) return;
+
+    /* First make sure that we don't try to start a thread that is
+       already running. */
+    for(iter = smt_list; iter; iter = iter->next)
+    {
+        /* If we found the thread on the  thread list, we bail out. */
+        if (iter == thread) return;
+    }
+
+    PRINTF("smt: initial exec of %p \n", thread);
+    mt_start(thread,function,data);
+    mt_exec(thread); /* exec thread once to get to first blocking situation */
+
+    if(thread->state == MT_STATE_EXITED) /* thread exited ... thread did not wait for any event */
+        return;
+
+    /* Put on the thread list.*/
+    thread->next = smt_list;
+    smt_list = thread;
+    PRINTF("smt: added %p to scheduler \n", thread);
+}
+
+/* !!! only smt_post is allowed to send a process event to mt_scheduler_process !!! */
+int smt_post(struct mt_thread *thread, process_event_t ev, process_data_t data)
+{
+    struct smt_event_ext_t *smt_event_ext;
+
+    smt_event_ext = memb_alloc(&memb_smt_event_ext); /* OOOUCH!  */
+
+    if (!smt_event_ext) return SMT_ERR_FULL;
+
+    smt_event_ext->target = thread;
+    smt_event_ext->data = data;
+    PRINTF("smt: post ev 0x%X to mt %p\n",ev,thread);
+    return process_post(&mt_scheduler_process, ev, smt_event_ext);
+}
+
+
+
+void smt_init()
+{
+    PRINTF("smt: process start\n");
+    process_start(&mt_scheduler_process,NULL);
+}
+
+void smt_wakeup_call(void *data)
+{
+    PRINTF("smt: wake up call for %p\n", ((struct smt_event_ext_t*)data)->target);
+    /* mt_exec((struct mt_thread*)data); */
+    process_post(&mt_scheduler_process,PROCESS_EVENT_TIMER,data);
+}
+
+
+void smt_sleep(clock_time_t interval)
+{
+    struct ctimer ct;
+    struct smt_event_ext_t smt_event_ext;
+
+    smt_event_ext.target = mt_current();
+
+    ctimer_set(&ct,interval,smt_wakeup_call,&smt_event_ext);
+    PRINTF("smt: %p goes to bed\n", smt_event_ext.target);
+    smt_wait_event_until(ctimer_expired(&ct));
+    PRINTF("smt: %p wakes up\n", smt_event_ext.target);
+}
+
+/*---------------------------------------------------------------------------*/
+
+PROCESS_THREAD(mt_scheduler_process, ev, data)
+{
+  PROCESS_BEGIN();
+
+  while(1)
+  {
+      PROCESS_WAIT_EVENT();
+      {
+          mt_thread *iter, *target;
+
+          target = ((struct smt_event_ext_t*)data)->target;
+
+          /* Try to find the thread the event is addressed to */
+          for(iter = smt_list; iter; iter = iter->next)
+          {
+              /* If we found the thread on the  thread list,
+                 we deliver the event to the thread */
+              if (iter == target)
+              {
+                  /* move event into global scope */
+                  smt_ev = ev;
+                  smt_data = ((struct smt_event_ext_t*)data)->data;
+
+                  mt_exec(target); /* deliver event to thread */
+
+                  /* event delivered ... postprocessing ... */
+
+                  if(target->state == MT_STATE_EXITED) /* Event caused the thread to exit */
+                  {
+
+                        mt_stop(target);
+
+                        /* remove thread from thread list */
+                        if(target == smt_list) {
+                            smt_list = smt_list->next;
+                        } else {
+                            for(iter = smt_list; iter; iter = iter->next) {
+                                if(iter->next == target) {
+                                    iter->next = target->next;
+                                    break;
+                                }
+                            }
+                        }
+
+                        PRINTF("smt: removed %p from scheduler \n", target);
+                  }
+
+
+                  break; /* event delivered ... break loop thread finder */
+              }
+          }
+      }
+
+      /* free the extended event data allocated by smt_post*/
+      memb_free(&memb_smt_event_ext,data); /* OUCH! */
+
+
+  }
+
+  mtarch_remove();
+
+  PROCESS_END();
+}
+/*---------------------------------------------------------------------------*/

--- a/examples/multi-threading/mt-scheduler/smt.h
+++ b/examples/multi-threading/mt-scheduler/smt.h
@@ -1,0 +1,160 @@
+/*
+ * Copyright (c) 2014, marcas756@gmail.com.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * This file is part of the Contiki operating system.
+ *
+ * Author: marcas756 <marcas756@gmail.com>
+ *
+ */
+
+/**
+ * \file
+ *         Scheduled multi threading library
+ * \author
+ *         marcas756 <marcas756@gmail.com>
+ */
+#ifndef SMT_H_
+#define SMT_H_
+
+#include "contiki.h"
+#include "sys/mt.h"
+#include "memb.h"
+
+
+
+#define SMT_ERR_FULL        PROCESS_ERR_FULL
+#define SMT_ERR_OK          PROCESS_ERR_OK;
+#define SMT_MAX_EVENTS      10
+
+/*
+ * Access macros to smt event data and smt event id
+ * In comparison to contiki processes the void pointer provided to mt_threads
+ * will be the same as long as the process does not exit. Thus we need access
+ * to global event data and event id (see smt.c).
+ */
+#define SMT_DATA()          smt_data
+#define SMT_EVENT()         smt_ev
+
+
+/** \brief  Extended smt event structure
+ *
+ *  \details
+ *  A contiki event delivered to porcesses consists of an event ID
+ *  and a pointer to data associated with the event. Also a pointer
+ *  to the process to be serviced with the event has to be stored.
+ *
+ *  As there is no support for mthread events, the contiki process event
+ *  has to be extended by an mthread pointer.
+ *
+ *  So first the smt process will receive the process event and extract
+ *  The target mthread pointer and the event data pointer from process event
+ *  data pointer.
+ *
+ **/
+struct smt_event_ext_t {
+    mt_thread *target;  /*!< Target thread to send the event to */
+    void *data;         /*!< Data associated with the event */
+};
+
+extern process_event_t smt_ev;     /*!< Any mthread may access this event id */
+extern process_data_t smt_data;    /*!< Any mthread may access this event data */
+
+/**
+ * Wait for an event within a mt_thread function
+ *
+ * Must only be called within a mt_thread function!
+ *
+ * Waits for any event within the mt_thread function.
+ * The only way to reschedule an mt_thread is to send
+ * an event to the smt scheduler process. This can be done
+ * via smt_post by mt_threads or contiki processes.
+ */
+#define smt_wait_event() \
+    mt_yield()
+
+/**
+ * Wait for an event within a mt_thread function until a condition is met
+ *
+ * Must only be called within a mt_thread function!
+ *
+ * Waits for any event within the mt_thread function until a condition is met.
+ * Is similar to PROCESS_WAIT_EVENT_UNTIL.
+ * The only way to reschedule an mt_thread is to send
+ * an event to the smt scheduler process. This can be done
+ * via smt_post by mt_threads or contiki processes.
+ */
+#define smt_wait_event_until(cond)  \
+    do{                             \
+        smt_wait_event();           \
+    }while(!(cond))
+
+
+
+/**
+ * \brief      Initialize the smt library
+ * \param c    Briefly describe all parameters.
+ *
+ * Currently only starts the smt scheduler process. *
+ */
+void smt_init();
+
+/**
+ * \brief      Starts an smt mt_thread
+ *
+ * \param   thread      Thread control instance
+ * \param   function    Thread function
+ * \param   data        Pointer to dat to start the thread with
+ */
+void smt_start(struct mt_thread *thread, void (* function)(void *), void *data);
+
+/**
+ * \brief      Posts an event to an smt mt_thread
+ *
+ * May be invoked by any other function except irq functions (non preemtive!)
+ * Thus a contiki process is able to send an event to a smt m_thread
+ *
+ * \param   thread      Thread control instance
+ * \param   ev          Event id
+ * \param   data        Data associated with the event
+ */
+int smt_post(struct mt_thread *thread, process_event_t ev, process_data_t data);
+
+/**
+ * \brief      Suspends the thread for a given time
+ *
+ * Must only be called within a mt_thread function!
+ *
+ * The mt_thread function calling this sleep suspends for interval time.
+ * Does not block the rest of the system.
+ *
+ * \param   interval    Duration (1s=CLOCK_SECOND)
+ */
+void smt_sleep(clock_time_t interval);
+
+
+#endif /* SMT_H_ */


### PR DESCRIPTION
This is just a proof of concept. Thus I placed it in /examples/multi-threading/mt-scheduler

Compiles without warnings and the examples work on native linux
- Non preemtive mt-scheduler (context switch during irq not allowed for this implementation)
- contiki process -> event -> smt_thread works
- smt_thread -> event -> smt_thread works
- smt_thread -> event -> contiki process work 
- pausing smt_thread works (sleep ... wakeup via ctimer + event)
- minor changes in mt.h, mt.c (mt_current(), mt_thread -> list node)
- Additional MEMB for extended event data structure required (OUCH!)
- Increased stack size for native linux mt ... no tests with MSP430 so far
- mt_thread has to exit on its own! (no kill allowed ... see smt_sleep autovars ... maybe memb_alloc instead?)

To be done:
- PROCESS_BROADCAST handling (sends to all processes, also mt_scheduler_process -> problem!)
- PROCESS_EVENT_EXIT handling (sends to all processes, also mt_scheduler_process -> ignore event?)
