### PR TITLE
[cc2538] Corrected ANA_REGS_IVCTRL register address value.

### DIFF
--- a/cpu/cc2538/dev/ana-regs.h
+++ b/cpu/cc2538/dev/ana-regs.h
@@ -43,7 +43,7 @@
  * \name ANA_REGS register offsets
  * @{
  */
-#define ANA_REGS_IVCTRL       0x00000004
+#define ANA_REGS_IVCTRL       0x400D6004
 /** @} */
 /*---------------------------------------------------------------------------*/
 /**


### PR DESCRIPTION
TI defined the `address offset` instead of the `physical address` in their header file for ANA_REGS_IVCTRL (Analog control register).

This bug was discovered by @bagel99 as mentioned in #856, I'm just making a PR out of it.
