### PR TITLE
CC2538: added support for SSI1

### DIFF
--- a/core/dev/radio.h
+++ b/core/dev/radio.h
@@ -159,6 +159,11 @@ enum {
    */
   RADIO_PARAM_64BIT_ADDR,
 
+  /*
+   * The preamble length if using sniff mode / wake-up preambles
+   */
+  RADIO_PARAM_PREAMBLE_LENGTH,
+
   /* Constants (read only) */
 
   /* The lowest radio channel. */

--- a/core/dev/radio.h
+++ b/core/dev/radio.h
@@ -159,11 +159,6 @@ enum {
    */
   RADIO_PARAM_64BIT_ADDR,
 
-  /*
-   * The preamble length if using sniff mode / wake-up preambles
-   */
-  RADIO_PARAM_PREAMBLE_LENGTH,
-
   /* Constants (read only) */
 
   /* The lowest radio channel. */

--- a/core/dev/spi.h
+++ b/core/dev/spi.h
@@ -57,15 +57,15 @@ extern unsigned char spi_busy;
 /* Deprecated */
 void spi_init(void);
 /*---------------------------------------------------------------------------*/
-/* New SPI API supporting mutliple instances. 
-   See /cpu/cc2538/spi-arch.h + cpu/cc2538/dev/spi.c for an example on 
-   how this new API could be implemented. 
-   In addition to spix_init() we also define a new set of "SPIX_" macros 
+/* New SPI API supporting mutliple instances.
+   See /cpu/cc2538/spi-arch.h + cpu/cc2538/dev/spi.c for an example on
+   how this new API could be implemented.
+   In addition to spix_init() we also define a new set of "SPIX_" macros
    like this
-   
+
    #define SPIX_WAITFORTxREADY(x)			SPI##x##_WAITFORTxREADY()
    #define SPIX_WAITFOREOTx(x)				SPI##x##_WAIT_FOREOTx()
-   #define SPIX_WAITFOREORx(x)				SPI##x##_WAITFOREORx()	
+   #define SPIX_WAITFOREORx(x)				SPI##x##_WAITFOREORx()
    #define SPIX_FLUSH(x)					SPI##x##_FLUSH()
 
    which are then mapped to the corresponding hardware specific code */
@@ -73,36 +73,36 @@ void spix_init(uint8_t instance);
 /*---------------------------------------------------------------------------*/
 
 /* Write one character to SPI */
-#define SPI_WRITE(data)                         \
-  do {                                          \
-    SPI_WAITFORTx_BEFORE();                     \
-    SPI_TXBUF = data;                           \
-    SPI_WAITFOREOTx();                          \
+#define SPI_WRITE(data) \
+  do { \
+    SPI_WAITFORTx_BEFORE(); \
+    SPI_TXBUF = data; \
+    SPI_WAITFOREOTx(); \
   } while(0)
 
 /* Write one character to SPI - will not wait for end
    useful for multiple writes with wait after final */
-#define SPI_WRITE_FAST(data)                    \
-  do {                                          \
-    SPI_WAITFORTx_BEFORE();                     \
-    SPI_TXBUF = data;                           \
-    SPI_WAITFORTx_AFTER();                      \
+#define SPI_WRITE_FAST(data) \
+  do { \
+    SPI_WAITFORTx_BEFORE(); \
+    SPI_TXBUF = data; \
+    SPI_WAITFORTx_AFTER(); \
   } while(0)
 
 /* Read one character from SPI */
-#define SPI_READ(data)   \
-  do {                   \
-    SPI_TXBUF = 0;       \
-    SPI_WAITFOREORx();   \
-    data = SPI_RXBUF;    \
+#define SPI_READ(data) \
+  do { \
+    SPI_TXBUF = 0; \
+    SPI_WAITFOREORx(); \
+    data = SPI_RXBUF; \
   } while(0)
 
 /* Flush the SPI read register */
 #ifndef SPI_FLUSH
 #define SPI_FLUSH() \
-  do {              \
-    SPI_RXBUF;      \
-  } while(0);
+  do { \
+    SPI_RXBUF; \
+  } while(0)
 #endif
 
 #endif /* SPI_H_ */

--- a/core/dev/spi.h
+++ b/core/dev/spi.h
@@ -64,8 +64,6 @@ void spi_init(void);
    like this
    
    #define SPIX_WAITFORTxREADY(x)			SPI##x##_WAITFORTxREADY()
-   #define SPIX_TXBUF(x)					SPI##x##_TXBUF()
-   #define SPIX_RXBUF(x)					SPI##x##_RXBUF()
    #define SPIX_WAITFOREOTx(x)				SPI##x##_WAIT_FOREOTx()
    #define SPIX_WAITFOREORx(x)				SPI##x##_WAITFOREORx()	
    #define SPIX_FLUSH(x)					SPI##x##_FLUSH()

--- a/core/dev/spi.h
+++ b/core/dev/spi.h
@@ -59,16 +59,7 @@ void spi_init(void);
 /*---------------------------------------------------------------------------*/
 /* New SPI API supporting mutliple instances.
    See /cpu/cc2538/spi-arch.h + cpu/cc2538/dev/spi.c for an example on
-   how this new API could be implemented.
-   In addition to spix_init() we also define a new set of "SPIX_" macros
-   like this
-
-   #define SPIX_WAITFORTxREADY(x)			SPI##x##_WAITFORTxREADY()
-   #define SPIX_WAITFOREOTx(x)				SPI##x##_WAIT_FOREOTx()
-   #define SPIX_WAITFOREORx(x)				SPI##x##_WAITFOREORx()
-   #define SPIX_FLUSH(x)					SPI##x##_FLUSH()
-
-   which are then mapped to the corresponding hardware specific code */
+   how this new API could be implemented. */
 void spix_init(uint8_t instance);
 /*---------------------------------------------------------------------------*/
 

--- a/core/dev/spi.h
+++ b/core/dev/spi.h
@@ -54,7 +54,25 @@
 
 extern unsigned char spi_busy;
 
+/* Deprecated */
 void spi_init(void);
+/*---------------------------------------------------------------------------*/
+/* New SPI API supporting mutliple instances. 
+   See /cpu/cc2538/spi-arch.h + cpu/cc2538/dev/spi.c for an example on 
+   how this new API could be implemented. 
+   In addition to spix_init() we also define a new set of "SPIX_" macros 
+   like this
+   
+   #define SPIX_WAITFORTxREADY(x)			SPI##x##_WAITFORTxREADY()
+   #define SPIX_TXBUF(x)					SPI##x##_TXBUF()
+   #define SPIX_RXBUF(x)					SPI##x##_RXBUF()
+   #define SPIX_WAITFOREOTx(x)				SPI##x##_WAIT_FOREOTx()
+   #define SPIX_WAITFOREORx(x)				SPI##x##_WAITFOREORx()	
+   #define SPIX_FLUSH(x)					SPI##x##_FLUSH()
+
+   which are then mapped to the corresponding hardware specific code */
+void spix_init(uint8_t instance);
+/*---------------------------------------------------------------------------*/
 
 /* Write one character to SPI */
 #define SPI_WRITE(data)                         \

--- a/core/sys/cc.h
+++ b/core/sys/cc.h
@@ -129,12 +129,18 @@
 
 #define CC_CONCAT2(s1, s2) s1##s2
 /**
- * A C preprocessing macro for concatenating to
- * strings.
+ * A C preprocessing macro for concatenating two preprocessor tokens.
  *
  * We need use two macros (CC_CONCAT and CC_CONCAT2) in order to allow
  * concatenation of two \#defined macros.
  */
 #define CC_CONCAT(s1, s2) CC_CONCAT2(s1, s2)
+#define CC_CONCAT_EXT_2(s1, s2) CC_CONCAT2(s1, s2)
+
+/**
+ * A C preprocessing macro for concatenating three preprocessor tokens.
+ */
+#define CC_CONCAT3(s1, s2, s3) s1##s2##s3
+#define CC_CONCAT_EXT_3(s1, s2, s3) CC_CONCAT3(s1, s2, s3)
 
 #endif /* CC_H_ */

--- a/cpu/cc2538/dev/spi.c
+++ b/cpu/cc2538/dev/spi.c
@@ -41,268 +41,308 @@
 #include "dev/spi.h"
 #include "dev/ssi.h"
 #include "dev/gpio.h"
-
-#if defined(SPI_CLK_PORT) && defined(SPI_CLK_PIN) && \
-	defined(SPI_MISO_PORT) && defined(SPI_MISO_PIN) && \
-	defined(SPI_MOSI_PORT) && defined(SPI_MOSI_PIN)
-
-/* For compatibility reasons */
-#define spi_init()						spi0_init()	
-#define spi_cs_init(port, pin)			spi0_cs_init(port, pin)	
-#define spi_enable()					spi0_enable()	
-#define spi_disable()					spi0_disable()	
-#define spi_set_mode(fr, po, ph, sz)	spi0_set_mode(fr,po,ph,sz)	
-
-#define USE_SPI0						1
-
-#define SPI0_CLK_PORT					SPI_CLK_PORT	
-#define SPI0_CLK_PIN					SPI_CLK_PIN	
-#define SPI0_MOSI_PORT					SPI_MOSI_PORT
-#define SPI0_MOSI_PIN					SPI_MOSI_PIN
-#define SPI0_MISO_PORT					SPI_MISO_PORT
-#define SPI0_MISO_PIN					SPI_MISO_PIN
-
-#elif defined(SPI0_CLK_PORT) && defined(SPI0_CLK_PIN) && \
-	defined(SPI0_MISO_PORT) && defined(SPI0_MISO_PIN) && \
-	defined(SPI0_MOSI_PORT) && 	defined(SPI0_MOSI_PIN)
-
-#define USE_SPI0						1
-
-#endif	/* #if SPI0 port / pins defined */
-
-#if USE_SPI0
-
-#define SPI0_CLK_PORT_BASE				GPIO_PORT_TO_BASE(SPI0_CLK_PORT)
-#define SPI0_CLK_PIN_MASK				GPIO_PIN_MASK(SPI0_CLK_PIN)
-#define SPI0_MOSI_PORT_BASE				GPIO_PORT_TO_BASE(SPI0_MOSI_PORT)
-#define SPI0_MOSI_PIN_MASK				GPIO_PIN_MASK(SPI0_MOSI_PIN)
-#define SPI0_MISO_PORT_BASE				GPIO_PORT_TO_BASE(SPI0_MISO_PORT)
-#define SPI0_MISO_PIN_MASK				GPIO_PIN_MASK(SPI0_MISO_PIN)
-
-#endif	/* #if USE_SPI0 */
-
-#if defined(SPI1_CLK_PORT) && defined(SPI1_CLK_PIN) && \
-	defined(SPI1_MISO_PORT) && defined(SPI1_MISO_PIN) && \
-	defined(SPI1_MOSI_PORT) && 	defined(SPI1_MOSI_PIN) 
-
-#define USE_SPI1						1
-#define SPI1_CLK_PORT_BASE				GPIO_PORT_TO_BASE(SPI1_CLK_PORT)
-#define SPI1_CLK_PIN_MASK				GPIO_PIN_MASK(SPI1_CLK_PIN)
-#define SPI1_MOSI_PORT_BASE				GPIO_PORT_TO_BASE(SPI1_MOSI_PORT)
-#define SPI1_MOSI_PIN_MASK				GPIO_PIN_MASK(SPI1_MOSI_PIN)
-#define SPI1_MISO_PORT_BASE				GPIO_PORT_TO_BASE(SPI1_MISO_PORT)
-#define SPI1_MISO_PIN_MASK				GPIO_PIN_MASK(SPI1_MISO_PIN)
-
-#endif	/* #if SPI1 port / pins defined */
-
 /*---------------------------------------------------------------------------*/
-/**
- * \brief Initialize the SPI bus for SSI0
- *
- * This SPI init() function uses the following defines to set the pins:
- *    SPI0_CLK_PORT               SPI0_CLK_PIN
- *    SPI0_MOSI_PORT              SPI0_MOSI_PIN
- *    SPI0_MISO_PORT              SPI0_MISO_PIN
- *
- * This sets the mode to Motorola SPI with the following format options:
- *    Clock phase:               1; data captured on second (rising) edge
- *    Clock polarity:            1; clock is high when idle
- *    Data size:                 8 bits
- */
-#if USE_SPI0
-void
-spi0_init(void)
+/* Map the old port / pin names to the new ones for compatibility reasons */
+#if (SPI_DEFAULT_INSTANCE==0)
+#ifdef SPI_CLK_PORT
+#define SPI0_CLK_PORT					SPI_CLK_PORT
+#endif
+#ifdef SPI_CLK_PIN
+#define SPI0_CLK_PIN					SPI_CLK_PIN
+#endif
+#ifdef SPI_MOSI_PORT
+#define SPI0_TX_PORT					SPI_MOSI_PORT
+#endif
+#ifdef SPI_MOSI_PIN
+#define SPI0_TX_PIN						SPI_MOSI_PIN
+#endif
+#ifdef SPI_MISO_PORT
+#define SPI0_RX_PORT					SPI_MISO_PORT
+#endif
+#ifdef SPI_MISO_PIN
+#define SPI0_RX_PIN						SPI_MISO_PIN
+#endif
+#elif (SPI_DEFAULT_INSTANCE==1)
+#ifdef SPI_CLK_PORT
+#define SPI1_CLK_PORT					SPI_CLK_PORT
+#endif
+#ifdef SPI_CLK_PIN
+#define SPI1_CLK_PIN					SPI_CLK_PIN
+#endif
+#ifdef SPI_MOSI_PORT
+#define SPI1_TX_PORT					SPI_MOSI_PORT
+#endif
+#ifdef SPI_MOSI_PIN
+#define SPI1_TX_PIN						SPI_MOSI_PIN
+#endif
+#ifdef SPI_MISO_PORT
+#define SPI1_RX_PORT					SPI_MISO_PORT
+#endif
+#ifdef SPI_MISO_PIN
+#define SPI1_RX_PIN						SPI_MISO_PIN
+#endif
+#else
+#error "Invalid SPI instance. Valid values are 0 or 1"
+#endif
+/*---------------------------------------------------------------------------*/
+/* Check port / pin settings for SPI0 and provide default values for spi_cfg */
+#ifndef SPI0_CLK_PORT
+#define SPI0_CLK_PORT					(-1)
+#endif
+#ifndef SPI0_CLK_PIN
+#define SPI0_CLK_PIN					(-1)
+#endif
+#if SPI0_CLK_PORT >= 0 && SPI0_CLK_PIN < 0 || \
+    SPI0_CLK_PORT < 0 && SPI0_CLK_PIN >= 0
+#error "Both SPI0_CLK_PORT and SPI0_CLK_PIN must be valid or invalid"
+#endif
+
+#ifndef SPI0_TX_PORT
+#define SPI0_TX_PORT					(-1)
+#endif
+#ifndef SPI0_TX_PIN
+#define SPI0_TX_PIN						(-1)
+#endif
+#if SPI0_TX_PORT >= 0 && SPI0_TX_PIN < 0 || \
+    SPI0_TX_PORT < 0 && SPI0_TX_PIN >= 0
+#error "Both SPI0_TX_PORT and SPI0_TX_PIN must be valid or invalid"
+#endif
+
+#ifndef SPI0_RX_PORT
+#define SPI0_RX_PORT					(-1)
+#endif
+#ifndef SPI0_RX_PIN
+#define SPI0_RX_PIN						(-1)
+#endif
+#if SPI0_RX_PORT >= 0 && SPI0_RX_PIN < 0 || \
+    SPI0_RX_PORT < 0 && SPI0_RX_PIN >= 0
+#error "Both SPI0_RX_PORT and SPI0_RX_PIN must be valid or invalid"
+#endif
+
+/* Here we check that either all or none of the ports are defined. As
+   we did already check that both ports + pins are either defined or
+   not for every pin, this means that we can check for an incomplete 
+   configuration by only looking at the port defines */
+#if (SPI0_CLK_PORT < 0 && SPI0_TX_PORT < 0 && SPI0_RX_PORT >= 0) ||  \
+	(SPI0_CLK_PORT < 0 && SPI0_TX_PORT >= 0 && SPI0_RX_PORT < 0) ||  \
+	(SPI0_CLK_PORT < 0 && SPI0_TX_PORT >= 0 && SPI0_RX_PORT >= 0) || \
+	(SPI0_CLK_PORT >= 0 && SPI0_TX_PORT < 0 && SPI0_RX_PORT < 0) ||  \
+	(SPI0_CLK_PORT >= 0 && SPI0_TX_PORT < 0 && SPI0_RX_PORT >= 0) || \
+	(SPI0_CLK_PORT >= 0 && SPI0_TX_PORT >= 0 && SPI0_RX_PORT < 0) ||
+#error "SPI0 port / pin definition incomplete"
+#endif
+/*---------------------------------------------------------------------------*/
+/* Check port / pin settings for SPI1 and provide default values for spi_cfg */
+#ifndef SPI1_CLK_PORT
+#define SPI1_CLK_PORT					(-1)
+#endif
+#ifndef SPI1_CLK_PIN
+#define SPI1_CLK_PIN					(-1)
+#endif
+#if SPI1_CLK_PORT >= 0 && SPI1_CLK_PIN < 0 || \
+    SPI1_CLK_PORT < 0 && SPI1_CLK_PIN >= 0
+#error "Both SPI1_CLK_PORT and SPI1_CLK_PIN must be valid or invalid"
+#endif
+
+#ifndef SPI1_TX_PORT
+#define SPI1_TX_PORT					(-1)
+#endif
+#ifndef SPI1_TX_PIN
+#define SPI1_TX_PIN					   	(-1)
+#endif
+#if SPI1_TX_PORT >= 0 && SPI1_TX_PIN < 0 || \
+    SPI1_TX_PORT < 0 && SPI1_TX_PIN >= 0
+#error "Both SPI1_TX_PORT and SPI1_TX_PIN must be valid or invalid"
+#endif
+
+#ifndef SPI1_RX_PORT
+#define SPI1_RX_PORT				   	(-1)
+#endif
+#ifndef SPI1_RX_PIN
+#define SPI1_RX_PIN					   	(-1)
+#endif
+#if SPI1_RX_PORT >= 0 && SPI1_RX_PIN < 0 || \
+    SPI1_RX_PORT < 0 && SPI1_RX_PIN >= 0
+#error "Both SPI1_RX_PORT and SPI1_RX_PIN must be valid or invalid"
+#endif
+
+/* Here we check that either all or none of the ports are defined. As
+   we did already check that both ports + pins are either defined or
+   not for every pin, this means that we can check for an incomplete 
+   configuration by only looking at the port defines */
+#if (SPI1_CLK_PORT < 0 && SPI1_TX_PORT < 0 && SPI1_RX_PORT >= 0) ||  \
+	(SPI1_CLK_PORT < 0 && SPI1_TX_PORT >= 0 && SPI1_RX_PORT < 0) ||  \
+	(SPI1_CLK_PORT < 0 && SPI1_TX_PORT >= 0 && SPI1_RX_PORT >= 0) || \
+	(SPI1_CLK_PORT >= 0 && SPI1_TX_PORT < 0 && SPI1_RX_PORT < 0) ||  \
+	(SPI1_CLK_PORT >= 0 && SPI1_TX_PORT < 0 && SPI1_RX_PORT >= 0) || \
+	(SPI1_CLK_PORT >= 0 && SPI1_TX_PORT >= 0 && SPI1_RX_PORT < 0) ||
+#error "SPI1 port / pin definition incomplete"
+#endif
+/*---------------------------------------------------------------------------*/
+typedef struct
 {
-  spi0_enable();
-
-  /* Start by disabling the peripheral before configuring it */
-  REG(SSI0_BASE + SSI_CR1) = 0;
-
-  /* Set the IO clock as the SSI clock */
-  REG(SSI0_BASE + SSI_CC) = 1;
-
-  /* Set the mux correctly to connect the SSI pins to the correct GPIO pins */
-  ioc_set_sel(SPI0_CLK_PORT, SPI0_CLK_PIN, IOC_PXX_SEL_SSI0_CLKOUT);
-  ioc_set_sel(SPI0_MOSI_PORT, SPI0_MOSI_PIN, IOC_PXX_SEL_SSI0_TXD);
-  REG(IOC_SSIRXD_SSI0) = (SPI0_MISO_PORT * 8) + SPI0_MISO_PIN;
-
-  /* Put all the SSI gpios into peripheral mode */
-  GPIO_PERIPHERAL_CONTROL(SPI0_CLK_PORT_BASE, SPI0_CLK_PIN_MASK);
-  GPIO_PERIPHERAL_CONTROL(SPI0_MOSI_PORT_BASE, SPI0_MOSI_PIN_MASK);
-  GPIO_PERIPHERAL_CONTROL(SPI0_MISO_PORT_BASE, SPI0_MISO_PIN_MASK);
-
-  /* Disable any pull ups or the like */
-  ioc_set_over(SPI0_CLK_PORT, SPI0_CLK_PIN, IOC_OVERRIDE_DIS);
-  ioc_set_over(SPI0_MOSI_PORT, SPI0_MOSI_PIN, IOC_OVERRIDE_DIS);
-  ioc_set_over(SPI0_MISO_PORT, SPI0_MISO_PIN, IOC_OVERRIDE_DIS);
-
-  /* Configure the clock */
-  REG(SSI0_BASE + SSI_CPSR) = 2;
-
-  /* Configure the default SPI options.
-   *   mode:  Motorola frame format
-   *   clock: High when idle
-   *   data:  Valid on rising edges of the clock
-   *   bits:  8 byte data
-   */
-  REG(SSI0_BASE + SSI_CR0) = SSI_CR0_SPH | SSI_CR0_SPO | (0x07);
-
-  /* Enable the SSI */
-  REG(SSI0_BASE + SSI_CR1) |= SSI_CR1_SSE;
-}
-#endif	/* #if USE_SPI0 */
+	int8_t port_num;
+	int8_t pin_num;
+} spi_pad_t;
+typedef struct {
+	uint32_t base;
+	uint32_t ioc_ssirxd_ssi;
+	uint32_t ioc_pxx_sel_ssi_clkout;
+	uint32_t ioc_pxx_sel_ssi_txd;
+	spi_pad_t clk;
+	spi_pad_t txd;
+	spi_pad_t rxd;
+} spi_cfg_t;
 /*---------------------------------------------------------------------------*/
-/**
- * \brief Initialize the SPI bus for SSI1
- *
- * This SPI init() function uses the following defines to set the pins:
- *    SPI1_CLK_PORT               SPI1_CLK_PIN
- *    SPI1_MOSI_PORT              SPI1_MOSI_PIN
- *    SPI1_MISO_PORT              SPI1_MISO_PIN
- *
- * This sets the mode to Motorola SPI with the following format options:
- *    Clock phase:               1; data captured on second (rising) edge
- *    Clock polarity:            1; clock is high when idle
- *    Data size:                 8 bits
- */
-#if USE_SPI1
-void
-spi1_init(void)
+static const spi_cfg_t spi_regs[SSI_INSTANCE_COUNT] = {
+	{
+		.base = SSI0_BASE,
+		.ioc_ssirxd_ssi = IOC_SSIRXD_SSI0,
+		.ioc_pxx_sel_ssi_clkout = IOC_PXX_SEL_SSI0_CLKOUT,
+		.ioc_pxx_sel_ssi_txd = IOC_PXX_SEL_SSI0_TXD,
+		.clk = {SPI0_CLK_PORT, SPI0_CLK_PIN},
+		.tx = {SPI0_TX_PORT, SPI0_TX_PIN},
+		.rx = {SPI0_RX_PORT, SPI0_RX_PIN}
+	}, {
+		.base = SSI1_BASE,
+		.ioc_ssirxd_ssi = IOC_SSIRXD_SSI1,
+		.ioc_pxx_sel_ssi_clkout = IOC_PXX_SEL_SSI1_CLKOUT,
+		.ioc_pxx_sel_ssi_txd = IOC_PXX_SEL_SSI1_TXD,
+		.clk = {SPI1_CLK_PORT, SPI1_CLK_PIN},
+		.tx = {SPI1_TX_PORT, SPI1_TX_PIN},
+		.rx = {SPI1_RX_PORT, SPI1_RX_PIN}
+	}
+};
+/*---------------------------------------------------------------------------*/
+void spix_init(uint8_t instance)
 {
-  spi1_enable();
+	const spi_cfg_t *cfg; 
+	
+	if (instance >= SSI_INSTANCE_COUNT) {
+		return;
+	}
 
-  /* Start by disabling the peripheral before configuring it */
-  REG(SSI1_BASE + SSI_CR1) = 0;
+	spix_enable(instance);
 
-  /* Set the IO clock as the SSI clock */
-  REG(SSI1_BASE + SSI_CC) = 1;
+	cfg = &spi_cfg[instance];
 
-  /* Set the mux correctly to connect the SSI pins to the correct GPIO pins */
-  ioc_set_sel(SPI1_CLK_PORT, SPI1_CLK_PIN, IOC_PXX_SEL_SSI1_CLKOUT);
-  ioc_set_sel(SPI1_MOSI_PORT, SPI1_MOSI_PIN, IOC_PXX_SEL_SSI1_TXD);
-  REG(IOC_SSIRXD_SSI1) = (SPI1_MISO_PORT * 8) + SPI1_MISO_PIN;
+	if (cfg->clk.port < 0)
+	{ 
+		/* Port / pin configuration invalid. We checked for completeness
+		   above. If clk.port is < 0, this means that all other defines are
+		   < 0 as well */
+		return;
+	}
 
-  /* Put all the SSI gpios into peripheral mode */
-  GPIO_PERIPHERAL_CONTROL(SPI1_CLK_PORT_BASE, SPI1_CLK_PIN_MASK);
-  GPIO_PERIPHERAL_CONTROL(SPI1_MOSI_PORT_BASE, SPI1_MOSI_PIN_MASK);
-  GPIO_PERIPHERAL_CONTROL(SPI1_MISO_PORT_BASE, SPI1_MISO_PIN_MASK);
+	/* Start by disabling the peripheral before configuring it */
+	REG(cfg->base + SSI_CR1) = 0;
+	
+	/* Set the IO clock as the SSI clock */
+	REG(cfg->base + SSI_CC) = 1;
 
-  /* Disable any pull ups or the like */
-  ioc_set_over(SPI1_CLK_PORT, SPI1_CLK_PIN, IOC_OVERRIDE_DIS);
-  ioc_set_over(SPI1_MOSI_PORT, SPI1_MOSI_PIN, IOC_OVERRIDE_DIS);
-  ioc_set_over(SPI1_MISO_PORT, SPI1_MISO_PIN, IOC_OVERRIDE_DIS);
+	/* Set the mux correctly to connect the SSI pins to the correct GPIO pins */
+	ioc_set_sel(cfg->clk.port, 
+				cfg->clk.pin,
+				cfg->ioc_pxx_sel_ssi_clkout);
+	ioc_set_sel(cfg->tx.port, 
+				cfg->tx.pin,
+				cfg->ioc_pxx_sel_ssi_txd);
+	REG(cfg->ioc_ssirxd_ssi) = (cfg->rx.port * 8) + cfg->rx.pin;
+	
+	/* Put all the SSI gpios into peripheral mode */
+	GPIO_PERIPHERAL_CONTROL(GPIO_PORT_TO_BASE(cfg->clk.port),
+							GPIO_PIN_MASK(cfg->clk.pin));
+	GPIO_PERIPHERAL_CONTROL(GPIO_PORT_TO_BASE(cfg->tx.port),
+							GPIO_PIN_MASK(cfg->tx.pin));
+	GPIO_PERIPHERAL_CONTROL(GPIO_PORT_TO_BASE(cfg->rx.port),
+							GPIO_PIN_MASK(cfg->rx.pin));
+	
+	/* Disable any pull ups or the like */
+	ioc_set_over(cfg->clk.port, cfg->clk.pin, IOC_OVERRIDE_DIS);
+	ioc_set_over(cfg->tx.port, cfg->tx.pin, IOC_OVERRIDE_DIS);
+	ioc_set_over(cfg->rx.port, cfg->rx.pin, IOC_OVERRIDE_DIS);
 
-  /* Configure the clock */
-  REG(SSI1_BASE + SSI_CPSR) = 2;
-
-  /* Configure the default SPI options.
-   *   mode:  Motorola frame format
-   *   clock: High when idle
-   *   data:  Valid on rising edges of the clock
-   *   bits:  8 byte data
-   */
-  REG(SSI1_BASE + SSI_CR0) = SSI_CR0_SPH | SSI_CR0_SPO | (0x07);
-
-  /* Enable the SSI */
-  REG(SSI1_BASE + SSI_CR1) |= SSI_CR1_SSE;
+	/* Configure the clock */
+	REG(cfg->base + SSI_CPSR) = 2;
+	
+	/* 
+	 * Configure the default SPI options.
+	 *   mode:  Motorola frame format
+	 *   clock: High when idle
+	 *   data:  Valid on rising edges of the clock
+	 *   bits:  8 byte data
+	 */
+	REG(cfg->base + SSI_CR0) = SSI_CR0_SPH | SSI_CR0_SPO | (0x07);
+	
+	/* Enable the SSI */
+	REG(cfg->base + SSI_CR1) |= SSI_CR1_SSE;
 }
-#endif	/* #if USE_SPI1 */
 /*---------------------------------------------------------------------------*/
-#if USE_SPI0
 void
-spi0_cs_init(uint8_t port, uint8_t pin)
+spix_enable(uint8_t instance)
 {
-  GPIO_SOFTWARE_CONTROL(GPIO_PORT_TO_BASE(port), GPIO_PIN_MASK(pin));
-  ioc_set_over(port, pin, IOC_OVERRIDE_DIS);
-  GPIO_SET_OUTPUT(GPIO_PORT_TO_BASE(port), GPIO_PIN_MASK(pin));
-  GPIO_SET_PIN(GPIO_PORT_TO_BASE(port), GPIO_PIN_MASK(pin));
+	if (instance >= SSI_INSTANCE_COUNT) {
+		return;
+	}
+
+	/* Enable the clock for the SSI peripheral */
+	if (instance == 0) {
+		/* Enable the clock for the SSI peripheral */
+		REG(SYS_CTRL_RCGCSSI) |= 1;
+	} else {
+		REG(SYS_CTRL_RCGCSSI) |= 2;
+	}
 }
-#endif	/* #if USE_SPI0 */
 /*---------------------------------------------------------------------------*/
-#if USE_SPI1
 void
-spi1_cs_init(uint8_t port, uint8_t pin)
+spix_disable(uint8_t instance)
 {
-  GPIO_SOFTWARE_CONTROL(GPIO_PORT_TO_BASE(port), GPIO_PIN_MASK(pin));
-  ioc_set_over(port, pin, IOC_OVERRIDE_DIS);
-  GPIO_SET_OUTPUT(GPIO_PORT_TO_BASE(port), GPIO_PIN_MASK(pin));
-  GPIO_SET_PIN(GPIO_PORT_TO_BASE(port), GPIO_PIN_MASK(pin));
+	if (instance >= SSI_INSTANCE_COUNT) {
+		return;
+	}
+
+	/* Gate the clock for the SSI peripheral */
+	if (instance == 0) {
+		REG(SYS_CTRL_RCGCSSI) &= ~1;
+	} else {
+		REG(SYS_CTRL_RCGCSSI) &= ~2;
+	}
 }
-#endif	/* #if USE_SPI1 */
 /*---------------------------------------------------------------------------*/
-#if USE_SPI0
-void
-spi0_enable(void)
-{
-  /* Enable the clock for the SSI peripheral */
-  REG(SYS_CTRL_RCGCSSI) |= 1;
-}
-#endif	/* #if USE_SPI0 */
-/*---------------------------------------------------------------------------*/
-#if USE_SPI1
-void
-spi1_enable(void)
-{
-  /* Enable the clock for the SSI peripheral */
-  REG(SYS_CTRL_RCGCSSI) |= 2;
-}
-#endif	/* #if USE_SPI1 */
-/*---------------------------------------------------------------------------*/
-#if USE_SPI0
-void
-spi0_disable(void)
-{
-  /* Gate the clock for the SSI peripheral */
-  REG(SYS_CTRL_RCGCSSI) &= ~1;
-}
-#endif	/* #if USE_SPI0 */
-/*---------------------------------------------------------------------------*/
-#if USE_SPI1
-void
-spi1_disable(void)
-{
-  /* Gate the clock for the SSI peripheral */
-  REG(SYS_CTRL_RCGCSSI) &= ~2;
-}
-#endif	/* #if USE_SPI1 */
-/*---------------------------------------------------------------------------*/
-#if USE_SPI0
-void spi0_set_mode(uint32_t frame_format, 
+void spix_set_mode(uint8_t instance,
+				   uint32_t frame_format, 
 				   uint32_t clock_polarity, 
 				   uint32_t clock_phase, 
 				   uint32_t data_size)
 {
-  /* Disable the SSI peripheral to configure it */
-  REG(SSI0_BASE + SSI_CR1) = 0;
+	const spi_cfg_t *cfg; 
+	
+	if (instance >= SSI_INSTANCE_COUNT) {
+		return;
+	}
 
-  /* Configure the SSI options */
-  REG(SSI0_BASE + SSI_CR0) = clock_phase | 
-	  clock_polarity | 
-	  frame_format | 
-	  (data_size - 1);
+	cfg = &spi_cfg[instance];
 
-  /* Re-enable the SSI */
-  REG(SSI0_BASE + SSI_CR1) |= SSI_CR1_SSE;
+	/* Disable the SSI peripheral to configure it */
+	REG(cfg->base + SSI_CR1) = 0;
+
+	/* Configure the SSI options */
+	REG(cfg->base + SSI_CR0) = clock_phase | 
+		clock_polarity | 
+		frame_format | 
+		(data_size - 1);
+
+	/* Re-enable the SSI */
+	REG(cfg->base + SSI_CR1) |= SSI_CR1_SSE;
 }
-#endif	/* #if USE_SPI0 */
 /*---------------------------------------------------------------------------*/
-#if USE_SPI1
-void spi1_set_mode(uint32_t frame_format, 
-				   uint32_t clock_polarity, 
-				   uint32_t clock_phase, 
-				   uint32_t data_size)
+void spix_cs_init(uint8_t port, uint8_t pin)
 {
-  /* Disable the SSI peripheral to configure it */
-  REG(SSI1_BASE + SSI_CR1) = 0;
-
-  /* Configure the SSI options */
-  REG(SSI1_BASE + SSI_CR0) = clock_phase | 
-	  clock_polarity | 
-	  frame_format | 
-	  (data_size - 1);
-
-  /* Re-enable the SSI */
-  REG(SSI1_BASE + SSI_CR1) |= SSI_CR1_SSE;
+  GPIO_SOFTWARE_CONTROL(GPIO_PORT_TO_BASE(port), 
+						GPIO_PIN_MASK(pin));
+  ioc_set_over(port, pin, IOC_OVERRIDE_DIS);
+  GPIO_SET_OUTPUT(GPIO_PORT_TO_BASE(port), GPIO_PIN_MASK(pin));
+  GPIO_SET_PIN(GPIO_PORT_TO_BASE(port), GPIO_PIN_MASK(pin));
 }
-#endif	/* #if USE_SPI1 */
+
 /** @} */

--- a/cpu/cc2538/dev/spi.c
+++ b/cpu/cc2538/dev/spi.c
@@ -43,43 +43,43 @@
 #include "dev/gpio.h"
 /*---------------------------------------------------------------------------*/
 /* Map the old port / pin names to the new ones for compatibility reasons */
-#if (SPI_DEFAULT_INSTANCE==0)
+#if (SPI_DEFAULT_INSTANCE == 0)
 #ifdef SPI_CLK_PORT
-#define SPI0_CLK_PORT					SPI_CLK_PORT
+#define SPI0_CLK_PORT         SPI_CLK_PORT
 #endif
 #ifdef SPI_CLK_PIN
-#define SPI0_CLK_PIN					SPI_CLK_PIN
+#define SPI0_CLK_PIN          SPI_CLK_PIN
 #endif
 #ifdef SPI_MOSI_PORT
-#define SPI0_TX_PORT					SPI_MOSI_PORT
+#define SPI0_TX_PORT          SPI_MOSI_PORT
 #endif
 #ifdef SPI_MOSI_PIN
-#define SPI0_TX_PIN						SPI_MOSI_PIN
+#define SPI0_TX_PIN           SPI_MOSI_PIN
 #endif
 #ifdef SPI_MISO_PORT
-#define SPI0_RX_PORT					SPI_MISO_PORT
+#define SPI0_RX_PORT          SPI_MISO_PORT
 #endif
 #ifdef SPI_MISO_PIN
-#define SPI0_RX_PIN						SPI_MISO_PIN
+#define SPI0_RX_PIN           SPI_MISO_PIN
 #endif
-#elif (SPI_DEFAULT_INSTANCE==1)
+#elif (SPI_DEFAULT_INSTANCE == 1)
 #ifdef SPI_CLK_PORT
-#define SPI1_CLK_PORT					SPI_CLK_PORT
+#define SPI1_CLK_PORT         SPI_CLK_PORT
 #endif
 #ifdef SPI_CLK_PIN
-#define SPI1_CLK_PIN					SPI_CLK_PIN
+#define SPI1_CLK_PIN          SPI_CLK_PIN
 #endif
 #ifdef SPI_MOSI_PORT
-#define SPI1_TX_PORT					SPI_MOSI_PORT
+#define SPI1_TX_PORT          SPI_MOSI_PORT
 #endif
 #ifdef SPI_MOSI_PIN
-#define SPI1_TX_PIN						SPI_MOSI_PIN
+#define SPI1_TX_PIN           SPI_MOSI_PIN
 #endif
 #ifdef SPI_MISO_PORT
-#define SPI1_RX_PORT					SPI_MISO_PORT
+#define SPI1_RX_PORT          SPI_MISO_PORT
 #endif
 #ifdef SPI_MISO_PIN
-#define SPI1_RX_PIN						SPI_MISO_PIN
+#define SPI1_RX_PIN           SPI_MISO_PIN
 #endif
 #else
 #error "Invalid SPI instance. Valid values are 0 or 1"
@@ -87,262 +87,291 @@
 /*---------------------------------------------------------------------------*/
 /* Check port / pin settings for SPI0 and provide default values for spi_cfg */
 #ifndef SPI0_CLK_PORT
-#define SPI0_CLK_PORT					(-1)
+#define SPI0_CLK_PORT         (-1)
 #endif
 #ifndef SPI0_CLK_PIN
-#define SPI0_CLK_PIN					(-1)
+#define SPI0_CLK_PIN          (-1)
 #endif
 #if SPI0_CLK_PORT >= 0 && SPI0_CLK_PIN < 0 || \
-    SPI0_CLK_PORT < 0 && SPI0_CLK_PIN >= 0
+  SPI0_CLK_PORT < 0 && SPI0_CLK_PIN >= 0
 #error "Both SPI0_CLK_PORT and SPI0_CLK_PIN must be valid or invalid"
 #endif
 
 #ifndef SPI0_TX_PORT
-#define SPI0_TX_PORT					(-1)
+#define SPI0_TX_PORT          (-1)
 #endif
 #ifndef SPI0_TX_PIN
-#define SPI0_TX_PIN						(-1)
+#define SPI0_TX_PIN           (-1)
 #endif
 #if SPI0_TX_PORT >= 0 && SPI0_TX_PIN < 0 || \
-    SPI0_TX_PORT < 0 && SPI0_TX_PIN >= 0
+  SPI0_TX_PORT < 0 && SPI0_TX_PIN >= 0
 #error "Both SPI0_TX_PORT and SPI0_TX_PIN must be valid or invalid"
 #endif
 
 #ifndef SPI0_RX_PORT
-#define SPI0_RX_PORT					(-1)
+#define SPI0_RX_PORT          (-1)
 #endif
 #ifndef SPI0_RX_PIN
-#define SPI0_RX_PIN						(-1)
+#define SPI0_RX_PIN           (-1)
 #endif
 #if SPI0_RX_PORT >= 0 && SPI0_RX_PIN < 0 || \
-    SPI0_RX_PORT < 0 && SPI0_RX_PIN >= 0
+  SPI0_RX_PORT < 0 && SPI0_RX_PIN >= 0
 #error "Both SPI0_RX_PORT and SPI0_RX_PIN must be valid or invalid"
 #endif
 
 /* Here we check that either all or none of the ports are defined. As
    we did already check that both ports + pins are either defined or
-   not for every pin, this means that we can check for an incomplete 
+   not for every pin, this means that we can check for an incomplete
    configuration by only looking at the port defines */
-#if (SPI0_CLK_PORT < 0 && SPI0_TX_PORT < 0 && SPI0_RX_PORT >= 0) ||  \
-	(SPI0_CLK_PORT < 0 && SPI0_TX_PORT >= 0 && SPI0_RX_PORT < 0) ||  \
-	(SPI0_CLK_PORT < 0 && SPI0_TX_PORT >= 0 && SPI0_RX_PORT >= 0) || \
-	(SPI0_CLK_PORT >= 0 && SPI0_TX_PORT < 0 && SPI0_RX_PORT < 0) ||  \
-	(SPI0_CLK_PORT >= 0 && SPI0_TX_PORT < 0 && SPI0_RX_PORT >= 0) || \
-	(SPI0_CLK_PORT >= 0 && SPI0_TX_PORT >= 0 && SPI0_RX_PORT < 0) ||
+#if (SPI0_CLK_PORT < 0 && SPI0_TX_PORT < 0 && SPI0_RX_PORT >= 0) || \
+  (SPI0_CLK_PORT < 0 && SPI0_TX_PORT >= 0 && SPI0_RX_PORT < 0) || \
+  (SPI0_CLK_PORT < 0 && SPI0_TX_PORT >= 0 && SPI0_RX_PORT >= 0) || \
+  (SPI0_CLK_PORT >= 0 && SPI0_TX_PORT < 0 && SPI0_RX_PORT < 0) || \
+  (SPI0_CLK_PORT >= 0 && SPI0_TX_PORT < 0 && SPI0_RX_PORT >= 0) || \
+  (SPI0_CLK_PORT >= 0 && SPI0_TX_PORT >= 0 && SPI0_RX_PORT < 0)
 #error "SPI0 port / pin definition incomplete"
 #endif
 /*---------------------------------------------------------------------------*/
 /* Check port / pin settings for SPI1 and provide default values for spi_cfg */
 #ifndef SPI1_CLK_PORT
-#define SPI1_CLK_PORT					(-1)
+#define SPI1_CLK_PORT         (-1)
 #endif
 #ifndef SPI1_CLK_PIN
-#define SPI1_CLK_PIN					(-1)
+#define SPI1_CLK_PIN          (-1)
 #endif
 #if SPI1_CLK_PORT >= 0 && SPI1_CLK_PIN < 0 || \
-    SPI1_CLK_PORT < 0 && SPI1_CLK_PIN >= 0
+  SPI1_CLK_PORT < 0 && SPI1_CLK_PIN >= 0
 #error "Both SPI1_CLK_PORT and SPI1_CLK_PIN must be valid or invalid"
 #endif
 
 #ifndef SPI1_TX_PORT
-#define SPI1_TX_PORT					(-1)
+#define SPI1_TX_PORT          (-1)
 #endif
 #ifndef SPI1_TX_PIN
-#define SPI1_TX_PIN					   	(-1)
+#define SPI1_TX_PIN             (-1)
 #endif
 #if SPI1_TX_PORT >= 0 && SPI1_TX_PIN < 0 || \
-    SPI1_TX_PORT < 0 && SPI1_TX_PIN >= 0
+  SPI1_TX_PORT < 0 && SPI1_TX_PIN >= 0
 #error "Both SPI1_TX_PORT and SPI1_TX_PIN must be valid or invalid"
 #endif
 
 #ifndef SPI1_RX_PORT
-#define SPI1_RX_PORT				   	(-1)
+#define SPI1_RX_PORT            (-1)
 #endif
 #ifndef SPI1_RX_PIN
-#define SPI1_RX_PIN					   	(-1)
+#define SPI1_RX_PIN             (-1)
 #endif
 #if SPI1_RX_PORT >= 0 && SPI1_RX_PIN < 0 || \
-    SPI1_RX_PORT < 0 && SPI1_RX_PIN >= 0
+  SPI1_RX_PORT < 0 && SPI1_RX_PIN >= 0
 #error "Both SPI1_RX_PORT and SPI1_RX_PIN must be valid or invalid"
 #endif
 
 /* Here we check that either all or none of the ports are defined. As
    we did already check that both ports + pins are either defined or
-   not for every pin, this means that we can check for an incomplete 
+   not for every pin, this means that we can check for an incomplete
    configuration by only looking at the port defines */
-#if (SPI1_CLK_PORT < 0 && SPI1_TX_PORT < 0 && SPI1_RX_PORT >= 0) ||  \
-	(SPI1_CLK_PORT < 0 && SPI1_TX_PORT >= 0 && SPI1_RX_PORT < 0) ||  \
-	(SPI1_CLK_PORT < 0 && SPI1_TX_PORT >= 0 && SPI1_RX_PORT >= 0) || \
-	(SPI1_CLK_PORT >= 0 && SPI1_TX_PORT < 0 && SPI1_RX_PORT < 0) ||  \
-	(SPI1_CLK_PORT >= 0 && SPI1_TX_PORT < 0 && SPI1_RX_PORT >= 0) || \
-	(SPI1_CLK_PORT >= 0 && SPI1_TX_PORT >= 0 && SPI1_RX_PORT < 0) ||
+#if (SPI1_CLK_PORT < 0 && SPI1_TX_PORT < 0 && SPI1_RX_PORT >= 0) || \
+  (SPI1_CLK_PORT < 0 && SPI1_TX_PORT >= 0 && SPI1_RX_PORT < 0) || \
+  (SPI1_CLK_PORT < 0 && SPI1_TX_PORT >= 0 && SPI1_RX_PORT >= 0) || \
+  (SPI1_CLK_PORT >= 0 && SPI1_TX_PORT < 0 && SPI1_RX_PORT < 0) || \
+  (SPI1_CLK_PORT >= 0 && SPI1_TX_PORT < 0 && SPI1_RX_PORT >= 0) || \
+  (SPI1_CLK_PORT >= 0 && SPI1_TX_PORT >= 0 && SPI1_RX_PORT < 0)
 #error "SPI1 port / pin definition incomplete"
 #endif
 /*---------------------------------------------------------------------------*/
-typedef struct
-{
-	int8_t port_num;
-	int8_t pin_num;
+typedef struct {
+  int8_t port;
+  int8_t pin;
 } spi_pad_t;
 typedef struct {
-	uint32_t base;
-	uint32_t ioc_ssirxd_ssi;
-	uint32_t ioc_pxx_sel_ssi_clkout;
-	uint32_t ioc_pxx_sel_ssi_txd;
-	spi_pad_t clk;
-	spi_pad_t txd;
-	spi_pad_t rxd;
+  uint32_t base;
+  uint32_t ioc_ssirxd_ssi;
+  uint32_t ioc_pxx_sel_ssi_clkout;
+  uint32_t ioc_pxx_sel_ssi_txd;
+  spi_pad_t clk;
+  spi_pad_t tx;
+  spi_pad_t rx;
 } spi_cfg_t;
 /*---------------------------------------------------------------------------*/
-static const spi_cfg_t spi_regs[SSI_INSTANCE_COUNT] = {
-	{
-		.base = SSI0_BASE,
-		.ioc_ssirxd_ssi = IOC_SSIRXD_SSI0,
-		.ioc_pxx_sel_ssi_clkout = IOC_PXX_SEL_SSI0_CLKOUT,
-		.ioc_pxx_sel_ssi_txd = IOC_PXX_SEL_SSI0_TXD,
-		.clk = {SPI0_CLK_PORT, SPI0_CLK_PIN},
-		.tx = {SPI0_TX_PORT, SPI0_TX_PIN},
-		.rx = {SPI0_RX_PORT, SPI0_RX_PIN}
-	}, {
-		.base = SSI1_BASE,
-		.ioc_ssirxd_ssi = IOC_SSIRXD_SSI1,
-		.ioc_pxx_sel_ssi_clkout = IOC_PXX_SEL_SSI1_CLKOUT,
-		.ioc_pxx_sel_ssi_txd = IOC_PXX_SEL_SSI1_TXD,
-		.clk = {SPI1_CLK_PORT, SPI1_CLK_PIN},
-		.tx = {SPI1_TX_PORT, SPI1_TX_PIN},
-		.rx = {SPI1_RX_PORT, SPI1_RX_PIN}
-	}
+static const spi_cfg_t spi_cfg[SSI_INSTANCE_COUNT] = {
+  {
+    .base = SSI0_BASE,
+    .ioc_ssirxd_ssi = IOC_SSIRXD_SSI0,
+    .ioc_pxx_sel_ssi_clkout = IOC_PXX_SEL_SSI0_CLKOUT,
+    .ioc_pxx_sel_ssi_txd = IOC_PXX_SEL_SSI0_TXD,
+    .clk = { SPI0_CLK_PORT, SPI0_CLK_PIN },
+    .tx = { SPI0_TX_PORT, SPI0_TX_PIN },
+    .rx = { SPI0_RX_PORT, SPI0_RX_PIN }
+  }, {
+    .base = SSI1_BASE,
+    .ioc_ssirxd_ssi = IOC_SSIRXD_SSI1,
+    .ioc_pxx_sel_ssi_clkout = IOC_PXX_SEL_SSI1_CLKOUT,
+    .ioc_pxx_sel_ssi_txd = IOC_PXX_SEL_SSI1_TXD,
+    .clk = { SPI1_CLK_PORT, SPI1_CLK_PIN },
+    .tx = { SPI1_TX_PORT, SPI1_TX_PIN },
+    .rx = { SPI1_RX_PORT, SPI1_RX_PIN }
+  }
 };
 /*---------------------------------------------------------------------------*/
-void spix_init(uint8_t instance)
+/* Deprecated function calls provided for compatibility reasons */
+void
+spi_init(void)
 {
-	const spi_cfg_t *cfg; 
-	
-	if (instance >= SSI_INSTANCE_COUNT) {
-		return;
-	}
+  spix_init(SPI_DEFAULT_INSTANCE);
+}
+void
+spi_enable(void)
+{
+  spix_enable(SPI_DEFAULT_INSTANCE);
+}
+void
+spi_disable(void)
+{
+  spix_disable(SPI_DEFAULT_INSTANCE);
+}
+void
+spi_set_mode(uint32_t frame_format, uint32_t clock_polarity,
+             uint32_t clock_phase, uint32_t data_size)
+{
+  spix_set_mode(SPI_DEFAULT_INSTANCE, frame_format, clock_polarity,
+                clock_phase, data_size);
+}
+void
+spi_cs_init(uint8_t port, uint8_t pin)
+{
+  spix_cs_init(port, pin);
+}
+/*---------------------------------------------------------------------------*/
+void
+spix_init(uint8_t instance)
+{
+  const spi_cfg_t *cfg;
 
-	spix_enable(instance);
+  if(instance >= SSI_INSTANCE_COUNT) {
+    return;
+  }
 
-	cfg = &spi_cfg[instance];
+  spix_enable(instance);
 
-	if (cfg->clk.port < 0)
-	{ 
-		/* Port / pin configuration invalid. We checked for completeness
-		   above. If clk.port is < 0, this means that all other defines are
-		   < 0 as well */
-		return;
-	}
+  cfg = &spi_cfg[instance];
 
-	/* Start by disabling the peripheral before configuring it */
-	REG(cfg->base + SSI_CR1) = 0;
-	
-	/* Set the IO clock as the SSI clock */
-	REG(cfg->base + SSI_CC) = 1;
+  if(cfg->clk.port < 0) {
+    /* Port / pin configuration invalid. We checked for completeness
+       above. If clk.port is < 0, this means that all other defines are
+       < 0 as well */
+    return;
+  }
 
-	/* Set the mux correctly to connect the SSI pins to the correct GPIO pins */
-	ioc_set_sel(cfg->clk.port, 
-				cfg->clk.pin,
-				cfg->ioc_pxx_sel_ssi_clkout);
-	ioc_set_sel(cfg->tx.port, 
-				cfg->tx.pin,
-				cfg->ioc_pxx_sel_ssi_txd);
-	REG(cfg->ioc_ssirxd_ssi) = (cfg->rx.port * 8) + cfg->rx.pin;
-	
-	/* Put all the SSI gpios into peripheral mode */
-	GPIO_PERIPHERAL_CONTROL(GPIO_PORT_TO_BASE(cfg->clk.port),
-							GPIO_PIN_MASK(cfg->clk.pin));
-	GPIO_PERIPHERAL_CONTROL(GPIO_PORT_TO_BASE(cfg->tx.port),
-							GPIO_PIN_MASK(cfg->tx.pin));
-	GPIO_PERIPHERAL_CONTROL(GPIO_PORT_TO_BASE(cfg->rx.port),
-							GPIO_PIN_MASK(cfg->rx.pin));
-	
-	/* Disable any pull ups or the like */
-	ioc_set_over(cfg->clk.port, cfg->clk.pin, IOC_OVERRIDE_DIS);
-	ioc_set_over(cfg->tx.port, cfg->tx.pin, IOC_OVERRIDE_DIS);
-	ioc_set_over(cfg->rx.port, cfg->rx.pin, IOC_OVERRIDE_DIS);
+  /* Start by disabling the peripheral before configuring it */
+  REG(cfg->base + SSI_CR1) = 0;
 
-	/* Configure the clock */
-	REG(cfg->base + SSI_CPSR) = 2;
-	
-	/* 
-	 * Configure the default SPI options.
-	 *   mode:  Motorola frame format
-	 *   clock: High when idle
-	 *   data:  Valid on rising edges of the clock
-	 *   bits:  8 byte data
-	 */
-	REG(cfg->base + SSI_CR0) = SSI_CR0_SPH | SSI_CR0_SPO | (0x07);
-	
-	/* Enable the SSI */
-	REG(cfg->base + SSI_CR1) |= SSI_CR1_SSE;
+  /* Set the IO clock as the SSI clock */
+  REG(cfg->base + SSI_CC) = 1;
+
+  /* Set the mux correctly to connect the SSI pins to the correct GPIO pins */
+  ioc_set_sel(cfg->clk.port,
+              cfg->clk.pin,
+              cfg->ioc_pxx_sel_ssi_clkout);
+  ioc_set_sel(cfg->tx.port,
+              cfg->tx.pin,
+              cfg->ioc_pxx_sel_ssi_txd);
+  REG(cfg->ioc_ssirxd_ssi) = (cfg->rx.port * 8) + cfg->rx.pin;
+
+  /* Put all the SSI gpios into peripheral mode */
+  GPIO_PERIPHERAL_CONTROL(GPIO_PORT_TO_BASE(cfg->clk.port),
+                          GPIO_PIN_MASK(cfg->clk.pin));
+  GPIO_PERIPHERAL_CONTROL(GPIO_PORT_TO_BASE(cfg->tx.port),
+                          GPIO_PIN_MASK(cfg->tx.pin));
+  GPIO_PERIPHERAL_CONTROL(GPIO_PORT_TO_BASE(cfg->rx.port),
+                          GPIO_PIN_MASK(cfg->rx.pin));
+
+  /* Disable any pull ups or the like */
+  ioc_set_over(cfg->clk.port, cfg->clk.pin, IOC_OVERRIDE_DIS);
+  ioc_set_over(cfg->tx.port, cfg->tx.pin, IOC_OVERRIDE_DIS);
+  ioc_set_over(cfg->rx.port, cfg->rx.pin, IOC_OVERRIDE_DIS);
+
+  /* Configure the clock */
+  REG(cfg->base + SSI_CPSR) = 2;
+
+  /*
+   * Configure the default SPI options.
+   *   mode:  Motorola frame format
+   *   clock: High when idle
+   *   data:  Valid on rising edges of the clock
+   *   bits:  8 byte data
+   */
+  REG(cfg->base + SSI_CR0) = SSI_CR0_SPH | SSI_CR0_SPO | (0x07);
+
+  /* Enable the SSI */
+  REG(cfg->base + SSI_CR1) |= SSI_CR1_SSE;
 }
 /*---------------------------------------------------------------------------*/
 void
 spix_enable(uint8_t instance)
 {
-	if (instance >= SSI_INSTANCE_COUNT) {
-		return;
-	}
+  if(instance >= SSI_INSTANCE_COUNT) {
+    return;
+  }
 
-	/* Enable the clock for the SSI peripheral */
-	if (instance == 0) {
-		/* Enable the clock for the SSI peripheral */
-		REG(SYS_CTRL_RCGCSSI) |= 1;
-	} else {
-		REG(SYS_CTRL_RCGCSSI) |= 2;
-	}
+  /* Enable the clock for the SSI peripheral */
+  if(instance == 0) {
+    /* Enable the clock for the SSI peripheral */
+    REG(SYS_CTRL_RCGCSSI) |= 1;
+  } else {
+    REG(SYS_CTRL_RCGCSSI) |= 2;
+  }
 }
 /*---------------------------------------------------------------------------*/
 void
 spix_disable(uint8_t instance)
 {
-	if (instance >= SSI_INSTANCE_COUNT) {
-		return;
-	}
+  if(instance >= SSI_INSTANCE_COUNT) {
+    return;
+  }
 
-	/* Gate the clock for the SSI peripheral */
-	if (instance == 0) {
-		REG(SYS_CTRL_RCGCSSI) &= ~1;
-	} else {
-		REG(SYS_CTRL_RCGCSSI) &= ~2;
-	}
+  /* Gate the clock for the SSI peripheral */
+  if(instance == 0) {
+    REG(SYS_CTRL_RCGCSSI) &= ~1;
+  } else {
+    REG(SYS_CTRL_RCGCSSI) &= ~2;
+  }
 }
 /*---------------------------------------------------------------------------*/
-void spix_set_mode(uint8_t instance,
-				   uint32_t frame_format, 
-				   uint32_t clock_polarity, 
-				   uint32_t clock_phase, 
-				   uint32_t data_size)
+void
+spix_set_mode(uint8_t instance,
+              uint32_t frame_format,
+              uint32_t clock_polarity,
+              uint32_t clock_phase,
+              uint32_t data_size)
 {
-	const spi_cfg_t *cfg; 
-	
-	if (instance >= SSI_INSTANCE_COUNT) {
-		return;
-	}
+  const spi_cfg_t *cfg;
 
-	cfg = &spi_cfg[instance];
+  if(instance >= SSI_INSTANCE_COUNT) {
+    return;
+  }
 
-	/* Disable the SSI peripheral to configure it */
-	REG(cfg->base + SSI_CR1) = 0;
+  cfg = &spi_cfg[instance];
 
-	/* Configure the SSI options */
-	REG(cfg->base + SSI_CR0) = clock_phase | 
-		clock_polarity | 
-		frame_format | 
-		(data_size - 1);
+  /* Disable the SSI peripheral to configure it */
+  REG(cfg->base + SSI_CR1) = 0;
 
-	/* Re-enable the SSI */
-	REG(cfg->base + SSI_CR1) |= SSI_CR1_SSE;
+  /* Configure the SSI options */
+  REG(cfg->base + SSI_CR0) = clock_phase |
+    clock_polarity |
+    frame_format |
+    (data_size - 1);
+
+  /* Re-enable the SSI */
+  REG(cfg->base + SSI_CR1) |= SSI_CR1_SSE;
 }
 /*---------------------------------------------------------------------------*/
-void spix_cs_init(uint8_t port, uint8_t pin)
+void
+spix_cs_init(uint8_t port, uint8_t pin)
 {
-  GPIO_SOFTWARE_CONTROL(GPIO_PORT_TO_BASE(port), 
-						GPIO_PIN_MASK(pin));
+  GPIO_SOFTWARE_CONTROL(GPIO_PORT_TO_BASE(port),
+                        GPIO_PIN_MASK(pin));
   ioc_set_over(port, pin, IOC_OVERRIDE_DIS);
   GPIO_SET_OUTPUT(GPIO_PORT_TO_BASE(port), GPIO_PIN_MASK(pin));
   GPIO_SET_PIN(GPIO_PORT_TO_BASE(port), GPIO_PIN_MASK(pin));
 }
-
 /** @} */

--- a/cpu/cc2538/dev/spi.c
+++ b/cpu/cc2538/dev/spi.c
@@ -42,30 +42,78 @@
 #include "dev/ssi.h"
 #include "dev/gpio.h"
 
-#define SPI_CLK_PORT_BASE        GPIO_PORT_TO_BASE(SPI_CLK_PORT)
-#define SPI_CLK_PIN_MASK         GPIO_PIN_MASK(SPI_CLK_PIN)
-#define SPI_MOSI_PORT_BASE       GPIO_PORT_TO_BASE(SPI_MOSI_PORT)
-#define SPI_MOSI_PIN_MASK        GPIO_PIN_MASK(SPI_MOSI_PIN)
-#define SPI_MISO_PORT_BASE       GPIO_PORT_TO_BASE(SPI_MISO_PORT)
-#define SPI_MISO_PIN_MASK        GPIO_PIN_MASK(SPI_MISO_PIN)
+#if defined(SPI_CLK_PORT) && defined(SPI_CLK_PIN) && \
+	defined(SPI_MISO_PORT) && defined(SPI_MISO_PIN) && \
+	defined(SPI_MOSI_PORT) && defined(SPI_MOSI_PIN)
 
+/* For compatibility reasons */
+#define spi_init()						spi0_init()	
+#define spi_cs_init(port, pin)			spi0_cs_init(port, pin)	
+#define spi_enable()					spi0_enable()	
+#define spi_disable()					spi0_disable()	
+#define spi_set_mode(fr, po, ph, sz)	spi0_set_mode(fr,po,ph,sz)	
+
+#define USE_SPI0						1
+
+#define SPI0_CLK_PORT					SPI_CLK_PORT	
+#define SPI0_CLK_PIN					SPI_CLK_PIN	
+#define SPI0_MOSI_PORT					SPI_MOSI_PORT
+#define SPI0_MOSI_PIN					SPI_MOSI_PIN
+#define SPI0_MISO_PORT					SPI_MISO_PORT
+#define SPI0_MISO_PIN					SPI_MISO_PIN
+
+#elif defined(SPI0_CLK_PORT) && defined(SPI0_CLK_PIN) && \
+	defined(SPI0_MISO_PORT) && defined(SPI0_MISO_PIN) && \
+	defined(SPI0_MOSI_PORT) && 	defined(SPI0_MOSI_PIN)
+
+#define USE_SPI0						1
+
+#endif	/* #if SPI0 port / pins defined */
+
+#if USE_SPI0
+
+#define SPI0_CLK_PORT_BASE				GPIO_PORT_TO_BASE(SPI0_CLK_PORT)
+#define SPI0_CLK_PIN_MASK				GPIO_PIN_MASK(SPI0_CLK_PIN)
+#define SPI0_MOSI_PORT_BASE				GPIO_PORT_TO_BASE(SPI0_MOSI_PORT)
+#define SPI0_MOSI_PIN_MASK				GPIO_PIN_MASK(SPI0_MOSI_PIN)
+#define SPI0_MISO_PORT_BASE				GPIO_PORT_TO_BASE(SPI0_MISO_PORT)
+#define SPI0_MISO_PIN_MASK				GPIO_PIN_MASK(SPI0_MISO_PIN)
+
+#endif	/* #if USE_SPI0 */
+
+#if defined(SPI1_CLK_PORT) && defined(SPI1_CLK_PIN) && \
+	defined(SPI1_MISO_PORT) && defined(SPI1_MISO_PIN) && \
+	defined(SPI1_MOSI_PORT) && 	defined(SPI1_MOSI_PIN) 
+
+#define USE_SPI1						1
+#define SPI1_CLK_PORT_BASE				GPIO_PORT_TO_BASE(SPI1_CLK_PORT)
+#define SPI1_CLK_PIN_MASK				GPIO_PIN_MASK(SPI1_CLK_PIN)
+#define SPI1_MOSI_PORT_BASE				GPIO_PORT_TO_BASE(SPI1_MOSI_PORT)
+#define SPI1_MOSI_PIN_MASK				GPIO_PIN_MASK(SPI1_MOSI_PIN)
+#define SPI1_MISO_PORT_BASE				GPIO_PORT_TO_BASE(SPI1_MISO_PORT)
+#define SPI1_MISO_PIN_MASK				GPIO_PIN_MASK(SPI1_MISO_PIN)
+
+#endif	/* #if SPI1 port / pins defined */
+
+/*---------------------------------------------------------------------------*/
 /**
- * \brief Initialize the SPI bus.
+ * \brief Initialize the SPI bus for SSI0
  *
  * This SPI init() function uses the following defines to set the pins:
- *    SPI_CLK_PORT               SPI_CLK_PIN
- *    SPI_MOSI_PORT              SPI_MOSI_PIN
- *    SPI_MISO_PORT              SPI_MISO_PIN
+ *    SPI0_CLK_PORT               SPI0_CLK_PIN
+ *    SPI0_MOSI_PORT              SPI0_MOSI_PIN
+ *    SPI0_MISO_PORT              SPI0_MISO_PIN
  *
  * This sets the mode to Motorola SPI with the following format options:
  *    Clock phase:               1; data captured on second (rising) edge
  *    Clock polarity:            1; clock is high when idle
  *    Data size:                 8 bits
  */
+#if USE_SPI0
 void
-spi_init(void)
+spi0_init(void)
 {
-  spi_enable();
+  spi0_enable();
 
   /* Start by disabling the peripheral before configuring it */
   REG(SSI0_BASE + SSI_CR1) = 0;
@@ -74,19 +122,19 @@ spi_init(void)
   REG(SSI0_BASE + SSI_CC) = 1;
 
   /* Set the mux correctly to connect the SSI pins to the correct GPIO pins */
-  ioc_set_sel(SPI_CLK_PORT, SPI_CLK_PIN, IOC_PXX_SEL_SSI0_CLKOUT);
-  ioc_set_sel(SPI_MOSI_PORT, SPI_MOSI_PIN, IOC_PXX_SEL_SSI0_TXD);
-  REG(IOC_SSIRXD_SSI0) = (SPI_MISO_PORT * 8) + SPI_MISO_PIN;
+  ioc_set_sel(SPI0_CLK_PORT, SPI0_CLK_PIN, IOC_PXX_SEL_SSI0_CLKOUT);
+  ioc_set_sel(SPI0_MOSI_PORT, SPI0_MOSI_PIN, IOC_PXX_SEL_SSI0_TXD);
+  REG(IOC_SSIRXD_SSI0) = (SPI0_MISO_PORT * 8) + SPI0_MISO_PIN;
 
   /* Put all the SSI gpios into peripheral mode */
-  GPIO_PERIPHERAL_CONTROL(SPI_CLK_PORT_BASE, SPI_CLK_PIN_MASK);
-  GPIO_PERIPHERAL_CONTROL(SPI_MOSI_PORT_BASE, SPI_MOSI_PIN_MASK);
-  GPIO_PERIPHERAL_CONTROL(SPI_MISO_PORT_BASE, SPI_MISO_PIN_MASK);
+  GPIO_PERIPHERAL_CONTROL(SPI0_CLK_PORT_BASE, SPI0_CLK_PIN_MASK);
+  GPIO_PERIPHERAL_CONTROL(SPI0_MOSI_PORT_BASE, SPI0_MOSI_PIN_MASK);
+  GPIO_PERIPHERAL_CONTROL(SPI0_MISO_PORT_BASE, SPI0_MISO_PIN_MASK);
 
   /* Disable any pull ups or the like */
-  ioc_set_over(SPI_CLK_PORT, SPI_CLK_PIN, IOC_OVERRIDE_DIS);
-  ioc_set_over(SPI_MOSI_PORT, SPI_MOSI_PIN, IOC_OVERRIDE_DIS);
-  ioc_set_over(SPI_MISO_PORT, SPI_MISO_PIN, IOC_OVERRIDE_DIS);
+  ioc_set_over(SPI0_CLK_PORT, SPI0_CLK_PIN, IOC_OVERRIDE_DIS);
+  ioc_set_over(SPI0_MOSI_PORT, SPI0_MOSI_PIN, IOC_OVERRIDE_DIS);
+  ioc_set_over(SPI0_MISO_PORT, SPI0_MISO_PIN, IOC_OVERRIDE_DIS);
 
   /* Configure the clock */
   REG(SSI0_BASE + SSI_CPSR) = 2;
@@ -102,41 +150,159 @@ spi_init(void)
   /* Enable the SSI */
   REG(SSI0_BASE + SSI_CR1) |= SSI_CR1_SSE;
 }
+#endif	/* #if USE_SPI0 */
 /*---------------------------------------------------------------------------*/
+/**
+ * \brief Initialize the SPI bus for SSI1
+ *
+ * This SPI init() function uses the following defines to set the pins:
+ *    SPI1_CLK_PORT               SPI1_CLK_PIN
+ *    SPI1_MOSI_PORT              SPI1_MOSI_PIN
+ *    SPI1_MISO_PORT              SPI1_MISO_PIN
+ *
+ * This sets the mode to Motorola SPI with the following format options:
+ *    Clock phase:               1; data captured on second (rising) edge
+ *    Clock polarity:            1; clock is high when idle
+ *    Data size:                 8 bits
+ */
+#if USE_SPI1
 void
-spi_cs_init(uint8_t port, uint8_t pin)
+spi1_init(void)
+{
+  spi1_enable();
+
+  /* Start by disabling the peripheral before configuring it */
+  REG(SSI1_BASE + SSI_CR1) = 0;
+
+  /* Set the IO clock as the SSI clock */
+  REG(SSI1_BASE + SSI_CC) = 1;
+
+  /* Set the mux correctly to connect the SSI pins to the correct GPIO pins */
+  ioc_set_sel(SPI1_CLK_PORT, SPI1_CLK_PIN, IOC_PXX_SEL_SSI1_CLKOUT);
+  ioc_set_sel(SPI1_MOSI_PORT, SPI1_MOSI_PIN, IOC_PXX_SEL_SSI1_TXD);
+  REG(IOC_SSIRXD_SSI1) = (SPI1_MISO_PORT * 8) + SPI1_MISO_PIN;
+
+  /* Put all the SSI gpios into peripheral mode */
+  GPIO_PERIPHERAL_CONTROL(SPI1_CLK_PORT_BASE, SPI1_CLK_PIN_MASK);
+  GPIO_PERIPHERAL_CONTROL(SPI1_MOSI_PORT_BASE, SPI1_MOSI_PIN_MASK);
+  GPIO_PERIPHERAL_CONTROL(SPI1_MISO_PORT_BASE, SPI1_MISO_PIN_MASK);
+
+  /* Disable any pull ups or the like */
+  ioc_set_over(SPI1_CLK_PORT, SPI1_CLK_PIN, IOC_OVERRIDE_DIS);
+  ioc_set_over(SPI1_MOSI_PORT, SPI1_MOSI_PIN, IOC_OVERRIDE_DIS);
+  ioc_set_over(SPI1_MISO_PORT, SPI1_MISO_PIN, IOC_OVERRIDE_DIS);
+
+  /* Configure the clock */
+  REG(SSI1_BASE + SSI_CPSR) = 2;
+
+  /* Configure the default SPI options.
+   *   mode:  Motorola frame format
+   *   clock: High when idle
+   *   data:  Valid on rising edges of the clock
+   *   bits:  8 byte data
+   */
+  REG(SSI1_BASE + SSI_CR0) = SSI_CR0_SPH | SSI_CR0_SPO | (0x07);
+
+  /* Enable the SSI */
+  REG(SSI1_BASE + SSI_CR1) |= SSI_CR1_SSE;
+}
+#endif	/* #if USE_SPI1 */
+/*---------------------------------------------------------------------------*/
+#if USE_SPI0
+void
+spi0_cs_init(uint8_t port, uint8_t pin)
 {
   GPIO_SOFTWARE_CONTROL(GPIO_PORT_TO_BASE(port), GPIO_PIN_MASK(pin));
   ioc_set_over(port, pin, IOC_OVERRIDE_DIS);
   GPIO_SET_OUTPUT(GPIO_PORT_TO_BASE(port), GPIO_PIN_MASK(pin));
   GPIO_SET_PIN(GPIO_PORT_TO_BASE(port), GPIO_PIN_MASK(pin));
 }
+#endif	/* #if USE_SPI0 */
 /*---------------------------------------------------------------------------*/
+#if USE_SPI1
 void
-spi_enable(void)
+spi1_cs_init(uint8_t port, uint8_t pin)
+{
+  GPIO_SOFTWARE_CONTROL(GPIO_PORT_TO_BASE(port), GPIO_PIN_MASK(pin));
+  ioc_set_over(port, pin, IOC_OVERRIDE_DIS);
+  GPIO_SET_OUTPUT(GPIO_PORT_TO_BASE(port), GPIO_PIN_MASK(pin));
+  GPIO_SET_PIN(GPIO_PORT_TO_BASE(port), GPIO_PIN_MASK(pin));
+}
+#endif	/* #if USE_SPI1 */
+/*---------------------------------------------------------------------------*/
+#if USE_SPI0
+void
+spi0_enable(void)
 {
   /* Enable the clock for the SSI peripheral */
   REG(SYS_CTRL_RCGCSSI) |= 1;
 }
+#endif	/* #if USE_SPI0 */
 /*---------------------------------------------------------------------------*/
+#if USE_SPI1
 void
-spi_disable(void)
+spi1_enable(void)
+{
+  /* Enable the clock for the SSI peripheral */
+  REG(SYS_CTRL_RCGCSSI) |= 2;
+}
+#endif	/* #if USE_SPI1 */
+/*---------------------------------------------------------------------------*/
+#if USE_SPI0
+void
+spi0_disable(void)
 {
   /* Gate the clock for the SSI peripheral */
   REG(SYS_CTRL_RCGCSSI) &= ~1;
 }
+#endif	/* #if USE_SPI0 */
 /*---------------------------------------------------------------------------*/
+#if USE_SPI1
 void
-spi_set_mode(uint32_t frame_format, uint32_t clock_polarity,
-             uint32_t clock_phase, uint32_t data_size)
+spi1_disable(void)
+{
+  /* Gate the clock for the SSI peripheral */
+  REG(SYS_CTRL_RCGCSSI) &= ~2;
+}
+#endif	/* #if USE_SPI1 */
+/*---------------------------------------------------------------------------*/
+#if USE_SPI0
+void spi0_set_mode(uint32_t frame_format, 
+				   uint32_t clock_polarity, 
+				   uint32_t clock_phase, 
+				   uint32_t data_size)
 {
   /* Disable the SSI peripheral to configure it */
   REG(SSI0_BASE + SSI_CR1) = 0;
 
   /* Configure the SSI options */
-  REG(SSI0_BASE + SSI_CR0) = clock_phase | clock_polarity | frame_format | (data_size - 1);
+  REG(SSI0_BASE + SSI_CR0) = clock_phase | 
+	  clock_polarity | 
+	  frame_format | 
+	  (data_size - 1);
 
   /* Re-enable the SSI */
   REG(SSI0_BASE + SSI_CR1) |= SSI_CR1_SSE;
 }
+#endif	/* #if USE_SPI0 */
+/*---------------------------------------------------------------------------*/
+#if USE_SPI1
+void spi1_set_mode(uint32_t frame_format, 
+				   uint32_t clock_polarity, 
+				   uint32_t clock_phase, 
+				   uint32_t data_size)
+{
+  /* Disable the SSI peripheral to configure it */
+  REG(SSI1_BASE + SSI_CR1) = 0;
+
+  /* Configure the SSI options */
+  REG(SSI1_BASE + SSI_CR0) = clock_phase | 
+	  clock_polarity | 
+	  frame_format | 
+	  (data_size - 1);
+
+  /* Re-enable the SSI */
+  REG(SSI1_BASE + SSI_CR1) |= SSI_CR1_SSE;
+}
+#endif	/* #if USE_SPI1 */
 /** @} */

--- a/cpu/cc2538/dev/spi.c
+++ b/cpu/cc2538/dev/spi.c
@@ -182,12 +182,14 @@ static const spi_regs_t spi_regs[SSI_INSTANCE_COUNT] = {
   }
 };
 /*---------------------------------------------------------------------------*/
-/* Deprecated function calls provided for compatibility reasons */
+/* Deprecated function call provided for compatibility reasons */
+#ifdef SPI_DEFAULT_INSTANCE
 void
 spi_init(void)
 {
   spix_init(SPI_DEFAULT_INSTANCE);
 }
+#endif	/* #ifdef SPI_DEFAULT_INSTANCE */
 /*---------------------------------------------------------------------------*/
 void
 spix_init(uint8_t spi)

--- a/cpu/cc2538/dev/spi.c
+++ b/cpu/cc2538/dev/spi.c
@@ -1,5 +1,9 @@
 /*
  * Copyright (c) 2013, University of Michigan.
+ *
+ * Copyright (c) 2015, Weptech elektronik GmbH
+ * Author: Ulf Knoblich, ulf.knoblich@weptech.de
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -42,141 +46,106 @@
 #include "dev/ssi.h"
 #include "dev/gpio.h"
 /*---------------------------------------------------------------------------*/
-/* Map the old port / pin names to the new ones for compatibility reasons */
-#if (SPI_DEFAULT_INSTANCE == 0)
-#ifdef SPI_CLK_PORT
-#define SPI0_CLK_PORT         SPI_CLK_PORT
-#endif
-#ifdef SPI_CLK_PIN
-#define SPI0_CLK_PIN          SPI_CLK_PIN
-#endif
-#ifdef SPI_MOSI_PORT
-#define SPI0_TX_PORT          SPI_MOSI_PORT
-#endif
-#ifdef SPI_MOSI_PIN
-#define SPI0_TX_PIN           SPI_MOSI_PIN
-#endif
-#ifdef SPI_MISO_PORT
-#define SPI0_RX_PORT          SPI_MISO_PORT
-#endif
-#ifdef SPI_MISO_PIN
-#define SPI0_RX_PIN           SPI_MISO_PIN
-#endif
-#elif (SPI_DEFAULT_INSTANCE == 1)
-#ifdef SPI_CLK_PORT
-#define SPI1_CLK_PORT         SPI_CLK_PORT
-#endif
-#ifdef SPI_CLK_PIN
-#define SPI1_CLK_PIN          SPI_CLK_PIN
-#endif
-#ifdef SPI_MOSI_PORT
-#define SPI1_TX_PORT          SPI_MOSI_PORT
-#endif
-#ifdef SPI_MOSI_PIN
-#define SPI1_TX_PIN           SPI_MOSI_PIN
-#endif
-#ifdef SPI_MISO_PORT
-#define SPI1_RX_PORT          SPI_MISO_PORT
-#endif
-#ifdef SPI_MISO_PIN
-#define SPI1_RX_PIN           SPI_MISO_PIN
-#endif
-#else
-#error "Invalid SPI instance. Valid values are 0 or 1"
-#endif
-/*---------------------------------------------------------------------------*/
 /* Check port / pin settings for SPI0 and provide default values for spi_cfg */
 #ifndef SPI0_CLK_PORT
-#define SPI0_CLK_PORT         (-1)
+#define SPI0_CLK_PORT					(-1)
 #endif
 #ifndef SPI0_CLK_PIN
-#define SPI0_CLK_PIN          (-1)
+#define SPI0_CLK_PIN					(-1)
 #endif
 #if SPI0_CLK_PORT >= 0 && SPI0_CLK_PIN < 0 || \
   SPI0_CLK_PORT < 0 && SPI0_CLK_PIN >= 0
-#error "Both SPI0_CLK_PORT and SPI0_CLK_PIN must be valid or invalid"
+#error Both SPI0_CLK_PORT and SPI0_CLK_PIN must be valid or invalid
 #endif
 
 #ifndef SPI0_TX_PORT
-#define SPI0_TX_PORT          (-1)
+#define SPI0_TX_PORT					(-1)
 #endif
 #ifndef SPI0_TX_PIN
-#define SPI0_TX_PIN           (-1)
+#define SPI0_TX_PIN						(-1)
 #endif
 #if SPI0_TX_PORT >= 0 && SPI0_TX_PIN < 0 || \
   SPI0_TX_PORT < 0 && SPI0_TX_PIN >= 0
-#error "Both SPI0_TX_PORT and SPI0_TX_PIN must be valid or invalid"
+#error Both SPI0_TX_PORT and SPI0_TX_PIN must be valid or invalid
 #endif
 
 #ifndef SPI0_RX_PORT
-#define SPI0_RX_PORT          (-1)
+#define SPI0_RX_PORT					(-1)
 #endif
 #ifndef SPI0_RX_PIN
-#define SPI0_RX_PIN           (-1)
+#define SPI0_RX_PIN						(-1)
 #endif
 #if SPI0_RX_PORT >= 0 && SPI0_RX_PIN < 0 || \
   SPI0_RX_PORT < 0 && SPI0_RX_PIN >= 0
-#error "Both SPI0_RX_PORT and SPI0_RX_PIN must be valid or invalid"
+#error Both SPI0_RX_PORT and SPI0_RX_PIN must be valid or invalid
 #endif
 
 /* Here we check that either all or none of the ports are defined. As
    we did already check that both ports + pins are either defined or
    not for every pin, this means that we can check for an incomplete
    configuration by only looking at the port defines */
-#if (SPI0_CLK_PORT < 0 && SPI0_TX_PORT < 0 && SPI0_RX_PORT >= 0) || \
-  (SPI0_CLK_PORT < 0 && SPI0_TX_PORT >= 0 && SPI0_RX_PORT < 0) || \
-  (SPI0_CLK_PORT < 0 && SPI0_TX_PORT >= 0 && SPI0_RX_PORT >= 0) || \
-  (SPI0_CLK_PORT >= 0 && SPI0_TX_PORT < 0 && SPI0_RX_PORT < 0) || \
-  (SPI0_CLK_PORT >= 0 && SPI0_TX_PORT < 0 && SPI0_RX_PORT >= 0) || \
-  (SPI0_CLK_PORT >= 0 && SPI0_TX_PORT >= 0 && SPI0_RX_PORT < 0)
-#error "SPI0 port / pin definition incomplete"
+/* If some SPI0 pads are valid */
+#if SPI0_CLK_PORT >= 0 || SPI0_TX_PORT >= 0 || SPI0_RX_PORT >= 0
+/* but not all */
+#if SPI0_CLK_PORT < 0 || SPI0_TX_PORT < 0 || SPI0_RX_PORT < 0
+#error Some SPI0 pad definitions are invalid
+#endif
+#define SPI0_PADS_VALID
 #endif
 /*---------------------------------------------------------------------------*/
 /* Check port / pin settings for SPI1 and provide default values for spi_cfg */
 #ifndef SPI1_CLK_PORT
-#define SPI1_CLK_PORT         (-1)
+#define SPI1_CLK_PORT					(-1)
 #endif
 #ifndef SPI1_CLK_PIN
-#define SPI1_CLK_PIN          (-1)
+#define SPI1_CLK_PIN					(-1)
 #endif
 #if SPI1_CLK_PORT >= 0 && SPI1_CLK_PIN < 0 || \
   SPI1_CLK_PORT < 0 && SPI1_CLK_PIN >= 0
-#error "Both SPI1_CLK_PORT and SPI1_CLK_PIN must be valid or invalid"
+#error Both SPI1_CLK_PORT and SPI1_CLK_PIN must be valid or invalid
 #endif
 
 #ifndef SPI1_TX_PORT
-#define SPI1_TX_PORT          (-1)
+#define SPI1_TX_PORT					(-1)
 #endif
 #ifndef SPI1_TX_PIN
-#define SPI1_TX_PIN             (-1)
+#define SPI1_TX_PIN						(-1)
 #endif
 #if SPI1_TX_PORT >= 0 && SPI1_TX_PIN < 0 || \
   SPI1_TX_PORT < 0 && SPI1_TX_PIN >= 0
-#error "Both SPI1_TX_PORT and SPI1_TX_PIN must be valid or invalid"
+#error Both SPI1_TX_PORT and SPI1_TX_PIN must be valid or invalid
 #endif
 
 #ifndef SPI1_RX_PORT
-#define SPI1_RX_PORT            (-1)
+#define SPI1_RX_PORT					(-1)
 #endif
 #ifndef SPI1_RX_PIN
-#define SPI1_RX_PIN             (-1)
+#define SPI1_RX_PIN						(-1)
 #endif
 #if SPI1_RX_PORT >= 0 && SPI1_RX_PIN < 0 || \
   SPI1_RX_PORT < 0 && SPI1_RX_PIN >= 0
-#error "Both SPI1_RX_PORT and SPI1_RX_PIN must be valid or invalid"
+#error Both SPI1_RX_PORT and SPI1_RX_PIN must be valid or invalid
 #endif
 
-/* Here we check that either all or none of the ports are defined. As
-   we did already check that both ports + pins are either defined or
-   not for every pin, this means that we can check for an incomplete
-   configuration by only looking at the port defines */
-#if (SPI1_CLK_PORT < 0 && SPI1_TX_PORT < 0 && SPI1_RX_PORT >= 0) || \
-  (SPI1_CLK_PORT < 0 && SPI1_TX_PORT >= 0 && SPI1_RX_PORT < 0) || \
-  (SPI1_CLK_PORT < 0 && SPI1_TX_PORT >= 0 && SPI1_RX_PORT >= 0) || \
-  (SPI1_CLK_PORT >= 0 && SPI1_TX_PORT < 0 && SPI1_RX_PORT < 0) || \
-  (SPI1_CLK_PORT >= 0 && SPI1_TX_PORT < 0 && SPI1_RX_PORT >= 0) || \
-  (SPI1_CLK_PORT >= 0 && SPI1_TX_PORT >= 0 && SPI1_RX_PORT < 0)
-#error "SPI1 port / pin definition incomplete"
+/* If some SPI1 pads are valid */
+#if SPI1_CLK_PORT >= 0 || SPI1_TX_PORT >= 0 || SPI1_RX_PORT >= 0
+/* but not all */
+#if SPI1_CLK_PORT < 0 || SPI1_TX_PORT < 0 || SPI1_RX_PORT < 0
+#error Some SPI1 pad definitions are invalid
+#endif
+#define SPI1_PADS_VALID
+#endif
+
+#ifdef SPI_DEFAULT_INSTANCE
+#if SPI_DEFAULT_INSTANCE == 0
+#ifndef SPI0_PADS_VALID
+#error SPI_DEFAULT_INSTANCE is set to SPI0, but its pads are not valid
+#endif
+#elif SPI_DEFAULT_INSTANCE == 1
+#ifndef SPI1_PADS_VALID
+#error SPI_DEFAULT_INSTANCE is set to SPI1, but its pads are not valid
+#endif
+#endif
 #endif
 /*---------------------------------------------------------------------------*/
 typedef struct {
@@ -191,9 +160,9 @@ typedef struct {
   spi_pad_t clk;
   spi_pad_t tx;
   spi_pad_t rx;
-} spi_cfg_t;
+} spi_regs_t;
 /*---------------------------------------------------------------------------*/
-static const spi_cfg_t spi_cfg[SSI_INSTANCE_COUNT] = {
+static const spi_regs_t spi_regs[SSI_INSTANCE_COUNT] = {
   {
     .base = SSI0_BASE,
     .ioc_ssirxd_ssi = IOC_SSIRXD_SSI0,
@@ -219,79 +188,57 @@ spi_init(void)
 {
   spix_init(SPI_DEFAULT_INSTANCE);
 }
-void
-spi_enable(void)
-{
-  spix_enable(SPI_DEFAULT_INSTANCE);
-}
-void
-spi_disable(void)
-{
-  spix_disable(SPI_DEFAULT_INSTANCE);
-}
-void
-spi_set_mode(uint32_t frame_format, uint32_t clock_polarity,
-             uint32_t clock_phase, uint32_t data_size)
-{
-  spix_set_mode(SPI_DEFAULT_INSTANCE, frame_format, clock_polarity,
-                clock_phase, data_size);
-}
-void
-spi_cs_init(uint8_t port, uint8_t pin)
-{
-  spix_cs_init(port, pin);
-}
 /*---------------------------------------------------------------------------*/
 void
-spix_init(uint8_t instance)
+spix_init(uint8_t spi)
 {
-  const spi_cfg_t *cfg;
+  const spi_regs_t *regs;
 
-  if(instance >= SSI_INSTANCE_COUNT) {
+  if(spi >= SSI_INSTANCE_COUNT) {
     return;
   }
 
-  spix_enable(instance);
+  regs = &spi_regs[spi];
 
-  cfg = &spi_cfg[instance];
-
-  if(cfg->clk.port < 0) {
+  if(regs->clk.port < 0) {
     /* Port / pin configuration invalid. We checked for completeness
        above. If clk.port is < 0, this means that all other defines are
        < 0 as well */
     return;
   }
 
+  spix_enable(spi);
+
   /* Start by disabling the peripheral before configuring it */
-  REG(cfg->base + SSI_CR1) = 0;
+  REG(regs->base + SSI_CR1) = 0;
 
   /* Set the IO clock as the SSI clock */
-  REG(cfg->base + SSI_CC) = 1;
+  REG(regs->base + SSI_CC) = 1;
 
   /* Set the mux correctly to connect the SSI pins to the correct GPIO pins */
-  ioc_set_sel(cfg->clk.port,
-              cfg->clk.pin,
-              cfg->ioc_pxx_sel_ssi_clkout);
-  ioc_set_sel(cfg->tx.port,
-              cfg->tx.pin,
-              cfg->ioc_pxx_sel_ssi_txd);
-  REG(cfg->ioc_ssirxd_ssi) = (cfg->rx.port * 8) + cfg->rx.pin;
+  ioc_set_sel(regs->clk.port,
+              regs->clk.pin,
+              regs->ioc_pxx_sel_ssi_clkout);
+  ioc_set_sel(regs->tx.port,
+              regs->tx.pin,
+              regs->ioc_pxx_sel_ssi_txd);
+  REG(regs->ioc_ssirxd_ssi) = (regs->rx.port * 8) + regs->rx.pin;
 
   /* Put all the SSI gpios into peripheral mode */
-  GPIO_PERIPHERAL_CONTROL(GPIO_PORT_TO_BASE(cfg->clk.port),
-                          GPIO_PIN_MASK(cfg->clk.pin));
-  GPIO_PERIPHERAL_CONTROL(GPIO_PORT_TO_BASE(cfg->tx.port),
-                          GPIO_PIN_MASK(cfg->tx.pin));
-  GPIO_PERIPHERAL_CONTROL(GPIO_PORT_TO_BASE(cfg->rx.port),
-                          GPIO_PIN_MASK(cfg->rx.pin));
+  GPIO_PERIPHERAL_CONTROL(GPIO_PORT_TO_BASE(regs->clk.port),
+                          GPIO_PIN_MASK(regs->clk.pin));
+  GPIO_PERIPHERAL_CONTROL(GPIO_PORT_TO_BASE(regs->tx.port),
+                          GPIO_PIN_MASK(regs->tx.pin));
+  GPIO_PERIPHERAL_CONTROL(GPIO_PORT_TO_BASE(regs->rx.port),
+                          GPIO_PIN_MASK(regs->rx.pin));
 
   /* Disable any pull ups or the like */
-  ioc_set_over(cfg->clk.port, cfg->clk.pin, IOC_OVERRIDE_DIS);
-  ioc_set_over(cfg->tx.port, cfg->tx.pin, IOC_OVERRIDE_DIS);
-  ioc_set_over(cfg->rx.port, cfg->rx.pin, IOC_OVERRIDE_DIS);
+  ioc_set_over(regs->clk.port, regs->clk.pin, IOC_OVERRIDE_DIS);
+  ioc_set_over(regs->tx.port, regs->tx.pin, IOC_OVERRIDE_DIS);
+  ioc_set_over(regs->rx.port, regs->rx.pin, IOC_OVERRIDE_DIS);
 
   /* Configure the clock */
-  REG(cfg->base + SSI_CPSR) = 2;
+  REG(regs->base + SSI_CPSR) = 2;
 
   /*
    * Configure the default SPI options.
@@ -300,69 +247,56 @@ spix_init(uint8_t instance)
    *   data:  Valid on rising edges of the clock
    *   bits:  8 byte data
    */
-  REG(cfg->base + SSI_CR0) = SSI_CR0_SPH | SSI_CR0_SPO | (0x07);
+  REG(regs->base + SSI_CR0) = SSI_CR0_SPH | SSI_CR0_SPO | (0x07);
 
   /* Enable the SSI */
-  REG(cfg->base + SSI_CR1) |= SSI_CR1_SSE;
+  REG(regs->base + SSI_CR1) |= SSI_CR1_SSE;
 }
 /*---------------------------------------------------------------------------*/
 void
-spix_enable(uint8_t instance)
+spix_enable(uint8_t spi)
 {
-  if(instance >= SSI_INSTANCE_COUNT) {
+  if(spi >= SSI_INSTANCE_COUNT) {
     return;
   }
-
-  /* Enable the clock for the SSI peripheral */
-  if(instance == 0) {
-    /* Enable the clock for the SSI peripheral */
-    REG(SYS_CTRL_RCGCSSI) |= 1;
-  } else {
-    REG(SYS_CTRL_RCGCSSI) |= 2;
-  }
+  REG(SYS_CTRL_RCGCSSI) |= (1 << spi);
 }
 /*---------------------------------------------------------------------------*/
 void
-spix_disable(uint8_t instance)
+spix_disable(uint8_t spi)
 {
-  if(instance >= SSI_INSTANCE_COUNT) {
+  if(spi >= SSI_INSTANCE_COUNT) {
     return;
   }
-
-  /* Gate the clock for the SSI peripheral */
-  if(instance == 0) {
-    REG(SYS_CTRL_RCGCSSI) &= ~1;
-  } else {
-    REG(SYS_CTRL_RCGCSSI) &= ~2;
-  }
+  REG(SYS_CTRL_RCGCSSI) &= ~(1 << spi);
 }
 /*---------------------------------------------------------------------------*/
 void
-spix_set_mode(uint8_t instance,
+spix_set_mode(uint8_t spi,
               uint32_t frame_format,
               uint32_t clock_polarity,
               uint32_t clock_phase,
               uint32_t data_size)
 {
-  const spi_cfg_t *cfg;
+  const spi_regs_t *regs;
 
-  if(instance >= SSI_INSTANCE_COUNT) {
+  if(spi >= SSI_INSTANCE_COUNT) {
     return;
   }
 
-  cfg = &spi_cfg[instance];
+  regs = &spi_regs[spi];
 
   /* Disable the SSI peripheral to configure it */
-  REG(cfg->base + SSI_CR1) = 0;
+  REG(regs->base + SSI_CR1) = 0;
 
   /* Configure the SSI options */
-  REG(cfg->base + SSI_CR0) = clock_phase |
+  REG(regs->base + SSI_CR0) = clock_phase |
     clock_polarity |
     frame_format |
     (data_size - 1);
 
   /* Re-enable the SSI */
-  REG(cfg->base + SSI_CR1) |= SSI_CR1_SSE;
+  REG(regs->base + SSI_CR1) |= SSI_CR1_SSE;
 }
 /*---------------------------------------------------------------------------*/
 void

--- a/cpu/cc2538/dev/ssi.h
+++ b/cpu/cc2538/dev/ssi.h
@@ -49,7 +49,7 @@
 /** \name Number of SSI instances supported by this CPU.
  * @{
  */
-#define SSI_INSTANCE_COUNT	2
+#define SSI_INSTANCE_COUNT  2
 /** @} */
 /*---------------------------------------------------------------------------*/
 /** \name Base register memory locations.

--- a/cpu/cc2538/dev/ssi.h
+++ b/cpu/cc2538/dev/ssi.h
@@ -46,6 +46,12 @@
 #define SSI_H_
 
 /*---------------------------------------------------------------------------*/
+/** \name Number of SSI instances supported by this CPU.
+ * @{
+ */
+#define SSI_INSTANCE_COUNT	2
+/** @} */
+/*---------------------------------------------------------------------------*/
 /** \name Base register memory locations.
  * @{
  */

--- a/cpu/cc2538/spi-arch.h
+++ b/cpu/cc2538/spi-arch.h
@@ -35,7 +35,7 @@
  * implementation of the low-level SPI primitives such as waiting for the TX
  * FIFO to be ready, inserting into the TX FIFO, etc.
  *
- * It supports the usage of SSI_NUM_INSTANCES instances by providing new 
+ * It supports the usage of SSI_NUM_INSTANCES instances by providing new
  * functions calls like
  *
  * - spix_init(uint8_t instance)
@@ -44,15 +44,13 @@
  * - spix_set_mode(unit8_t instance, ...)
  *
  * and new macros like
- * 
+ *
  * - SPIX_WAITFORTxREADY(x)
- * - SPIX_TXBUF(x)
- * - SPIX_RXBUF(x)
  * - SPIX_WAITFOREOTx(x)
  * - SPIX_WAITFOREORx(x)
  * - SPIX_FLUSH(x)
  *
- * The old functions "spi_foo()" and macros "SPI_FOO()" are still supported, 
+ * The old functions "spi_foo()" and macros "SPI_FOO()" are still supported,
  * by mapping them to new ones. When using these deprecated functions, the SSI
  * module to use can be selected by means of the macro SPI_DEFAULT_INSTANCE.
  *
@@ -82,86 +80,100 @@
 #include "dev/ssi.h"
 /*---------------------------------------------------------------------------*/
 /* The default SPI instance to use. You can configure either instance 0 or 1
-   and proceed to use the "old" function calls / macros */ 
+   and proceed to use the "old" function calls / macros */
 #ifdef SPI_CONF_DEFAULT_INSTANCE
-#define SPI_DEFAULT_INSTANCE			SPI_CONF_DEFAULT_INSTANCE
+#define SPI_DEFAULT_INSTANCE      SPI_CONF_DEFAULT_INSTANCE
 #else
-#define SPI_DEFAULT_INSTANCE			0
+#define SPI_DEFAULT_INSTANCE      0
 #endif
 /*---------------------------------------------------------------------------*/
-/* Deprecated function calls provided for compatibility reasons */
-#define spi_init()						spix_init(SPI_DEFAULT_INSTANCE)	
-#define spi_enable()					spix_enable(SPI_DEFAULT_INSTANCE)	
-#define spi_disable()					spix_disable(SPI_DEFAULT_INSTANCE)	
-#define spi_set_mode(ff, cpo, cph, ds)	spix_set_mode(SPI_DEFAULT_INSTANCE, ff, cpo, cph, ds)
-#define spi_cs_init(port, pin );		spix_cs_init(port, pin)	
-/*---------------------------------------------------------------------------*/
-/* We define a new set of "SPIX" macros which will then be mapped to the 
+/* We define a new set of "SPIX" macros which will then be mapped to the
    corresponding macros defined later on */
-#define SPIX_WAITFORTxREADY(x)			SPI##x##_WAITFORTxREADY()
-#define SPIX_TXBUF(x)					SPI##x##_TXBUF()
-#define SPIX_RXBUF(x)					SPI##x##_RXBUF()
-#define SPIX_WAITFOREOTx(x)				SPI##x##_WAIT_FOREOTx()
-#define SPIX_WAITFOREORx(x)				SPI##x##_WAITFOREORx()	
-#define SPIX_FLUSH(x)					SPI##x##_FLUSH()
+#define SPIX_WAITFORTxREADY(x)      SPI##x##_WAITFORTxREADY()
+#define SPIX_WAITFOREOTx(x)       SPI##x##_WAIT_FOREOTx()
+#define SPIX_WAITFOREORx(x)       SPI##x##_WAITFOREORx()
+#define SPIX_FLUSH(x)         SPI##x##_FLUSH()
 /*---------------------------------------------------------------------------*/
 /* Deprecated macros provided for compatibility reasons */
-#define SPI_WAITFORTxREADY()			SPIX_WAITFORTxREADY(SPI_DEFAULT_INSTANCE)	
-#define SPI_TXBUF						SPIX_TXBUF(SPI_DEFAULT_INSTANCE)
-#define SPI_RXBUF						SPIX_RXBUF(SPI_DEFAULT_INSTANCE)
-#define SPI_WAITFOREOTx()				SPIX_WAITFOREOTx(SPI_DEFAULT_INSTANCE)	
-#define SPI_WAITFOREORx()				SPIX_WAITFOREORx(SPI_DEFAULT_INSTANCE)	
+#if (SPI_DEFAULT_INSTANCE == 0)
+#define SPI_WAITFORTxREADY()      SPIX_WAITFORTxREADY(0)
+#define SPI_TXBUF           SPI0_TXBUF
+#define SPI_RXBUF           SPI0_RXBUF
+#define SPI_WAITFOREOTx()       SPIX_WAITFOREOTx(0)
+#define SPI_WAITFOREORx()       SPIX_WAITFOREORx(0)
 #ifdef SPI_FLUSH
 #error "You must include spi-arch.h before spi.h for the CC2538."
+#else
+#define SPI_FLUSH()           SPIX_FLUSH(0)
 #endif
-#define SPI_FLUSH()						SPIX_FLUSH(SPI_DEFAULT_INSTANCE)
+#elif (SPI_DEFAULT_INSTANCE == 1)
+#define SPI_WAITFORTxREADY()      SPIX_WAITFORTxREADY(1)
+#define SPI_TXBUF           SPI1_TXBUF
+#define SPI_RXBUF           SPI1_RXBUF
+#define SPI_WAITFOREOTx()       SPIX_WAITFOREOTx(1)
+#define SPI_WAITFOREORx()       SPIX_WAITFOREORx(1)
+#ifdef SPI_FLUSH
+#error "You must include spi-arch.h before spi.h for the CC2538."
+#else
+#define SPI_FLUSH()           SPIX_FLUSH(1)
 #endif
-#define SPI_CS_CLR(port, pin)			SPIX_CS_CLR(port, pin)	
-#define SPI_CS_SET(port, pin)			SPIX_CS_SET(port, pin)	
+#else
+#error "Invalid SPI instance. Valid values are 0 or 1"
+#endif
+
+#define SPI_CS_CLR(port, pin)     SPIX_CS_CLR(port, pin)
+#define SPI_CS_SET(port, pin)     SPIX_CS_SET(port, pin)
 /*---------------------------------------------------------------------------*/
 /* New API macros */
 #define SPI0_WAITFORTxREADY() do { \
-  while(!(REG(SSI0_BASE + SSI_SR) & SSI_SR_TNF)); \
+    while(!(REG(SSI0_BASE + SSI_SR) & SSI_SR_TNF)) ; \
 } while(0)
 #define SPI0_TXBUF REG(SSI0_BASE + SSI_DR)
 #define SPI0_RXBUF REG(SSI0_BASE + SSI_DR)
 #define SPI0_WAITFOREOTx() do { \
-  while(REG(SSI0_BASE + SSI_SR) & SSI_SR_BSY); \
+    while(REG(SSI0_BASE + SSI_SR) & SSI_SR_BSY) ; \
 } while(0)
 #define SPI0_WAITFOREORx() do { \
-  while(!(REG(SSI0_BASE + SSI_SR) & SSI_SR_RNE)); \
+    while(!(REG(SSI0_BASE + SSI_SR) & SSI_SR_RNE)) ; \
 } while(0)
 #define SPI0_FLUSH() do { \
-  SPI_WAITFOREORx(); \
-  while (REG(SSI0_BASE + SSI_SR) & SSI_SR_RNE) { \
-    SPI_RXBUF; \
-  } \
+    SPI_WAITFOREORx(); \
+    while(REG(SSI0_BASE + SSI_SR) & SSI_SR_RNE) { \
+      SPI_RXBUF; \
+    } \
 } while(0)
 
 #define SPI1_WAITFORTxREADY() do { \
-  while(!(REG(SSI1_BASE + SSI_SR) & SSI_SR_TNF)); \
+    while(!(REG(SSI1_BASE + SSI_SR) & SSI_SR_TNF)) ; \
 } while(0)
 #define SPI1_TXBUF REG(SSI1_BASE + SSI_DR)
 #define SPI1_RXBUF REG(SSI1_BASE + SSI_DR)
 #define SPI1_WAITFOREOTx() do { \
-  while(REG(SSI1_BASE + SSI_SR) & SSI_SR_BSY); \
+    while(REG(SSI1_BASE + SSI_SR) & SSI_SR_BSY) ; \
 } while(0)
 #define SPI1_WAITFOREORx() do { \
-  while(!(REG(SSI1_BASE + SSI_SR) & SSI_SR_RNE)); \
+    while(!(REG(SSI1_BASE + SSI_SR) & SSI_SR_RNE)) ; \
 } while(0)
 #define SPI1_FLUSH() do { \
-  SPI_WAITFOREORx(); \
-  while (REG(SSI1_BASE + SSI_SR) & SSI_SR_RNE) { \
-    SPI_RXBUF; \
-  } \
+    SPI_WAITFOREORx(); \
+    while(REG(SSI1_BASE + SSI_SR) & SSI_SR_RNE) { \
+      SPI_RXBUF; \
+    } \
 } while(0)
 
 #define SPIX_CS_CLR(port, pin) do { \
-  GPIO_CLR_PIN(GPIO_PORT_TO_BASE(port), GPIO_PIN_MASK(pin)); \
+    GPIO_CLR_PIN(GPIO_PORT_TO_BASE(port), GPIO_PIN_MASK(pin)); \
 } while(0)
 #define SPIX_CS_SET(port, pin) do { \
-  GPIO_SET_PIN(GPIO_PORT_TO_BASE(port), GPIO_PIN_MASK(pin)); \
+    GPIO_SET_PIN(GPIO_PORT_TO_BASE(port), GPIO_PIN_MASK(pin)); \
 } while(0)
+/*---------------------------------------------------------------------------*/
+/* Deprecated function calls provided for compatibility reasons */
+void spi_enable(void);
+void spi_disable(void);
+void spi_set_mode(uint32_t frame_format, uint32_t clock_polarity,
+                  uint32_t clock_phase, uint32_t data_size);
+void spi_cs_init(uint8_t port, uint8_t pin);
 /*---------------------------------------------------------------------------*/
 /** \name Arch-specific SPI functions
  * @{
@@ -179,12 +191,12 @@
  */
 void spix_init(uint8_t instance);
 
-/** 
- * \brief Enables the SPI peripheral 
+/**
+ * \brief Enables the SPI peripheral
  */
 void spix_enable(uint8_t instance);
 
-/** 
+/**
  * \brief Disables the SPI peripheral
  * \note Call this function to save power when the SPI is unused.
  */
@@ -209,13 +221,13 @@ void spix_disable(uint8_t instance);
  *                       between 4 and 16, inclusive.
  */
 /* New API */
-void spix_set_mode(uint8_t instance,
-				   uint32_t frame_format, uint32_t clock_polarity,
-				   uint32_t clock_phase, uint32_t data_size);
+void spix_set_mode(uint8_t instance, uint32_t frame_format,
+                   uint32_t clock_polarity, uint32_t clock_phase,
+                   uint32_t data_size);
 
 /**
  * \brief Configure a GPIO to be the chip select pin.
- * 
+ *
  * Even if this function does not depend on the SPI instance used, we rename
  * it to reflect the new naming convention.
  */

--- a/cpu/cc2538/spi-arch.h
+++ b/cpu/cc2538/spi-arch.h
@@ -34,43 +34,132 @@
  * Header file for the cc2538 SPI driver, including macros for the
  * implementation of the low-level SPI primitives such as waiting for the TX
  * FIFO to be ready, inserting into the TX FIFO, etc.
+ *
+ * It supports the usage of SSI_NUM_INSTANCES instances by providing new 
+ * functions calls like
+ *
+ * - spix_init(uint8_t instance)
+ * - spix_enable(uint8_t instance)
+ * - spix_disable(uint8_t instance)
+ * - spix_set_mode(unit8_t instance, ...)
+ *
+ * and new macros like
+ * 
+ * - SPIX_WAITFORTxREADY(x)
+ * - SPIX_TXBUF(x)
+ * - SPIX_RXBUF(x)
+ * - SPIX_WAITFOREOTx(x)
+ * - SPIX_WAITFOREORx(x)
+ * - SPIX_FLUSH(x)
+ *
+ * The old functions "spi_foo()" and macros "SPI_FOO()" are still supported, 
+ * by mapping them to new ones. When using these deprecated functions, the SSI
+ * module to use can be selected by means of the macro SPI_DEFAULT_INSTANCE.
+ *
+ * This SPI driver depends on the following defines:
+ *
+ * For the SSI0 module:
+ *
+ * - SPI0_CKL_PORT
+ * - SPI0_CLK_PIN
+ * - SPI0_TX_PORT
+ * - SPI0_TX_PIN
+ * - SPI0_RX_PORT
+ * - SPI0_RX_PIN
+ *
+ * For the SSI1 module:
+ *
+ * - SPI1_CKL_PORT
+ * - SPI1_CLK_PIN
+ * - SPI1_TX_PORT
+ * - SPI1_TX_PIN
+ * - SPI1_RX_PORT
+ * - SPI1_RX_PIN
  */
 #ifndef SPI_ARCH_H_
 #define SPI_ARCH_H_
 
 #include "dev/ssi.h"
-
-#define SPI_WAITFORTxREADY() do { \
-  while(!(REG(SSI0_BASE + SSI_SR) & SSI_SR_TNF)); \
-} while(0)
-
-#define SPI_TXBUF REG(SSI0_BASE + SSI_DR)
-
-#define SPI_RXBUF REG(SSI0_BASE + SSI_DR)
-
-#define SPI_WAITFOREOTx() do { \
-  while(REG(SSI0_BASE + SSI_SR) & SSI_SR_BSY); \
-} while(0)
-
-#define SPI_WAITFOREORx() do { \
-  while(!(REG(SSI0_BASE + SSI_SR) & SSI_SR_RNE)); \
-} while(0)
-
+/*---------------------------------------------------------------------------*/
+/* The default SPI instance to use. You can configure either instance 0 or 1
+   and proceed to use the "old" function calls / macros */ 
+#ifdef SPI_CONF_DEFAULT_INSTANCE
+#define SPI_DEFAULT_INSTANCE			SPI_CONF_DEFAULT_INSTANCE
+#else
+#define SPI_DEFAULT_INSTANCE			0
+#endif
+/*---------------------------------------------------------------------------*/
+/* Deprecated function calls provided for compatibility reasons */
+#define spi_init()						spix_init(SPI_DEFAULT_INSTANCE)	
+#define spi_enable()					spix_enable(SPI_DEFAULT_INSTANCE)	
+#define spi_disable()					spix_disable(SPI_DEFAULT_INSTANCE)	
+#define spi_set_mode(ff, cpo, cph, ds)	spix_set_mode(SPI_DEFAULT_INSTANCE, ff, cpo, cph, ds)
+#define spi_cs_init(port, pin );		spix_cs_init(port, pin)	
+/*---------------------------------------------------------------------------*/
+/* We define a new set of "SPIX" macros which will then be mapped to the 
+   corresponding macros defined later on */
+#define SPIX_WAITFORTxREADY(x)			SPI##x##_WAITFORTxREADY()
+#define SPIX_TXBUF(x)					SPI##x##_TXBUF()
+#define SPIX_RXBUF(x)					SPI##x##_RXBUF()
+#define SPIX_WAITFOREOTx(x)				SPI##x##_WAIT_FOREOTx()
+#define SPIX_WAITFOREORx(x)				SPI##x##_WAITFOREORx()	
+#define SPIX_FLUSH(x)					SPI##x##_FLUSH()
+/*---------------------------------------------------------------------------*/
+/* Deprecated macros provided for compatibility reasons */
+#define SPI_WAITFORTxREADY()			SPIX_WAITFORTxREADY(SPI_DEFAULT_INSTANCE)	
+#define SPI_TXBUF						SPIX_TXBUF(SPI_DEFAULT_INSTANCE)
+#define SPI_RXBUF						SPIX_RXBUF(SPI_DEFAULT_INSTANCE)
+#define SPI_WAITFOREOTx()				SPIX_WAITFOREOTx(SPI_DEFAULT_INSTANCE)	
+#define SPI_WAITFOREORx()				SPIX_WAITFOREORx(SPI_DEFAULT_INSTANCE)	
 #ifdef SPI_FLUSH
 #error "You must include spi-arch.h before spi.h for the CC2538."
 #endif
-#define SPI_FLUSH() do { \
+#define SPI_FLUSH()						SPIX_FLUSH(SPI_DEFAULT_INSTANCE)
+#endif
+#define SPI_CS_CLR(port, pin)			SPIX_CS_CLR(port, pin)	
+#define SPI_CS_SET(port, pin)			SPIX_CS_SET(port, pin)	
+/*---------------------------------------------------------------------------*/
+/* New API macros */
+#define SPI0_WAITFORTxREADY() do { \
+  while(!(REG(SSI0_BASE + SSI_SR) & SSI_SR_TNF)); \
+} while(0)
+#define SPI0_TXBUF REG(SSI0_BASE + SSI_DR)
+#define SPI0_RXBUF REG(SSI0_BASE + SSI_DR)
+#define SPI0_WAITFOREOTx() do { \
+  while(REG(SSI0_BASE + SSI_SR) & SSI_SR_BSY); \
+} while(0)
+#define SPI0_WAITFOREORx() do { \
+  while(!(REG(SSI0_BASE + SSI_SR) & SSI_SR_RNE)); \
+} while(0)
+#define SPI0_FLUSH() do { \
   SPI_WAITFOREORx(); \
   while (REG(SSI0_BASE + SSI_SR) & SSI_SR_RNE) { \
     SPI_RXBUF; \
   } \
 } while(0)
 
