### PR TITLE
Concept : cooperative mt scheduler with events

### DIFF
--- a/core/sys/mt.c
+++ b/core/sys/mt.c
@@ -64,7 +64,6 @@ mt_remove(void)
 void
 mt_start(struct mt_thread *thread, void (* function)(void *), void *data)
 {
-  thread->needspoll = 0;
   /* Call the architecture dependant function to set up the processor
      stack with the correct parameters. */
   mtarch_start(&thread->thread, function, data);
@@ -113,8 +112,20 @@ mt_stop(struct mt_thread *thread)
 }
 /*--------------------------------------------------------------------------*/
 
-mt_thread*
-mt_current()
+
+
+
+/**
+ * Returns the currently running thread
+ *
+ * This function returns the currently running thread.
+ *
+ * \return  Either NULL if no thread is running or a pointer to the
+ *          mt_thread instance of the currently running thread is returned.
+ *
+ */
+struct mt_thread*
+mt_current(void)
 {
     return current;
 }

--- a/core/sys/mt.h
+++ b/core/sys/mt.h
@@ -181,14 +181,12 @@ void mtarch_pstop(void);
 
 #include "mtarch.h"
 
-typedef struct mt_thread mt_thread;
-
 struct mt_thread {
-  mt_thread *next;      /*!< pointer to the next thread in a thread list */
+  int state;
+  process_event_t *evptr;
+  process_data_t *dataptr;
   struct mtarch_thread thread;
-  unsigned char state, needspoll;
 };
-
 
 /**
  * No error.
@@ -269,17 +267,6 @@ void mt_exit(void);
  *
  */
 void mt_stop(struct mt_thread *thread);
-
-/**
- * Returns the currently running thread
- *
- * This function returns the currently running thread.
- *
- * \return  Either NULL if no thread is running or a pointer to the
- *          mt_thread instance of the currently running thread is returned.
- *
- */
-mt_thread* mt_current();
 
 /** @} */
 /** @} */

--- a/examples/multi-threading/mt-scheduler/Makefile
+++ b/examples/multi-threading/mt-scheduler/Makefile
@@ -1,7 +1,7 @@
-CONTIKI_PROJECT = smt-sleep-test smt-event-test smt-poll-test
+CONTIKI_PROJECT = cmt-sleep-test cmt-event-test cmt-poll-test
 all: $(CONTIKI_PROJECT)
 
-PROJECT_SOURCEFILES += smt.c
+PROJECT_SOURCEFILES += cmt.c
 
 CONTIKI = ../../..
 include $(CONTIKI)/Makefile.include

--- a/examples/multi-threading/mt-scheduler/cmt-poll-test.c
+++ b/examples/multi-threading/mt-scheduler/cmt-poll-test.c
@@ -43,9 +43,9 @@
 
 
 #include "contiki.h"
-#include "smt.h"
 #include <stdint.h>
 #include <stdlib.h>
+#include "cmt.h"
 
 #define DEBUG 1
 #if DEBUG
@@ -58,8 +58,8 @@
 #define NUM_OF_THREADS 5
 #define MAX_POLL_DELAY CLOCK_SECOND
 
-static mt_thread threads[NUM_OF_THREADS];
-static mt_thread poller_thread;
+static cmt_thread threads[NUM_OF_THREADS];
+static cmt_thread poller_thread;
 
 
 void poller_thread_func(void *data)
@@ -67,15 +67,15 @@ void poller_thread_func(void *data)
     PRINTF("THREAD poller started \n");
     while(1)
     {
-        smt_sleep(rand()%MAX_POLL_DELAY);
-        smt_poll(&threads[rand()%NUM_OF_THREADS]);
+        cmt_sleep(rand()%MAX_POLL_DELAY);
+        cmt_poll(&threads[rand()%NUM_OF_THREADS]);
         PRINTF("THREAD sent poll event \n");
     }
 
     mt_exit();
 }
 
-int get_thread_id(mt_thread *thread)
+int get_thread_id(cmt_thread *thread)
 {
     return (thread-threads);
 }
@@ -84,16 +84,16 @@ void test_thread_func(void *data)
 {
     int thread_id;
 
-    thread_id = get_thread_id(mt_current());
+    thread_id = get_thread_id(cmt_current());
 
     while(1)
     {
 
-        smt_wait_event_until(SMT_EVENT() == SMT_EVENT_POLL);
-        PRINTF("Thread [%d] %p received poll \n",thread_id,mt_current());
+        cmt_wait_event_until(cmt_get_ev() == CMT_EVENT_POLL);
+        PRINTF("Thread [%d] %p received poll \n",thread_id,cmt_current());
     }
 
-    mt_exit();
+    cmt_exit();
 }
 
 
@@ -111,21 +111,21 @@ PROCESS_THREAD(smt_example, ev, data)
           int tmp;
 
           mt_init();
