### PR TITLE
[z1] compilation error when z1 with specific reference number pattern attached

### DIFF
--- a/platform/z1/Makefile.common
+++ b/platform/z1/Makefile.common
@@ -68,7 +68,7 @@ ifeq ($(HOST_OS),Darwin)
       ifneq (,$(REFNUM))
         # No device fo-und
         ifeq (,$(findstring und, $(REFNUM)))
-          CFLAGS += -DSERIALNUM=$(REFNUM)
+          CFLAGS += -DSERIALNUM=0x$(REFNUM)
         endif
       endif
   endif
@@ -89,7 +89,7 @@ else
       ifneq (,$(REFNUM))
         # No device fo-und
         ifeq (,$(findstring und, $(REFNUM)))
-          CFLAGS += -DSERIALNUM=$(REFNUM)
+          CFLAGS += -DSERIALNUM=0x$(REFNUM)
         endif
       endif
     endif


### PR DESCRIPTION
#820 introduced functionality that uses the 4 last digits of the built-in reference number as node_id. If however these 4 last digits start with a leading zero, the SERIALNUM macro will be interpreted as an octal number [here](https://github.com/contiki-os/contiki/blob/010a338630a78db15fbb269a199272180b7bacf8/platform/z1/contiki-z1-main.c#L227). If any of the other three last digits is a '9', a compilation error occurs.

This behaviour can be reproduced (without a z1 attached) in examples/hello-world with `make TARGET=z1 DEFINES=SERIALNUM=0789`.

This fix simply casts SERIALNUM to a hexadecimal value by prepending '0x'. As a side-effect, since we get rid of dec-hex base conversions, the last two bytes of node_mac will now match exactly with node_id when printed out.
