### PR TITLE
Fix CC26xx RF frame filtering for frames with version==1

### DIFF
--- a/cpu/cc26xx/dev/cc26xx-rf.c
+++ b/cpu/cc26xx/dev/cc26xx-rf.c
@@ -937,6 +937,7 @@ init_rf_params(void)
     BITVALUE(CMD_IEEE_RX, frameFiltOpt, defaultPend, 0) |
     BITVALUE(CMD_IEEE_RX, frameFiltOpt, bPendDataReqOnly, 0) |
     BITVALUE(CMD_IEEE_RX, frameFiltOpt, bPanCoord, 0) |
+    BITVALUE(CMD_IEEE_RX, frameFiltOpt, maxFrameVersion, 1) |
     BITVALUE(CMD_IEEE_RX, frameFiltOpt, bStrictLenFilter, 0);
   /* Receive all frame types */
   GET_FIELD(cmd_ieee_rx_buf, CMD_IEEE_RX, frameTypes) =


### PR DESCRIPTION
This was pointed out in TI's E2E forum:

https://e2e.ti.com/support/wireless_connectivity/f/158/t/415130

The CC26xx RF will reject frames with version == 1.

Until a while ago, Contiki would send out frames with version==0 (`FRAME802154_IEEE802154_2003`), but as of #557 (19c9ef0a) we are sending out 1 (`FRAME802154_IEEE802154_2006`). 

I've been using the hardware with an older version of 6lbr, which still sends out version==0 and for that reason I had not noticed this up to now.

This pull updates the CC26xx RF driver to accept frames with version==1.

This is basically a very very nasty bug: CC26xx will refuse to talk to any device using our current master (including a 2nd CC26xx), so I'll be merging this immediately as soon as travis passes.