### PR TITLE
Fix: Misconfigurations to compile for avr-zigbit platform

### DIFF
--- a/platform/avr-zigbit/Makefile.avr-zigbit
+++ b/platform/avr-zigbit/Makefile.avr-zigbit
@@ -1,30 +1,20 @@
-CONTIKI_TARGET_DIRS = . apps net loader
-CONTIKI_CORE=contiki-avr-zigbit
+CONTIKIDIRS += ${addprefix $(CONTIKI)/core/, net/mac net/mac/sicslowmac . }
+
+CONTIKI_TARGET_DIRS = . apps  /core/net/mac/ /core/net/mac/sicslowmac/
+CONTIKI_CORE = contiki-avr-zigbit
 CONTIKI_TARGET_MAIN = ${CONTIKI_CORE}.o
 
-CONTIKI_TARGET_SOURCEFILES +=	rs232.c cfs-eeprom.c eeprom.c random.c \
-				mmem.c contiki-avr-zigbit-main.c
+CONTIKI_TARGET_SOURCEFILES +=	rs232.c cfs-eeprom.c eeprom.c random.c mmem.c \
+				contiki-avr-zigbit-main.c \
+				sicslowmac.c linkaddr.c queuebuf.c nullmac.c packetbuf.c \
+				frame802154.c framer-802154.c framer.c nullsec.c nbr-table.c
 
-CONTIKIAVR=$(CONTIKI)/cpu/avr
-CONTIKIBOARD=.
+CONTIKIAVR = $(CONTIKI)/cpu/avr
+CONTIKIBOARD = .
 
 CONTIKI_PLAT_DEFS = -DF_CPU=8000000UL -DAUTO_CRC_PADDING=2
 
-MCU=atmega1281
-AVRDUDE_PROGRAMMER=jtag2
-
-# For usb devices, you may either use PORT=usb, or (e.g. if you have more than one
-# programmer connected) you can use the following trick to find out the serial number:
-#
-# The example is for an JTAGICE mkII used to program an ATmega128:
-# avrdude -v -P usb:xxxx -c jtag2 -p atmega128
-AVRDUDE_PORT=usb:00B000000D79
-
-
-# Additional avrdude options
-# Verify off
-AVRDUDE_OPTIONS=-V
-
+MCU = atmega1281
 
 include $(CONTIKIAVR)/Makefile.avr
 include $(CONTIKIAVR)/radio/Makefile.radio

--- a/platform/avr-zigbit/contiki-avr-zigbit-main.c
+++ b/platform/avr-zigbit/contiki-avr-zigbit-main.c
@@ -95,15 +95,19 @@ PROCINIT(&etimer_process, &mac_process );
 #endif
 #endif
 /* Put default MAC address in EEPROM */
+#if MY_NODE_ID
+uint8_t mac_address[8] EEMEM = {0x02, 0x11, 0x22, 0xff, 0xfe, 0x33, 0x44, 
+  MY_NODE_ID};
+#else
 uint8_t mac_address[8] EEMEM = {0x02, 0x11, 0x22, 0xff, 0xfe, 0x33, 0x44, 0x55};
-
+#endif
 
 void
 init_lowlevel(void)
 {
 
   /* Second rs232 port for debugging */
-  rs232_init(RS232_PORT_1, USART_BAUD_115200,
+  rs232_init(RS232_PORT_1, USART_BAUD_38400,
              USART_PARITY_NONE | USART_STOP_BITS_1 | USART_DATA_BITS_8);
 
   /* Redirect stdout to second port */
@@ -167,8 +171,8 @@ init_lowlevel(void)
 #if ANNOUNCE_BOOT
   printf_P(PSTR("Routing Enabled\n"));
 #endif
-  rime_init(rime_udp_init(NULL));
-  uip_router_register(&rimeroute);
+  //rime_init(rime_udp_init(NULL));
+  //uip_router_register(&rimeroute);
 #endif
 #if NETSTACK_CONF_WITH_IPV6 || NETSTACK_CONF_WITH_IPV4
   process_start(&tcpip_process, NULL);
@@ -195,12 +199,12 @@ main(void)
   /* Register initial processes */
 //  procinit_init();
 
-  /* Autostart processes */
-  autostart_start(autostart_processes);
-
   printf_P(PSTR("\n********BOOTING CONTIKI*********\n"));
 
   printf_P(PSTR("System online.\n"));
+
+  /* Autostart processes */
+  autostart_start(autostart_processes);
 
   /* Main scheduler loop */
   while(1) {


### PR DESCRIPTION
I had some reference errors for avr-zigbit platform.
I added to the makefile some necessary files and from contiki-avr-zigbit-main.c I commented the rime-stack initializations and modified the baud rate.