### PR TITLE
Added missing sanity check in uip-ds6-route.c

### DIFF
--- a/core/net/ipv6/uip-ds6-route.c
+++ b/core/net/ipv6/uip-ds6-route.c
@@ -280,7 +280,7 @@ uip_ds6_route_add(uip_ipaddr_t *ipaddr, uint8_t length,
   if(r != NULL) {
     uip_ipaddr_t *current_nexthop;
     current_nexthop = uip_ds6_route_nexthop(r);
-    if(uip_ipaddr_cmp(nexthop, current_nexthop)) {
+    if(current_nexthop != NULL && uip_ipaddr_cmp(nexthop, current_nexthop)) {
       /* no need to update route - already correct! */
       return r;
     }


### PR DESCRIPTION
We have no guarantee that `current_nexthop` is not null even when `r` is a valid entry. On platforms with memory protection, `memcpy` on a null pointer can hurt. Found this bug while playing with a regression test with native compilation.