### PR TITLE
Improve HTTPD in the CC26xx web demo

### DIFF
--- a/examples/cc26xx/cc26xx-web-demo/httpd-simple.c
+++ b/examples/cc26xx/cc26xx-web-demo/httpd-simple.c
@@ -395,12 +395,12 @@ PT_THREAD(generate_top_matter(struct httpd_state *s, const char *title,
 
   s->page = list_head(pages_list);
   PT_WAIT_THREAD(&s->top_matter_pt,
-                 enqueue_chunk(s, 0, "<a href=\"%s\">[ %s ]</a>",
+                 enqueue_chunk(s, 0, "[ <a href=\"%s\">%s</a> ]",
                                s->page->filename, s->page->title));
 
   for(s->page = s->page->next; s->page != NULL; s->page = s->page->next) {
     PT_WAIT_THREAD(&s->top_matter_pt,
-                   enqueue_chunk(s, 0, " | <a href=\"%s\">[ %s ]</a>",
+                   enqueue_chunk(s, 0, " | [ <a href=\"%s\">%s</a> ]",
                                  s->page->filename, s->page->title));
   }
 
@@ -1279,8 +1279,8 @@ PROCESS_THREAD(httpd_simple_process, ev, data)
   init();
 
   snprintf(http_mqtt_a, IBM_QUICKSTART_LINK_LEN,
-           "<a href=\"http://quickstart.internetofthings.ibmcloud.com/#/device/"
-           "%02x%02x%02x%02x%02x%02x/sensor/\">[ IBM Quickstart ]</a>",
+           "[ <a href=\"http://quickstart.internetofthings.ibmcloud.com/#/device/"
+           "%02x%02x%02x%02x%02x%02x/sensor/\">IBM Quickstart</a> ]",
            linkaddr_node_addr.u8[0], linkaddr_node_addr.u8[1],
            linkaddr_node_addr.u8[2], linkaddr_node_addr.u8[5],
            linkaddr_node_addr.u8[6], linkaddr_node_addr.u8[7]);

--- a/examples/cc26xx/cc26xx-web-demo/httpd-simple.c
+++ b/examples/cc26xx/cc26xx-web-demo/httpd-simple.c
@@ -1124,6 +1124,15 @@ PT_THREAD(handle_input(struct httpd_state *s))
     }
   } else if(strncasecmp(s->inputbuf, http_post, 5) == 0) {
     s->request_type = REQUEST_TYPE_POST;
+    PSOCK_READTO(&s->sin, ISO_space);
+
+    if(s->inputbuf[0] != ISO_slash) {
+      PSOCK_CLOSE_EXIT(&s->sin);
+    }
+
+    s->inputbuf[PSOCK_DATALEN(&s->sin) - 1] = 0;
+    strncpy(s->filename, s->inputbuf, sizeof(s->filename));
+
     /* POST: Read out the rest of the line and ignore it */
     PSOCK_READTO(&s->sin, ISO_nl);
 

--- a/examples/cc26xx/cc26xx-web-demo/httpd-simple.c
+++ b/examples/cc26xx/cc26xx-web-demo/httpd-simple.c
@@ -538,7 +538,8 @@ PT_THREAD(generate_config(struct httpd_state *s))
 
   PT_WAIT_THREAD(&s->generate_pt,
                  enqueue_chunk(s, 0,
-                               "<form name=\"input\" action=\"config\" "));
+                               "<form name=\"input\" action=\"%s\" ",
+                               http_dev_cfg_page.filename));
   PT_WAIT_THREAD(&s->generate_pt,
                  enqueue_chunk(s, 0, "method=\"post\" enctype=\""));
   PT_WAIT_THREAD(&s->generate_pt,
@@ -577,7 +578,8 @@ PT_THREAD(generate_config(struct httpd_state *s))
   PT_WAIT_THREAD(&s->generate_pt, enqueue_chunk(s, 0, "<h1>Actions</h1>"));
   PT_WAIT_THREAD(&s->generate_pt,
                  enqueue_chunk(s, 0,
-                               "<form name=\"input\" action=\"defaults\" "));
+                               "<form name=\"input\" action=\"%s\" ",
+                               http_dev_cfg_page.filename));
   PT_WAIT_THREAD(&s->generate_pt,
                  enqueue_chunk(s, 0, "method=\"post\" enctype=\""));
   PT_WAIT_THREAD(&s->generate_pt,
@@ -614,7 +616,8 @@ PT_THREAD(generate_mqtt_config(struct httpd_state *s))
 
   PT_WAIT_THREAD(&s->generate_pt,
                  enqueue_chunk(s, 0,
-                               "<form name=\"input\" action=\"config\" "));
+                               "<form name=\"input\" action=\"%s\" ",
+                               http_mqtt_cfg_page.filename));
   PT_WAIT_THREAD(&s->generate_pt,
                  enqueue_chunk(s, 0, "method=\"post\" enctype=\""));
   PT_WAIT_THREAD(&s->generate_pt,
@@ -754,7 +757,8 @@ PT_THREAD(generate_mqtt_config(struct httpd_state *s))
                  enqueue_chunk(s, 0, "</form>"));
   PT_WAIT_THREAD(&s->generate_pt,
                  enqueue_chunk(s, 0,
-                               "<form name=\"input\" action=\"config\" "));
+                               "<form name=\"input\" action=\"%s\" ",
+                               http_mqtt_cfg_page.filename));
   PT_WAIT_THREAD(&s->generate_pt,
                  enqueue_chunk(s, 0, "method=\"post\" enctype=\""));
   PT_WAIT_THREAD(&s->generate_pt,
@@ -793,7 +797,8 @@ PT_THREAD(generate_net_uart_config(struct httpd_state *s))
 
   PT_WAIT_THREAD(&s->generate_pt,
                  enqueue_chunk(s, 0,
-                               "<form name=\"input\" action=\"net_uart\" "));
+                               "<form name=\"input\" action=\"%s\" ",
+                               http_net_cfg_page.filename));
   PT_WAIT_THREAD(&s->generate_pt,
                  enqueue_chunk(s, 0, "method=\"post\" enctype=\""));
   PT_WAIT_THREAD(&s->generate_pt,


### PR DESCRIPTION
This pull proposes improvements to the HTTPD part of the CC26xx web demo example:

* Prettifies top matter: [[ link ]](#) becomes [ [link](#) ]
* Send the correct filename as part of the HTTP POST when clicking the action button in HTML forms.
* Correctly parses the first line of a POST request to extract the target filename
* Returns the correct value for the HTTP "Location:" header, used by the browser to retrieve a fresh copy of the respective page after configuration updates.