### PR TITLE
Produce ihex files usable with TI's Flash Programmer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,10 +41,11 @@ before_script:
 
   ## Install mainline ARM toolchain.  gcc-arm-none-eabi is available
   ## in Ubuntu >= 14.04, but this external PPA is needed for 12.04.
+  ## Install srecord
   - if [ ${BUILD_ARCH:-0} = arm-aapcs ] ; then
       sudo add-apt-repository -y ppa:terry.guo/gcc-arm-embedded &&
       sudo apt-get -qq update &&
-      sudo apt-get -qq install gcc-arm-none-eabi &&
+      sudo apt-get -qq install gcc-arm-none-eabi srecord &&
       arm-none-eabi-gcc --version ;
     fi
 

--- a/cpu/cc26xx/Makefile.cc26xx
+++ b/cpu/cc26xx/Makefile.cc26xx
@@ -6,6 +6,7 @@ OBJCOPY = arm-none-eabi-objcopy
 OBJDUMP = arm-none-eabi-objdump
 NM      = arm-none-eabi-nm
 SIZE    = arm-none-eabi-size
+SREC_CAT = srec_cat
 
 ### TI CC26xxware out-of-tree
 ### TI_CC26XXWARE is the home directory of the cc26xxware
@@ -106,8 +107,11 @@ CUSTOM_RULE_LINK=1
 	$(TRACE_LD)
 	$(Q)$(LD) $(LDFLAGS) ${filter-out $(LDSCRIPT) %.a,$^} ${filter %.a,$^} $(TARGET_LIBFILES) -lm -o $@
 
-%.hex: %.elf
+%.i16hex: %.elf
 	$(OBJCOPY) -O ihex $< $@
+
+%.hex: %.i16hex
+	$(SREC_CAT) $< -intel -o $@ -intel
 
 %.bin: %.elf
 	$(OBJCOPY) $(OBJCOPY_FLAGS) $< $@

--- a/platform/srf06-cc26xx/README.md
+++ b/platform/srf06-cc26xx/README.md
@@ -69,6 +69,7 @@ To use the port you need:
     [...]
     gcc version 4.9.3 20141119 (release) [ARM/embedded-4_9-branch revision 218278] (GNU Tools for ARM Embedded Processors)
 
+* srecord (http://srecord.sourceforge.net/)
 * You may also need other drivers so that the SmartRF can communicate with your
 operating system and so that you can use the chip's UART for I/O. Please read
 the section ["Drivers" in the CC2538DK readme](https://github.com/contiki-os/contiki/tree/master/platform/cc2538dk#drivers).


### PR DESCRIPTION
As per the discussion in #1058, TI's Flash Programmer seems to dislike 03 records in ihex files. As a result, the `.hex` file generated by the CC26xx build system cannot be used with Flash Programmer.

This pull changes the CC26xx build system as follows:
* We `objcopy` from the `.elf` to an intermediate `.hex` ~~which has all addresses offset by `0x200000`. This forces `objcopy` to only use 04/05 records instead of 02/03.~~
* We use `srecord` to post-process this intermediate hex. This produces a final hex file that uses 32-bit linear addresses ~~by offsetting everything back by `-0x200000`. This produces a final `.hex` which has correct addresses, but which only uses 04/05 records.~~

This final `.hex` was used successfully to program Srf+CC2650 EM as well as the SensorTag with cc26xx-demo as well as with cc26xx-web-demo.

Closes #1058