### PR TITLE
Fix: set uip_ext_len to 0 after dropping packet

### DIFF
--- a/core/net/ip/tcpip.c
+++ b/core/net/ip/tcpip.c
@@ -549,12 +549,14 @@ tcpip_ipv6_output(void)
   if(uip_len > UIP_LINK_MTU) {
     UIP_LOG("tcpip_ipv6_output: Packet to big");
     uip_len = 0;
+    uip_ext_len = 0;
     return;
   }
 
   if(uip_is_addr_unspecified(&UIP_IP_BUF->destipaddr)){
     UIP_LOG("tcpip_ipv6_output: Destination address unspecified");
     uip_len = 0;
+    uip_ext_len = 0;
     return;
   }
 
@@ -592,6 +594,7 @@ tcpip_ipv6_output(void)
           PRINTF("tcpip_ipv6_output: Destination off-link but no route\n");
 #endif /* !UIP_FALLBACK_INTERFACE */
           uip_len = 0;
+          uip_ext_len = 0;
           return;
         }
 
@@ -644,6 +647,7 @@ tcpip_ipv6_output(void)
 #if UIP_CONF_IPV6_RPL
     if(rpl_update_header_final(nexthop)) {
       uip_len = 0;
+      uip_ext_len = 0;
       return;
     }
 #endif /* UIP_CONF_IPV6_RPL */
@@ -652,6 +656,7 @@ tcpip_ipv6_output(void)
 #if UIP_ND6_SEND_NA
       if((nbr = uip_ds6_nbr_add(nexthop, NULL, 0, NBR_INCOMPLETE)) == NULL) {
         uip_len = 0;
+        uip_ext_len = 0;
         return;
       } else {
 #if UIP_CONF_IPV6_QUEUE_PKT
@@ -690,6 +695,7 @@ tcpip_ipv6_output(void)
         }
 #endif /*UIP_CONF_IPV6_QUEUE_PKT*/
         uip_len = 0;
+        uip_ext_len = 0;
         return;
       }
       /* Send in parallel if we are running NUD (nbc state is either STALE,
@@ -720,6 +726,7 @@ tcpip_ipv6_output(void)
 #endif /*UIP_CONF_IPV6_QUEUE_PKT*/
 
       uip_len = 0;
+      uip_ext_len = 0;
       return;
     }
     return;

--- a/core/net/ipv6/multicast/smrf.c
+++ b/core/net/ipv6/multicast/smrf.c
@@ -80,6 +80,9 @@ mcast_fwd(void *p)
   UIP_IP_BUF->ttl--;
   tcpip_output(NULL);
   uip_len = 0;
+#if NETSTACK_CONF_WITH_IPV6
+  uip_ext_len = 0;
+#endif /*NETSTACK_CONF_WITH_IPV6*/
 }
 /*---------------------------------------------------------------------------*/
 static uint8_t

--- a/core/net/ipv6/uip-nd6.c
+++ b/core/net/ipv6/uip-nd6.c
@@ -317,6 +317,7 @@ create_na:
 
 discard:
   uip_len = 0;
+  uip_ext_len = 0;
   return;
 }
 
@@ -552,6 +553,7 @@ na_input(void)
 
 discard:
   uip_len = 0;
+  uip_ext_len = 0;
   return;
 }
 
@@ -641,6 +643,7 @@ rs_input(void)
 
 discard:
   uip_len = 0;
+  uip_ext_len = 0;
   return;
 }
 
@@ -984,6 +987,7 @@ ra_input(void)
 
 discard:
   uip_len = 0;
+  uip_ext_len = 0;
   return;
 }
 #endif /* !UIP_CONF_ROUTER */


### PR DESCRIPTION
###### Bug description:
If outgoing packet with hop-by-hop header is dropped in `tcpip_ipv6_output()` function, uip_ext_len is not set to 0. It causes next packet with no hop-by-hop header (for example ICMP) to become corrupt. Bug can be easily observed with ipv6/rpl-udp example client. If client looses connection with parrent, some outgoing DIO messages become corrupt (depending on the frequency of outgoing UDP messages). 

###### Fix description:
Issue can be solved by adding:
```
uip_ext_len = 0;
```
before every return statement in `tcpip_ipv6_output()`. 

After comment on mailing list from Laurent Deru, `uip_ext_len = 0` is also added in other places where packet is discarded.