### PR TITLE
Fix: Passing cooja_mt_thread datapointer via RDI register (x86-64) and add mtarch

### DIFF
--- a/platform/cooja/Makefile.cooja
+++ b/platform/cooja/Makefile.cooja
@@ -47,7 +47,7 @@ CONTIKI_TARGET_DIRS = . dev lib sys cfs net
 # (COOJA_SOURCEDIRS contains additional sources dirs set from simulator)
 vpath %.c $(COOJA_SOURCEDIRS)
 
-COOJA_BASE	= simEnvChange.c cooja_mt.c cooja_mtarch.c rtimer-arch.c slip.c watchdog.c rimestats.c
+COOJA_BASE	= simEnvChange.c cooja_mt.c cooja_mtarch.c rtimer-arch.c slip.c watchdog.c rimestats.c mtarch.c
 
 COOJA_INTFS	= beep.c button-sensor.c ip.c leds-arch.c moteid.c \
 		    pir-sensor.c rs232.c vib-sensor.c \

--- a/platform/cooja/mtarch.c
+++ b/platform/cooja/mtarch.c
@@ -1,43 +1,190 @@
 /*
- * Copyright (c) 2007, Swedish Institute of Computer Science.
- * All rights reserved. 
+ * Copyright (c) 2005, Swedish Institute of Computer Science
+ * All rights reserved.
  *
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met: 
- * 1. Redistributions of source code must retain the above copyright 
- *    notice, this list of conditions and the following disclaimer. 
- * 2. Redistributions in binary form must reproduce the above copyright 
- *    notice, this list of conditions and the following disclaimer in the 
- *    documentation and/or other materials provided with the distribution. 
- * 3. Neither the name of the Institute nor the names of its contributors 
- *    may be used to endorse or promote products derived from this software 
- *    without specific prior written permission. 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
  *
- * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND 
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
- * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE 
- * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL 
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS 
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) 
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY 
- * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
- * SUCH DAMAGE. 
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
  *
  * This file is part of the Contiki operating system.
- * 
- * Author: Oliver Schmidt <ol.sc@web.de>
  *
  */
 
-#include "mtarch.h"
+#include <stddef.h>
 