-          smt_init();
+          cmt_init();
 
 
           for(tmp = 0; tmp < NUM_OF_THREADS; tmp+=2)
           {
-              smt_start(&threads[tmp],test_thread_func,NULL);
+              cmt_start(&threads[tmp],test_thread_func,NULL);
           }
 
-          smt_start(&poller_thread,poller_thread_func,NULL);
+          cmt_start(&poller_thread,poller_thread_func,NULL);
 
           while(1)
           {
               etimer_set(&et,rand()%MAX_POLL_DELAY);
               PROCESS_WAIT_EVENT_UNTIL(etimer_expired(&et));
-              smt_poll(&threads[rand()%NUM_OF_THREADS]);
+              cmt_poll(&threads[rand()%NUM_OF_THREADS]);
               PRINTF("PROCESS sent poll event \n");
           }
 

--- a/examples/multi-threading/mt-scheduler/cmt-sleep-test.c
+++ b/examples/multi-threading/mt-scheduler/cmt-sleep-test.c
@@ -35,7 +35,7 @@
 /**
  * \file
  *         Testing mt sleep functionality
- *         Example implementation of an contiki event enabled  mt scheduler
+ *         Example implementation of an contiki event enabled  cooperative mt scheduler
  * \author
  *         marcas756 <marcas756@gmail.com>
  */
@@ -43,8 +43,8 @@
 
 
 #include "contiki.h"
-#include "smt.h"
 #include <stdint.h>
+#include "cmt.h"
 
 #define DEBUG 1
 #if DEBUG
@@ -61,57 +61,57 @@
 void cntdwn_thread(void *data)
 {
     uint8_t* cntdwn = data;
-    mt_thread *this_thread = mt_current();
-    smt_pause();
+    cmt_thread *this_thread = cmt_current();
+    cmt_pause();
     PRINTF("%p : Starting\n",this_thread);
-    smt_pause();
+    cmt_pause();
 
     while (*cntdwn)
     {
-        smt_pause();
+        cmt_pause();
         PRINTF("%p : cntdwn = %d\n",this_thread, *cntdwn);
-        smt_pause();
-        smt_sleep(CLOCK_SECOND);
-        smt_pause();
+        cmt_pause();
+        cmt_sleep(CLOCK_SECOND);
+        cmt_pause();
         (*cntdwn)--;
-        smt_pause();
-        smt_pause();
-        smt_pause();
-        smt_pause();
+        cmt_pause();
+        cmt_pause();
+        cmt_pause();
+        cmt_pause();
 
     }
 
     PRINTF("%p : Terminating\n",this_thread);
 
-    mt_exit();
+    cmt_exit();
 }
 
 
 uint8_t countdown1 = 10;
 uint8_t countdown2 = 20;
 
-static mt_thread threads[4];
+static cmt_thread threads[4];
 
 /*---------------------------------------------------------------------------*/
-PROCESS(smt_example, "smt example");
-AUTOSTART_PROCESSES(&smt_example);
+PROCESS(cmt_example, "cmt example");
+AUTOSTART_PROCESSES(&cmt_example);
 /*---------------------------------------------------------------------------*/
