### PR TITLE
Erbium: client-side support for CoAP Observe

### DIFF
--- a/apps/er-coap/Makefile.er-coap
+++ b/apps/er-coap/Makefile.er-coap
@@ -1,4 +1,6 @@
-er-coap_src = er-coap.c er-coap-engine.c er-coap-transactions.c er-coap-observe.c er-coap-separate.c er-coap-res-well-known-core.c er-coap-block1.c
+er-coap_src = er-coap.c er-coap-engine.c er-coap-transactions.c      \
+  er-coap-observe.c er-coap-separate.c er-coap-res-well-known-core.c \
+  er-coap-block1.c er-coap-observe-client.c
 
 # Erbium will implement the REST Engine
 CFLAGS += -DREST=coap_rest_implementation

--- a/apps/er-coap/er-coap-engine.c
+++ b/apps/er-coap/er-coap-engine.c
@@ -253,6 +253,16 @@ coap_receive(void)
         }
         /* if(ACKed transaction) */
         transaction = NULL;
+
+#if COAP_OBSERVE_CLIENT
+	/* if observe notification */
+        if((message->type == COAP_TYPE_CON || message->type == COAP_TYPE_NON)
+              && IS_OPTION(message, COAP_OPTION_OBSERVE)) {
+          PRINTF("Observe [%u]\n", message->observe);
+          coap_handle_notification(&UIP_IP_BUF->srcipaddr, UIP_UDP_BUF->srcport,
+              message);
+        }
+#endif /* COAP_OBSERVE_CLIENT */
       } /* request or response */
     } /* parsed correctly */
 

--- a/apps/er-coap/er-coap-engine.h
+++ b/apps/er-coap/er-coap-engine.h
@@ -44,6 +44,7 @@
 #include "er-coap-transactions.h"
 #include "er-coap-observe.h"
 #include "er-coap-separate.h"
+#include "er-coap-observe-client.h"
 
 #define SERVER_LISTEN_PORT      UIP_HTONS(COAP_SERVER_PORT)
 

