### PR TITLE
Examples: Change name of executable on d64 image to $(CONTIKI_PROJECT) for target c64

### DIFF
--- a/platform/c64/Makefile.c64
+++ b/platform/c64/Makefile.c64
@@ -46,7 +46,12 @@ endif
 
 disk: all
 	$(C1541) -format contiki,00 d64 contiki.d64
-	$(C1541) -attach contiki.d64 -write $(CONTIKI_PROJECT).$(TARGET)          contiki,p
+
+	# CONTIKI_PROJECT may contain more than one project
+	for SUBPROJECT in $(CONTIKI_PROJECT); do \
+	$(C1541) -attach contiki.d64 -write $$SUBPROJECT.$(TARGET)                $$SUBPROJECT,p ; \
+	done
+	
 	$(C1541) -attach contiki.d64 -write $(CONTIKI)/tools/$(TARGET)/sample.cfg contiki.cfg,s
 	$(C1541) -attach contiki.d64 -write cs8900a.eth                           cs8900a.eth,s
 	$(C1541) -attach contiki.d64 -write lan91c96.eth                          lan91c96.eth,s

--- a/platform/c64/Makefile.c64
+++ b/platform/c64/Makefile.c64
@@ -46,12 +46,7 @@ endif
 
 disk: all
 	$(C1541) -format contiki,00 d64 contiki.d64
-
-	# CONTIKI_PROJECT may contain more than one project
-	for SUBPROJECT in $(CONTIKI_PROJECT); do \
-	$(C1541) -attach contiki.d64 -write $$SUBPROJECT.$(TARGET)                $$SUBPROJECT,p ; \
-	done
-	
+	$(C1541) -attach contiki.d64 -write $(CONTIKI_PROJECT).$(TARGET)          $(CONTIKI_PROJECT),p
 	$(C1541) -attach contiki.d64 -write $(CONTIKI)/tools/$(TARGET)/sample.cfg contiki.cfg,s
 	$(C1541) -attach contiki.d64 -write cs8900a.eth                           cs8900a.eth,s
 	$(C1541) -attach contiki.d64 -write lan91c96.eth                          lan91c96.eth,s


### PR DESCRIPTION
Currently only one executable is allowed for target c64 examples. Mentioned executable is stored on a d64 image with file name "contiki".

As it is also possible to define multiple subprojects (executables) in a CONTIKI_PROJECT, it  is obvious to store each subproject on disk by name.

As an example (derived from #934) :
```
cmt-scheduler/
├── cmt.c
├── cmt-event-test.c
├── cmt.h
├── cmt-join-test.c
├── cmt-poll-test.c
├── cmt-sleep-test.c
├── Makefile
└── Makefile.c64.defines
```
where the "test" source files are sources for stand alone executables.

Makefile would contain:
```
CONTIKI_PROJECT = cmt-sleep-test cmt-poll-test cmt-event-test cmt-join-test
```

Directory content after build:
```
cmt-scheduler/
├── cmt.c
├── cmt-event-test.c
├── cmt-event-test.c64
├── cmt.h
├── cmt-join-test.c
├── cmt-join-test.c64
├── cmt-poll-test.c
├── cmt-poll-test.c64
├── cmt-sleep-test.c
├── cmt-sleep-test.c64
├── contiki-c64.a
├── contiki-c64.map
├── contiki.d64
├── cs8900a.eth
├── cs8900a.eth.map
├── lan91c96.eth
├── lan91c96.eth.map
├── Makefile
├── Makefile.c64.defines
├── obj_c64
│   ├── ...
|   
├── w5100.eth
└── w5100.eth.map
```

The .c64 files are the executables that are build anyway. To store them on disk they would need unique names. This is provided by this PR.

On disk following would be stored:

![subprojects](https://cloud.githubusercontent.com/assets/8344035/6673490/d23676d8-cc13-11e4-83e8-8cc41654f891.png)
