### PR TITLE
Default NDP configuration

### DIFF
--- a/core/contiki-default-conf.h
+++ b/core/contiki-default-conf.h
@@ -192,10 +192,16 @@
 #define NBR_TABLE_CONF_MAX_NEIGHBORS 8
 #endif /* NBR_TABLE_CONF_MAX_NEIGHBORS */
 
+/* UIP_CONF_ND6_SEND_RA enables standard IPv6 Router Advertisement.
+ * This is unneeded when RPL is used. */
+#ifndef UIP_CONF_ND6_SEND_RA
+#define UIP_CONF_ND6_SEND_RA (NETSTACK_CONF_WITH_IPV6 && !UIP_CONF_IPV6_RPL)
+#endif /* UIP_CONF_ND6_SEND_RA */
+
 /* UIP_CONF_ND6_SEND_NA enables standard IPv6 Neighbor Discovery Protocol.
-   This is unneeded when RPL is used. Disable to save ROM and a little RAM. */
+   This is unneeded when RPL is used. */
 #ifndef UIP_CONF_ND6_SEND_NA
-#define UIP_CONF_ND6_SEND_NA 1
+#define UIP_CONF_ND6_SEND_NA (NETSTACK_CONF_WITH_IPV6 && !UIP_CONF_IPV6_RPL)
 #endif /* UIP_CONF_ND6_SEND_NA */
 
 /*---------------------------------------------------------------------------*/

--- a/core/contiki-default-conf.h
+++ b/core/contiki-default-conf.h
@@ -193,13 +193,21 @@
 #endif /* NBR_TABLE_CONF_MAX_NEIGHBORS */
 
 /* UIP_CONF_ND6_SEND_RA enables standard IPv6 Router Advertisement.
- * This is unneeded when RPL is used. */
+ * We enable it by default when IPv6 is used without RPL. */
 #ifndef UIP_CONF_ND6_SEND_RA
 #define UIP_CONF_ND6_SEND_RA (NETSTACK_CONF_WITH_IPV6 && !UIP_CONF_IPV6_RPL)
 #endif /* UIP_CONF_ND6_SEND_RA */
 
 /* UIP_CONF_ND6_SEND_NA enables standard IPv6 Neighbor Discovery Protocol.
-   This is unneeded when RPL is used. */
+   We enable it by default when IPv6 is used without RPL.
+   With RPL, the neighbor cache (link-local IPv6 <-> MAC address mapping)
+   is fed whenever receiving DIO and DAO messages. This is always sufficient
+   for RPL routing, i.e. to send to the preferred parent or any child.
+   Link-local unicast to other neighbors may, however, not be possible if
+   we never receive any DIO from them. This may happen if the link from the
+   neighbor to us is weak, if DIO transmissions are suppressed (Trickle
+   timer) or if the neighbor chooses not to transmit DIOs because it is
+   a leaf node or for any reason. */
 #ifndef UIP_CONF_ND6_SEND_NA
 #define UIP_CONF_ND6_SEND_NA (NETSTACK_CONF_WITH_IPV6 && !UIP_CONF_IPV6_RPL)
 #endif /* UIP_CONF_ND6_SEND_NA */

--- a/examples/cc2530dk/udp-ipv6/project-conf.h
+++ b/examples/cc2530dk/udp-ipv6/project-conf.h
@@ -45,5 +45,6 @@
 #define BUTTON_SENSOR_CONF_ON 1
 #define UIP_CONF_ICMP6        1
 #define RIMESTATS_CONF_ENABLED 1
+#define UIP_CONF_ND6_SEND_NA 1
 
 #endif /* PROJECT_CONF_H_ */

--- a/examples/cc2538dk/udp-ipv6-echo-server/Makefile
+++ b/examples/cc2538dk/udp-ipv6-echo-server/Makefile
@@ -4,4 +4,5 @@ all: $(CONTIKI_PROJECT)
 
 CONTIKI = ../../..
 CONTIKI_WITH_IPV6 = 1
+CFLAGS += -DUIP_CONF_ND6_SEND_NA=1
 include $(CONTIKI)/Makefile.include

--- a/examples/sensinode/udp-ipv6/project-conf.h
+++ b/examples/sensinode/udp-ipv6/project-conf.h
@@ -47,5 +47,6 @@
 #define BUTTON_SENSOR_CONF_ON 1
 #define RIMESTATS_CONF_ENABLED 1
 #define VIZTOOL_CONF_ON         0
+#define UIP_CONF_ND6_SEND_NA 1
 
 #endif /* PROJECT_CONF_H_ */

--- a/examples/udp-ipv6/Makefile
+++ b/examples/udp-ipv6/Makefile
@@ -2,4 +2,5 @@ all: udp-server udp-client
 
 CONTIKI = ../..
 CONTIKI_WITH_IPV6 = 1
+CFLAGS += -DUIP_CONF_ND6_SEND_NA=1
 include $(CONTIKI)/Makefile.include

--- a/regression-tests/11-ipv6/code/receiver/project-conf.h
+++ b/regression-tests/11-ipv6/code/receiver/project-conf.h
@@ -1,4 +1,5 @@
-
+#undef UIP_CONF_ND6_SEND_NA
+#define UIP_CONF_ND6_SEND_NA 1
 
 #ifdef BUFSIZE
 #undef UIP_CONF_BUFFER_SIZE

--- a/regression-tests/11-ipv6/code/sender/project-conf.h
+++ b/regression-tests/11-ipv6/code/sender/project-conf.h
@@ -1,4 +1,5 @@
-
+#undef UIP_CONF_ND6_SEND_NA
+#define UIP_CONF_ND6_SEND_NA 1
 
 #ifdef BUFSIZE
 #undef UIP_CONF_BUFFER_SIZE


### PR DESCRIPTION
This PR proposes to enable IPv6 NDP (Neighbor Discovery Protocol) only when IPv6 is set without RPL. This means that by default, in projects with `CONTIKI_WITH_IPV6` (implies IPv6+RPL) NA will be disabled. To re-enable it, set `UIP_CONF_ND6_SEND_NA` in `project-conf.h` or unset `CONTIKI_WITH_RPL` in the makefile.

This is only a proposal, no strong opinion on it. One could just as well disable NDP explicitly when needed. The PR includes a fix to a number of examples that need NA, but I might have missed a few.

Reasons to **not** run NDP along with RPL:
* NDP adds unneeded traffic (NDP is not designed for multi-hop, RPL DIO are sufficient to handle MAC-IP mapping)
* NDP adds complexity and might have bad interactions with RPL, e.g. delete a neighbor RPL still needs