+#include <limits.h>
+#include <stdio.h>
+#include <string.h>
+#include "sys/mt.h"
+
+#ifndef __WORDSIZE
+#define __WORDSIZE 32
+#endif /* __WORDSIZE */
+
+#ifndef ON_64BIT_ARCH
+#if __WORDSIZE == 64
+#define ON_64BIT_ARCH 1
+#else /* ON_64BIT_ARCH */
+#define ON_64BIT_ARCH 0
+#endif /* __WORDSIZE == 64 */
+#endif /* ON_64BIT_ARCH */
+
+struct frame {
+  unsigned long flags;
+#if ON_64BIT_ARCH
+  unsigned long rbp;
+  unsigned long rdi;
+  unsigned long rsi;
+  unsigned long rdx;
+  unsigned long rcx;
+  unsigned long rbx;
+  unsigned long rax;
+#else /* ON_64BIT_ARCH */
+  unsigned long ebp;
+  unsigned long edi;
+  unsigned long esi;
+  unsigned long edx;
+  unsigned long ecx;
+  unsigned long ebx;
+  unsigned long eax;
+#endif /* ON_64BIT_ARCH */
+  unsigned long retaddr;
+  unsigned long retaddr2;
+  unsigned long data;
+};
 /*--------------------------------------------------------------------------*/
 void
 mtarch_init(void)
 {
+}
+/*--------------------------------------------------------------------------*/
+void
+mtarch_start(struct mtarch_thread *t,
+    void (*function)(void *), void *data)
+{
+  struct frame *f = (struct frame *)&t->stack[MTARCH_STACKSIZE - sizeof(struct frame)/sizeof(unsigned long)];
+  int i;
+
+  for(i = 0; i < MTARCH_STACKSIZE; ++i) {
+    t->stack[i] = i;
+  }
+
+  memset(f, 0, sizeof(struct frame));
+  f->retaddr = (unsigned long)function;
+  t->sp      = (unsigned long)&f->flags;
+#if ON_64BIT_ARCH
+  f->rdi     = (unsigned long)data;
+  f->rbp     = (unsigned long)&f->rax;
+#else /* ON_64BIT_ARCH */
+  f->data    = (unsigned long)data;
+  f->ebp     = (unsigned long)&f->eax;
+#endif /* ON_64BIT_ARCH */
+}
+/*--------------------------------------------------------------------------*/
+static struct mtarch_thread *running_thread;
+/*--------------------------------------------------------------------------*/
+void sw(void)
+{
+  /* Store registers */
+#if ON_64BIT_ARCH
+  __asm__ (
+      "pushq %rax\n\t"
+      "pushq %rbx\n\t"
+      "pushq %rcx\n\t"
+      "pushq %rdx\n\t"
+      "pushq %rsi\n\t"
+      "pushq %rdi\n\t"
+      "pushq %rbp\n\t"
+      "pushq %rbp\n\t");
+#else /* ON_64BIT_ARCH */
+  __asm__ (
+      "pushl %eax\n\t"
+      "pushl %ebx\n\t"
+      "pushl %ecx\n\t"
+      "pushl %edx\n\t"
+      "pushl %esi\n\t"
+      "pushl %edi\n\t"
+      "pushl %ebp\n\t"
+      "pushl %ebp\n\t");
+#endif /* ON_64BIT_ARCH */
+
+  /* Switch stack pointer */
+#if ON_64BIT_ARCH
+  __asm__ ("movq %0, %%rax\n\t" : : "m" (running_thread));
+  __asm__ (
+      "movq (%rax), %rbx\n\t"
+      "movq %rsp, (%rax)\n\t"
+      "movq %rbx, %rsp\n\t"
+  );
+#else /* ON_64BIT_ARCH */
+  __asm__ ("movl %0, %%eax\n\t" : : "m" (running_thread));
+  __asm__ (
+      "movl (%eax), %ebx\n\t"
+      "movl %esp, (%eax)\n\t"
+      "movl %ebx, %esp\n\t"
+  );
+#endif /* ON_64BIT_ARCH */
+
+  /* Restore previous registers */
+#if ON_64BIT_ARCH
+  __asm__ (
+      "popq %rbp\n\t"
+      "popq %rbp\n\t"
+      "popq %rdi\n\t"
+      "popq %rsi\n\t"
+      "popq %rdx\n\t"
+      "popq %rcx\n\t"
+      "popq %rbx\n\t"
+      "popq %rax\n\t"
+
+      "leave\n\t"
+      "ret\n\t"
+  );
+#else /* ON_64BIT_ARCH */
+  __asm__ (
+      "popl %ebp\n\t"
+      "popl %ebp\n\t"
+      "popl %edi\n\t"
+      "popl %esi\n\t"
+      "popl %edx\n\t"
+      "popl %ecx\n\t"
+      "popl %ebx\n\t"
+      "popl %eax\n\t"
+
+      "leave\n\t"
+      "ret\n\t"
+  );
+#endif /* ON_64BIT_ARCH */
+
+}
+
+/*--------------------------------------------------------------------------*/
+void
+mtarch_exec(struct mtarch_thread *t)
+{
+  running_thread = t;
+  sw();
+  running_thread = NULL;
 }
 /*--------------------------------------------------------------------------*/
 void
@@ -46,24 +193,13 @@ mtarch_remove(void)
 }
 /*--------------------------------------------------------------------------*/
 void
-mtarch_start(struct mtarch_thread *thread,
-	     void (* function)(void *data),
-	     void *data)
-{
-}
-/*--------------------------------------------------------------------------*/
-void
 mtarch_yield(void)
 {
+  sw();
 }
 /*--------------------------------------------------------------------------*/
 void
-mtarch_exec(struct mtarch_thread *thread)
-{
-}
-/*--------------------------------------------------------------------------*/
-void
-mtarch_stop(struct mtarch_thread *thread)
+mtarch_pstop(void)
 {
 }
 /*--------------------------------------------------------------------------*/
@@ -72,8 +208,15 @@ mtarch_pstart(void)
 {
 }
 /*--------------------------------------------------------------------------*/
-void
-mtarch_pstop(void)
+int
+mtarch_stack_usage(struct mt_thread *t)
 {
+  int i;
+  for(i = 0; i < MTARCH_STACKSIZE; ++i) {
+    if(t->thread.stack[i] != i) {
+      return MTARCH_STACKSIZE - i;
+    }
+  }
+  return -1;
 }
 /*--------------------------------------------------------------------------*/

--- a/platform/cooja/mtarch.h
+++ b/platform/cooja/mtarch.h
@@ -1,40 +1,52 @@
 /*
- * Copyright (c) 2007, Swedish Institute of Computer Science.
- * All rights reserved. 
+ * Copyright (c) 2003, Adam Dunkels.
+ * All rights reserved.
  *
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met: 
- * 1. Redistributions of source code must retain the above copyright 
- *    notice, this list of conditions and the following disclaimer. 
- * 2. Redistributions in binary form must reproduce the above copyright 
- *    notice, this list of conditions and the following disclaimer in the 
- *    documentation and/or other materials provided with the distribution. 
- * 3. Neither the name of the Institute nor the names of its contributors 
- *    may be used to endorse or promote products derived from this software 
- *    without specific prior written permission. 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ * 3. The name of the author may not be used to endorse or promote
+ *    products derived from this software without specific prior
+ *    written permission.
  *
- * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND 
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
- * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE 
- * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL 
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS 
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) 
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY 
- * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
- * SUCH DAMAGE. 
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
- * This file is part of the Contiki operating system.
- * 
  */
