### PR TITLE
Fix: Cooja HC packet analyzer fix for SAC and DAC fields

### DIFF
--- a/tools/cooja/java/org/contikios/cooja/plugins/analyzers/IPHCPacketAnalyzer.java
+++ b/tools/cooja/java/org/contikios/cooja/plugins/analyzers/IPHCPacketAnalyzer.java
@@ -115,10 +115,10 @@ public class IPHCPacketAnalyzer extends PacketAnalyzer {
             .append(", NH = ").append(nhc ? "compressed" : "inline")
             .append(", HLIM = ").append(hlim == 0 ? "inline" : hlim)
             .append(", CID = ").append(cid)
-            .append(", SAC = ").append(sac == 1 ? "stateless" : "stateful")
+            .append(", SAC = ").append(sac == 0 ? "stateless" : "stateful")
             .append(", SAM = ").append(sam)
             .append(", MCast = ").append(m)
-            .append(", DAC = ").append(dac == 1 ? "stateless" : "stateful")
+            .append(", DAC = ").append(dac == 0 ? "stateless" : "stateful")
             .append(", DAM = ").append(dam);
     if (cid == 1) {
       verbose.append("<br>Contexts: sci=").append(packet.get(2) >> 4).


### PR DESCRIPTION
This pull request fixes a wrong interpretation of some fields in the packet analyzer of Cooja, when dealing with a compressed header.
According to RFC 6282 section 3.2 (https://tools.ietf.org/html/rfc6282#section-3.2) a 0 in the address compression fields (SAC and DAC) indicates a stateless compression, not a stateful one.
