### PR TITLE
cc2538 i2c bug in clock computation

### DIFF
--- a/cpu/cc2538/dev/i2c.c
+++ b/cpu/cc2538/dev/i2c.c
@@ -50,7 +50,7 @@ get_sys_clock(void)
 {
   /* Get the clock status diviser */
   return SYS_CTRL_32MHZ /
-         ((REG(SYS_CTRL_CLOCK_STA) & SYS_CTRL_CLOCK_STA_SYS_DIV) + 1);
+         (1 << (REG(SYS_CTRL_CLOCK_STA) & SYS_CTRL_CLOCK_STA_SYS_DIV));
 }
 /*---------------------------------------------------------------------------*/
 void


### PR DESCRIPTION
While working on the clock system of the CC2538 (wanted to make it run at 32 MHz) i found a bug in the clock computation of the i2c module.
This is the second, hopefully clean pull request for this issue.