### PR TITLE
RPL probing

### DIFF
--- a/core/net/rpl/rpl-conf.h
+++ b/core/net/rpl/rpl-conf.h
@@ -227,6 +227,15 @@
 #endif
 
 /*
+ * RPL probing expiration time.
+ * */
+#ifdef RPL_CONF_PROBING_EXPIRATION_TIME
+#define RPL_PROBING_EXPIRATION_TIME RPL_CONF_PROBING_EXPIRATION_TIME
+#else
+#define RPL_PROBING_EXPIRATION_TIME (10 * 60 * CLOCK_SECOND)
+#endif
+
+/*
  * Function used to select the next parent to be probed.
  * */
 #ifdef RPL_CONF_PROBING_SELECT_FUNC

--- a/core/net/rpl/rpl-conf.h
+++ b/core/net/rpl/rpl-conf.h
@@ -249,4 +249,14 @@
 #define RPL_PROBING_SEND_FUNC(instance, addr) dio_output((instance), (addr))
 #endif
 
+/*
+ * Function used to calculate next RPL probing interval
+ * */
+#ifdef RPL_CONF_PROBING_DELAY_FUNC
+#define RPL_PROBING_DELAY_FUNC RPL_CONF_PROBING_DELAY_FUNC
+#else
+#define RPL_PROBING_DELAY_FUNC() ((RPL_PROBING_INTERVAL / 2) \
+    + random_rand() % (RPL_PROBING_INTERVAL))
+#endif
+
 #endif /* RPL_CONF_H */

--- a/core/net/rpl/rpl-conf.h
+++ b/core/net/rpl/rpl-conf.h
@@ -207,4 +207,46 @@
 #define RPL_INSERT_HBH_OPTION       1
 #endif
 
+/*
+ * RPL probing. When enabled, probes will be sent periodically to keep
+ * parent link estimates up to date.
+ * */
+#ifdef RPL_CONF_WITH_PROBING
+#define RPL_WITH_PROBING RPL_CONF_WITH_PROBING
+#else
+#define RPL_WITH_PROBING 1
+#endif
+
+/*
+ * RPL probing interval.
+ * */
+#ifdef RPL_CONF_PROBING_INTERVAL
+#define RPL_PROBING_INTERVAL RPL_CONF_PROBING_INTERVAL
+#else
+#define RPL_PROBING_INTERVAL (120 * CLOCK_SECOND)
+#endif
+
+/*
+ * Function used to select the next parent to be probed.
+ * */
+#ifdef RPL_CONF_PROBING_SELECT_FUNC
+#define RPL_PROBING_SELECT_FUNC RPL_CONF_PROBING_SELECT_FUNC
+#else
+#define RPL_PROBING_SELECT_FUNC(dag) get_probing_target((dag))
+#endif
+
+/*
+ * Function used to send RPL probes.
+ * To probe with DIO, use:
+ * #define RPL_CONF_PROBING_SEND_FUNC(instance, addr) dio_output((instance), (addr))
+ * To probe with DIS, use:
+ * #define RPL_CONF_PROBING_SEND_FUNC(instance, addr) dis_output((addr))
+ * Any other custom probing function is also acceptable.
+ * */
+#ifdef RPL_CONF_PROBING_SEND_FUNC
+#define RPL_PROBING_SEND_FUNC RPL_CONF_PROBING_SEND_FUNC
+#else
+#define RPL_PROBING_SEND_FUNC(instance, addr) dio_output((instance), (addr))
+#endif
+
 #endif /* RPL_CONF_H */

--- a/core/net/rpl/rpl-dag.c
+++ b/core/net/rpl/rpl-dag.c
@@ -82,6 +82,28 @@ rpl_instance_t instance_table[RPL_MAX_INSTANCES];
 rpl_instance_t *default_instance;
 
 /*---------------------------------------------------------------------------*/
+void
+rpl_print_neighbor_list()
+{
+  if(default_instance != NULL && default_instance->current_dag != NULL &&
+      default_instance->of != NULL && default_instance->of->calculate_rank != NULL) {
+    int curr_dio_interval = default_instance->dio_intcurrent;
+    int curr_rank = default_instance->current_dag->rank;
+    rpl_parent_t *p = nbr_table_head(rpl_parents);
+
+    printf("RPL: rank %u dioint %u, %u nbr(s)\n", curr_rank, curr_dio_interval, uip_ds6_nbr_num());
+    while(p != NULL) {
+      uip_ds6_nbr_t *nbr = rpl_get_nbr(p);
+      printf("RPL: nbr %3u %5u, %5u => %5u %c\n",
+          nbr_table_get_lladdr(rpl_parents, p)->u8[7],
+          p->rank, nbr ? nbr->link_metric : 0, default_instance->of->calculate_rank(p, 0),
+          p == default_instance->current_dag->preferred_parent ? '*' : ' ');
+      p = nbr_table_next(rpl_parents, p);
+    }
+    printf("RPL: end of list\n");
+  }
+}
+/*---------------------------------------------------------------------------*/
 uip_ds6_nbr_t *
 rpl_get_nbr(rpl_parent_t *parent)
 {
@@ -729,6 +751,9 @@ rpl_select_dag(rpl_instance_t *instance, rpl_parent_t *p)
       rpl_schedule_dao(instance);
     }
     rpl_reset_dio_timer(instance);