--- a/apps/er-coap/er-coap-observe-client.c
+++ b/apps/er-coap/er-coap-observe-client.c
@@ -1,0 +1,342 @@
+/*
+ * Copyright (c) 2014, Daniele Alessandrelli.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * This file is part of the Contiki operating system.
+ *
+ */
+
+/*
+ * \file
+ *        Extension to Erbium for enabling CoAP observe clients
+ * \author
+ *        Daniele Alessandrelli <daniele.alessandrelli@gmail.com>
+ */
+
+#include <stdio.h>
+#include <string.h>
+
+#include "er-coap.h"
+#include "er-coap-observe-client.h"
+
+/* Compile this code only if client-side support for CoAP Observe is required */
+#if COAP_OBSERVE_CLIENT
+
+#define DEBUG 1
+#if DEBUG
+#define PRINTF(...) printf(__VA_ARGS__)
+#define PRINT6ADDR(addr) PRINTF("[%02x%02x:%02x%02x:%02x%02x:%02x%02x:" \
+                                "%02x%02x:%02x%02x:%02x%02x:%02x%02x]", \
+                                ((uint8_t *)addr)[0], ((uint8_t *)addr)[1], \
+                                ((uint8_t *)addr)[2], ((uint8_t *)addr)[3], \
+                                ((uint8_t *)addr)[4], ((uint8_t *)addr)[5], \
+                                ((uint8_t *)addr)[6], ((uint8_t *)addr)[7], \
+                                ((uint8_t *)addr)[8], ((uint8_t *)addr)[9], \
+                                ((uint8_t *)addr)[10], ((uint8_t *)addr)[11], \
+                                ((uint8_t *)addr)[12], ((uint8_t *)addr)[13], \
+                                ((uint8_t *)addr)[14], ((uint8_t *)addr)[15])
+#define PRINTLLADDR(lladdr) PRINTF("[%02x:%02x:%02x:%02x:%02x:%02x]", \
+                                   (lladdr)->addr[0], (lladdr)->addr[1], \
+                                   (lladdr)->addr[2], (lladdr)->addr[3], \
+                                   (lladdr)->addr[4], (lladdr)->addr[5])
+#else
+#define PRINTF(...)
+#define PRINT6ADDR(addr)
+#define PRINTLLADDR(addr)
+#endif
+
+MEMB(obs_subjects_memb, coap_observee_t, COAP_MAX_OBSERVEES);
+LIST(obs_subjects_list);
+
+/*----------------------------------------------------------------------------*/
+static size_t
+get_token(void *packet, const uint8_t **token)
+{
+  coap_packet_t *const coap_pkt = (coap_packet_t *)packet;
+
+  *token = coap_pkt->token;
+
+  return coap_pkt->token_len;
+}
+/*----------------------------------------------------------------------------*/
+static int
+set_token(void *packet, const uint8_t *token, size_t token_len)
+{
+  coap_packet_t *const coap_pkt = (coap_packet_t *)packet;
+
+  coap_pkt->token_len = MIN(COAP_TOKEN_LEN, token_len);
+  memcpy(coap_pkt->token, token, coap_pkt->token_len);
+
+  return coap_pkt->token_len;
+}
+/*----------------------------------------------------------------------------*/
+coap_observee_t *
+coap_obs_add_observee(uip_ipaddr_t *addr, uint16_t port,
+                      const uint8_t *token, size_t token_len, const char *url,
+                      notification_callback_t notification_callback,
+                      void *data)
+{
+  coap_observee_t *o;
+
+  /* Remove existing observe relationship, if any. */
+  coap_obs_remove_observee_by_url(addr, port, url);
+  o = memb_alloc(&obs_subjects_memb);
+  if(o) {
+    o->url = url;
+    uip_ipaddr_copy(&o->addr, addr);
+    o->port = port;
+    o->token_len = token_len;
+    memcpy(o->token, token, token_len);
+    /* o->last_mid = 0; */
+    o->notification_callback = notification_callback;
+    o->data = data;
+    /* stimer_set(&o->refresh_timer, COAP_OBSERVING_REFRESH_INTERVAL); */
+    PRINTF("Adding obs_subject for /%s [0x%02X%02X]\n", o->url, o->token[0],
+           o->token[1]);
+    list_add(obs_subjects_list, o);
+  }
+
+  return o;
+}
+/*----------------------------------------------------------------------------*/
+void
+coap_obs_remove_observee(coap_observee_t *o)
+{
+  PRINTF("Removing obs_subject for /%s [0x%02X%02X]\n", o->url, o->token[0],
+         o->token[1]);
+  memb_free(&obs_subjects_memb, o);
+  list_remove(obs_subjects_list, o);
+}
+/*----------------------------------------------------------------------------*/
+coap_observee_t *
+coap_get_obs_subject_by_token(const uint8_t *token, size_t token_len)
+{
+  coap_observee_t *obs = NULL;
+
+  for(obs = (coap_observee_t *)list_head(obs_subjects_list); obs;
+      obs = obs->next) {
+    PRINTF("Looking for token 0x%02X%02X\n", token[0], token[1]);
+    if(obs->token_len == token_len
+       && memcmp(obs->token, token, token_len) == 0) {
+      return obs;
+    }
+  }
+
+  return NULL;
+}
+/*----------------------------------------------------------------------------*/
+int
+coap_obs_remove_observee_by_token(uip_ipaddr_t *addr, uint16_t port,
+                                  uint8_t *token, size_t token_len)
+{
+  int removed = 0;
+  coap_observee_t *obs = NULL;
+
+  for(obs = (coap_observee_t *)list_head(obs_subjects_list); obs;
+      obs = obs->next) {
+    PRINTF("Remove check Token 0x%02X%02X\n", token[0], token[1]);
+    if(uip_ipaddr_cmp(&obs->addr, addr)
+       && obs->port == port
+       && obs->token_len == token_len
+       && memcmp(obs->token, token, token_len) == 0) {
+      coap_obs_remove_observee(obs);
+      removed++;
+    }
+  }
+  return removed;
+}
+/*----------------------------------------------------------------------------*/
+int
+coap_obs_remove_observee_by_url(uip_ipaddr_t *addr, uint16_t port,
+                                const char *url)
+{
+  int removed = 0;
+  coap_observee_t *obs = NULL;
+
+  for(obs = (coap_observee_t *)list_head(obs_subjects_list); obs;
+      obs = obs->next) {
+    PRINTF("Remove check URL %s\n", url);
+    if(uip_ipaddr_cmp(&obs->addr, addr)
+       && obs->port == port
+       && (obs->url == url || memcmp(obs->url, url, strlen(obs->url)) == 0)) {
+      coap_obs_remove_observee(obs);
+      removed++;
+    }
+  }
+  return removed;
+}
+/*----------------------------------------------------------------------------*/
+static void
+simple_reply(coap_message_type_t type, uip_ip6addr_t *addr, uint16_t port,
+             coap_packet_t *notification)
+{
+  static coap_packet_t response[1];
+  size_t len;
+
+  coap_init_message(response, type, NO_ERROR, notification->mid);
+  len = coap_serialize_message(response, uip_appdata);
+  coap_send_message(addr, port, uip_appdata, len);
+}
+/*----------------------------------------------------------------------------*/
+static coap_notification_flag_t
+classify_notification(void *response, int first)
+{
+  coap_packet_t *pkt;
+
+  pkt = (coap_packet_t *)response;
+  if(!pkt) {
+    PRINTF("no response\n");
+    return NO_REPLY_FROM_SERVER;
+  }
+  PRINTF("server replied\n");
+  if(!IS_RESPONSE_CODE_2_XX(pkt)) {
+    PRINTF("error response code\n");
+    return ERROR_RESPONSE_CODE;
+  }
+  if(!IS_OPTION(pkt, COAP_OPTION_OBSERVE)) {
+    PRINTF("server does not support observe\n");
+    return OBSERVE_NOT_SUPPORTED;
+  }
+  if(first) {
+    return OBSERVE_OK;
+  }
+  return NOTIFICATION_OK;
+}
+/*----------------------------------------------------------------------------*/
+void
+coap_handle_notification(uip_ipaddr_t *addr, uint16_t port,
+                         coap_packet_t *notification)
+{
+  coap_packet_t *pkt;
+  const uint8_t *token;
+  int token_len;
+  coap_observee_t *obs;
+  coap_notification_flag_t flag;
+  uint32_t observe;
+
+  PRINTF("coap_handle_notification()\n");
+  pkt = (coap_packet_t *)notification;
+  token_len = get_token(pkt, &token);
+  PRINTF("Getting token\n");
+  if(0 == token_len) {
+    PRINTF("Error while handling coap observe notification: "
+           "no token in message\n");
+    return;
+  }
+  PRINTF("Getting observee info\n");
+  obs = coap_get_obs_subject_by_token(token, token_len);
+  if(NULL == obs) {
+    PRINTF("Error while handling coap observe notification: "
+           "no matching token found\n");
+    simple_reply(COAP_TYPE_RST, addr, port, notification);
+    return;
+  }
+  if(notification->type == COAP_TYPE_CON) {
+    simple_reply(COAP_TYPE_ACK, addr, port, notification);
+  }
+  if(obs->notification_callback != NULL) {
+    flag = classify_notification(notification, 0);
+    /* TODO: the following mechanism for discarding duplicates is too trivial */
+    /* refer to Observe RFC for a better solution */
+    if(flag == NOTIFICATION_OK) {
+      coap_get_header_observe(notification, &observe);
+      if(observe == obs->last_observe) {
+        PRINTF("Discarding duplicate\n");
+        return;
+      }
+      obs->last_observe = observe;
+    }
+    obs->notification_callback(obs, notification, flag);
+  }
+}
+/*----------------------------------------------------------------------------*/
+static void
+handle_obs_registration_response(void *data, void *response)
+{
+  coap_observee_t *obs;
+  notification_callback_t notification_callback;
+  coap_notification_flag_t flag;
+
+  PRINTF("handle_obs_registration_response(): ");
+  obs = (coap_observee_t *)data;
+  notification_callback = obs->notification_callback;
+  flag = classify_notification(response, 1);
+  if(notification_callback) {
+    notification_callback(obs, response, flag);
+  }
+  if(flag != OBSERVE_OK) {
+    coap_obs_remove_observee(obs);
+  }
+}
+/*----------------------------------------------------------------------------*/
+uint8_t
+coap_generate_token(uint8_t **token_ptr)
+{
+  static uint8_t token = 0;
+
+  token++;
+  /* FIXME: we should check that this token is not already used */
+  *token_ptr = (uint8_t *)&token;
+  return sizeof(token);
+}
+/*----------------------------------------------------------------------------*/
+coap_observee_t *
+coap_obs_request_registration(uip_ipaddr_t *addr, uint16_t port, char *uri,
+                              notification_callback_t notification_callback,
+                              void *data)
+{
+  coap_packet_t request[1];
+  coap_transaction_t *t;
+  uint8_t *token;
+  uint8_t token_len;
+  coap_observee_t *obs;
+
+  obs = NULL;
+  coap_init_message(request, COAP_TYPE_CON, COAP_GET, coap_get_mid());
+  coap_set_header_uri_path(request, uri);
+  coap_set_header_observe(request, 0);
+  token_len = coap_generate_token(&token);
+  set_token(request, token, token_len);
+  t = coap_new_transaction(request->mid, addr, port);
+  if(t) {
+    obs = coap_obs_add_observee(addr, port, (uint8_t *)token, token_len, uri,
+                                notification_callback, data);
+    if(obs) {
+      t->callback = handle_obs_registration_response;
+      t->callback_data = obs;
+      t->packet_len = coap_serialize_message(request, t->packet);
+      coap_send_transaction(t);
+    } else {
+      PRINTF("Could not allocate obs_subject resource buffer");
+      coap_clear_transaction(t);
+    }
+  } else {
+    PRINTF("Could not allocate transaction buffer");
+  }
+  return obs;
+}
+#endif /* COAP_OBSERVE_CLIENT */

