### PR TITLE
change value of RPL_DIO_MOP_MASK 

### DIFF
--- a/core/net/rpl/rpl-icmp6.c
+++ b/core/net/rpl/rpl-icmp6.c
@@ -64,7 +64,7 @@
 /*---------------------------------------------------------------------------*/
 #define RPL_DIO_GROUNDED                 0x80
 #define RPL_DIO_MOP_SHIFT                3
-#define RPL_DIO_MOP_MASK                 0x3c
+#define RPL_DIO_MOP_MASK                 0x38
 #define RPL_DIO_PREFERENCE_MASK          0x07
 
 #define UIP_IP_BUF       ((struct uip_ip_hdr *)&uip_buf[UIP_LLH_LEN])


### PR DESCRIPTION
There is a overlap between RPL_DIO_MOP_MASK and RPL_DIO_PREFRENCE_MASK.
according to rfc 6550, RPL_DIO_MOP_MASK should be 0x38