-#define SPI_CS_CLR(port, pin) do { \
-  GPIO_CLR_PIN(GPIO_PORT_TO_BASE(port), GPIO_PIN_MASK(pin)); \
+#define SPI1_WAITFORTxREADY() do { \
+  while(!(REG(SSI1_BASE + SSI_SR) & SSI_SR_TNF)); \
+} while(0)
+#define SPI1_TXBUF REG(SSI1_BASE + SSI_DR)
+#define SPI1_RXBUF REG(SSI1_BASE + SSI_DR)
+#define SPI1_WAITFOREOTx() do { \
+  while(REG(SSI1_BASE + SSI_SR) & SSI_SR_BSY); \
+} while(0)
+#define SPI1_WAITFOREORx() do { \
+  while(!(REG(SSI1_BASE + SSI_SR) & SSI_SR_RNE)); \
+} while(0)
+#define SPI1_FLUSH() do { \
+  SPI_WAITFOREORx(); \
+  while (REG(SSI1_BASE + SSI_SR) & SSI_SR_RNE) { \
+    SPI_RXBUF; \
+  } \
 } while(0)
 
-#define SPI_CS_SET(port, pin) do { \
+#define SPIX_CS_CLR(port, pin) do { \
+  GPIO_CLR_PIN(GPIO_PORT_TO_BASE(port), GPIO_PIN_MASK(pin)); \
+} while(0)
+#define SPIX_CS_SET(port, pin) do { \
   GPIO_SET_PIN(GPIO_PORT_TO_BASE(port), GPIO_PIN_MASK(pin)); \
 } while(0)
 /*---------------------------------------------------------------------------*/