-
+/*
+ * This file is ripped from x86/mtarch.h of the Contiki Multi-threading library.
+ * Fredrik Osterlind <fros@sics.se>
+ */
 #ifndef MTARCH_H_
 #define MTARCH_H_
 
+#ifndef MTARCH_STACKSIZE
+#define MTARCH_STACKSIZE 1024
+#endif /* MTARCH_STACKSIZE */
+
 struct mtarch_thread {
-  void *mt_thread;
+  unsigned long sp;  /* Note: stack pointer must be first var in struct! */
+  unsigned long stack[MTARCH_STACKSIZE];
 };
 
-#endif /* MTARCH_H_ */
+struct mt_thread;
+
+int mtarch_stack_usage(struct mt_thread *t);
+
+#endif /* COOJA_MTARCH_H_ */
+	

--- a/platform/cooja/sys/cooja_mtarch.c
+++ b/platform/cooja/sys/cooja_mtarch.c
@@ -71,6 +71,7 @@ struct frame {
   unsigned long retaddr;
   unsigned long retaddr2;
   unsigned long data;
+
 };
 /*--------------------------------------------------------------------------*/
 void
@@ -91,11 +92,12 @@ cooja_mtarch_start(struct cooja_mtarch_thread *t,
 
   memset(f, 0, sizeof(struct frame));
   f->retaddr = (unsigned long)function;
-  f->data    = (unsigned long)data;
   t->sp      = (unsigned long)&f->flags;
 #if ON_64BIT_ARCH
+  f->rdi     = (unsigned long)data;
   f->rbp     = (unsigned long)&f->rax;
 #else /* ON_64BIT_ARCH */
+  f->data    = (unsigned long)data;
   f->ebp     = (unsigned long)&f->eax;
 #endif /* ON_64BIT_ARCH */
 }

--- a/platform/cooja/sys/cooja_mtarch.c
+++ b/platform/cooja/sys/cooja_mtarch.c
@@ -70,8 +70,9 @@ struct frame {
 #endif /* ON_64BIT_ARCH */
   unsigned long retaddr;
   unsigned long retaddr2;
+#if !ON_64BIT_ARCH
   unsigned long data;
-
+#endif
 };
 /*--------------------------------------------------------------------------*/
 void

--- a/platform/cooja/sys/cooja_mtarch.c
+++ b/platform/cooja/sys/cooja_mtarch.c
@@ -70,9 +70,7 @@ struct frame {
 #endif /* ON_64BIT_ARCH */
   unsigned long retaddr;
   unsigned long retaddr2;
-#if !ON_64BIT_ARCH
   unsigned long data;
-#endif
 };
 /*--------------------------------------------------------------------------*/
 void


### PR DESCRIPTION
http://en.wikipedia.org/wiki/X86_calling_conventions :
x86-64 calling conventions take advantage of the additional register space to pass more arguments in registers. 
...
The calling convention of the System V AMD64 ABI is followed on Solaris, Linux, FreeBSD, Mac OS X, and other UNIX-like or POSIX-compliant operating systems. The first six integer or pointer arguments are passed in registers __RDI__, RSI, RDX, RCX, R8, and R9.
...
The Microsoft x64 calling convention is followed on Microsoft Windows and pre-boot UEFI (for long mode on x86-64). It uses registers RCX, RDX, R8, R9 for the first four integer or pointer arguments (in that order).

Example :

```C
#include <stdio.h>
#include <stdlib.h>

void test(void *data)
{
    *((int*)data) += 1;
}

int global_int = 0;

int main(void) {
    test(&global_int);
	return EXIT_SUCCESS;
}
```

```
                  test:
00000000004004ed:   push %rbp
00000000004004ee:   mov %rsp,%rbp
00000000004004f1:   mov %rdi,-0x8(%rbp)
00000000004004f5:   mov -0x8(%rbp),%rax
00000000004004f9:   mov (%rax),%eax
00000000004004fb:   lea 0x1(%rax),%edx
00000000004004fe:   mov -0x8(%rbp),%rax
0000000000400502:   mov %edx,(%rax)
0000000000400504:   pop %rbp
0000000000400505:   retq 
                  main:
0000000000400506:   push %rbp
0000000000400507:   mov %rsp,%rbp
22                    test(&global_int);
000000000040050a:   mov $0x60103c,%edi
000000000040050f:   callq 0x4004ed <test>
23                	return EXIT_SUCCESS;
0000000000400514:   mov $0x0,%eax
24                }
``` 

