### PR TITLE
Remove duplicate call to board_init

### DIFF
--- a/platform/srf06-cc26xx/contiki-main.c
+++ b/platform/srf06-cc26xx/contiki-main.c
@@ -177,8 +177,6 @@ main(void)
   clock_init();
   rtimer_init();
 
-  board_init();
-
   watchdog_init();
   process_init();
 


### PR DESCRIPTION
The CC26xx startup sequence calls `board_init()` twice. This pull eliminates one of the calls.