### PR TITLE
Make the CC2538DK button sensor clearer to work with

### DIFF
--- a/platform/cc2538dk/dev/button-sensor.c
+++ b/platform/cc2538dk/dev/button-sensor.c
@@ -103,25 +103,17 @@ btn_callback(uint8_t port, uint8_t pin)
   }
 
   timer_set(&debouncetimer, CLOCK_SECOND / 8);
-  if(port == GPIO_A_NUM) {
+
+  if((port == BUTTON_SELECT_PORT) && (pin == BUTTON_SELECT_PIN)) {
     sensors_changed(&button_select_sensor);
-  } else if(port == GPIO_C_NUM) {
-    switch(pin) {
-    case BUTTON_LEFT_PIN:
-      sensors_changed(&button_left_sensor);
-      break;
-    case BUTTON_RIGHT_PIN:
-      sensors_changed(&button_right_sensor);
-      break;
-    case BUTTON_UP_PIN:
-      sensors_changed(&button_up_sensor);
-      break;
-    case BUTTON_DOWN_PIN:
-      sensors_changed(&button_down_sensor);
-      break;
-    default:
-      return;
-    }
+  } else if((port == BUTTON_LEFT_PORT) && (pin == BUTTON_LEFT_PIN)) {
+    sensors_changed(&button_left_sensor);
+  } else if((port == BUTTON_RIGHT_PORT) && (pin == BUTTON_RIGHT_PIN)) {
+    sensors_changed(&button_right_sensor);
+  } else if((port == BUTTON_UP_PORT) && (pin == BUTTON_UP_PIN)) {
+    sensors_changed(&button_up_sensor);
+  } else if((port == BUTTON_DOWN_PORT) && (pin == BUTTON_DOWN_PIN)) {
+    sensors_changed(&button_down_sensor);
   }
 }
 /*---------------------------------------------------------------------------*/


### PR DESCRIPTION
It's now more convenient to add new buttons. If button is redirected to another port, this could doesn't need to be changed. The code itself now is more clear.