### PR TITLE
Enable slip-radio and rpl-border-router for CC26xx

### DIFF
--- a/examples/cc26xx/cc26xx-web-demo/project-conf.h
+++ b/examples/cc26xx/cc26xx-web-demo/project-conf.h
@@ -44,10 +44,14 @@
 #define CC26XX_WEB_DEMO_CONF_COAP_SERVER      1
 #define CC26XX_WEB_DEMO_CONF_NET_UART         1
 /*---------------------------------------------------------------------------*/
-/* Shrink the size of the uIP buffer, routing table and ND cache */
+/*
+ * Shrink the size of the uIP buffer, routing table and ND cache.
+ * Set the TCP MSS
+ */
 #define UIP_CONF_BUFFER_SIZE                900
 #define NBR_TABLE_CONF_MAX_NEIGHBORS          8
 #define UIP_CONF_MAX_ROUTES                   8
+#define UIP_CONF_TCP_MSS                    128
 /*---------------------------------------------------------------------------*/
 #endif /* PROJECT_CONF_H_ */
 /*---------------------------------------------------------------------------*/

--- a/platform/srf06-cc26xx/contiki-conf.h
+++ b/platform/srf06-cc26xx/contiki-conf.h
@@ -220,7 +220,7 @@
 #define UIP_CONF_TCP                         1
 #endif
 #ifndef UIP_CONF_TCP_MSS
-#define UIP_CONF_TCP_MSS                   128
+#define UIP_CONF_TCP_MSS                    64
 #endif
 
 #define UIP_CONF_UDP                         1

--- a/platform/srf06-cc26xx/contiki-conf.h
+++ b/platform/srf06-cc26xx/contiki-conf.h
@@ -310,6 +310,13 @@
 
 /* Notify various examples that we have Buttons */
 #define PLATFORM_HAS_BUTTON      1
+
+/*
+ * Override button symbols from dev/button-sensor.h, for the examples that
+ * include it
+ */
+#define button_sensor button_left_sensor
+#define button_sensor2 button_right_sensor
 /** @} */
 /*---------------------------------------------------------------------------*/
 /* Platform-specific define to signify sensor reading failure */

--- a/platform/srf06-cc26xx/sensortag/button-sensor.h
+++ b/platform/srf06-cc26xx/sensortag/button-sensor.h
@@ -54,7 +54,6 @@
 #define BUTTON_SENSOR_VALUE_RELEASED 0
 #define BUTTON_SENSOR_VALUE_PRESSED  1
 /*---------------------------------------------------------------------------*/
-#define button_sensor button_left_sensor
 extern const struct sensors_sensor button_left_sensor;
 extern const struct sensors_sensor button_right_sensor;
 /*---------------------------------------------------------------------------*/

--- a/platform/srf06-cc26xx/srf06/button-sensor.h
+++ b/platform/srf06-cc26xx/srf06/button-sensor.h
@@ -49,7 +49,6 @@
 #define BUTTON_SENSOR_VALUE_RELEASED 0
 #define BUTTON_SENSOR_VALUE_PRESSED  1
 /*---------------------------------------------------------------------------*/
-#define button_sensor button_select_sensor
 extern const struct sensors_sensor button_select_sensor;
 extern const struct sensors_sensor button_left_sensor;
 extern const struct sensors_sensor button_right_sensor;


### PR DESCRIPTION
This pull makes some small changes to the CC26xx platform code, so that slip-radio and rpl-border-router will compile off-the-shelf.