### PR TITLE
Remove all the DODAG from the instance when the node is set as Root

### DIFF
--- a/core/net/rpl/rpl-dag.c
+++ b/core/net/rpl/rpl-dag.c
@@ -269,17 +269,27 @@ rpl_set_root(uint8_t instance_id, uip_ipaddr_t *dag_id)
   rpl_dag_t *dag;
   rpl_instance_t *instance;
   uint8_t version;
+  int i;
 
   version = RPL_LOLLIPOP_INIT;
-  dag = get_dag(instance_id, dag_id);
-  if(dag != NULL) {
-    version = dag->version;
-    RPL_LOLLIPOP_INCREMENT(version);
-    PRINTF("RPL: Dropping a joined DAG when setting this node as root");
-    if(dag == dag->instance->current_dag) {
-      dag->instance->current_dag = NULL;
+  instance = rpl_get_instance(instance_id);
+  if(instance != NULL) {
+    for(i = 0; i < RPL_MAX_DAG_PER_INSTANCE; ++i) {
+      dag = &instance->dag_table[i];
+      if(dag->used) {
+        if(uip_ipaddr_cmp(&dag->dag_id, dag_id)) {
+          version = dag->version;
+          RPL_LOLLIPOP_INCREMENT(version);
+        }
+        if(dag == dag->instance->current_dag) {
+          PRINTF("RPL: Dropping a joined DAG when setting this node as root");
+          dag->instance->current_dag = NULL;
+        } else {
+          PRINTF("RPL: Dropping a DAG when setting this node as root");
+        }
+        rpl_free_dag(dag);
+      }
     }
-    rpl_free_dag(dag);
   }
 
   dag = rpl_alloc_dag(instance_id, dag_id);


### PR DESCRIPTION
When a node becomes a DODAG root within a given instance, it must leave any DODAG it has joined previously, not only the current DODAG and remove any references to the known DODAGs.