### PR TITLE
Time Drifting Motes

### DIFF
--- a/tools/cooja/apps/avrora/src/org/contikios/cooja/avrmote/interfaces/MicaClock.java
+++ b/tools/cooja/apps/avrora/src/org/contikios/cooja/avrmote/interfaces/MicaClock.java
@@ -54,10 +54,12 @@ public class MicaClock extends Clock {
   private MicaZMote myMote;
 
   private long timeDrift; /* Microseconds */
+  private double deviation;
   
   public MicaClock(Mote mote) {
     simulation = mote.getSimulation();
     myMote = (MicaZMote) mote;
+    deviation = 1.0;
   }
 
   public void setTime(long newTime) {
@@ -90,4 +92,12 @@ public class MicaClock extends Clock {
   public void setConfigXML(Collection<Element> configXML, boolean visAvailable) {
   }
 
+  public double getDeviation() {
+    return deviation;
+  }
+
+  public void setDeviation(double deviation) {
+    assert deviation > 0.0;
+    this.deviation = deviation;
+  }
 }

--- a/tools/cooja/apps/avrora/src/org/contikios/cooja/avrmote/interfaces/MicaClock.java
+++ b/tools/cooja/apps/avrora/src/org/contikios/cooja/avrmote/interfaces/MicaClock.java
@@ -54,6 +54,7 @@ public class MicaClock extends Clock {
   private MicaZMote myMote;
 
   private long timeDrift; /* Microseconds */
+  private double referenceTime; /* Microseconds */
   private double deviation;
   
   public MicaClock(Mote mote) {
@@ -70,12 +71,29 @@ public class MicaClock extends Clock {
     return simulation.getSimulationTime() + timeDrift;
   }
 
+  public double getDeviation() {
+    return deviation;
+  }
+
+  public void setDeviation(double deviation) {
+    assert (deviation>0.0) && (deviation<=1.0);
+    this.deviation = deviation;
+  }
+
   public void setDrift(long drift) {
     timeDrift = drift;
   }
 
   public long getDrift() {
     return timeDrift;
+  }
+
+  public void setReferenceTime(double referenceTime) {
+    this.referenceTime = referenceTime;
+  }
+
+  public double getReferenceTime() {
+    return referenceTime;
   }
 
   public JPanel getInterfaceVisualizer() {
@@ -90,14 +108,5 @@ public class MicaClock extends Clock {
   }
 
   public void setConfigXML(Collection<Element> configXML, boolean visAvailable) {
-  }
-
-  public double getDeviation() {
-    return deviation;
-  }
-
-  public void setDeviation(double deviation) {
-    assert deviation > 0.0;
-    this.deviation = deviation;
   }
 }

--- a/tools/cooja/apps/avrora/src/org/contikios/cooja/avrmote/interfaces/MicaClock.java
+++ b/tools/cooja/apps/avrora/src/org/contikios/cooja/avrmote/interfaces/MicaClock.java
@@ -54,7 +54,6 @@ public class MicaClock extends Clock {
   private MicaZMote myMote;
 
   private long timeDrift; /* Microseconds */
-  private double referenceTime; /* Microseconds */
   private double deviation;
   
   public MicaClock(Mote mote) {
@@ -86,13 +85,5 @@ public class MicaClock extends Clock {
 
   public long getDrift() {
     return timeDrift;
-  }
-
-  public void setReferenceTime(double referenceTime) {
-    this.referenceTime = referenceTime;
-  }
-
-  public double getReferenceTime() {
-    return referenceTime;
   }
 }

--- a/tools/cooja/apps/avrora/src/org/contikios/cooja/avrmote/interfaces/MicaClock.java
+++ b/tools/cooja/apps/avrora/src/org/contikios/cooja/avrmote/interfaces/MicaClock.java
@@ -95,18 +95,4 @@ public class MicaClock extends Clock {
   public double getReferenceTime() {
     return referenceTime;
   }
-
-  public JPanel getInterfaceVisualizer() {
-    return null;
-  }
-
-  public void releaseInterfaceVisualizer(JPanel panel) {
-  }
-
-  public Collection<Element> getConfigXML() {
-    return null;
-  }
-
-  public void setConfigXML(Collection<Element> configXML, boolean visAvailable) {
-  }
 }

--- a/tools/cooja/apps/mspsim/src/org/contikios/cooja/mspmote/MspMote.java
+++ b/tools/cooja/apps/mspsim/src/org/contikios/cooja/mspmote/MspMote.java
@@ -325,7 +325,7 @@ public abstract class MspMote extends AbstractEmulatedMote implements Mote, Watc
     }
 
     if (((1-deviation) * executed) > skipped) {
-      lastExecute = t;
+      lastExecute = lastExecute + duration; // (t+duration) - (t-lastExecute);
       nextExecute = t+duration;
       skipped += duration;
       scheduleNextWakeup(nextExecute);

--- a/tools/cooja/apps/mspsim/src/org/contikios/cooja/mspmote/MspMote.java
+++ b/tools/cooja/apps/mspsim/src/org/contikios/cooja/mspmote/MspMote.java
@@ -334,7 +334,7 @@ public abstract class MspMote extends AbstractEmulatedMote implements Mote, Watc
     /* Execute MSPSim-based mote */
     /* TODO Try-catch overhead */
     try {
-      nextExecute = myCpu.stepMicros(t-lastExecute, duration) + t + duration;
+      nextExecute = myCpu.stepMicros(Math.max(0, t-lastExecute), duration) + t + duration;
       lastExecute = t;
     } catch (EmulationException e) {
       String trace = e.getMessage() + "\n\n" + getStackTrace();

--- a/tools/cooja/apps/mspsim/src/org/contikios/cooja/mspmote/interfaces/MspClock.java
+++ b/tools/cooja/apps/mspsim/src/org/contikios/cooja/mspmote/interfaces/MspClock.java
@@ -52,9 +52,11 @@ public class MspClock extends Clock {
   private Simulation simulation;
   
   private long timeDrift; /* Microseconds */
+  private double deviation;
 
   public MspClock(Mote mote) {
     simulation = mote.getSimulation();
+    deviation = 1.0;
   }
 
   public void setTime(long newTime) {
@@ -71,6 +73,15 @@ public class MspClock extends Clock {
 
   public long getDrift() {
     return timeDrift;
+  }
+
+  public void setDeviation(double deviation) {
+    assert deviation>0.0;
+    this.deviation = deviation;
+  }
+
+  public double getDeviation() {
+    return deviation;
   }
 
   public JPanel getInterfaceVisualizer() {

--- a/tools/cooja/apps/mspsim/src/org/contikios/cooja/mspmote/interfaces/MspClock.java
+++ b/tools/cooja/apps/mspsim/src/org/contikios/cooja/mspmote/interfaces/MspClock.java
@@ -52,12 +52,10 @@ public class MspClock extends Clock {
   private Simulation simulation;
   
   private long timeDrift; /* Microseconds */
-  private double referenceTime; /* Microseconds */
   private double deviation;
 
   public MspClock(Mote mote) {
     simulation = mote.getSimulation();
-    referenceTime = 0.0;
     deviation = 1.0;
   }
 
@@ -75,14 +73,6 @@ public class MspClock extends Clock {
 
   public long getDrift() {
     return timeDrift;
-  }
-
-  public void setReferenceTime(double referenceTime) {
-    this.referenceTime = referenceTime;
-  }
-  
-  public double getReferenceTime() {
-    return referenceTime;
   }
   
   public void setDeviation(double deviation) {

--- a/tools/cooja/apps/mspsim/src/org/contikios/cooja/mspmote/interfaces/MspClock.java
+++ b/tools/cooja/apps/mspsim/src/org/contikios/cooja/mspmote/interfaces/MspClock.java
@@ -52,11 +52,13 @@ public class MspClock extends Clock {
   private Simulation simulation;
   
   private long timeDrift; /* Microseconds */
+  private double referenceTime; /* Microseconds */
   private double deviation;
 
   public MspClock(Mote mote) {
     simulation = mote.getSimulation();
-    deviation = 1.0;
+    referenceTime = 0.0;
+    deviation = 0.999;
   }
 
   public void setTime(long newTime) {
@@ -75,8 +77,16 @@ public class MspClock extends Clock {
     return timeDrift;
   }
 
+  public void setReferenceTime(double referenceTime) {
+    this.referenceTime = referenceTime;
+  }
+  
+  public double getReferenceTime() {
+    return referenceTime;
+  }
+  
   public void setDeviation(double deviation) {
-    assert deviation>0.0;
+    assert (deviation>0.0) && (deviation<=1.0);
     this.deviation = deviation;
   }
 

--- a/tools/cooja/apps/mspsim/src/org/contikios/cooja/mspmote/interfaces/MspClock.java
+++ b/tools/cooja/apps/mspsim/src/org/contikios/cooja/mspmote/interfaces/MspClock.java
@@ -93,20 +93,4 @@ public class MspClock extends Clock {
   public double getDeviation() {
     return deviation;
   }
-
-  public JPanel getInterfaceVisualizer() {
-    /* TODO Show current CPU speed */
-    return null;
-  }
-
-  public void releaseInterfaceVisualizer(JPanel panel) {
-  }
-
-  public Collection<Element> getConfigXML() {
-    return null;
-  }
-
-  public void setConfigXML(Collection<Element> configXML, boolean visAvailable) {
-  }
-
 }

--- a/tools/cooja/apps/mspsim/src/org/contikios/cooja/mspmote/interfaces/MspClock.java
+++ b/tools/cooja/apps/mspsim/src/org/contikios/cooja/mspmote/interfaces/MspClock.java
@@ -58,7 +58,7 @@ public class MspClock extends Clock {
   public MspClock(Mote mote) {
     simulation = mote.getSimulation();
     referenceTime = 0.0;
-    deviation = 0.999;
+    deviation = 1.0;
   }
 
   public void setTime(long newTime) {

--- a/tools/cooja/java/org/contikios/cooja/contikimote/interfaces/ContikiClock.java
+++ b/tools/cooja/java/org/contikios/cooja/contikimote/interfaces/ContikiClock.java
@@ -76,7 +76,6 @@ public class ContikiClock extends Clock implements ContikiMoteInterface, PolledB
 
   private long moteTime; /* Microseconds */
   private long timeDrift; /* Microseconds */
-  private double deviation;
 
   /**
    * @param mote Mote
@@ -90,7 +89,6 @@ public class ContikiClock extends Clock implements ContikiMoteInterface, PolledB
     this.moteMem = new VarMemory(mote.getMemory());
     timeDrift = 0;
     moteTime = 0;
-    deviation = 1.0;
   }
 
   public static String[] getCoreInterfaceDependencies() {
@@ -118,12 +116,11 @@ public class ContikiClock extends Clock implements ContikiMoteInterface, PolledB
   }
   
   public void setDeviation(double deviation) {
-  	assert deviation>0.0;
-  	this.deviation = deviation;
+    logger.fatal("Can't change deviation");;
   }
 
   public double getDeviation() {
-  	return deviation;
+  	return 1.0;
   }
 
   public void doActionsBeforeTick() {

--- a/tools/cooja/java/org/contikios/cooja/contikimote/interfaces/ContikiClock.java
+++ b/tools/cooja/java/org/contikios/cooja/contikimote/interfaces/ContikiClock.java
@@ -76,6 +76,7 @@ public class ContikiClock extends Clock implements ContikiMoteInterface, PolledB
 
   private long moteTime; /* Microseconds */
   private long timeDrift; /* Microseconds */
+  private double deviation;
 
   /**
    * @param mote Mote
@@ -89,6 +90,7 @@ public class ContikiClock extends Clock implements ContikiMoteInterface, PolledB
     this.moteMem = new VarMemory(mote.getMemory());
     timeDrift = 0;
     moteTime = 0;
+    deviation = 1.0;
   }
 
   public static String[] getCoreInterfaceDependencies() {
@@ -113,6 +115,15 @@ public class ContikiClock extends Clock implements ContikiMoteInterface, PolledB
 
   public long getTime() {
     return moteTime;
+  }
+  
+  public void setDeviation(double deviation) {
+  	assert deviation>0.0;
+  	this.deviation = deviation;
+  }
+
+  public double getDeviation() {
+  	return deviation;
   }
 
   public void doActionsBeforeTick() {
@@ -161,5 +172,4 @@ public class ContikiClock extends Clock implements ContikiMoteInterface, PolledB
 
   public void setConfigXML(Collection<Element> configXML, boolean visAvailable) {
   }
-
 }

--- a/tools/cooja/java/org/contikios/cooja/interfaces/Clock.java
+++ b/tools/cooja/java/org/contikios/cooja/interfaces/Clock.java
@@ -30,7 +30,19 @@
 
 package org.contikios.cooja.interfaces;
 
+import java.awt.GridLayout;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.util.ArrayList;
+import java.util.Collection;
+
+import javax.swing.JButton;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JTextField;
+
 import org.contikios.cooja.*;
+import org.jdom.Element;
 
 /**
  * Represents a mote's internal clock. Notice that the overall
@@ -43,7 +55,6 @@ import org.contikios.cooja.*;
  */
 @ClassDescription("Clock")
 public abstract class Clock extends MoteInterface {
-
   /**
    * Set mote's time to given time.
    *
@@ -94,4 +105,71 @@ public abstract class Clock extends MoteInterface {
    * Get deviation factor
    */
   public abstract double getDeviation();
+  
+  @Override
+  public JPanel getInterfaceVisualizer() {
+    JPanel panel = new JPanel();
+    GridLayout layout = new GridLayout(0,2);
+    
+    /* elements */
+    final JLabel timeLabel = new JLabel("Time (ms)");
+    final JTextField timeField = new JTextField(String.valueOf(getTime() / 1000));
+    final JLabel deviationLabel = new JLabel("Deviation Factor");
+    final JTextField deviationField = new JTextField(String.valueOf(getDeviation()));
+    final JButton readButton = new JButton("Read Clock Values");
+    final JButton updateButton = new JButton("Write Clock Values");
+    /* set layout */
+    panel.setLayout(layout);
+    /* add components */
+    panel.add(timeLabel);
+    panel.add(timeField);
+    panel.add(deviationLabel);
+    panel.add(deviationField);
+    panel.add(readButton);
+    panel.add(updateButton);
+    
+    readButton.addMouseListener(new MouseAdapter() {      
+      @Override
+      public void mouseClicked(MouseEvent ev) {
+        if (ev.getButton()==1) {
+          timeField.setText(String.valueOf(getTime() / 1000));
+          deviationField.setText(String.valueOf(getDeviation()));
+        }
+      }
+    });
+    
+    updateButton.addMouseListener(new MouseAdapter() {      
+      @Override
+      public void mouseClicked(MouseEvent ev) {
+        if (ev.getButton()==1) {
+          setTime(Long.parseLong(timeField.getText()) * 1000);
+          setDeviation(Double.parseDouble(deviationField.getText()));
+        }
+      }
+    });
+    
+    return panel;
+  }
+  
+  @Override
+  public void releaseInterfaceVisualizer(JPanel panel) {
+  }
+ 
+  @Override
+  public Collection<Element> getConfigXML() {
+    ArrayList<Element> config = new ArrayList<Element>();
+    Element element = new Element("deviation");
+    element.setText(String.valueOf(getDeviation()));
+    config.add(element);
+    return config;
+  }
+
+  @Override
+  public void setConfigXML(Collection<Element> configXML, boolean visAvailable) {
+    for (Element element : configXML) {
+      if (element.getName().equals("deviation")) {
+        setDeviation(Double.parseDouble(element.getText()));
+      }
+    }
+  }
 }

--- a/tools/cooja/java/org/contikios/cooja/interfaces/Clock.java
+++ b/tools/cooja/java/org/contikios/cooja/interfaces/Clock.java
@@ -39,6 +39,7 @@ import org.contikios.cooja.*;
  * This observable never notifies.
  *
  * @author Fredrik Osterlind
+ *         Andreas Löscher
  */
 @ClassDescription("Clock")
 public abstract class Clock extends MoteInterface {
@@ -76,4 +77,21 @@ public abstract class Clock extends MoteInterface {
    */
   public abstract long getDrift();
 
+
+  /**
+   * The clock deviation is a factor that represents with how much speed the
+   * mote progresses through the simulation in relation to the simulation speed.
+   *
+   * A value of 1.0 results in the mote beeing simulated with the same speed
+   * as the simulation. A value of 0.5 results in the mote beeing simulation
+   * at half of the simulation speed.
+   *
+   *  @param deviation Deviation factor
+   */
+  public abstract void setDeviation(double deviation);
+
+  /**
+   * Get deviation factor
+   */
+  public abstract double getDeviation();
 }

--- a/tools/cooja/java/org/contikios/cooja/interfaces/Clock.java
+++ b/tools/cooja/java/org/contikios/cooja/interfaces/Clock.java
@@ -82,8 +82,8 @@ public abstract class Clock extends MoteInterface {
    * The clock deviation is a factor that represents with how much speed the
    * mote progresses through the simulation in relation to the simulation speed.
    *
-   * A value of 1.0 results in the mote beeing simulated with the same speed
-   * as the simulation. A value of 0.5 results in the mote beeing simulation
+   * A value of 1.0 results in the mote being simulated with the same speed
+   * as the simulation. A value of 0.5 results in the mote being simulation
    * at half of the simulation speed.
    *
    *  @param deviation Deviation factor


### PR DESCRIPTION
This pull requests implements support for motes that progress with different speed.

Currently the clock of all simulated motes is perfectly synchronized with the simulation time. In reality, the clocks of two nodes will drift apart (hardware imperfections/temperature differences/etc.). This PR enables to simulate and test systems where the clocks are not perfectly aligned. 

Each the mote clock interface has now the possibility to set a deviation factor between 0.0 and 1.0. A factor of 1.0 means that the clocks will be perfectly aligned with the simulation time. 0.5 means that the mote is running in half speed. 

Standard values are 1.0 and there is no gui to change the value, but it is accessible through the java interface for the motes. 