### PR TITLE
CC2538 RF driver issues x3

### DIFF
--- a/cpu/cc2538/dev/cc2538-rf.c
+++ b/cpu/cc2538/dev/cc2538-rf.c
@@ -964,17 +964,18 @@ PROCESS_THREAD(cc2538_rf_process, ev, data)
 
     /* If we were polled due to an RF error, reset the transceiver */
     if(rf_flags & RF_MUST_RESET) {
+      uint8_t was_on;
       rf_flags = 0;
 
       /* save state so we know if to switch on again after re-init */
       if((REG(RFCORE_XREG_FSMSTAT0) & RFCORE_XREG_FSMSTAT0_FSM_FFCTRL_STATE) == 0) {
-        rf_flags |= WAS_OFF;
+        was_on = 0;
       } else {
-        rf_flags &= ~WAS_OFF;
+        was_on = 1;
       }
       off();
       init();
-      if ((rf_flags & WAS_OFF) != WAS_OFF) {
+      if (was_on) {
         /* switch back on */
         on();
       }

--- a/cpu/cc2538/dev/cc2538-rf.c
+++ b/cpu/cc2538/dev/cc2538-rf.c
@@ -975,7 +975,7 @@ PROCESS_THREAD(cc2538_rf_process, ev, data)
       }
       off();
       init();
-      if (was_on) {
+      if(was_on) {
         /* switch back on */
         on();
       }


### PR DESCRIPTION
When using the cc2538-rf driver without using radio duty cycling I discovered that if an error occurs, the radio is switched off, reinitialized, but never switched back on again, which killed all radio reception until the stack decided to switch the radio on again for any reason.

Also, the channel was reset to the default in this case, instead of what was last set. 

Thirdly, the radio was switched on whenever channel was changed, even if radio was currently off. This makes sleepy nodes switch on their radio of for instance using multichan.

* This patch stores the RF channel internally in the module and always reinitialize to the last set value.
* This patch only switch on radio when chaning channel iff the radio was on
* This patch switches radio back on after reinitializing