### PR TITLE
Turn on the CC2538 RF explicitly in the sniffer example

### DIFF
--- a/examples/cc2538dk/sniffer/netstack.c
+++ b/examples/cc2538dk/sniffer/netstack.c
@@ -41,5 +41,6 @@ void
 netstack_init(void)
 {
   NETSTACK_RADIO.init();
+  NETSTACK_RADIO.on();
 }
 /*---------------------------------------------------------------------------*/


### PR DESCRIPTION
The CC2538 sniffer example is currently broken. The RF is forever off, therefore what we have is a sniffer which doesn't sniff a whole lot...

The CC2538 RF driver's init() does not put the RF in RX mode.

* When using NullRDC, NETSTACK_RDC.init() will ultimately call NETSTACK_RADIO.on();
* The sniffer example used to work by accident: set_channel() would leave the RF unintentionally on. This was fixed in #946, but as a consequence the sniffer stopped working.

This pull changes the sniffer example to explicitly put the RF in RX after initialisation.