+#if DEBUG
+    rpl_print_neighbor_list();
+#endif
   } else if(best_dag->rank != old_rank) {
     PRINTF("RPL: Preferred parent update, rank changed from %u to %u\n",
   	(unsigned)old_rank, best_dag->rank);

--- a/core/net/rpl/rpl-dag.c
+++ b/core/net/rpl/rpl-dag.c
@@ -1329,7 +1329,7 @@ rpl_process_dio(uip_ipaddr_t *from, rpl_dio_t *dio)
   PRINTF(", rank %u, min_rank %u, ",
 	 instance->current_dag->rank, instance->current_dag->min_rank);
   PRINTF("parent rank %u, parent etx %u, link metric %u, instance etx %u\n",
-	 p->rank, -1/*p->mc.obj.etx*/, p->link_metric, instance->mc.obj.etx);
+	 p->rank, -1/*p->mc.obj.etx*/, rpl_get_nbr(p)->link_metric, instance->mc.obj.etx);
 
   /* We have allocated a candidate parent; process the DIO further. */
 

--- a/core/net/rpl/rpl-dag.c
+++ b/core/net/rpl/rpl-dag.c
@@ -75,7 +75,7 @@ static rpl_of_t * const objective_functions[] = {&RPL_OF};
 
 /*---------------------------------------------------------------------------*/
 /* Per-parent RPL information */
-NBR_TABLE(rpl_parent_t, rpl_parents);
+NBR_TABLE_GLOBAL(rpl_parent_t, rpl_parents);
 /*---------------------------------------------------------------------------*/
 /* Allocate instance table. */
 rpl_instance_t instance_table[RPL_MAX_INSTANCES];
@@ -90,14 +90,17 @@ rpl_print_neighbor_list()
     int curr_dio_interval = default_instance->dio_intcurrent;
     int curr_rank = default_instance->current_dag->rank;
     rpl_parent_t *p = nbr_table_head(rpl_parents);
+    clock_time_t now = clock_time();
 
     printf("RPL: rank %u dioint %u, %u nbr(s)\n", curr_rank, curr_dio_interval, uip_ds6_nbr_num());
     while(p != NULL) {
       uip_ds6_nbr_t *nbr = rpl_get_nbr(p);
-      printf("RPL: nbr %3u %5u, %5u => %5u %c\n",
+      printf("RPL: nbr %3u %5u, %5u => %5u %c (last tx %u min ago)\n",
           nbr_table_get_lladdr(rpl_parents, p)->u8[7],
-          p->rank, nbr ? nbr->link_metric : 0, default_instance->of->calculate_rank(p, 0),
-          p == default_instance->current_dag->preferred_parent ? '*' : ' ');
+          p->rank, nbr ? nbr->link_metric : 0,
+          default_instance->of->calculate_rank(p, 0),
+          p == default_instance->current_dag->preferred_parent ? '*' : ' ',
+          (now - p->last_tx_time) / (60 * CLOCK_SECOND));
       p = nbr_table_next(rpl_parents, p);
     }
     printf("RPL: end of list\n");
@@ -496,6 +499,9 @@ rpl_alloc_instance(uint8_t instance_id)
       instance->instance_id = instance_id;
       instance->def_route = NULL;
       instance->used = 1;
+#if RPL_WITH_PROBING
+      rpl_schedule_probing(instance);
+#endif /* RPL_WITH_PROBING */
       return instance;
     }
   }
@@ -556,6 +562,9 @@ rpl_free_instance(rpl_instance_t *instance)
 
   rpl_set_default_route(instance, NULL);
 
+#if RPL_WITH_PROBING
+  ctimer_stop(&instance->probing_timer);
+#endif /* RPL_WITH_PROBING */
   ctimer_stop(&instance->dio_timer);
   ctimer_stop(&instance->dao_timer);
   ctimer_stop(&instance->dao_lifetime_timer);