--- a/apps/er-coap/er-coap-observe-client.h
+++ b/apps/er-coap/er-coap-observe-client.h
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2014, Daniele Alessandrelli.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * This file is part of the Contiki operating system.
+ *
+ */
+
+/*
+ * \file
+ *        Extension to Erbium for enabling CoAP observe clients
+ * \author
+ *        Daniele Alessandrelli <daniele.alessandrelli@gmail.com>
+ */
+
+#ifndef COAP_OBSERVING_CLIENT_H_
+#define COAP_OBSERVING_CLIENT_H_
+
+#include "er-coap.h"
+#include "er-coap-transactions.h"
+
+#ifndef COAP_OBSERVE_CLIENT
+#define COAP_OBSERVE_CLIENT 0
+#endif
+
+#ifdef COAP_CONF_MAX_OBSERVEES
+#define COAP_MAX_OBSERVEES COAP_CONF_MAX_OBSERVEES
+#else
+#define COAP_MAX_OBSERVEES      4
+#endif /* COAP_CONF_MAX_OBSERVEES */
+
+#if COAP_MAX_OPEN_TRANSACTIONS < COAP_MAX_OBSERVEES
+#warning "COAP_MAX_OPEN_TRANSACTIONS smaller than COAP_MAX_OBSERVEES: " \
+  "this may be a problem"
+#endif
+
+#define IS_RESPONSE_CODE_2_XX(message) (64 < message->code \
+                                        && message->code < 128)
+
+/*----------------------------------------------------------------------------*/
+typedef enum {
+  OBSERVE_OK,
+  NOTIFICATION_OK,
+  OBSERVE_NOT_SUPPORTED,
+  ERROR_RESPONSE_CODE,
+  NO_REPLY_FROM_SERVER,
+} coap_notification_flag_t;
+
+/*----------------------------------------------------------------------------*/
+typedef struct coap_observee_s coap_observee_t;
+
+typedef void (*notification_callback_t)(coap_observee_t *subject,
+                                        void *notification,
+                                        coap_notification_flag_t);
+
+struct coap_observee_s {
+  coap_observee_t *next;        /* for LIST */
+  uip_ipaddr_t addr;
+  uint16_t port;
+  const char *url;
+  uint8_t token_len;
+  uint8_t token[COAP_TOKEN_LEN];
+  void *data;                   /* generic pointer for storing user data */
+  notification_callback_t notification_callback;
+  uint32_t last_observe;
+};
+
+/*----------------------------------------------------------------------------*/
+coap_observee_t *coap_obs_add_observee(uip_ipaddr_t *addr, uint16_t port,
+                                       const uint8_t *token, size_t token_len,
+                                       const char *url,
+                                       notification_callback_t
+                                       notification_callback, void *data);
+
+void coap_obs_remove_observee(coap_observee_t *o);
+
+coap_observee_t *coap_obs_get_observee_by_token(const uint8_t *token,
+                                                size_t token_len);
+
+int coap_obs_remove_observee_by_token(uip_ipaddr_t *addr, uint16_t port,
+                                      uint8_t *token, size_t token_len);
+
+int coap_obs_remove_observee_by_url(uip_ipaddr_t *addr, uint16_t port,
+                                    const char *url);
+
+void coap_handle_notification(uip_ipaddr_t *, uint16_t port,
+                              coap_packet_t *notification);
+
+coap_observee_t *coap_obs_request_registration(uip_ipaddr_t *addr,
+                                               uint16_t port, char *uri,
+                                               notification_callback_t
+                                               notification_callback,
+                                               void *data);
+/* TODO: this function may be moved to er-coap.c */
+uint8_t coap_generate_token(uint8_t **token_ptr);
+
+#endif /* COAP_OBSERVING_CLIENT_H_ */

