### PR TITLE
Update CC2650 SensorTag SPI Flash Support

### DIFF
--- a/platform/srf06-cc26xx/sensortag/board.h
+++ b/platform/srf06-cc26xx/sensortag/board.h
@@ -156,7 +156,7 @@
  */
 #define BOARD_IOID_FLASH_CS       IOID_14
 #define BOARD_FLASH_CS            (1 << BOARD_IOID_FLASH_CS)
-#define BOARD_SPI_CLK_FLASH       IOID_11
+#define BOARD_SPI_CLK_FLASH       IOID_17
 /** @} */
 /*---------------------------------------------------------------------------*/
 /**

--- a/platform/srf06-cc26xx/sensortag/ext-flash.c
+++ b/platform/srf06-cc26xx/sensortag/ext-flash.c
@@ -72,7 +72,7 @@
 /* Part specific constants */
 
 #define BLS_MANUFACTURER_ID       0xEF
-#define BLS_DEVICE_ID             0x11
+#define BLS_DEVICE_ID             0x12
 
 #define BLS_PROGRAM_PAGE_SIZE      256
 #define BLS_ERASE_SECTOR_SIZE     4096

--- a/platform/srf06-cc26xx/sensortag/ext-flash.c
+++ b/platform/srf06-cc26xx/sensortag/ext-flash.c
@@ -182,8 +182,8 @@ power_standby(void)
 }
 /*---------------------------------------------------------------------------*/
 /**
- * Verify the flash part.
- * @return True when successful.
+ * \brief Verify the flash part.
+ * \return True when successful.
  */
 static bool
 verify_part(void)


### PR DESCRIPTION
This pull updates SPI clock IOID mapping and Device ID for the CC2650 SensorTag's external flash. It also fixes a doxygen comment.