-PROCESS_THREAD(smt_example, ev, data)
+PROCESS_THREAD(cmt_example, ev, data)
 {
       static struct etimer et;
 
       PROCESS_BEGIN();
 
       mt_init();
-      smt_init();
+      cmt_init();
 
-      smt_start(&threads[CNTDWN_THREAD_1],cntdwn_thread,&countdown1);
+      cmt_start(&threads[CNTDWN_THREAD_1],cntdwn_thread,&countdown1);
 
       /* Delay start of second thread for 0.5s */
       etimer_set(&et,CLOCK_SECOND/2);
       PROCESS_WAIT_EVENT();
 
-      smt_start(&threads[CNTDWN_THREAD_2],cntdwn_thread,&countdown2);
+      cmt_start(&threads[CNTDWN_THREAD_2],cntdwn_thread,&countdown2);
 
 
       PROCESS_END();

--- a/examples/multi-threading/mt-scheduler/cmt.h
+++ b/examples/multi-threading/mt-scheduler/cmt.h
@@ -34,7 +34,7 @@
 
 /**
  * \file
- *         Scheduled multi threading library
+ *         Scheduled cooperative multi threading implementation
  *
  *         - Non preemtive mt-scheduler (context switch during irq not
  *           allowed for this implementation)
@@ -52,58 +52,74 @@
  *           target thread to SMT_BROADCAST when invoking smt_post.
  *         - Don't forget to call mt_init() and smt_init() before using this lib.
  *         - polling threads from irq or main thread by using smt_poll()
+ *         - does not break current mt_thread implementation
  *
  * \author
  *         marcas756 <marcas756@gmail.com>
  */
-#ifndef SMT_H_
-#define SMT_H_
+#ifndef CMT_H_
+#define CMT_H_
 
 #include "contiki.h"
 #include "sys/mt.h"
 #include "memb.h"
 
+#define CMT_ERR_FULL        PROCESS_ERR_FULL
+#define CMT_ERR_OK          PROCESS_ERR_OK
+#define CMT_MAX_EVENTS      PROCESS_CONF_NUMEVENTS
+#define CMT_BROADCAST       PROCESS_BROADCAST
+#define CMT_EVENT_POLL      PROCESS_EVENT_POLL
+#define CMT_EVENT_CONTINUE  PROCESS_EVENT_CONTINUE
 
+extern struct mt_thread* mt_current(void); /*  access to currently running mt_thread */
 
-#define SMT_ERR_FULL        PROCESS_ERR_FULL
-#define SMT_ERR_OK          PROCESS_ERR_OK
-#define SMT_MAX_EVENTS      PROCESS_CONF_NUMEVENTS
-#define SMT_BROADCAST       PROCESS_BROADCAST
-#define SMT_EVENT_POLL      PROCESS_EVENT_POLL
-#define SMT_EVENT_CONTINUE  PROCESS_EVENT_CONTINUE
+#define cmt_current() \
+    ((cmt_thread *)mt_current())
 
-/*
- * Access macros to smt event data and smt event id
- * In comparison to contiki processes the void pointer provided to mt_threads
- * will be the same as long as the process does not exit. Thus we need access
- * to global event data and event id (see smt.c).
- */
-#define SMT_DATA()          smt_data
-#define SMT_EVENT()         smt_ev
+#define cmt_exit() \
+    mt_exit()
 
-
-/** \brief  Extended smt event structure
+/** \brief  Extended cmt thread structure
  *
- *  \details
+ *  This structure extends the mt_thread structure.
+ *  This kind of extension makes it possible to keep the current
+ *  mt_structure intact without breaking anything in Contiki, but
+ *  also makes this implementation less efficient than an optimized mt
+ *  implementation that covers cmt (cooperative) and pmt (preemtive).
+ *
+ **/
+typedef struct cmt_thread cmt_thread;
+struct cmt_thread {
+    struct mt_thread mt_thread; /*!< associated mt_thread ... has to be the first member due to casting */
+    cmt_thread *next;           /*!< pointer to the next thread in the list */
+    char needspoll;             /*!< threads polling flag (equivalent to processes polling flag) */
+    struct ctimer ct;           /*!< sleep timer ... may not be defined as auto var due to stack swapping 6502 arch */
+};
+
+
+/** \brief  Extended cmt event structure
+ *
  *  A contiki event delivered to porcesses consists of an event ID
  *  and a pointer to data associated with the event. Also a pointer
  *  to the process to be serviced with the event has to be stored.
  *
- *  As there is no support for mthread events, the contiki process event
- *  has to be extended by an mthread pointer.
+ *  As there is no support for mt_thread events, the contiki process event
+ *  has to be extended by an mt_thread pointer.
  *
- *  So first the smt process will receive the process event and extract
- *  The target mthread pointer and the event data pointer from process event
+ *  So first the cmt process will receive the process event and extract
+ *  The target mt_thread pointer and the event data pointer from process event
  *  data pointer.
  *
  **/
-struct smt_event_ext_t {
-    mt_thread *target;  /*!< Target thread to send the event to */
-    void *data;         /*!< Data associated with the event */
+struct cmt_event_ext_t {
+    cmt_thread *target;  /*!< Target thread to send the event to */
+    void *data;          /*!< Data associated with the event */
 };
 
-extern process_event_t smt_ev;     /*!< Any mthread may access this event id */
-extern process_data_t smt_data;    /*!< Any mthread may access this event data */
+
+extern process_event_t cmt_ev;     /*!< Any cmt thread may access this event id */
+extern process_data_t  cmt_data;   /*!< Any cmt thread may access this event data */
+
 
 /**
  * Wait for an event within a mt_thread function
@@ -112,85 +128,84 @@ extern process_data_t smt_data;    /*!< Any mthread may access this event data *
  *
  * Waits for any event within the mt_thread function.
  * The only way to reschedule an mt_thread is to send
- * an event to the smt scheduler process. This can be done
- * via smt_post by mt_threads or contiki processes.
+ * an event to the cmt scheduler process. This can be done
+ * via cmt_post by cmt_threads or contiki processes.
  */
-#define smt_wait_event() \
+#define cmt_wait_event() \
     mt_yield()
 
 /**
- * Wait for an event within a mt_thread function until a condition is met
+ * Wait for an event within a cmt_thread function until a condition is met
  *
  * Must only be called within a mt_thread function!
  *
- * Waits for any event within the mt_thread function until a condition is met.
+ * Waits for any event within the cmt_thread function until a condition is met.
  * Is similar to PROCESS_WAIT_EVENT_UNTIL.
- * The only way to reschedule an mt_thread is to send
- * an event to the smt scheduler process. This can be done
- * via smt_post by mt_threads or contiki processes.
+ * The only way to reschedule an cmt_thread is to send
+ * an event to the cmt scheduler process. This can be done
+ * via cmt_post by cmt_threads or contiki processes.
  */
-#define smt_wait_event_until(cond)  \
+#define cmt_wait_event_until(cond)  \
     do{                             \
-        smt_wait_event();           \
+        cmt_wait_event();           \
     }while(!(cond))
 
 
 
 /**
- * \brief      Initialize the smt library
- * \param c    Briefly describe all parameters.
+ * \brief      Initialize the cmt implementation
  *
- * Currently only starts the smt scheduler process. *
+ * Currently only starts the cmt scheduler process.
  */
 void
-smt_init(void);
+cmt_init(void);
 
 /**
- * \brief      Starts an smt mt_thread
+ * \brief      Starts an cmt mt_thread
  *
- * \param   thread      Thread control instance
+ * \param   thread      cmt thread control instance
  * \param   function    Thread function
- * \param   data        Pointer to dat to start the thread with
+ * \param   data        Pointer to data to start the thread with
  */
 void
-smt_start(struct mt_thread *thread, void (* function)(void *), void *data);
+cmt_start(struct cmt_thread *thread, void (* function)(void *), void *data);
 
 /**
- * \brief      Posts an event to an smt mt_thread
+ * \brief      Posts an event to a cmt thread
  *
- * May be invoked by any other function except irq functions (non preemtive!)
- * Thus a contiki process is able to send an event to a smt m_thread
+ * May be invoked by any other function except irq functions (remeber, we are non preemtive here!)
+ * Thus a contiki process is able to send an event to a cmt thread
  *
  * \param   thread      Thread control instance
  * \param   ev          Event id
  * \param   data        Data associated with the event
  */
 int
-smt_post(struct mt_thread *thread, process_event_t ev, process_data_t data);
+cmt_post(struct cmt_thread *thread, process_event_t ev, process_data_t data);
 
 /**
  * \brief      Suspends the thread for a given time
  *
- * Must only be called within a mt_thread function!
+ * Must only be called within a cmt thread function!
  *
- * The mt_thread function calling this sleep suspends for interval time.
- * Does not block the rest of the system.
+ * The cmt thread function calling this sleep suspends for interval time,
+ * but does not block the rest of the system.
  *
  * \param   interval    Duration (1s=CLOCK_SECOND)
  */
 void
-smt_sleep(clock_time_t interval);
+cmt_sleep(clock_time_t interval);
 
 /**
- * Request a thread to be polled.
+ * Request a cmt thread to be polled.
  *
  * This function typically is called from an interrupt handler to
- * cause a thread to be polled.
+ * cause a cmt thread to be polled.
  *
- * \param thread A pointer to the threads mt_thread structure.
+ * \param thread A pointer to the cmt thread to be polled
  */
 void
-smt_poll(mt_thread *thread);
+cmt_poll(cmt_thread *thread);
 
 /**
  * Yield the thread for a short while.
@@ -201,6 +216,24 @@ smt_poll(mt_thread *thread);
  * \hideinitializer
  */
 void
-smt_pause();
+cmt_pause(void);
+
+/**
+ * Returns the current event id.
+ *
+ * \hideinitializer
+ */
+process_event_t
+cmt_get_ev(void);
+
+/**
+ * Returns the current event data pointer.
+ *
+ * \hideinitializer
+ */
+process_data_t
+cmt_get_data(void);
+
+
 
 #endif /* SMT_H_ */


### PR DESCRIPTION
- Non preemtive mt-scheduler (context switch during irq not allowed for this implementation)
- sending events from a contiki-process to a smt-thread works by  using smt_post in the contiki-process
- sending events from a smt-thread to a smt-thread works by using smt_post in the source smt_thread
- sending events from a smt-thread to a contiki-process works by using process_post / process_post_synch in the smt-thread
- smt-thread can be sent to bed with smt_sleep. This does only block the smt-thread calling sleep, not the whole system.
- an smt-thread has to exit on its own. Killing the thread from outside is not possible
- A broadcast of an event to all smt-threads can be achieved by setting the target thread to SMT_BROADCAST when invoking smt_post.
- Don't forget to call mt_init() and smt_init() before using this lib.
- polling threads from irq, main thread or other threads context by using smt_poll()
- pausing mt_threads, similar to PROCESS_PAUSE
- does not break current mt_thread implementation

Changed stack size for native linux

This pull request replaces #923 