@@ -79,18 +168,27 @@
  */
 
 /**
- * \brief Configure a GPIO to be the chip select pin
+ * \brief Initialize the SPI bus for the instance given
+ *
+ * This sets the mode to Motorola SPI with the following format options:
+ *    Clock phase:               1; data captured on second (rising) edge
+ *    Clock polarity:            1; clock is high when idle
+ *    Data size:                 8 bits
+ *
+ * Use spix_set_mode() to change the spi mode.
  */
-void spi_cs_init(uint8_t port, uint8_t pin);
+void spix_init(uint8_t instance);
 
-/** \brief Enables the SPI peripheral
+/** 
+ * \brief Enables the SPI peripheral 
  */
-void spi_enable(void);
+void spix_enable(uint8_t instance);
 
-/** \brief Disables the SPI peripheral
+/** 
+ * \brief Disables the SPI peripheral
  * \note Call this function to save power when the SPI is unused.
  */
-void spi_disable(void);
+void spix_disable(uint8_t instance);
 
 /**
  * \brief Configure the SPI data and clock polarity and the data size.
@@ -110,8 +208,18 @@ void spi_disable(void);
  * \param data_size      The number of bits in each "byte" of data. Must be
  *                       between 4 and 16, inclusive.
  */
-void spi_set_mode(uint32_t frame_format, uint32_t clock_polarity,
-                  uint32_t clock_phase, uint32_t data_size);
+/* New API */
+void spix_set_mode(uint8_t instance,
+				   uint32_t frame_format, uint32_t clock_polarity,
+				   uint32_t clock_phase, uint32_t data_size);
+
+/**
+ * \brief Configure a GPIO to be the chip select pin.
+ * 
+ * Even if this function does not depend on the SPI instance used, we rename
+ * it to reflect the new naming convention.
+ */
+void spix_cs_init(uint8_t port, uint8_t pin);
 
 /** @} */
 

