### PR TITLE
Test cc2538dk with the recommended toolchain

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ before_script:
   - sudo apt-get -qq install libc6:i386 libgcc1:i386 gcc-4.6-base:i386
       libstdc++5:i386 libstdc++6:i386
 
-  ## Install old APCS ARM toolchain for mc1233x, cc2538 and mbxxx
+  ## Install old APCS ARM toolchain for mc1233x and mbxxx
   - if [ ${BUILD_ARCH:-0} = arm-apcs ] ; then
       $WGET https://raw.githubusercontent.com/wiki/malvira/libmc1322x/files/arm-2008q3-66-arm-none-eabi-i686-pc-linux-gnu.tar.bz2 &&
       tar xjf arm-2008q3*.tar.bz2 -C /tmp/ &&

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ before_script:
 
   ## Install mainline ARM toolchain.  gcc-arm-none-eabi is available
   ## in Ubuntu >= 14.04, but this external PPA is needed for 12.04.
-  - if [ ${BUILD_ARCH:-0} = arm ] ; then
+  - if [ ${BUILD_ARCH:-0} = arm-aapcs ] ; then
       sudo add-apt-repository -y ppa:terry.guo/gcc-arm-embedded &&
       sudo apt-get -qq update &&
       sudo apt-get -qq install gcc-arm-none-eabi &&
@@ -49,7 +49,7 @@ before_script:
     fi
 
   ## Download and extract cc26xxware
-  - if [ ${BUILD_ARCH:-0} = arm ] ; then
+  - if [ ${BUILD_ARCH:-0} = arm-aapcs ] ; then
       wget http://www.ti.com/lit/sw/swrc296/swrc296.zip &&
       unzip swrc296.zip &&
       export TI_CC26XXWARE=cc26xxware_2_20_06_14829 ;
@@ -122,6 +122,6 @@ env:
   - BUILD_TYPE='compile-8051-ports' BUILD_CATEGORY='compile' BUILD_ARCH='8051'
   - BUILD_TYPE='compile-arm-apcs-ports' BUILD_CATEGORY='compile' BUILD_ARCH='arm-apcs'
   - BUILD_TYPE='compile-6502-ports' BUILD_CATEGORY='compile' BUILD_ARCH='6502'
-  - BUILD_TYPE='compile-arm-ports' BUILD_CATEGORY='compile' BUILD_ARCH='arm'
+  - BUILD_TYPE='compile-arm-ports' BUILD_CATEGORY='compile' BUILD_ARCH='arm-aapcs'
   - BUILD_TYPE='slip-radio' MAKE_TARGETS='cooja'
   - BUILD_TYPE='llsec' MAKE_TARGETS='cooja'

--- a/platform/cc2538dk/README.md
+++ b/platform/cc2538dk/README.md
@@ -74,10 +74,9 @@ The toolchain used to build contiki is arm-gcc, also used by other arm-based Con
     Thread model: single
     gcc version 4.3.2 (Sourcery G++ Lite 2008q3-66)
 
-The platform is currently being used/tested with the following toolchains:
+The platform is currently being used/tested with "GNU Tools for ARM Embedded Processors". This is the recommended version and the one being used by Contiki's regression tests on Travis. <https://launchpad.net/gcc-arm-embedded>
 
-* GNU Tools for ARM Embedded Processors. This is the recommended version. Works nicely on OS X. <https://launchpad.net/gcc-arm-embedded>
-* Alternatively, you can use this older version for Linux. At the time of writing, this is the version used by Contiki's regression tests. <https://sourcery.mentor.com/public/gnu_toolchain/arm-none-eabi/arm-2008q3-66-arm-none-eabi-i686-pc-linux-gnu.tar.bz2>
+The older version (Sourcery G++ Lite 2008q3-66) shown above should still work, but the port is no longer being tested with it.
 
 Drivers
 -------

--- a/regression-tests/15-compile-arm-apcs-ports/Makefile
+++ b/regression-tests/15-compile-arm-apcs-ports/Makefile
@@ -4,19 +4,10 @@ TOOLSDIR=../../tools
 EXAMPLES = \
 hello-world/econotag \
 hello-world/mbxxx \
-hello-world/cc2538dk \
 ipv6/rpl-border-router/econotag \
-ipv6/rpl-border-router/cc2538dk \
 er-rest-example/econotag \
-er-rest-example/cc2538dk \
 webserver-ipv6/econotag \
-webserver-ipv6/cc2538dk \
-cc2538dk/cc2538dk \
-cc2538dk/udp-ipv6-echo-server/cc2538dk \
-cc2538dk/sniffer/cc2538dk \
-cc2538dk/mqtt-demo/cc2538dk \
 ipv6/multicast/econotag \
-ipv6/multicast/cc2538dk \
 
 TOOLS=
 

--- a/regression-tests/18-compile-arm-ports/Makefile
+++ b/regression-tests/18-compile-arm-ports/Makefile
@@ -8,6 +8,15 @@ webserver-ipv6/ev-aducrf101mkxz \
 ipv6/multicast/ev-aducrf101mkxz \
 cc2538dk/sniffer/ev-aducrf101mkxz \
 cc26xx/cc26xx-web-demo/srf06-cc26xx \
+hello-world/cc2538dk \
+ipv6/rpl-border-router/cc2538dk \
+er-rest-example/cc2538dk \
+webserver-ipv6/cc2538dk \
+cc2538dk/cc2538dk \
+cc2538dk/udp-ipv6-echo-server/cc2538dk \
+cc2538dk/sniffer/cc2538dk \
+cc2538dk/mqtt-demo/cc2538dk \
+ipv6/multicast/cc2538dk \
 
 TOOLS=
 


### PR DESCRIPTION
As per the subject, the objective of this pull is to test cc2538dk with the toolchain recommended in the platform's README (GNU Tools for ARM Embedded Processors), instead of the one that was being used two years ago (Sourcery G++ Lite 2008q3-66). The job using the former is currently disabled on Travis, due to being broken for the ev-aducrf101mkxz platform.

With this in mind, this pull:
* Moves cc2538dk tests to the arm-aapcs job, which is the one using GNU Tools for ARM Embedded Processors
* ~~Re-enables the job in `.travis.yml` and~~~ changes `BUILD_ARCH` from 'arm'  to 'arm-aapcs' for clarity
* ~~ev-aducrf101mkxz tests remain disabled, but this is now done within the job's Makefile rather than in `.travis.yml`. Re-enabling tests for this platform will be a trivial patch.~~

And a quick ping @jimparis for ideas on how to restore ev-aducrf101mkxz tests