### PR TITLE
Fix "CC26xx delayed wakeup after RF TX" bug

### DIFF
--- a/cpu/cc26xx/dev/cc26xx-rf.c
+++ b/cpu/cc26xx/dev/cc26xx-rf.c
@@ -267,15 +267,17 @@ const output_config_t *tx_power_current = &output_power[0];
 /*---------------------------------------------------------------------------*/
 /* RF interrupts */
 #define RX_IRQ       IRQ_IEEE_RX_ENTRY_DONE
-#define TX_IRQ       IRQ_IEEE_TX_FRAME
 #define TX_ACK_IRQ   IRQ_IEEE_TX_ACK
 #define ERROR_IRQ    IRQ_INTERNAL_ERROR
 
+/* Those IRQs are enabled all the time */
+#define ENABLED_IRQS (RX_IRQ + ERROR_IRQ)
+
 /*
- * We don't really care about TX ISR, we just use it to bring the CM3 out
- * of sleep, which it enters while the RF is TXing
+ * We only enable this right before starting frame TX, so we can sleep while
+ * the TX is ongoing
  */
-#define ENABLED_IRQS (RX_IRQ + TX_IRQ + ERROR_IRQ)
+#define LAST_FG_CMD_DONE  IRQ_LAST_FG_COMMAND_DONE
 
 #define cc26xx_rf_cpe0_isr RFCCPE0IntHandler
 #define cc26xx_rf_cpe1_isr RFCCPE1IntHandler
@@ -1295,6 +1297,10 @@ transmit(unsigned short transmit_len)
   GET_FIELD(cmd_immediate_buf, CMD_IEEE_TX, payloadLen) = transmit_len;
   GET_FIELD(cmd_immediate_buf, CMD_IEEE_TX, pPayload) = tx_buf;
 
+  /* Enable the LAST_FG_COMMAND_DONE interrupt, which will wake us up */
+  HWREG(RFC_DBELL_NONBUF_BASE + RFC_DBELL_O_RFCPEIEN) = ENABLED_IRQS +
+    LAST_FG_CMD_DONE;
+
   ret = rf_send_cmd((uint32_t)cmd_immediate_buf, &cmd_status);
 
   if(ret) {
@@ -1335,9 +1341,11 @@ transmit(unsigned short transmit_len)
   ENERGEST_OFF(ENERGEST_TYPE_TRANSMIT);
   ENERGEST_ON(ENERGEST_TYPE_LISTEN);
 
-  if(was_off) {
-    off();
-  }
+  /*
+   * Disable LAST_FG_COMMAND_DONE interrupt. We don't really care about it
+   * except when we are transmitting
+   */
+  HWREG(RFC_DBELL_NONBUF_BASE + RFC_DBELL_O_RFCPEIEN) = ENABLED_IRQS;
 
   return ret;
 }


### PR DESCRIPTION
The CC26xx RF driver puts the CM3 to sleep while waiting for TX to finish.

Theory: The CM3 wakes up by the TX_DONE interrupt, checks that TX has finished and continues / returns.

In reality though, this logic is broken: The TX command's status field is updated by the CPE _after_ throwing TX_DONE. As a result, the CM3 wakes up, inspects the command's status field, thinks that TX is still ongoing and goes back to sleep until something else wakes it up (usually an RTC tick).

The result of this is that `.transmit()` takes way too long to return, the exact duration depending on exactly when the next RTC tick happens to take place. The final outcome of this is that ContikiMAC's TX only sends a small number of strobes, which in turn increases packet loss.

With this pull, we change the wakeup trigger from TX_DONE to LAST_FG_CMD_DONE. This is guaranteed to be thrown _after_ the TX command's status field has been updated. We only enable / disable this interrupt before/after TX so as to avoid the overhead of jumping to the interrupt handler after every FG command.

This pull also changes the RF on/off logic slightly: To avoid the overhead of powering up the RFCORE power domain, booting the CPE and switching oscillators, `.transmit()` will no longer turn the RF back off when it finishes. We rely on ContikiMAC to do this for us at the end of a packet train.

This has been discussed extensively in http://thread.gmane.org/gmane.os.contiki.devel/24767 and this fix has already been tested by the user who originally reported the problem.