--- a/cpu/cc2538/spi-arch.h
+++ b/cpu/cc2538/spi-arch.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2013, University of Michigan.
  *
- * Copyright (c) 2015, Weptech elektronik GmbH
+ * Copyright (c) 2015, Weptech elektronik GmbH Germany
  * Author: Ulf Knoblich, ulf.knoblich@weptech.de
  *
  * All rights reserved.

--- a/platform/cc2538dk/dev/board.h
+++ b/platform/cc2538dk/dev/board.h
@@ -184,15 +184,41 @@
 /**
  * \name SPI configuration
  *
- * These values configure which CC2538 pins to use for the SPI lines.
+ * These values configure which CC2538 pins to use for the SPI lines. Both
+ * SPI instances can be used independently by providing the corresponding 
+ * port / pin macros.
  * @{
  */
-#define SPI_CLK_PORT             GPIO_A_NUM /**< Clock port */
-#define SPI_CLK_PIN              2          /**< Clock pin */
-#define SPI_MOSI_PORT            GPIO_A_NUM /**< MOSI port */
-#define SPI_MOSI_PIN             4          /**< MOSI pin */
-#define SPI_MISO_PORT            GPIO_A_NUM /**< MISO port */
-#define SPI_MISO_PIN             5          /**< MISO pin */
+#define SPI0_IN_USE				 0
+#define SPI1_IN_USE				 0
+#if SPI0_IN_USE
+/** Clock port SPI0 */
+#define SPI0_CLK_PORT            GPIO_A_NUM 
+/** Clock pin SPI0 */
+#define SPI0_CLK_PIN             2
+/** TX port SPI0 (master mode: MOSI) */
+#define SPI0_TX_PORT             GPIO_A_NUM 
+/** TX pin SPI0 */
+#define SPI0_TX_PIN              4
+/** RX port SPI0 (master mode: MISO */
+#define SPI0_RX_PORT             GPIO_A_NUM
+/** RX pin SPI0 */
+#define SPI0_RX_PIN				 5 
+#endif	/* #if SPI0_IN_USE */
+#if SPI1_IN_USE
+/** Clock port SPI1 */
+#define SPI1_CLK_PORT            GPIO_A_NUM 
+/** Clock pin SPI1 */
+#define SPI1_CLK_PIN             2
+/** TX port SPI1 (master mode: MOSI) */
+#define SPI1_TX_PORT             GPIO_A_NUM 
+/** TX pin SPI1 */
+#define SPI1_TX_PIN              4
+/** RX port SPI1 (master mode: MISO) */
+#define SPI1_RX_PORT             GPIO_A_NUM
+/** RX pin SPI1 */
+#define SPI1_RX_PIN				 5 
+#endif	/* #if SPI1_IN_USE */
 /** @} */
 /*---------------------------------------------------------------------------*/
 /**

--- a/regression-tests/01-compile-base/Makefile
+++ b/regression-tests/01-compile-base/Makefile
@@ -30,7 +30,6 @@ sky-shell-webserver/sky \
 tcp-socket/minimal-net \
 telnet-server/minimal-net \
 webserver/minimal-net \
-webserver-ipv6/exp5438 \
 webserver-ipv6/eval-adf7xxxmb4z \
 wget/minimal-net \
 z1/z1 \


### PR DESCRIPTION
I am preparing a new platform using the cc2538 + cc1200 + enc28j60. The cc1200 and the enj28j60 use different SPI moduls, so i have added support for the SSI1. I did the following changes:
- renaming the "old" functions spi_foo() to spi0_foo()
- adding support for SSI1 by duplicating the code spi0_foo() -> spi1_foo() and changing the registers accordingly
- adding macros for the old spi_foo() functions + defines so the still work
When using SSI0, the macros have to be defined

*     SPI0_CLK_PORT               SPI0_CLK_PIN
*    SPI0_MOSI_PORT              SPI0_MOSI_PIN
*    SPI0_MISO_PORT              SPI0_MISO_PIN

When using SSI1, the macros have to be defined

*    SPI1_CLK_PORT               SPI1_CLK_PIN
*    SPI1_MOSI_PORT              SPI1_MOSI_PIN
*    SPI1_MISO_PORT              SPI1_MISO_PIN

The old macros 

*   SPI_CLK_PORT               SPI_CLK_PIN
*    SPI_MOSI_PORT              SPI_MOSI_PIN
*    SPI_MISO_PORT              SPI_MISO_PIN

still work and enable the use of SSI0