--- a/examples/er-rest-example/er-example-observe-client.c
+++ b/examples/er-rest-example/er-example-observe-client.c
@@ -1,0 +1,181 @@
+/*
+ * Copyright (c) 2014, Daniele Alessandrelli.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * This file is part of the Contiki operating system.
+ */
+
+/**
+ * \file
+ *      Erbium (Er) CoAP observe client example.
+ * \author
+ *      Daniele Alessandrelli <daniele.alessandrelli@gmail.com>
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "contiki.h"
+#include "contiki-net.h"
+#include "er-coap-engine.h"
+#include "dev/button-sensor.h"
+
+/*----------------------------------------------------------------------------*/
+#define DEBUG 0
+#if DEBUG
+#define PRINTF(...) printf(__VA_ARGS__)
+#define PRINTFLN(format, ...) printf(format "\n", ##__VA_ARGS__)
+#define PRINT6ADDR(addr) PRINTF("[%02x%02x:%02x%02x:%02x%02x:%02x%02x:" \
+                                "%02x%02x:%02x%02x:%02x%02x:%02x%02x]", \
+                                ((uint8_t *)addr)[0], ((uint8_t *)addr)[1], \
+                                ((uint8_t *)addr)[2], ((uint8_t *)addr)[3], \
+                                ((uint8_t *)addr)[4], ((uint8_t *)addr)[5], \
+                                ((uint8_t *)addr)[6], ((uint8_t *)addr)[7], \
+                                ((uint8_t *)addr)[8], ((uint8_t *)addr)[9], \
+                                ((uint8_t *)addr)[10], ((uint8_t *)addr)[11], \
+                                ((uint8_t *)addr)[12], ((uint8_t *)addr)[13], \
+                                ((uint8_t *)addr)[14], ((uint8_t *)addr)[15])
+#else
+#define PRINTF(...)
+#define PRINT6ADDR(addr)
+#define PRINTFLN(...)
+#endif
+
+/*----------------------------------------------------------------------------*/
+/* FIXME: This server address is hard-coded for Cooja */
+#define SERVER_NODE(ipaddr)   uip_ip6addr(ipaddr, 0xfe80, 0, 0, 0, 0x0212, \
+                                          0x7402, 0x0002, 0x0202)
+#define REMOTE_PORT     UIP_HTONS(COAP_DEFAULT_PORT)
+/* Toggle interval in seconds */
+#define TOGGLE_INTERVAL 30
+/* The path of the resource to observe */
+#define OBS_RESOURCE_URI "test/push"
+
+/*----------------------------------------------------------------------------*/
+static uip_ipaddr_t server_ipaddr[1]; /* holds the server ip address */
+static coap_observee_t *obs;
+
+/*----------------------------------------------------------------------------*/
+PROCESS(er_example_observe_client, "Erbium Coap Observe Client Example");
+AUTOSTART_PROCESSES(&er_example_observe_client);
+
+/*----------------------------------------------------------------------------*/
+/*
+ * Handle the response to the observe request and the following notifications
+ */
+static void
+notification_callback(coap_observee_t *obs, void *notification,
+                      coap_notification_flag_t flag)
+{
+  int len = 0;
+  const uint8_t *payload = NULL;
+
+  printf("Notification handler\n");
+  printf("Observee URI: %s\n", obs->url);
+  if(notification) {
+    len = coap_get_payload(notification, &payload);
+  }
+  switch(flag) {
+  case NOTIFICATION_OK:
+    printf("NOTIFICATION OK: %*s\n", len, (char *)payload);
+    break;
+  case OBSERVE_OK: /* server accepeted observation request */
+    printf("OBSERVE_OK: %*s\n", len, (char *)payload);
+    break;
+  case OBSERVE_NOT_SUPPORTED:
+    printf("OBSERVE_NOT_SUPPORTED: %*s\n", len, (char *)payload);
+    obs = NULL;
+    break;
+  case ERROR_RESPONSE_CODE:
+    printf("ERROR_RESPONSE_CODE: %*s\n", len, (char *)payload);
+    obs = NULL;
+    break;
+  case NO_REPLY_FROM_SERVER:
+    printf("NO_REPLY_FROM_SERVER: "
+           "removing observe registration with token %x%x\n",
+           obs->token[0], obs->token[1]);
+    obs = NULL;
+    break;
+  }
+}
+/*----------------------------------------------------------------------------*/
+/*
+ * Toggle the observation of the remote resource
+ */
+void
+toggle_observation(void)
+{
+  if(obs) {
+    printf("Stopping observation\n");
+    coap_obs_remove_observee(obs);
+    obs = NULL;
+  } else {
+    printf("Starting observation\n");
+    obs = coap_obs_request_registration(server_ipaddr, REMOTE_PORT,
+                                        OBS_RESOURCE_URI, notification_callback, NULL);
+  }
+}
+/*----------------------------------------------------------------------------*/
+/*
+ * The main (proto-)thread. It starts/stops the observation of the remote
+ * resource every time the timer elapses or the button (if available) is
+ * pressed
+ */
+PROCESS_THREAD(er_example_observe_client, ev, data)
+{
+  PROCESS_BEGIN();
+
+  static struct etimer et;
+
+  /* store server address in server_ipaddr */
+  SERVER_NODE(server_ipaddr);
+  /* receives all CoAP messages */
+  coap_init_engine();
+  /* init timer and button (if available) */
+  etimer_set(&et, TOGGLE_INTERVAL * CLOCK_SECOND);
+#if PLATFORM_HAS_BUTTON
+  SENSORS_ACTIVATE(button_sensor);
+  printf("Press a button to start/stop observation of remote resource\n");
+#endif
+  /* toggle observation every time the timer elapses or the button is pressed */
+  while(1) {
+    PROCESS_YIELD();
+    if(etimer_expired(&et)) {
+      printf("--Toggle timer--\n");
+      toggle_observation();
+      printf("\n--Done--\n");
+      etimer_reset(&et);
+#if PLATFORM_HAS_BUTTON
+    } else if(ev == sensors_event && data == &button_sensor) {
+      printf("--Toggle tutton--\n");
+      toggle_observation();
+      printf("\n--Done--\n");
+#endif
+    }
+  }
+  PROCESS_END();
+}