--- a/core/net/rpl/rpl-icmp6.c
+++ b/core/net/rpl/rpl-icmp6.c
@@ -466,8 +466,12 @@ dio_output(rpl_instance_t *instance, uip_ipaddr_t *uc_addr)
 
   buffer[pos++] = instance->dtsn_out;
 
-  /* always request new DAO to refresh route */
-  RPL_LOLLIPOP_INCREMENT(instance->dtsn_out);
+  if(uc_addr == NULL) {
+    /* Request new DAO to refresh route. We do not do this for unicast DIO
+     * in order to avoid DAO messages after a DIS-DIO update,
+     * or upon unicast DIO probing. */
+    RPL_LOLLIPOP_INCREMENT(instance->dtsn_out);
+  }
 
   /* reserved 2 bytes */
   buffer[pos++] = 0; /* flags */

--- a/core/net/rpl/rpl-private.h
+++ b/core/net/rpl/rpl-private.h
@@ -313,6 +313,7 @@ rpl_of_t *rpl_find_of(rpl_ocp_t);
 void rpl_schedule_dao(rpl_instance_t *);
 void rpl_schedule_dao_immediately(rpl_instance_t *);
 void rpl_cancel_dao(rpl_instance_t *instance);
+void rpl_schedule_probing(rpl_instance_t *instance);
 
 void rpl_reset_dio_timer(rpl_instance_t *);
 void rpl_reset_periodic_timer(void);

