### PR TITLE
Added inital mtarch.c/h for platform/cooja

### DIFF
--- a/platform/cooja/Makefile.cooja
+++ b/platform/cooja/Makefile.cooja
@@ -47,7 +47,7 @@ CONTIKI_TARGET_DIRS = . dev lib sys cfs net
 # (COOJA_SOURCEDIRS contains additional sources dirs set from simulator)
 vpath %.c $(COOJA_SOURCEDIRS)
 
-COOJA_BASE	= simEnvChange.c cooja_mt.c cooja_mtarch.c rtimer-arch.c slip.c watchdog.c rimestats.c
+COOJA_BASE	= simEnvChange.c cooja_mt.c cooja_mtarch.c rtimer-arch.c slip.c watchdog.c rimestats.c mtarch.c
 
 COOJA_INTFS	= beep.c button-sensor.c ip.c leds-arch.c moteid.c \
 		    pir-sensor.c rs232.c vib-sensor.c \

--- a/platform/cooja/mtarch.c
+++ b/platform/cooja/mtarch.c
@@ -32,17 +32,59 @@
  *
  */
 
-#include "mtarch.h"
+#include "sys/mt.h"
+
+#ifndef MTARCH_STACKSIZE
+#define MTARCH_STACKSIZE 4096
+#endif /* MTARCH_STACKSIZE */
+
+#if defined(_WIN32) || defined(__CYGWIN__)
+
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+
+static void *main_fiber;
+
+#elif defined(__linux) || defined(__APPLE__)
+
+#ifdef __APPLE__
+/* Avoid deprecated error on Darwin */
+#define _XOPEN_SOURCE
+#endif
+
+#include <stdlib.h>
+#include <signal.h>
+#include <ucontext.h>
+
+struct mtarch_t {
+  char stack[MTARCH_STACKSIZE];
+  ucontext_t context;
+};
+
+static ucontext_t main_context;
+static ucontext_t *running_context;
+
+#endif /* _WIN32 || __CYGWIN__ || __linux */
 
 /*--------------------------------------------------------------------------*/
 void
 mtarch_init(void)
 {
+#if defined(_WIN32) || defined(__CYGWIN__)
+
+  main_fiber = ConvertThreadToFiber(NULL);
+
+#endif /* _WIN32 || __CYGWIN__ */
 }
 /*--------------------------------------------------------------------------*/
 void
 mtarch_remove(void)
 {
+#if defined(_WIN32) || defined(__CYGWIN__)
+
+  ConvertFiberToThread();
+
+#endif /* _WIN32 || __CYGWIN__ */
 }
 /*--------------------------------------------------------------------------*/
 void
@@ -50,21 +92,85 @@ mtarch_start(struct mtarch_thread *thread,
 	     void (* function)(void *data),
 	     void *data)
 {
+#if defined(_WIN32) || defined(__CYGWIN__)
+
+  thread->mt_thread = CreateFiber(0, (LPFIBER_START_ROUTINE)function, data);
+
+#elif defined(__linux)
+
+  thread->mt_thread = malloc(sizeof(struct mtarch_t));
+
+  getcontext(&((struct mtarch_t *)thread->mt_thread)->context);
+
+  ((struct mtarch_t *)thread->mt_thread)->context.uc_link = NULL;
+  ((struct mtarch_t *)thread->mt_thread)->context.uc_stack.ss_sp = 
+			((struct mtarch_t *)thread->mt_thread)->stack;
+  ((struct mtarch_t *)thread->mt_thread)->context.uc_stack.ss_size = 
+			sizeof(((struct mtarch_t *)thread->mt_thread)->stack);
+
+  /* Some notes:
+     - If a CPU needs stronger alignment for the stack than malloc()
+       guarantees (like i.e. IA64) then makecontext() is supposed to
+       add that alignment internally.
+     - According to POSIX the arguments to function() are of type int
+       and there are in fact 64-bit implementations which support only
+       32 bits per argument meaning that a pointer argument has to be
+       splitted into two arguments.
+     - Most implementations interpret context.uc_stack.ss_sp on entry
+       as the lowest stack address even if the CPU stack actually grows
+       downwards. Although this means that ss_sp does NOT represent the
+       CPU stack pointer this behaviour makes perfectly sense as it is
+       the only way to stay independent from the CPU architecture. But
+       Solaris prior to release 10 interprets ss_sp as highest stack
+       address thus requiring special handling. */
+  makecontext(&((struct mtarch_t *)thread->mt_thread)->context,
+	      (void (*)(void))function, 1, data);
+
+#endif /* _WIN32 || __CYGWIN__ || __linux */
 }
 /*--------------------------------------------------------------------------*/
 void
 mtarch_yield(void)
 {
+#if defined(_WIN32) || defined(__CYGWIN__)
+
+  SwitchToFiber(main_fiber);
+
+#elif defined(__linux)
+
+  swapcontext(running_context, &main_context);
+
+#endif /* _WIN32 || __CYGWIN__ || __linux */
 }
 /*--------------------------------------------------------------------------*/
 void
 mtarch_exec(struct mtarch_thread *thread)
 {
+#if defined(_WIN32) || defined(__CYGWIN__)
+
+  SwitchToFiber(thread->mt_thread);
+
+#elif defined(__linux)
+
+  running_context = &((struct mtarch_t *)thread->mt_thread)->context;
+  swapcontext(&main_context, running_context);
+  running_context = NULL;
+
+#endif /* _WIN32 || __CYGWIN__ || __linux */
 }
 /*--------------------------------------------------------------------------*/
 void
 mtarch_stop(struct mtarch_thread *thread)
 {
+#if defined(_WIN32) || defined(__CYGWIN__)
+
+  DeleteFiber(thread->mt_thread);
+
+#elif defined(linux) || defined(__linux)
+
+  free(thread->mt_thread);
+
+#endif /* _WIN32 || __CYGWIN__ || __linux */
 }
 /*--------------------------------------------------------------------------*/
 void

--- a/platform/cooja/mtarch.h
+++ b/platform/cooja/mtarch.h
@@ -28,6 +28,8 @@
  *
  * This file is part of the Contiki operating system.
  * 
+ * Author: Oliver Schmidt <ol.sc@web.de>
+ *
  */
 
 #ifndef MTARCH_H_


### PR DESCRIPTION
I am currently trying to get the multi-threading example up and running
for cooja motes.

I am not an expert in java and also not in getting native code running
in java.

I had a short look on the mtarch implementation in cooja. All stub
routines are empty at the moment.
cooja_mt_thread implements preemtive threading for rtimer and the
mainloop and may not be used for mt_threads I think.
I assume that this is used to simulate proper rtimer IRQ preemtion of
the main loop - right?

In a first step I just copied the mtarch.c(h) of cpu/native to get use
of fibers of windows and ucontext of posix.

I did not expected it to work from scratch, but I got this for a cooja
mote (one of the rare moments where an assumtion works out of the box):

...
22:24:40.118    ID:1    6543210
22:24:40.618    ID:1    GFEDCBA
22:24:41.118    ID:1    76543210
22:24:41.618    ID:1    HGFEDCBA
22:24:42.118    ID:1    876543210
22:24:42.618    ID:1    IHGFEDCBA
22:24:43.118    ID:1    9876543210
22:24:43.618    ID:1    JIHGFEDCBA
...

which in my opinion is the correct behaviour.

Is there another way planned for mtarch on cooja motes? Or is this
approach OK for a cooja pull request?