### PR TITLE
Move cc2538 startup-gcc.c to the CPU dir

### DIFF
--- a/cpu/cc2538/Makefile.cc2538
+++ b/cpu/cc2538/Makefile.cc2538
@@ -58,6 +58,13 @@ DEBUG_IO_SOURCEFILES += dbg-printf.c dbg-snprintf.c dbg-sprintf.c strformat.c
 USB_CORE_SOURCEFILES += usb-core.c cdc-acm.c
 USB_ARCH_SOURCEFILES += usb-arch.c usb-serial.c cdc-acm-descriptors.c
 
+ifneq ($(TARGET_START_SOURCEFILES),)
+  CPU_START_SOURCEFILES = TARGET_START_SOURCEFILES
+else
+  CPU_START_SOURCEFILES = startup-gcc.c
+endif
+CPU_STARTFILES = ${addprefix $(OBJECTDIR)/,${call oname, $(CPU_START_SOURCEFILES)}}
+
 CONTIKI_SOURCEFILES += $(CONTIKI_CPU_SOURCEFILES) $(DEBUG_IO_SOURCEFILES)
 CONTIKI_SOURCEFILES += $(USB_CORE_SOURCEFILES) $(USB_ARCH_SOURCEFILES)
 
@@ -74,7 +81,7 @@ $(OBJECTDIR)/ieee-addr.o: ieee-addr.c FORCE | $(OBJECTDIR)
 ### Compilation rules
 CUSTOM_RULE_LINK=1
 
-%.elf: $(TARGET_STARTFILES) %.co $(PROJECT_OBJECTFILES) $(PROJECT_LIBRARIES) contiki-$(TARGET).a $(LDSCRIPT)
+%.elf: $(CPU_STARTFILES) %.co $(PROJECT_OBJECTFILES) $(PROJECT_LIBRARIES) contiki-$(TARGET).a $(LDSCRIPT)
 	$(TRACE_LD)
 	$(Q)$(LD) $(LDFLAGS) ${filter-out $(LDSCRIPT) %.a,$^} ${filter %.a,$^} $(TARGET_LIBFILES) -o $@
 

--- a/cpu/cc2538/startup-gcc.c
+++ b/cpu/cc2538/startup-gcc.c
@@ -30,11 +30,11 @@
  *  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 /**
- * \addtogroup cc2538dk
+ * \addtogroup cc2538
  * @{
  *
  * \file
- * Startup code for the cc2538dk platform, to be used when building with gcc
+ * Startup code for the cc2538 chip, to be used when building with gcc
  */
 #include "contiki.h"
 #include "reg.h"
@@ -73,13 +73,13 @@ void udma_err_isr(void);
 #define FLASH_CCA_BOOTLDR_CFG_ACTIVE_LEVEL 0
 #endif
 
-#if ( (FLASH_CCA_CONF_BOOTLDR_BACKDOOR_PORT_A_PIN < 0) || (FLASH_CCA_CONF_BOOTLDR_BACKDOOR_PORT_A_PIN > 7) )
+#if ((FLASH_CCA_CONF_BOOTLDR_BACKDOOR_PORT_A_PIN < 0) || (FLASH_CCA_CONF_BOOTLDR_BACKDOOR_PORT_A_PIN > 7))
 #error Invalid boot loader backdoor pin. Please set FLASH_CCA_CONF_BOOTLDR_BACKDOOR_PORT_A_PIN between 0 and 7 (indicating PA0 - PA7).
 #endif
 
-#define FLASH_CCA_BOOTLDR_CFG ( FLASH_CCA_BOOTLDR_CFG_ENABLE \
+#define FLASH_CCA_BOOTLDR_CFG (FLASH_CCA_BOOTLDR_CFG_ENABLE \
   | FLASH_CCA_BOOTLDR_CFG_ACTIVE_LEVEL \
-  | (FLASH_CCA_CONF_BOOTLDR_BACKDOOR_PORT_A_PIN << FLASH_CCA_BOOTLDR_CFG_PORT_A_PIN_S) )
+  | (FLASH_CCA_CONF_BOOTLDR_BACKDOOR_PORT_A_PIN << FLASH_CCA_BOOTLDR_CFG_PORT_A_PIN_S))
 #else
 #define FLASH_CCA_BOOTLDR_CFG FLASH_CCA_BOOTLDR_CFG_DISABLE
 #endif

--- a/cpu/cc2538/startup-gcc.c
+++ b/cpu/cc2538/startup-gcc.c
@@ -40,11 +40,12 @@
 #include "reg.h"
 #include "flash-cca.h"
 #include "sys-ctrl.h"
-#include "uart.h"
 
 #include <stdint.h>
 /*---------------------------------------------------------------------------*/
 extern int main(void);
+/*---------------------------------------------------------------------------*/
+#define WEAK_ALIAS(x) __attribute__ ((weak, alias(#x)))
 /*---------------------------------------------------------------------------*/
 /* System handlers provided here */
 void reset_handler(void);
@@ -62,6 +63,9 @@ void cc2538_rf_rx_tx_isr(void);
 void cc2538_rf_err_isr(void);
 void udma_isr(void);
 void udma_err_isr(void);
+void usb_isr(void) WEAK_ALIAS(default_handler);
+void uart0_isr(void) WEAK_ALIAS(default_handler);
+void uart1_isr(void) WEAK_ALIAS(default_handler);
 
 /* Boot Loader Backdoor selection */
 #if FLASH_CCA_CONF_BOOTLDR_BACKDOOR
@@ -83,22 +87,6 @@ void udma_err_isr(void);
 #else
 #define FLASH_CCA_BOOTLDR_CFG FLASH_CCA_BOOTLDR_CFG_DISABLE
 #endif
-
-/* Link in the USB ISR only if USB is enabled */
-#if USB_SERIAL_CONF_ENABLE
-void usb_isr(void);
-#else
-#define usb_isr default_handler
-#endif
-
-/* Likewise for the UART[01] ISRs */
-#if UART_CONF_ENABLE
-void uart0_isr(void);
-void uart1_isr(void);
-#else /* UART_CONF_ENABLE */
-#define uart0_isr default_handler
-#define uart1_isr default_handler
-#endif /* UART_CONF_ENABLE */
 /*---------------------------------------------------------------------------*/
 /* Allocate stack space */
 static unsigned long stack[512];

--- a/platform/cc2538dk/Makefile.cc2538dk
+++ b/platform/cc2538dk/Makefile.cc2538dk
@@ -11,9 +11,6 @@ CONTIKI_TARGET_SOURCEFILES += contiki-main.c
 CONTIKI_TARGET_SOURCEFILES += sensors.c smartrf-sensors.c
 CONTIKI_TARGET_SOURCEFILES += button-sensor.c adc-sensor.c
 
-TARGET_START_SOURCEFILES += startup-gcc.c
-TARGET_STARTFILES = ${addprefix $(OBJECTDIR)/,${call oname, $(TARGET_START_SOURCEFILES)}}
-
 CONTIKI_SOURCEFILES += $(CONTIKI_TARGET_SOURCEFILES)
 
 CLEAN += *.cc2538dk


### PR DESCRIPTION
This pull proposes moving CC2538's `startup-gcc.c` to the CPU dir. This file contains startup code and initialises the vector table.

@adamdunkels suggested this move a few months ago, but I had some concerns about the various `#if` statements used to manage some of the interrupt handlers. Looks like they were unfounded, but please take a look if you will.

In the longer term, I think we should use weak symbols here for handlers. It should help get rid of those `#if`s altogether.

This pull also sneaks in a minor code style fix.