--- a/core/net/rpl/rpl-timers.c
+++ b/core/net/rpl/rpl-timers.c
@@ -332,18 +332,19 @@ static rpl_parent_t *
 get_probing_target(rpl_dag_t *dag)
 {
   /* Returns the next probing target. The current implementation probes the current
-   * preferred parent if we have not updated its link for 2 * RPL_PROBING_INTERVAL.
+   * preferred parent if we have not updated its link for RPL_PROBING_EXPIRATION_TIME.
    * Otherwise, it picks at random between:
-   * (1) selecting the best parent not updated for 2 * RPL_PROBING_INTERVAL
+   * (1) selecting the best parent not updated for RPL_PROBING_EXPIRATION_TIME
    * (2) selecting the least recently updated parent
    */
 
   rpl_parent_t *p;
   rpl_parent_t *probing_target = NULL;
   rpl_rank_t probing_target_rank = INFINITE_RANK;
-  /* min_last_tx is the clock time (2 * RPL_PROBING_INTERVAL) in the past */
+  /* min_last_tx is the clock time RPL_PROBING_EXPIRATION_TIME in the past */
   clock_time_t min_last_tx = clock_time();
-  min_last_tx = min_last_tx > 2 * RPL_PROBING_INTERVAL ? min_last_tx - 2 * RPL_PROBING_INTERVAL : 1;
+  min_last_tx = min_last_tx > 2 * RPL_PROBING_EXPIRATION_TIME
+      ? min_last_tx - RPL_PROBING_EXPIRATION_TIME : 1;
 
   if(dag == NULL ||
       dag->instance == NULL ||
@@ -357,7 +358,7 @@ get_probing_target(rpl_dag_t *dag)
   }
 
   if((random_rand() % 2) == 0) {
-    /* With 1/2 probability: probe best parent not updated for 2 * RPL_PROBING_INTERVAL */
+    /* With 1/2 probability: probe best parent not updated for RPL_PROBING_EXPIRATION_TIME */
     p = nbr_table_head(rpl_parents);
     while(p != NULL) {
       if(p->dag == dag && p->last_tx_time < min_last_tx) {

--- a/core/net/rpl/rpl-timers.c
+++ b/core/net/rpl/rpl-timers.c
@@ -327,5 +327,90 @@ rpl_cancel_dao(rpl_instance_t *instance)
   ctimer_stop(&instance->dao_lifetime_timer);
 }
 /*---------------------------------------------------------------------------*/
+#if RPL_WITH_PROBING
+static rpl_parent_t *
+get_probing_target(rpl_dag_t *dag)
+{
+  /* Returns the next probing target. The current implementation looks for the
+   * best parent to which we have not transmitted since 2 * RPL_PROBING_INTERVAL.
+   * This will mostly select the preferred and second best parents. Probing the
+   * second best parent is important: if the link is good, RPL might choose to
+   * switch to it. If the link is bad, the second best parent will decrease in
+   * ranking, and another parent will be probed next time. */
 
+  rpl_parent_t *p;
+  rpl_parent_t *probing_target;
+  rpl_rank_t probing_target_rank;
+  /* Look for a parent we have not sent to since 2 * RPL_PROBING_INTERVAL,
+   * e.g. with last_tx_time earlier than min_last_tx */
+  clock_time_t min_last_tx = clock_time();
+  min_last_tx = min_last_tx > 2 * RPL_PROBING_INTERVAL ? min_last_tx - 2 * RPL_PROBING_INTERVAL : 1;
+
+  if(dag == NULL ||
+      dag->instance == NULL ||
+      dag->preferred_parent == NULL) {
+    return NULL;
+  }
+
+  /* Our preferred parent needs probing */
+  if(dag->preferred_parent->last_tx_time < min_last_tx) {
+    return dag->preferred_parent;
+  }
+
+  /* Look for the best parent that needs probing. */
+  probing_target = NULL;
+  probing_target_rank = INFINITE_RANK;
+  p = nbr_table_head(rpl_parents);
+  while(p != NULL) {
+    if(p->dag == dag && p->last_tx_time < min_last_tx) {
+      rpl_rank_t p_rank = dag->instance->of->calculate_rank(p, 0);
+      /* p is in our dag and needs probing */
+      if(probing_target == NULL) {
+        probing_target = p;
+        probing_target_rank = p_rank;
+      } else {
+        if(p_rank < probing_target_rank) {
+          /* Found better candidate */
+          probing_target = p;
+          probing_target_rank = p_rank;
+        }
+      }
+    }
+    p = nbr_table_next(rpl_parents, p);
+  }
+
+  return probing_target;
+}
+/*---------------------------------------------------------------------------*/
+static void
+handle_probing_timer(void *ptr)
+{
+  rpl_instance_t *instance = (rpl_instance_t *)ptr;
+  rpl_parent_t *probing_target = RPL_PROBING_SELECT_FUNC(instance->current_dag);
+
+  /* Perform probing */
+  if(probing_target != NULL && rpl_get_parent_ipaddr(probing_target) != NULL) {
+    PRINTF("RPL: probing %3u\n",
+        nbr_table_get_lladdr(rpl_parents, probing_target)->u8[7]);
+    /* Send probe, e.g. unicast DIO or DIS */
+    RPL_PROBING_SEND_FUNC(instance, rpl_get_parent_ipaddr(probing_target));
+  }
+
+  /* Schedule next probing */
+  rpl_schedule_probing(instance);
+
+#if DEBUG
+  rpl_print_neighbor_list();
+#endif
+}
+/*---------------------------------------------------------------------------*/
+void
+rpl_schedule_probing(rpl_instance_t *instance)
+{
+  clock_time_t delay = (RPL_PROBING_INTERVAL / 2) +
+      random_rand() % (RPL_PROBING_INTERVAL / 2);
+  ctimer_set(&instance->probing_timer, delay,
+                  handle_probing_timer, instance);
+}
+#endif /* RPL_WITH_PROBING */
 /** @}*/

--- a/core/net/rpl/rpl-timers.c
+++ b/core/net/rpl/rpl-timers.c
@@ -331,18 +331,17 @@ rpl_cancel_dao(rpl_instance_t *instance)
 static rpl_parent_t *
 get_probing_target(rpl_dag_t *dag)
 {
-  /* Returns the next probing target. The current implementation looks for the
-   * best parent to which we have not transmitted since 2 * RPL_PROBING_INTERVAL.
-   * This will mostly select the preferred and second best parents. Probing the
-   * second best parent is important: if the link is good, RPL might choose to
-   * switch to it. If the link is bad, the second best parent will decrease in
-   * ranking, and another parent will be probed next time. */
+  /* Returns the next probing target. The current implementation probes the current
+   * preferred parent if we have not updated its link for 2 * RPL_PROBING_INTERVAL.
+   * Otherwise, it picks at random between:
+   * (1) selecting the best parent not updated for 2 * RPL_PROBING_INTERVAL
+   * (2) selecting the least recently updated parent
+   */
 
   rpl_parent_t *p;
-  rpl_parent_t *probing_target;
-  rpl_rank_t probing_target_rank;
-  /* Look for a parent we have not sent to since 2 * RPL_PROBING_INTERVAL,
-   * e.g. with last_tx_time earlier than min_last_tx */
+  rpl_parent_t *probing_target = NULL;
+  rpl_rank_t probing_target_rank = INFINITE_RANK;
+  /* min_last_tx is the clock time (2 * RPL_PROBING_INTERVAL) in the past */
   clock_time_t min_last_tx = clock_time();
   min_last_tx = min_last_tx > 2 * RPL_PROBING_INTERVAL ? min_last_tx - 2 * RPL_PROBING_INTERVAL : 1;
 
@@ -357,26 +356,34 @@ get_probing_target(rpl_dag_t *dag)
     return dag->preferred_parent;
   }
 
-  /* Look for the best parent that needs probing. */
-  probing_target = NULL;
-  probing_target_rank = INFINITE_RANK;
-  p = nbr_table_head(rpl_parents);
-  while(p != NULL) {
-    if(p->dag == dag && p->last_tx_time < min_last_tx) {
-      rpl_rank_t p_rank = dag->instance->of->calculate_rank(p, 0);
-      /* p is in our dag and needs probing */
-      if(probing_target == NULL) {
-        probing_target = p;
-        probing_target_rank = p_rank;
-      } else {
-        if(p_rank < probing_target_rank) {
-          /* Found better candidate */
+  if((random_rand() % 2) == 0) {
+    /* With 1/2 probability: probe best parent not updated for 2 * RPL_PROBING_INTERVAL */
+    p = nbr_table_head(rpl_parents);
+    while(p != NULL) {
+      if(p->dag == dag && p->last_tx_time < min_last_tx) {
+        /* p is in our dag and needs probing */
+        rpl_rank_t p_rank = dag->instance->of->calculate_rank(p, 0);
+        if(probing_target == NULL
+            || p_rank < probing_target_rank) {
           probing_target = p;
           probing_target_rank = p_rank;
         }
       }
+      p = nbr_table_next(rpl_parents, p);
     }
-    p = nbr_table_next(rpl_parents, p);
+  } else {
+    /* With 1/2 probability: probe the least recently updated parent */
+    p = nbr_table_head(rpl_parents);
+    while(p != NULL) {
+      if(p->dag == dag) {
+        if(probing_target == NULL
+            || p->last_tx_time < probing_target->last_tx_time) {
+          probing_target = p;
+        }
+      }
+      p = nbr_table_next(rpl_parents, p);
+    }
+
   }
 
   return probing_target;

--- a/core/net/rpl/rpl-timers.c
+++ b/core/net/rpl/rpl-timers.c
@@ -354,11 +354,11 @@ get_probing_target(rpl_dag_t *dag)
 
   /* Our preferred parent needs probing */
   if(dag->preferred_parent->last_tx_time < min_last_tx) {
-    return dag->preferred_parent;
+    probing_target = dag->preferred_parent;
   }
 
-  if((random_rand() % 2) == 0) {
-    /* With 1/2 probability: probe best parent not updated for RPL_PROBING_EXPIRATION_TIME */
+  /* With 50% probability: probe best parent not updated for RPL_PROBING_EXPIRATION_TIME */
+  if(probing_target == NULL && (random_rand() % 2) == 0) {
     p = nbr_table_head(rpl_parents);
     while(p != NULL) {
       if(p->dag == dag && p->last_tx_time < min_last_tx) {
@@ -372,8 +372,10 @@ get_probing_target(rpl_dag_t *dag)
       }
       p = nbr_table_next(rpl_parents, p);
     }
-  } else {
-    /* With 1/2 probability: probe the least recently updated parent */
+  }
+
+  /* The default probing target is the least recently updated parent */
+  if(probing_target == NULL) {
     p = nbr_table_head(rpl_parents);
     while(p != NULL) {
       if(p->dag == dag) {
@@ -384,7 +386,6 @@ get_probing_target(rpl_dag_t *dag)
       }
       p = nbr_table_next(rpl_parents, p);
     }
-
   }
 
   return probing_target;

--- a/core/net/rpl/rpl-timers.c
+++ b/core/net/rpl/rpl-timers.c
@@ -166,6 +166,10 @@ handle_dio_timer(void *ptr)
     }
     new_dio_interval(instance);
   }
+
+#if DEBUG
+  rpl_print_neighbor_list();
+#endif
 }
 /*---------------------------------------------------------------------------*/
 void

--- a/core/net/rpl/rpl-timers.c
+++ b/core/net/rpl/rpl-timers.c
@@ -414,9 +414,7 @@ handle_probing_timer(void *ptr)
 void
 rpl_schedule_probing(rpl_instance_t *instance)
 {
-  clock_time_t delay = (RPL_PROBING_INTERVAL / 2) +
-      random_rand() % (RPL_PROBING_INTERVAL / 2);
-  ctimer_set(&instance->probing_timer, delay,
+  ctimer_set(&instance->probing_timer, RPL_PROBING_DELAY_FUNC(),
                   handle_probing_timer, instance);
 }
 #endif /* RPL_WITH_PROBING */

--- a/core/net/rpl/rpl.c
+++ b/core/net/rpl/rpl.c
@@ -263,6 +263,7 @@ rpl_link_neighbor_callback(const linkaddr_t *addr, int status, int numtx)
         parent->flags |= RPL_PARENT_FLAG_UPDATED;
         if(instance->of->neighbor_link_callback != NULL) {
           instance->of->neighbor_link_callback(parent, status, numtx);
+          parent->last_tx_time = clock_time();
         }
       }
     }

--- a/core/net/rpl/rpl.h
+++ b/core/net/rpl/rpl.h
@@ -251,6 +251,7 @@ rpl_rank_t rpl_get_parent_rank(uip_lladdr_t *addr);
 uint16_t rpl_get_parent_link_metric(const uip_lladdr_t *addr);
 void rpl_dag_init(void);
 uip_ds6_nbr_t *rpl_get_nbr(rpl_parent_t *parent);
+void rpl_print_neighbor_list();
 
 /**
  * RPL modes

--- a/core/net/rpl/rpl.h
+++ b/core/net/rpl/rpl.h
@@ -114,6 +114,7 @@ struct rpl_parent {
   rpl_metric_container_t mc;
 #endif /* RPL_DAG_MC != RPL_DAG_MC_NONE */
   rpl_rank_t rank;
+  clock_time_t last_tx_time;
   uint8_t dtsn;
   uint8_t flags;
 };
@@ -224,6 +225,9 @@ struct rpl_instance {
   uint16_t dio_totrecv;
 #endif /* RPL_CONF_STATS */
   clock_time_t dio_next_delay; /* delay for completion of dio interval */
+#if RPL_WITH_PROBING
+  struct ctimer probing_timer;
+#endif /* RPL_WITH_PROBING */
   struct ctimer dio_timer;
   struct ctimer dao_timer;
   struct ctimer dao_lifetime_timer;
@@ -252,6 +256,9 @@ uint16_t rpl_get_parent_link_metric(const uip_lladdr_t *addr);
 void rpl_dag_init(void);
 uip_ds6_nbr_t *rpl_get_nbr(rpl_parent_t *parent);
 void rpl_print_neighbor_list();
+
+/* Per-parent RPL information */
+NBR_TABLE_DECLARE(rpl_parents);
 
 /**
  * RPL modes

--- a/regression-tests/12-rpl/09-rpl-probing.csc
+++ b/regression-tests/12-rpl/09-rpl-probing.csc
@@ -1,0 +1,258 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<simconf>
+  <project EXPORT="discard">[APPS_DIR]/mrm</project>
+  <project EXPORT="discard">[APPS_DIR]/mspsim</project>
+  <project EXPORT="discard">[APPS_DIR]/avrora</project>
+  <project EXPORT="discard">[APPS_DIR]/serial_socket</project>
+  <project EXPORT="discard">[APPS_DIR]/collect-view</project>
+  <project EXPORT="discard">[APPS_DIR]/powertracker</project>
+  <simulation>
+    <title>My simulation</title>
+    <randomseed>123456</randomseed>
+    <motedelay_us>1000000</motedelay_us>
+    <radiomedium>
+      org.contikios.cooja.radiomediums.UDGM
+      <transmitting_range>50.0</transmitting_range>
+      <interference_range>50.0</interference_range>
+      <success_ratio_tx>1.0</success_ratio_tx>
+      <success_ratio_rx>1.0</success_ratio_rx>
+    </radiomedium>
+    <events>
+      <logoutput>40000</logoutput>
+    </events>
+    <motetype>
+      org.contikios.cooja.contikimote.ContikiMoteType
+      <identifier>mtype190</identifier>
+      <description>Sender</description>
+      <source>[CONTIKI_DIR]/regression-tests/12-rpl/code/sender-node.c</source>
+      <commands>make clean TARGET=cooja
+make sender-node.cooja TARGET=cooja</commands>
+      <moteinterface>org.contikios.cooja.interfaces.Position</moteinterface>
+      <moteinterface>org.contikios.cooja.interfaces.Battery</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiVib</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiMoteID</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiRS232</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiBeeper</moteinterface>
+      <moteinterface>org.contikios.cooja.interfaces.RimeAddress</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiIPAddress</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiRadio</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiButton</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiPIR</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiClock</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiLED</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiCFS</moteinterface>
+      <moteinterface>org.contikios.cooja.interfaces.Mote2MoteRelations</moteinterface>
+      <moteinterface>org.contikios.cooja.interfaces.MoteAttributes</moteinterface>
+      <symbols>false</symbols>
+    </motetype>
+    <motetype>
+      org.contikios.cooja.contikimote.ContikiMoteType
+      <identifier>mtype481</identifier>
+      <description>RPL root</description>
+      <source>[CONTIKI_DIR]/regression-tests/12-rpl/code/root-node.c</source>
+      <commands>make clean TARGET=cooja
+make root-node.cooja TARGET=cooja</commands>
+      <moteinterface>org.contikios.cooja.interfaces.Position</moteinterface>
+      <moteinterface>org.contikios.cooja.interfaces.Battery</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiVib</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiMoteID</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiRS232</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiBeeper</moteinterface>
+      <moteinterface>org.contikios.cooja.interfaces.RimeAddress</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiIPAddress</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiRadio</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiButton</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiPIR</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiClock</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiLED</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiCFS</moteinterface>
+      <moteinterface>org.contikios.cooja.interfaces.Mote2MoteRelations</moteinterface>
+      <moteinterface>org.contikios.cooja.interfaces.MoteAttributes</moteinterface>
+      <symbols>false</symbols>
+    </motetype>
+    <motetype>
+      org.contikios.cooja.contikimote.ContikiMoteType
+      <identifier>mtype692</identifier>
+      <description>Receiver</description>
+      <source>[CONTIKI_DIR]/regression-tests/12-rpl/code/receiver-node.c</source>
+      <commands>make clean TARGET=cooja
+make receiver-node.cooja TARGET=cooja</commands>
+      <moteinterface>org.contikios.cooja.interfaces.Position</moteinterface>
+      <moteinterface>org.contikios.cooja.interfaces.Battery</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiVib</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiMoteID</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiRS232</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiBeeper</moteinterface>
+      <moteinterface>org.contikios.cooja.interfaces.RimeAddress</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiIPAddress</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiRadio</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiButton</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiPIR</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiClock</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiLED</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiCFS</moteinterface>
+      <moteinterface>org.contikios.cooja.interfaces.Mote2MoteRelations</moteinterface>
+      <moteinterface>org.contikios.cooja.interfaces.MoteAttributes</moteinterface>
+      <symbols>false</symbols>
+    </motetype>
+    <mote>
+      <interface_config>
+        org.contikios.cooja.interfaces.Position
+        <x>8.0</x>
+        <y>2.0</y>
+        <z>0.0</z>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.contikimote.interfaces.ContikiMoteID
+        <id>1</id>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.contikimote.interfaces.ContikiRadio
+        <bitrate>250.0</bitrate>
+      </interface_config>
+      <motetype_identifier>mtype481</motetype_identifier>
+    </mote>
+    <mote>
+      <interface_config>
+        org.contikios.cooja.interfaces.Position
+        <x>-7.19071602882406</x>
+        <y>34.96668248624779</y>
+        <z>0.0</z>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.contikimote.interfaces.ContikiMoteID
+        <id>2</id>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.contikimote.interfaces.ContikiRadio
+        <bitrate>250.0</bitrate>
+      </interface_config>
+      <motetype_identifier>mtype190</motetype_identifier>
+    </mote>
+    <mote>
+      <interface_config>
+        org.contikios.cooja.interfaces.Position
+        <x>-17.870288882812428</x>
+        <y>4.581754854333804</y>
+        <z>0.0</z>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.contikimote.interfaces.ContikiMoteID
+        <id>3</id>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.contikimote.interfaces.ContikiRadio
+        <bitrate>250.0</bitrate>
+      </interface_config>
+      <motetype_identifier>mtype692</motetype_identifier>
+    </mote>
+  </simulation>
+  <plugin>
+    org.contikios.cooja.plugins.SimControl
+    <width>280</width>
+    <z>2</z>
+    <height>160</height>
+    <location_x>400</location_x>
+    <location_y>0</location_y>
+  </plugin>
+  <plugin>
+    org.contikios.cooja.plugins.Visualizer
+    <plugin_config>
+      <moterelations>true</moterelations>
+      <skin>org.contikios.cooja.plugins.skins.IDVisualizerSkin</skin>
+      <skin>org.contikios.cooja.plugins.skins.UDGMVisualizerSkin</skin>
+      <skin>org.contikios.cooja.plugins.skins.GridVisualizerSkin</skin>
+      <skin>org.contikios.cooja.plugins.skins.MoteTypeVisualizerSkin</skin>
+      <viewport>2.494541140753371 0.0 0.0 2.494541140753371 168.25302383129448 116.2254386098645</viewport>
+    </plugin_config>
+    <width>400</width>
+    <z>3</z>
+    <height>400</height>
+    <location_x>1</location_x>
+    <location_y>1</location_y>
+  </plugin>
+  <plugin>
+    org.contikios.cooja.plugins.LogListener
+    <plugin_config>
+      <filter />
+      <formatted_time />
+      <coloring />
+    </plugin_config>
+    <width>597</width>
+    <z>0</z>
+    <height>428</height>
+    <location_x>402</location_x>
+    <location_y>162</location_y>
+  </plugin>
+  <plugin>
+    org.contikios.cooja.plugins.Notes
+    <plugin_config>
+      <notes>Enter notes here</notes>
+      <decorations>true</decorations>
+    </plugin_config>
+    <width>904</width>
+    <z>4</z>
+    <height>160</height>
+    <location_x>680</location_x>
+    <location_y>0</location_y>
+  </plugin>
+  <plugin>
+    org.contikios.cooja.plugins.ScriptRunner
+    <plugin_config>
+      <script>GENERATE_MSG(1000000, "moving root 2 hops away");&#xD;
+GENERATE_MSG(1500000, "moving root back");&#xD;
+&#xD;
+lostMsgs = 0;&#xD;
+&#xD;
+TIMEOUT(6000000, if(lastMsg != -1 &amp;&amp; lastMsgHops == 1 &amp;&amp; lostMsgs &lt;= 2  &amp;&amp; num &gt; 20) { log.testOK(); } );&#xD;
+&#xD;
+lastMsg = -1;&#xD;
+packets = "_________";&#xD;
+hops = 0;&#xD;
+lastMsgHops = -1;&#xD;
+&#xD;
+while(true) {&#xD;
+    YIELD();&#xD;
+    if(msg.equals("moving root 2 hops away")) {&#xD;
+        var root = sim.getMoteWithID(1);&#xD;
+        root.getInterfaces().getPosition().setCoordinates(5, -20, 0);&#xD;
+        log.log("moving root 2 hops away\n");&#xD;
+    } else if(msg.equals("moving root back")) {&#xD;
+        var root = sim.getMoteWithID(1);&#xD;
+        root.getInterfaces().getPosition().setCoordinates(8, 2, 0);&#xD;
+        log.log("moving root back\n");&#xD;
+    } else if(msg.startsWith("Sending")) {&#xD;
+        hops = 0;&#xD;
+    } else if(msg.startsWith("#L") &amp;&amp; msg.endsWith("1; red")) {&#xD;
+        hops++;&#xD;
+    } else if(msg.startsWith("Data")) {&#xD;
+//        log.log("" + msg + "\n");    &#xD;
+        data = msg.split(" ");&#xD;
+        num = parseInt(data[14]);&#xD;
+        packets = packets.substr(0, num) + "*";&#xD;
+        log.log("" + hops + " " + packets + "\n");&#xD;
+//        log.log("Num " + num + "\n");&#xD;
+        if(lastMsg != -1) {&#xD;
+          if(num != lastMsg + 1) {&#xD;
+            numMissed = num - lastMsg - 1;&#xD;
+            lostMsgs += numMissed;&#xD;
+            log.log("Missed messages " + numMissed + " before " + num + "\n");            &#xD;
+            for(i = 0; i &lt; numMissed; i++) {&#xD;
+                packets = packets.substr(0, lastMsg + i) + "_";    &#xD;
+            }&#xD;
+          }    &#xD;
+        }&#xD;
+        lastMsgHops = hops;&#xD;
+        lastMsg = num;&#xD;
+    }&#xD;
+}</script>
+      <active>true</active>
+    </plugin_config>
+    <width>605</width>
+    <z>1</z>
+    <height>684</height>
+    <location_x>604</location_x>
+    <location_y>14</location_y>
+  </plugin>
+</simconf>
+


### PR DESCRIPTION
This PR implements an optional probing mechanism for RPL. Nodes will periodically send a unicast message (DIO or DIS) to one of their best parents (mostly the current preferred and second best parent, sometimes also the third best), to keep link metric estimates up to date. The main benefit is that it avoids switching to a parent which is seemingly good but has an outdated link metric (or never updated, stuck at its initial value). 

When probing and refreshing our link estimate to the second best parent **S**, there are three possible consequences:
(1) the link estimate remains roughly unchanged, **S** can be used safely as a backup in case the current preferred parent fails
(2) the link proves better than we thought, RPL may chose to switch parent a now use **S**
(3) the link proves worse than we thought, with its new link estimate **S** will no longer be the second best parent, we will be able to probe another parent until we find a safe backup to our current preferred parent

Through many deployments in different testbeds, with different platforms and MAC layers (Nullrdc, ContikiMAC, TSCH), we found that probing was a must when aiming for reliable RPL operation.
