### PR TITLE
Update CC26xxware download instructions

### DIFF
--- a/platform/srf06-cc26xx/README.md
+++ b/platform/srf06-cc26xx/README.md
@@ -75,10 +75,12 @@ the section ["Drivers" in the CC2538DK readme](https://github.com/contiki-os/con
 
 Environment
 ===========
-To use this port, you will need to download and extract CC26xxware sources,
-provided by TI here http://www.ti.com/tool/cc26xxware. Once you have done this,
-you will need to configure the Contiki build system so that it can locate and
-compile them as part of the build process.
+To use this port, you will need to download and extract CC26xxware sources. We
+currently use CC26xxware version 2.20.06.14829. The download link can be found
+here: http://processors.wiki.ti.com/index.php/CC26xxware
+
+Once you have done this, you will need to configure the Contiki build system so
+that it can locate and compile them as part of the build process.
 
 To do this, you will need to set the following environment variable:
 


### PR DESCRIPTION
TI released a new version of CC26xxware this week and our CC26xx port will fail to build with this version - see the discussion in #1058.

This pull merely updates the platform's README:
* It states the correct version number explicitly
* It provides a link to a page where the user can find a download link for this version

I am becoming increasingly convinced that we should pull CC26xxware as a submodule, which is something I will probably do when I update the port to use the latest version. So this is just a temporary counter-measure.