--- a/examples/er-rest-example/project-conf.h
+++ b/examples/er-rest-example/project-conf.h
@@ -93,4 +93,6 @@
 #undef COAP_PROXY_OPTION_PROCESSING
 #define COAP_PROXY_OPTION_PROCESSING   0
 
+/* Enable client-side support for COAP observe */
+#define COAP_OBSERVE_CLIENT 1
 #endif /* __PROJECT_ERBIUM_CONF_H__ */

--- a/examples/er-rest-example/server-client-observe.csc
+++ b/examples/er-rest-example/server-client-observe.csc
@@ -1,0 +1,203 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<simconf>
+  <project EXPORT="discard">[APPS_DIR]/mrm</project>
+  <project EXPORT="discard">[APPS_DIR]/mspsim</project>
+  <project EXPORT="discard">[APPS_DIR]/avrora</project>
+  <project EXPORT="discard">[APPS_DIR]/serial_socket</project>
+  <project EXPORT="discard">[APPS_DIR]/collect-view</project>
+  <project EXPORT="discard">[APPS_DIR]/powertracker</project>
+  <simulation>
+    <title>REST with RPL router</title>
+    <speedlimit>1.0</speedlimit>
+    <randomseed>123456</randomseed>
+    <motedelay_us>1000000</motedelay_us>
+    <radiomedium>
+      org.contikios.cooja.radiomediums.UDGM
+      <transmitting_range>50.0</transmitting_range>
+      <interference_range>50.0</interference_range>
+      <success_ratio_tx>1.0</success_ratio_tx>
+      <success_ratio_rx>1.0</success_ratio_rx>
+    </radiomedium>
+    <events>
+      <logoutput>40000</logoutput>
+    </events>
+    <motetype>
+      org.contikios.cooja.mspmote.SkyMoteType
+      <identifier>rplroot</identifier>
+      <description>Sky RPL Root</description>
+      <source EXPORT="discard">[CONTIKI_DIR]/examples/ipv6/rpl-border-router/border-router.c</source>
+      <commands EXPORT="discard">make border-router.sky TARGET=sky</commands>
+      <firmware EXPORT="copy">[CONTIKI_DIR]/examples/ipv6/rpl-border-router/border-router.sky</firmware>
+      <moteinterface>org.contikios.cooja.interfaces.Position</moteinterface>
+      <moteinterface>org.contikios.cooja.interfaces.RimeAddress</moteinterface>
+      <moteinterface>org.contikios.cooja.interfaces.IPAddress</moteinterface>
+      <moteinterface>org.contikios.cooja.interfaces.Mote2MoteRelations</moteinterface>
+      <moteinterface>org.contikios.cooja.interfaces.MoteAttributes</moteinterface>
+      <moteinterface>org.contikios.cooja.mspmote.interfaces.MspClock</moteinterface>
+      <moteinterface>org.contikios.cooja.mspmote.interfaces.MspMoteID</moteinterface>
+      <moteinterface>org.contikios.cooja.mspmote.interfaces.SkyButton</moteinterface>
+      <moteinterface>org.contikios.cooja.mspmote.interfaces.SkyFlash</moteinterface>
+      <moteinterface>org.contikios.cooja.mspmote.interfaces.SkyCoffeeFilesystem</moteinterface>
+      <moteinterface>org.contikios.cooja.mspmote.interfaces.Msp802154Radio</moteinterface>
+      <moteinterface>org.contikios.cooja.mspmote.interfaces.MspSerial</moteinterface>
+      <moteinterface>org.contikios.cooja.mspmote.interfaces.SkyLED</moteinterface>
+      <moteinterface>org.contikios.cooja.mspmote.interfaces.MspDebugOutput</moteinterface>
+      <moteinterface>org.contikios.cooja.mspmote.interfaces.SkyTemperature</moteinterface>
+    </motetype>
+    <motetype>
+      org.contikios.cooja.mspmote.SkyMoteType
+      <identifier>server</identifier>
+      <description>Erbium Server</description>
+      <source EXPORT="discard">[CONTIKI_DIR]/examples/er-rest-example/er-example-server.c</source>
+      <commands EXPORT="discard">make er-example-server.sky TARGET=sky</commands>
+      <firmware EXPORT="copy">[CONTIKI_DIR]/examples/er-rest-example/er-example-server.sky</firmware>
+      <moteinterface>org.contikios.cooja.interfaces.Position</moteinterface>
+      <moteinterface>org.contikios.cooja.interfaces.RimeAddress</moteinterface>
+      <moteinterface>org.contikios.cooja.interfaces.IPAddress</moteinterface>
+      <moteinterface>org.contikios.cooja.interfaces.Mote2MoteRelations</moteinterface>
+      <moteinterface>org.contikios.cooja.interfaces.MoteAttributes</moteinterface>
+      <moteinterface>org.contikios.cooja.mspmote.interfaces.MspClock</moteinterface>
+      <moteinterface>org.contikios.cooja.mspmote.interfaces.MspMoteID</moteinterface>
+      <moteinterface>org.contikios.cooja.mspmote.interfaces.SkyButton</moteinterface>
+      <moteinterface>org.contikios.cooja.mspmote.interfaces.SkyFlash</moteinterface>
+      <moteinterface>org.contikios.cooja.mspmote.interfaces.SkyCoffeeFilesystem</moteinterface>
+      <moteinterface>org.contikios.cooja.mspmote.interfaces.Msp802154Radio</moteinterface>
+      <moteinterface>org.contikios.cooja.mspmote.interfaces.MspSerial</moteinterface>
+      <moteinterface>org.contikios.cooja.mspmote.interfaces.SkyLED</moteinterface>
+      <moteinterface>org.contikios.cooja.mspmote.interfaces.MspDebugOutput</moteinterface>
+      <moteinterface>org.contikios.cooja.mspmote.interfaces.SkyTemperature</moteinterface>
+    </motetype>
+    <motetype>
+      org.contikios.cooja.mspmote.SkyMoteType
+      <identifier>client</identifier>
+      <description>Erbium Client</description>
+      <source EXPORT="discard">[CONTIKI_DIR]/examples/er-rest-example/er-example-observe-client.c</source>
+      <commands EXPORT="discard">make er-example-observe-client.sky TARGET=sky</commands>
+      <firmware EXPORT="copy">[CONTIKI_DIR]/examples/er-rest-example/er-example-observe-client.sky</firmware>
+      <moteinterface>org.contikios.cooja.interfaces.Position</moteinterface>
+      <moteinterface>org.contikios.cooja.interfaces.RimeAddress</moteinterface>
+      <moteinterface>org.contikios.cooja.interfaces.IPAddress</moteinterface>
+      <moteinterface>org.contikios.cooja.interfaces.Mote2MoteRelations</moteinterface>
+      <moteinterface>org.contikios.cooja.interfaces.MoteAttributes</moteinterface>
+      <moteinterface>org.contikios.cooja.mspmote.interfaces.MspClock</moteinterface>
+      <moteinterface>org.contikios.cooja.mspmote.interfaces.MspMoteID</moteinterface>
+      <moteinterface>org.contikios.cooja.mspmote.interfaces.SkyButton</moteinterface>
+      <moteinterface>org.contikios.cooja.mspmote.interfaces.SkyFlash</moteinterface>
+      <moteinterface>org.contikios.cooja.mspmote.interfaces.SkyCoffeeFilesystem</moteinterface>
+      <moteinterface>org.contikios.cooja.mspmote.interfaces.Msp802154Radio</moteinterface>
+      <moteinterface>org.contikios.cooja.mspmote.interfaces.MspSerial</moteinterface>
+      <moteinterface>org.contikios.cooja.mspmote.interfaces.SkyLED</moteinterface>
+      <moteinterface>org.contikios.cooja.mspmote.interfaces.MspDebugOutput</moteinterface>
+      <moteinterface>org.contikios.cooja.mspmote.interfaces.SkyTemperature</moteinterface>
+    </motetype>
+    <mote>
+      <breakpoints />
+      <interface_config>
+        org.contikios.cooja.interfaces.Position
+        <x>33.260163187353555</x>
+        <y>30.643217359962595</y>
+        <z>0.0</z>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspMoteID
+        <id>1</id>
+      </interface_config>
+      <motetype_identifier>rplroot</motetype_identifier>
+    </mote>
+    <mote>
+      <breakpoints />
+      <interface_config>
+        org.contikios.cooja.interfaces.Position
+        <x>54.537149936813485</x>
+        <y>51.51086225537906</y>
+        <z>0.0</z>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspMoteID
+        <id>2</id>
+      </interface_config>
+      <motetype_identifier>server</motetype_identifier>
+    </mote>
+    <mote>
+      <breakpoints />
+      <interface_config>
+        org.contikios.cooja.interfaces.Position
+        <x>77.97942851220571</x>
+        <y>67.86182390447284</y>
+        <z>0.0</z>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspMoteID
+        <id>3</id>
+      </interface_config>
+      <motetype_identifier>client</motetype_identifier>
+    </mote>
+  </simulation>
+  <plugin>
+    org.contikios.cooja.plugins.SimControl
+    <width>259</width>
+    <z>3</z>
+    <height>179</height>
+    <location_x>2</location_x>
+    <location_y>1</location_y>
+  </plugin>
+  <plugin>
+    org.contikios.cooja.plugins.Visualizer
+    <plugin_config>
+      <skin>org.contikios.cooja.plugins.skins.IDVisualizerSkin</skin>
+      <skin>org.contikios.cooja.plugins.skins.UDGMVisualizerSkin</skin>
+      <skin>org.contikios.cooja.plugins.skins.MoteTypeVisualizerSkin</skin>
+      <skin>org.contikios.cooja.plugins.skins.AttributeVisualizerSkin</skin>
+      <skin>org.contikios.cooja.plugins.skins.LEDVisualizerSkin</skin>
+      <skin>org.contikios.cooja.plugins.skins.AddressVisualizerSkin</skin>
+      <viewport>2.092412892721766 0.0 0.0 2.092412892721766 34.70057915472623 -45.606066372444175</viewport>
+    </plugin_config>
+    <width>300</width>
+    <z>4</z>
+    <height>178</height>
+    <location_x>261</location_x>
+    <location_y>1</location_y>
+  </plugin>
+  <plugin>
+    org.contikios.cooja.plugins.LogListener
+    <plugin_config>
+      <filter />
+      <formatted_time />
+      <coloring />
+    </plugin_config>
+    <width>762</width>
+    <z>0</z>
+    <height>491</height>
+    <location_x>2</location_x>
+    <location_y>182</location_y>
+  </plugin>
+  <plugin>
+    org.contikios.cooja.plugins.RadioLogger
+    <plugin_config>
+      <split>167</split>
+      <formatted_time />
+      <showdups>false</showdups>
+      <hidenodests>false</hidenodests>
+      <analyzers name="6lowpan" />
+    </plugin_config>
+    <width>560</width>
+    <z>1</z>
+    <height>492</height>
+    <location_x>764</location_x>
+    <location_y>181</location_y>
+  </plugin>
+  <plugin>
+    org.contikios.cooja.serialsocket.SerialSocketServer
+    <mote_arg>0</mote_arg>
+    <plugin_config>
+      <port>60001</port>
+      <bound>true</bound>
+    </plugin_config>
+    <width>362</width>
+    <z>2</z>
+    <height>116</height>
+    <location_x>561</location_x>
+    <location_y>1</location_y>
+  </plugin>
+</simconf>
+


### PR DESCRIPTION
This pull request extends Erbium with client-side support for CoAP Observe.
An example showing how to use the new functionality is also included.

As requested by @mkovatsc, the new code is not compiled by default. To enable it the `COAP_OBSERVE_CLIENT` macro must be defined equal to 1. On a Tmote Sky, this will increase the Text section by ~1100 bytes and the BSS section by ~300 bytes.

Happy Holidays! :)