### PR TITLE
Send the first NS attempt inside tcpip_ipv6_output()

### DIFF
--- a/core/net/ip/tcpip.c
+++ b/core/net/ip/tcpip.c
@@ -675,7 +675,11 @@ tcpip_ipv6_output(void)
 
         stimer_set(&nbr->sendns, uip_ds6_if.retrans_timer / 1000);
         nbr->nscount = 1;
+        /* Send the first NS try from here (multicast destination IP address). */
       }
+#else /* UIP_ND6_SEND_NA */
+      uip_len = 0;
+      return;  
 #endif /* UIP_ND6_SEND_NA */
     } else {
 #if UIP_ND6_SEND_NA
@@ -722,7 +726,6 @@ tcpip_ipv6_output(void)
       uip_len = 0;
       return;
     }
-    return;
   }
   /* Multicast IP destination address. */
   tcpip_output(NULL);


### PR DESCRIPTION
This pull request enables tcpip_ipv6_output() to send the first of the (possibly multiple) NS messages for a new IPv6 neighbor immediately after this neighbor is added to the neighbor list.

Under the current implementation, tcpip_ipv6_output() prepares a new NS packet, places it in the uip buffer, but returns, before sending it, relying on the periodic calls of the IPv6 engine to send the pending frame. However, if a packet arrival from the underlying MAC layer (e.g. sicslowpan) occurs before the following call of uip_ds6_periodic, the pending NS frame is lost (sicslowpan overwrites the uip_buf and uip_len may be set to 0 after processing the incoming frame). This pull request will force the NS transmission before tcpip_ipv6_output() releases the control.