### PR TITLE
Do not delete instance when a new DODAG can not be created

### DIFF
--- a/core/net/rpl/rpl-dag.c
+++ b/core/net/rpl/rpl-dag.c
@@ -507,7 +507,6 @@ rpl_alloc_dag(uint8_t instance_id, uip_ipaddr_t *dag_id)
   }
 
   RPL_STAT(rpl_stats.mem_overflows++);
-  rpl_free_instance(instance);
   return NULL;
 }
 /*---------------------------------------------------------------------------*/


### PR DESCRIPTION
When the maximum number of DODAG for a given instance is reached, the current code delete that instance.