### PR TITLE
Remove unnecessary #if guards

### DIFF
--- a/core/net/ipv4/uip.c
+++ b/core/net/ipv4/uip.c
@@ -75,18 +75,9 @@
 #include "net/ipv4/uip_arp.h"
 #include "net/ip/uip_arch.h"
 
-#if !NETSTACK_CONF_WITH_IPV6 /* If NETSTACK_CONF_WITH_IPV6 is defined, we compile the
-		      uip6.c file instead of this one. Therefore
-		      this #ifndef removes the entire compilation
-		      output of the uip.c file */
-
-
-#if NETSTACK_CONF_WITH_IPV6
 #include "net/ipv4/uip-neighbor.h"
-#endif /* NETSTACK_CONF_WITH_IPV6 */
 
 #include <string.h>
-
 /*---------------------------------------------------------------------------*/
 /* Variable definitions. */
 
@@ -1973,6 +1964,4 @@ uip_send(const void *data, int len)
   }
 }
 /*---------------------------------------------------------------------------*/
-#endif /* NETSTACK_CONF_WITH_IPV6 */
-
 /** @}*/


### PR DESCRIPTION
`net/ipv4/uip.c` will not even be included in the list of sources in the first place if we are building with NETSTACK_CONF_WITH_IPV6 (CONTIKI_WITH_IPV6). Thus, there is no longer a need to wrap the entire source code in an #if guard.

Closes #935