### PR TITLE
Removed duplicated condition in sht25 configuration

### DIFF
--- a/platform/z1/dev/sht25.c
+++ b/platform/z1/dev/sht25.c
@@ -46,7 +46,7 @@ static uint8_t enabled;
 static int
 configure(int type, int value)
 {
-  if((type != SENSORS_ACTIVE) && (type != SENSORS_ACTIVE)) {
+  if(type != SENSORS_ACTIVE) {
     return SHT25_ERROR;
   }
   if(value) {


### PR DESCRIPTION
Duplicated condition removed, the configuration should only be done on SENSORS_ACTIVE, to ble used from the SENSORS_ACTIVATE and SENSORS_DEACTIVATE macro.