### PR TITLE
Add support for DNS Service Discovery

### DIFF
--- a/core/net/ip/resolv.c
+++ b/core/net/ip/resolv.c
@@ -37,6 +37,7 @@
  * \author Adam Dunkels <adam@dunkels.com>
  * \author Robert Quattlebaum <darco@deepdarc.com>
  * \author Ronny Klauck <rklauck@informatik.tu-cottbus.de>
+ * \author Brad Campbell <bradjc@umich.edu>
  *
  *         This file implements a DNS host name to IP address resolver,
  *         as well as an MDNS responder and resolver.
@@ -148,6 +149,16 @@ strcasecmp(const char *s1, const char *s2)
 #define RESOLV_CONF_MAX_DOMAIN_NAME_SIZE 32
 #endif
 
+#if RESOLV_CONF_SUPPORTS_DNS_SD
+#ifndef RESOLV_CONF_MAX_TXT_SIZE
+#define RESOLV_CONF_MAX_TXT_SIZE 48
+#endif
+#endif /* RESOLV_CONF_SUPPORTS_DNS_SD */
+
+#ifndef RESOLV_CONF_TIMEOUT_SECONDS
+#define RESOLV_CONF_TIMEOUT_SECONDS 120
+#endif
+
 #ifdef RESOLV_CONF_AUTO_REMOVE_TRAILING_DOTS
 #define RESOLV_AUTO_REMOVE_TRAILING_DOTS RESOLV_CONF_AUTO_REMOVE_TRAILING_DOTS
 #else
@@ -244,12 +255,29 @@ struct dns_answer {
   uint16_t class;
   uint16_t ttl[2];
   uint16_t len;
+};
+
+struct dns_answer_native {
 #if NETSTACK_CONF_WITH_IPV6
   uint8_t ipaddr[16];
 #else
   uint8_t ipaddr[4];
 #endif
 };
+
+#if RESOLV_CONF_SUPPORTS_DNS_SD
+struct dns_answer_srv {
+  uint16_t priority;
+  uint16_t weight;
+  uint16_t port;
+};
+#endif
+
+#ifndef UIP_CONF_RESOLV_ENTRIES
+#define RESOLV_ENTRIES 4
+#else /* UIP_CONF_RESOLV_ENTRIES */
+#define RESOLV_ENTRIES UIP_CONF_RESOLV_ENTRIES
+#endif /* UIP_CONF_RESOLV_ENTRIES */
 
 struct namemap {
 #define STATE_UNUSED 0
@@ -270,33 +298,65 @@ struct namemap {
   uint8_t server;
 #if RESOLV_CONF_SUPPORTS_MDNS
   int is_mdns:1, is_probe:1;
-#if RESOLV_CONF_SUPPORTS_DNS_SD
-  int ipport;
-  char hostname[RESOLV_CONF_MAX_DOMAIN_NAME_SIZE + 1];
-#endif /* RESOLV_CONF_SUPPORTS_DNS_SD */
 #endif
+  /* This stores the hostname for mDNS. */
   char name[RESOLV_CONF_MAX_DOMAIN_NAME_SIZE + 1];
 };
 
-#ifndef UIP_CONF_RESOLV_ENTRIES
-#define RESOLV_ENTRIES 4
-#else /* UIP_CONF_RESOLV_ENTRIES */
-#define RESOLV_ENTRIES UIP_CONF_RESOLV_ENTRIES
-#endif /* UIP_CONF_RESOLV_ENTRIES */
-
+/*
+ * Array of cached hostnames (and service names if using DNS-SD) for other
+ * devices.
+ */
 static struct namemap names[RESOLV_ENTRIES];
 
+#if RESOLV_CONF_SUPPORTS_MDNS
 #if RESOLV_CONF_SUPPORTS_DNS_SD
-struct servicemap {
-#define STATE_UNUSED 0
+/* This keeps track of what services we are trying to discover. */
+struct servicelookupmap {
   uint8_t state;
-  char name[RESOLV_CONF_MAX_DOMAIN_NAME_SIZE * 2/3 + 1];
-  char txt[RESOLV_CONF_MAX_DOMAIN_NAME_SIZE + 1];
+  char service[RESOLV_CONF_MAX_DOMAIN_NAME_SIZE + 1];
+};
+
+static struct servicelookupmap services_looking[RESOLV_ENTRIES];
+
+/* This keeps track of what services on other devices we know about. */
+struct servicemap {
+  uint8_t state;   /* The states for this service map are as follows:
+                    * STATE_UNUSED : empty slot in array
+                    * STATE_NEW :    got PTR, have not gotten SRV. fullhostname
+                    *                contains the full service domain name,
+                    *                e.g.: ubuntu._server._udp.local
+                    * STATE_ASKING : got PTR and SRV, have not gotten TXT.
+                    *                hostname contains the correct domain,
+                    *                e.g.: ubuntu.local
+                    * STATE_DONE   : got all needed packets. */
+  char hostname[RESOLV_CONF_MAX_DOMAIN_NAME_SIZE + 1];     /* ubuntu.local */
+  char fullhostname[RESOLV_CONF_MAX_DOMAIN_NAME_SIZE + 1]; /* ubuntu._server._udp.local */
+  char service[RESOLV_CONF_MAX_DOMAIN_NAME_SIZE + 1];      /* _server._udp.local */
+  char txt[RESOLV_CONF_MAX_TXT_SIZE + 1];
+  int port;
+#if RESOLV_SUPPORTS_RECORD_EXPIRATION
+  unsigned long expiration;
+#endif /* RESOLV_SUPPORTS_RECORD_EXPIRATION */
+};
+
+/* This array needs to be separate from the names array because there is
+ * no longer a 1-to-1 mapping of services -> hostnames. */
+static struct servicemap services[RESOLV_ENTRIES];
+
+/* This keeps track of what services we provide. */
+struct myservicemap {
+  uint8_t state;
+  char service[RESOLV_CONF_MAX_DOMAIN_NAME_SIZE + 1];
+  char txt[RESOLV_CONF_MAX_TXT_SIZE + 1];
   int port;
 };
 
-static struct servicemap services[RESOLV_ENTRIES];
+/* Array of services this node provides.
+ */
+static struct myservicemap myservices[RESOLV_ENTRIES];
 #endif /* RESOLV_CONF_SUPPORTS_DNS_SD */
+#endif /* RESOLV_CONF_SUPPORTS_MDNS */
 
 static uint8_t seqno;
 
@@ -318,10 +378,6 @@ struct dns_question {
 
 #if RESOLV_CONF_SUPPORTS_MDNS
 static char resolv_hostname[RESOLV_CONF_MAX_DOMAIN_NAME_SIZE + 1];
-
-#if RESOLV_CONF_SUPPORTS_DNS_SD
-static char resolv_ownername[RESOLV_CONF_MAX_DOMAIN_NAME_SIZE / 8 + 1];
-#endif /* RESOLV_CONF_SUPPORTS_DNS_SD */
 
 enum {
   MDNS_STATE_WAIT_BEFORE_PROBE,
@@ -448,12 +504,12 @@ skip_name(unsigned char *query)
 {
   unsigned char n;
 
-  DEBUG_PRINTF("resolver: skip name: ");
+  // DEBUG_PRINTF("resolver: skip name: ");
 
   do {
     n = *query;
     if((n & 0xc0) == 0xc0) {
-      DEBUG_PRINTF("<skip-to-%d>", query[0] + ((n & ~0xC0) << 8));
+      // DEBUG_PRINTF("<skip-to-%d>", query[0] + ((n & ~0xC0) << 8));
       ++query;
       break;
     }
@@ -461,13 +517,13 @@ skip_name(unsigned char *query)
     ++query;
 
     while(n > 0) {
-      DEBUG_PRINTF("%c", *query);
+      // DEBUG_PRINTF("%c", *query);
       ++query;
       --n;
     };
-    DEBUG_PRINTF(".");
+    // DEBUG_PRINTF(".");
   } while(*query != 0);
-  DEBUG_PRINTF("\n");
+  // DEBUG_PRINTF("\n");
   return query + 1;
 }
 /*---------------------------------------------------------------------------*/
@@ -549,7 +605,7 @@ mdns_write_announce_records(unsigned char *queryptr, uint8_t *count)
       *queryptr++ = 0;
       *queryptr++ = 0;
       *queryptr++ = 0;
-      *queryptr++ = 120;
+      *queryptr++ = RESOLV_CONF_TIMEOUT_SECONDS;
 
       *queryptr++ = 0;
       *queryptr++ = sizeof(uip_ipaddr_t);
@@ -567,7 +623,7 @@ mdns_write_announce_records(unsigned char *queryptr, uint8_t *count)
   ans->type = UIP_HTONS(NATIVE_DNS_TYPE);
   ans->class = UIP_HTONS(DNS_CLASS_IN | 0x8000);
   ans->ttl[0] = 0;
-  ans->ttl[1] = UIP_HTONS(120);
+  ans->ttl[1] = UIP_HTONS(RESOLV_CONF_TIMEOUT_SECONDS);
   ans->len = UIP_HTONS(sizeof(uip_ipaddr_t));
   uip_gethostaddr((uip_ipaddr_t *) ans->ipaddr);
   queryptr = (unsigned char *)ans + sizeof(*ans);
@@ -592,12 +648,13 @@ mdns_prep_host_announce_packet(void)
   } nsec_record = {
     UIP_HTONS(DNS_TYPE_NSEC),
     UIP_HTONS(DNS_CLASS_IN | 0x8000),
-    { 0, UIP_HTONS(120) },
+    { 0, UIP_HTONS(RESOLV_CONF_TIMEOUT_SECONDS) },
     UIP_HTONS(8),
 
     {
       0xc0,
-      sizeof(struct dns_hdr), /* Name compression. Re-using the name of first record. */
+      sizeof(struct dns_hdr), /* Name compression. Re-using the name of first
+                               * record. */
       0x00,
       0x04,
 
@@ -659,43 +716,52 @@ mdns_prep_host_announce_packet(void)
  * TODO merge with mdns_*_announce_* functions?
  */
 static unsigned char *
-mdns_write_announce_service_record(unsigned char *queryptr, uint8_t *count, uint8_t record_type, struct servicemap *serviceptr)
+mdns_write_announce_service_record(unsigned char *queryptr, uint8_t *count,
+                                   uint8_t record_type, uint8_t generic,
+                                   struct myservicemap *serviceptr)
 {
-  struct dns_answer *ans;
+  char hostname_nolocal[RESOLV_CONF_MAX_DOMAIN_NAME_SIZE + 1];
+
+  memcpy(hostname_nolocal, resolv_hostname, strlen(resolv_hostname) - 6);
+  hostname_nolocal[strlen(resolv_hostname) - 6] = '\0';
 
   if(record_type == DNS_TYPE_SRV || record_type == DNS_TYPE_TXT) {
-    queryptr = encode_name(queryptr, resolv_ownername);
+    queryptr = encode_name(queryptr, hostname_nolocal);
     *queryptr-- = 0;
-    queryptr = encode_name(queryptr, serviceptr->name);
-    *queryptr-- = 0;
-    queryptr = encode_name(queryptr, "local");
+    queryptr = encode_name(queryptr, serviceptr->service);
   } else if(record_type == DNS_TYPE_PTR) {
-    queryptr = encode_name(queryptr, serviceptr->name);
-    *queryptr-- = 0;
-    queryptr = encode_name(queryptr, "local");
+    if(generic) {
+      /* Announce the service type "_services._dns-sd._udp.local" with
+       * this service in it. */
+      queryptr = encode_name(queryptr, "_services._dns-sd._udp.local");
+    } else {
+      queryptr = encode_name(queryptr, serviceptr->service);
+    }
   }
-
-  ans = (struct dns_answer *)queryptr;
 
   /* Type, class and TTL: 8 bytes
    */
   *queryptr++ = 0x00;
-  *queryptr++ = (uint8_t) ((record_type));
+  *queryptr++ = record_type;
+  if(record_type == DNS_TYPE_PTR) {
+    *queryptr++ = (uint8_t) ((DNS_CLASS_IN | 0x0000) >> 8);
+  } else {
+    *queryptr++ = (uint8_t) ((DNS_CLASS_IN | 0x8000) >> 8);
+  }
+  *queryptr++ = DNS_CLASS_IN;
 
-  *queryptr++ = (uint8_t) ((DNS_CLASS_IN | 0x8000) >> 8);
-  *queryptr++ = (uint8_t) ((DNS_CLASS_IN | 0x8000));
-
   *queryptr++ = 0;
   *queryptr++ = 0;
   *queryptr++ = 0;
-  *queryptr++ = 120;
+  *queryptr++ = RESOLV_CONF_TIMEOUT_SECONDS;
 
   if(record_type == DNS_TYPE_SRV) {
     /* Resource length: 2 bytes
      */
     *queryptr++ = 0;
-    /* Port + hostname - ".local" + ptr */
-    *queryptr++ = strlen((char *)resolv_hostname) - 1;
+    /* Priority (2) + Weight (2) + Port (2) + Length (1) + hostname
+     * - ".local" (6) + end (1) + offset (1) */
+    *queryptr++ = strlen((char *)resolv_hostname) + 3;
 
     /* Priority and weight: 4 bytes
      */
@@ -706,8 +772,8 @@ mdns_write_announce_service_record(unsigned char *queryptr, uint8_t *count, uint
 
     /* Port: 2 bytes
      */
-    *queryptr++ = (uint8_t) ((serviceptr->port) >> 8);;
-    *queryptr++ = (uint8_t) serviceptr->port;
+    *queryptr++ = (uint8_t)(serviceptr->port >> 8);
+    *queryptr++ = (uint8_t)serviceptr->port;
 
     /* Data
      */
@@ -715,21 +781,44 @@ mdns_write_announce_service_record(unsigned char *queryptr, uint8_t *count, uint
     queryptr -= 7;
     /* Use name compression to refer back to the first .local */
     *queryptr++ = 0xc0;
-    *queryptr++ = sizeof(struct dns_hdr) + 2 + strlen((char *)resolv_ownername) + strlen((char *)serviceptr->name);
+    *queryptr++ = sizeof(struct dns_hdr) + 2 +
+                  strlen((char *)hostname_nolocal) +
+                  strlen((char *)serviceptr->service) - 6;
   } else if(record_type == DNS_TYPE_PTR) {
-    /* Resource length: 2 bytes
-     */
-    *queryptr++ = 0;
-    /* Size of ptr + owner name */
-    *queryptr++ = 2 + strlen((char *)resolv_ownername);
+    if(generic) {
+      char service_nolocal[RESOLV_CONF_MAX_DOMAIN_NAME_SIZE + 1];
+      memcpy(service_nolocal, serviceptr->service, strlen(serviceptr->service) - 6);
+      service_nolocal[strlen(serviceptr->service) - 6] = '\0';
 
-    /* Data
-     */
-    queryptr = encode_name(queryptr, resolv_ownername);
-    *queryptr-- = 0;
-    /* Use name compression to refer back to the first name */
-    *queryptr++ = 0xc0;
-    *queryptr++ = sizeof(struct dns_hdr);
+      /* Resource length: 2 bytes
+       */
+      *queryptr++ = 0;
+      /* Size of ptr + hostname - len(.local) + offset */
+      *queryptr++ = 2 + strlen((char *)service_nolocal) + 1;
+
+      /* Data
+       */
+      queryptr = encode_name(queryptr, service_nolocal);
+      *queryptr-- = 0;
+      /* Use name compression to refer back to the .local after the
+       * generic name. */
+      *queryptr++ = 0xc0;
+      *queryptr++ = sizeof(struct dns_hdr) + 23;
+    } else {
+      /* Resource length: 2 bytes
+       */
+      *queryptr++ = 0;
+      /* Size of ptr + hostname - len(.local) + offset */
+      *queryptr++ = 2 + strlen((char *)hostname_nolocal) + 1;
+
+      /* Data
+       */
+      queryptr = encode_name(queryptr, hostname_nolocal);
+      *queryptr-- = 0;
+      /* Use name compression to refer back to the first name */
+      *queryptr++ = 0xc0;
+      *queryptr++ = sizeof(struct dns_hdr);
+    }
   } else if(record_type == DNS_TYPE_TXT) {
     if(strlen(serviceptr->txt) > 0) {
       /* Resource length: 2 bytes
@@ -753,10 +842,11 @@ mdns_write_announce_service_record(unsigned char *queryptr, uint8_t *count, uint
 }
 /*---------------------------------------------------------------------------*/
 /** \internal
- * Called when we need to announce our services (SRV, PTR, TXT)
+ * Called to announce the _services._dns-sd._udp.local PTR packet. This
+ * lets the receiver discover available services.
  */
 static size_t
-mdns_prep_service_announce_packet(uint8_t record_type, struct servicemap *serviceptr)
+mdns_prep_service_discover_packet(struct myservicemap *serviceptr)
 {
   unsigned char *queryptr;
 
@@ -772,8 +862,40 @@ mdns_prep_service_announce_packet(uint8_t record_type, struct servicemap *servic
   hdr->flags1 |= DNS_FLAG1_RESPONSE | DNS_FLAG1_AUTHORATIVE;
 
   queryptr = (unsigned char *)uip_appdata + sizeof(*hdr);
+  queryptr = mdns_write_announce_service_record(queryptr, &total_answers,
+                                                DNS_TYPE_PTR, 1, serviceptr);
 
-  queryptr = mdns_write_announce_service_record(queryptr, &total_answers, record_type, serviceptr);
+  /* This platform might be picky about alignment. To avoid the possibility
+   * of doing an unaligned write, we are going to do this manually. */
+  ((uint8_t*)&hdr->numanswers)[1] = total_answers;
+  ((uint8_t*)&hdr->numextrarr)[1] = 0;
+
+  return (queryptr - (unsigned char *)uip_appdata);
+}
+/*---------------------------------------------------------------------------*/
+/** \internal
+ * Called when we need to announce our services (SRV, PTR, TXT)
+ */
+static size_t
+mdns_prep_service_announce_packet(uint8_t record_type,
+                                  struct myservicemap *serviceptr)
+{
+  unsigned char *queryptr;
+
+  uint8_t total_answers = 0;
+
+  /* Be aware that, unless `ARCH_DOESNT_NEED_ALIGNED_STRUCTS` is set,
+   * writing directly to the uint16_t members of this struct is an error. */
+  struct dns_hdr *hdr = (struct dns_hdr *)uip_appdata;
+
+  /* Zero out the header */
+  memset((void *)hdr, 0, sizeof(*hdr));
+
+  hdr->flags1 |= DNS_FLAG1_RESPONSE | DNS_FLAG1_AUTHORATIVE;
+
+  queryptr = (unsigned char *)uip_appdata + sizeof(*hdr);
+  queryptr = mdns_write_announce_service_record(queryptr, &total_answers,
+                                                record_type, 0, serviceptr);
 
   /* This platform might be picky about alignment. To avoid the possibility
    * of doing an unaligned write, we are going to do this manually. */
@@ -915,7 +1037,7 @@ check_entries(void)
         uip_udp_packet_sendto(resolv_conn, uip_appdata,
                               (query - (uint8_t *) uip_appdata),
                               (const uip_ipaddr_t *)
-                                uip_nameserver_get(namemapptr->server), 
+                                uip_nameserver_get(namemapptr->server),
                               UIP_HTONS(DNS_PORT));
 
         PRINTF("resolver: (i=%d) Sent DNS request for \"%s\".\n", i,
@@ -924,7 +1046,7 @@ check_entries(void)
 #else /* RESOLV_CONF_SUPPORTS_MDNS */
       uip_udp_packet_sendto(resolv_conn, uip_appdata,
                             (query - (uint8_t *) uip_appdata),
-                            uip_nameserver_get(namemapptr->server), 
+                            uip_nameserver_get(namemapptr->server),
                             UIP_HTONS(DNS_PORT));
       PRINTF("resolver: (i=%d) Sent DNS request for \"%s\".\n", i,
              namemapptr->name);
@@ -932,6 +1054,39 @@ check_entries(void)
       break;
     }
   }
+
+#if RESOLV_CONF_SUPPORTS_MDNS && RESOLV_CONF_SUPPORTS_DNS_SD
+  /* Iterate all services that we are interested in discovering and send
+   * out requests. */
+  for(i = 0; i < RESOLV_ENTRIES; i++) {
+    struct servicelookupmap *servicemapptr = &services_looking[i];
+
+    if(servicemapptr->state == STATE_NEW || servicemapptr->state == STATE_ASKING) {
+      /* Send a mdns query PTR packet for the service. */
+
+      hdr = (struct dns_hdr *)uip_appdata;
+      memset(hdr, 0, sizeof(struct dns_hdr));
+      /* Flags and id stay set to 0. */
+      hdr->numquestions = UIP_HTONS(1);
+
+      /* Setup the body of the query */
+      query = (unsigned char *)uip_appdata + sizeof(*hdr);
+      query = encode_name(query, servicemapptr->service);
+      /* Need to send a PTR packet. */
+      *query++ = (uint8_t) ((DNS_TYPE_PTR) >> 8);
+      *query++ = (uint8_t) ((DNS_TYPE_PTR));
+      *query++ = (uint8_t) ((DNS_CLASS_IN) >> 8);
+      *query++ = (uint8_t) ((DNS_CLASS_IN));
+
+      uip_udp_packet_sendto(resolv_conn, uip_appdata,
+                            (query - (uint8_t *) uip_appdata),
+                            &resolv_mdns_addr, UIP_HTONS(MDNS_PORT));
+
+      PRINTF("resolver: (i=%d) Sent MDNS request for \"%s\".\n", i,
+             servicemapptr->service);
+    }
+  }
+#endif /* RESOLV_CONF_SUPPORTS_MDNS && RESOLV_CONF_SUPPORTS_DNS_SD */
 }
 /*---------------------------------------------------------------------------*/
 /** \internal
@@ -954,6 +1109,10 @@ newdata(void)
 
   const uint8_t is_request = ((hdr->flags1 & ~1) == 0) && (hdr->flags2 == 0);
 
+#if VERBOSE_DEBUG
+  static int8_t record_count = 0;
+#endif
+
   /* We only care about the question(s) and the answers. The authrr
    * and the extrarr are simply discarded.
    */
@@ -961,13 +1120,14 @@ newdata(void)
   nanswers = (uint8_t) uip_ntohs(hdr->numanswers);
 
   queryptr = (unsigned char *)hdr + sizeof(*hdr);
-  i = 0;
 
+#if VERBOSE_DEBUG
   DEBUG_PRINTF
     ("resolver: flags1=0x%02X flags2=0x%02X nquestions=%d, nanswers=%d, nauthrr=%d, nextrarr=%d\n",
      hdr->flags1, hdr->flags2, (uint8_t) nquestions, (uint8_t) nanswers,
      (uint8_t) uip_ntohs(hdr->numauthrr),
      (uint8_t) uip_ntohs(hdr->numextrarr));
+#endif
 
   if(is_request && (nquestions == 0)) {
     /* Skip requests with no questions. */
@@ -999,23 +1159,50 @@ newdata(void)
       question = &aligned;
 #endif /* !ARCH_DOESNT_NEED_ALIGNED_STRUCTS */
 
-      DEBUG_PRINTF("resolver: Question %d: type=%d class=%d\n", ++i,
-                   uip_htons(question->type), uip_htons(question->class));
+#if VERBOSE_DEBUG
+      {
+        static char debug_name[40];
+        decode_name(queryptr, debug_name, uip_appdata);
+        DEBUG_PRINTF("resolver: Question %d: \"%s\" type=%d class=%d\n",
+                     ++record_count, debug_name, uip_htons(question->type),
+                     uip_htons(question->class));
+      }
+#endif
 
       if(((uip_ntohs(question->class) & 0x7FFF) != DNS_CLASS_IN) ||
-         ((question->type != UIP_HTONS(DNS_TYPE_ANY)) &&
-          (question->type != UIP_HTONS(NATIVE_DNS_TYPE))
-/* TODO #if RESOLV_CONF_SUPPORTS_DNS_SD
+         ((question->type != UIP_HTONS(DNS_TYPE_ANY))
+          && (question->type != UIP_HTONS(NATIVE_DNS_TYPE))
+#if RESOLV_CONF_SUPPORTS_DNS_SD
           && (question->type != UIP_HTONS(DNS_TYPE_PTR))
-#endif */
+#endif /* RESOLV_CONF_SUPPORTS_DNS_SD */
       )){
         /* Skip unrecognised records. */
         continue;
       }
 
-      if(!dns_name_isequal(queryptr, resolv_hostname, uip_appdata)) {
-        continue;
+      if(question->type == UIP_HTONS(DNS_TYPE_ANY) ||
+         question->type == UIP_HTONS(NATIVE_DNS_TYPE)) {
+        /* Check if something is looking for our hostname.*/
+        if(!dns_name_isequal(queryptr, resolv_hostname, uip_appdata)) {
+          continue;
+        }
       }
+#if RESOLV_CONF_SUPPORTS_DNS_SD
+      else if(question->type == UIP_HTONS(DNS_TYPE_PTR)) {
+        /* Check if we provide the service that is being queried. */
+        uint8_t found = 0;
+        for(i = 0; i < RESOLV_ENTRIES; i++) {
+          struct myservicemap *myserviceptr = &myservices[i];
+          if(dns_name_isequal(queryptr, myserviceptr->service, uip_appdata)) {
+            found = 1;
+            break;
+          }
+        }
+        if(!found) {
+          continue;
+        }
+      }
+#endif /* RESOLV_CONF_SUPPORTS_DNS_SD */
 
       PRINTF("resolver: THIS IS A REQUEST FOR US!!!\n");
 
@@ -1068,7 +1255,6 @@ newdata(void)
      * because we can't use the `id` field. We will look up the
      * appropriate request in a later step. */
 
-    i = -1;
     namemapptr = NULL;
   } else
 #endif /* RESOLV_CONF_SUPPORTS_MDNS */
@@ -1106,25 +1292,29 @@ newdata(void)
     }
   }
 
-  i = 0;
+#if VERBOSE_DEBUG
+  record_count = 0;
+#endif
 
   /* Answer parsing loop */
   while(nanswers > 0) {
-    ans = (struct dns_answer *)skip_name(queryptr);
+    unsigned char* postqueryptr = skip_name(queryptr);
 
 #if !ARCH_DOESNT_NEED_ALIGNED_STRUCTS
     {
       static struct dns_answer aligned;
-      memcpy(&aligned, ans, sizeof(aligned));
+      memcpy(&aligned, postqueryptr, sizeof(aligned));
       ans = &aligned;
     }
+#else
+    ans = (struct dns_answer *)postqueryptr;
 #endif /* !ARCH_DOESNT_NEED_ALIGNED_STRUCTS */
 
 #if VERBOSE_DEBUG
     static char debug_name[40];
     decode_name(queryptr, debug_name, uip_appdata);
     DEBUG_PRINTF("resolver: Answer %d: \"%s\", type %d, class %d, ttl %d, length %d\n",
-                 ++i, debug_name, uip_ntohs(ans->type),
+                 ++record_count, debug_name, uip_ntohs(ans->type),
                  uip_ntohs(ans->class) & 0x7FFF,
                  (int)((uint32_t) uip_ntohs(ans->ttl[0]) << 16) | (uint32_t)
                  uip_ntohs(ans->ttl[1]), uip_ntohs(ans->len));
@@ -1136,125 +1326,239 @@ newdata(void)
     if(((uip_ntohs(ans->class) & 0x7FFF) != DNS_CLASS_IN)
 #if !RESOLV_CONF_SUPPORTS_MDNS && !RESOLV_CONF_SUPPORTS_DNS_SD
        || (ans->len != UIP_HTONS(sizeof(uip_ipaddr_t)))
-#endif
+#endif /* !RESOLV_CONF_SUPPORTS_MDNS && !RESOLV_CONF_SUPPORTS_DNS_SD */
     ) {
       goto skip_to_next_answer;
     }
 
+    /* We are only looking for certain records. These are the ones we
+     * care about. */
     if(ans->type != UIP_HTONS(NATIVE_DNS_TYPE)
-/* TODO #if RESOLV_CONF_SUPPORTS_MDNS && RESOLV_CONF_SUPPORTS_DNS_SD
+#if RESOLV_CONF_SUPPORTS_MDNS && RESOLV_CONF_SUPPORTS_DNS_SD
+      && ans->type != UIP_HTONS(DNS_TYPE_PTR)
       && ans->type != UIP_HTONS(DNS_TYPE_SRV)
-#endif*/
+      && ans->type != UIP_HTONS(DNS_TYPE_TXT)
+#endif /* RESOLV_CONF_SUPPORTS_MDNS && RESOLV_CONF_SUPPORTS_DNS_SD */
     ) {
       goto skip_to_next_answer;
     }
+
+    /* If this answer is an A or AAAA record, look for the hostname and
+     * IP address. */
+    if(ans->type == UIP_HTONS(NATIVE_DNS_TYPE)) {
+      struct dns_answer_native* ans_native =
+        (struct dns_answer_native *)(postqueryptr+sizeof(struct dns_answer));
+#if !ARCH_DOESNT_NEED_ALIGNED_STRUCTS
+      struct dns_answer_native aligned;
+      memcpy(&aligned, postqueryptr+sizeof(struct dns_answer), sizeof(aligned));
+      ans_native = &aligned;
+#endif /* !ARCH_DOESNT_NEED_ALIGNED_STRUCTS */
 
 #if RESOLV_CONF_SUPPORTS_MDNS
-    if(UIP_UDP_BUF->srcport == UIP_HTONS(MDNS_PORT) &&
-       hdr->id == 0) {
-      int8_t available_i = RESOLV_ENTRIES;
-
-      DEBUG_PRINTF("resolver: MDNS query.\n");
-
       /* For MDNS, we need to actually look up the name we
        * are looking for.
        */
-      for(i = 0; i < RESOLV_ENTRIES; ++i) {
-        namemapptr = &names[i];
-#if RESOLV_CONF_SUPPORTS_DNS_SD
-        /* Write IP address to our detected service's hostname. */
-        if(dns_name_isequal(queryptr, namemapptr->hostname, uip_appdata)) {
-          uip_ipaddr_copy(&namemapptr->ipaddr, (uip_ipaddr_t *) ans->ipaddr);
-          namemapptr->state = STATE_DONE;
+      if(UIP_UDP_BUF->srcport == UIP_HTONS(MDNS_PORT) && hdr->id == 0) {
+        int8_t available_i = RESOLV_ENTRIES;
 
-          process_post(PROCESS_BROADCAST, resolv_event_found, namemapptr->name);
+        DEBUG_PRINTF("resolver: MDNS A/AAAA answer.\n");
+
+        for(i = 0; i < RESOLV_ENTRIES; ++i) {
+          namemapptr = &names[i];
+
+          if(dns_name_isequal(queryptr, namemapptr->name, uip_appdata)) {
+            break;
+          }
+          if((namemapptr->state == STATE_UNUSED)
+  #if RESOLV_SUPPORTS_RECORD_EXPIRATION
+            || (namemapptr->state == STATE_DONE && clock_seconds() > namemapptr->expiration)
+  #endif /* RESOLV_SUPPORTS_RECORD_EXPIRATION */
+          ) {
+            available_i = i;
+          }
         }
-#endif
-        if(dns_name_isequal(queryptr, namemapptr->name, uip_appdata)) {
-          break;
+        if(i == RESOLV_ENTRIES) {
+          DEBUG_PRINTF("resolver: Unsolicited MDNS response.\n");
+          i = available_i;
+          namemapptr = &names[i];
+          if(!decode_name(queryptr, namemapptr->name, uip_appdata)) {
+            DEBUG_PRINTF("resolver: MDNS name too big to cache.\n");
+            namemapptr = NULL;
+            goto skip_to_next_answer;
+          }
         }
-        if((namemapptr->state == STATE_UNUSED)
-#if RESOLV_SUPPORTS_RECORD_EXPIRATION
-          || (namemapptr->state == STATE_DONE && clock_seconds() > namemapptr->expiration)
-#endif /* RESOLV_SUPPORTS_RECORD_EXPIRATION */
-        ) {
-          available_i = i;
-        }
-      }
-      if(i == RESOLV_ENTRIES) {
-        DEBUG_PRINTF("resolver: Unsolicited MDNS response.\n");
-        i = available_i;
-        namemapptr = &names[i];
-        if(!decode_name(queryptr, namemapptr->name, uip_appdata)) {
-          DEBUG_PRINTF("resolver: MDNS name too big to cache.\n");
+        if(i == RESOLV_ENTRIES) {
+          DEBUG_PRINTF("resolver: No room for unsolicited MDNS answer.\n");
+
+          if(dns_name_isequal(queryptr, resolv_hostname, uip_appdata)) {
+            /* Oh snap, they say they are us! We had better report them... */
+            resolv_found(resolv_hostname, (uip_ipaddr_t *) ans_native->ipaddr);
+          }
           namemapptr = NULL;
           goto skip_to_next_answer;
         }
-      }
-      if(i == RESOLV_ENTRIES) {
-        DEBUG_PRINTF
-          ("resolver: Not enough room to keep track of unsolicited MDNS answer.\n");
+        namemapptr = &names[i];
 
-        if(dns_name_isequal(queryptr, resolv_hostname, uip_appdata)) {
-          /* Oh snap, they say they are us! We had better report them... */
-          resolv_found(resolv_hostname, (uip_ipaddr_t *) ans->ipaddr);
-        }
-        namemapptr = NULL;
-        goto skip_to_next_answer;
       }
-      namemapptr = &names[i];
-
-    } else
 #endif /* RESOLV_CONF_SUPPORTS_MDNS */
-    {
-      /* This will force us to stop even if there are more answers. */
-      nanswers = 1;
-    }
 
 /*  This is disabled for now, so that we don't fail on CNAME records.
 #if RESOLV_VERIFY_ANSWER_NAMES
-    if(namemapptr && !dns_name_isequal(queryptr, namemapptr->name, uip_appdata)) {
-      DEBUG_PRINTF("resolver: Answer name doesn't match question...!\n");
-      goto skip_to_next_answer;
-    }
+      if(namemapptr && !dns_name_isequal(queryptr, namemapptr->name, uip_appdata)) {
+        DEBUG_PRINTF("resolver: Answer name doesn't match question...!\n");
+        goto skip_to_next_answer;
+      }
 #endif
 */
 
-    DEBUG_PRINTF("resolver: Answer for \"%s\" is usable.\n", namemapptr->name);
+      DEBUG_PRINTF("resolver: Answer for \"%s\" is usable.\n", namemapptr->name);
 
-    namemapptr->state = STATE_DONE;
+      namemapptr->state = STATE_DONE;
 #if RESOLV_SUPPORTS_RECORD_EXPIRATION
-    namemapptr->expiration = ans->ttl[1] + (ans->ttl[0] << 8);
-    namemapptr->expiration += clock_seconds();
+      namemapptr->expiration = (int)((uint32_t) uip_ntohs(ans->ttl[0]) << 16) |
+                                     (uint32_t) uip_ntohs(ans->ttl[1]);
+      namemapptr->expiration += clock_seconds();
 #endif /* RESOLV_SUPPORTS_RECORD_EXPIRATION */
 
-    uip_ipaddr_copy(&namemapptr->ipaddr, (uip_ipaddr_t *) ans->ipaddr);
+      uip_ipaddr_copy(&namemapptr->ipaddr, (uip_ipaddr_t *) ans_native->ipaddr);
 
-    resolv_found(namemapptr->name, &namemapptr->ipaddr);
-    break;
+      resolv_found(namemapptr->name, &namemapptr->ipaddr);
+#if !RESOLV_CONF_SUPPORTS_DNS_SD
+      /* If we don't care about services, then we can stop looking now.
+       * Otherwise we should keep parsing answers in case they contain
+       * information about services we care about. */
+      break;
+#endif /* !RESOLV_CONF_SUPPORTS_DNS_SD */
 
-  skip_to_next_answer:
+    }
+
 #if RESOLV_CONF_SUPPORTS_MDNS && RESOLV_CONF_SUPPORTS_DNS_SD
-    if(ans->type == UIP_HTONS(DNS_TYPE_SRV)) {
-      for(i = 0; i < RESOLV_ENTRIES; ++i) {
-        namemapptr = &names[i];
-        /* Find service name in SRV record, skip ownername */
-        if(dns_name_isequal(queryptr + strlen(resolv_ownername) + 1, namemapptr->name, uip_appdata)) {
+    /* For service discovery, we are interested in more answer types, notably
+     * PTR, SRV, and TXT. PTR records provide the mapping from service name to
+     * hostname, SRV records provide port and other information for a service,
+     * and TXT records provide other parameters for a service. */
+    if(UIP_UDP_BUF->srcport == UIP_HTONS(MDNS_PORT) && hdr->id == 0) {
+      unsigned char* domain;
+      if(ans->type == UIP_HTONS(DNS_TYPE_PTR)) {
+        domain = postqueryptr + sizeof(struct dns_answer);
+        DEBUG_PRINTF("resolver: checking PTR record.\n");
+
+        /* Check to see if the service name in this PTR record is one that we
+         * are looking for. */
+        for(i = 0; i < RESOLV_ENTRIES; i++) {
+          struct servicelookupmap *servicelookmapptr = &services_looking[i];
+          int j;
+
+          if(servicelookmapptr->state != STATE_UNUSED &&
+             dns_name_isequal(queryptr, servicelookmapptr->service, uip_appdata)) {
+            int8_t available_i = -1;
+            uint8_t found = 0;
+            /* Now that we care about this service, see if we already know about
+             * this host or need to add it to our list of known service providing
+             * hosts. */
+            for(j = 0; j < RESOLV_ENTRIES; j++) {
+              struct servicemap *servicemapptr = &services[i];
+              if(servicemapptr->state != STATE_UNUSED &&
+                 dns_name_isequal(queryptr, servicemapptr->service, uip_appdata)) {
+                /* Get a pointer to the domain name. Skip class, type, TTL, length. */
+                if(dns_name_isequal(domain, servicemapptr->fullhostname, uip_appdata)) {
+                  /* We already know this host provides this service. */
+                  found = 1;
+                  break;
+                }
+              } else if(available_i == -1 && servicemapptr->state == STATE_UNUSED) {
+                /* Make a note if we find an empty slot */
+                available_i = j;
+              }
 #if RESOLV_SUPPORTS_RECORD_EXPIRATION
-          namemapptr->expiration = ans->ttl[1] + (ans->ttl[0] << 8);
-          namemapptr->expiration += clock_seconds();
+              else if(available_i == -1 &&
+                      servicemapptr->state == STATE_DONE &&
+                      clock_seconds() > servicemapptr->expiration) {
+                available_i = j;
+              }
 #endif /* RESOLV_SUPPORTS_RECORD_EXPIRATION */
-          namemapptr->ipport = ans->ipaddr[5] + (ans->ipaddr[4] << 8);
+            }
+            if(!found && available_i > -1) {
+              struct servicemap *servicemapptr = &services[available_i];
+              decode_name(queryptr, servicemapptr->service, uip_appdata);
+              decode_name(domain, servicemapptr->fullhostname, uip_appdata);
+              servicemapptr->state = STATE_NEW;
+#if RESOLV_SUPPORTS_RECORD_EXPIRATION
+              servicemapptr->expiration = (int)((uint32_t) uip_ntohs(ans->ttl[0]) << 16) |
+                                                (uint32_t) uip_ntohs(ans->ttl[1]);
+              servicemapptr->expiration += clock_seconds();
+#endif /* RESOLV_SUPPORTS_RECORD_EXPIRATION */
+              DEBUG_PRINTF("resolver: found host \"%s\" that provides \"%s\"\n",
+                servicemapptr->fullhostname, servicemapptr->service);
+            } else if(!found && available_i == -1) {
+              DEBUG_PRINTF("resolver: found host for %s but ran out of space \
+                to store it.\n", servicelookmapptr->service);
+            }
 
-          decode_name(ans->ipaddr + 6, namemapptr->hostname, uip_appdata);
-          /* FIXME is needed because name ptr is not decoded */
-          strncat(namemapptr->hostname, "local", RESOLV_CONF_MAX_DOMAIN_NAME_SIZE);
+            break;
+          }
+        }
 
-          //break; // disable this saves 24 bytes on sky !!!
+      } else if(ans->type == UIP_HTONS(DNS_TYPE_SRV)) {
+        struct dns_answer_srv* ans_srv = (struct dns_answer_srv *)(postqueryptr+sizeof(struct dns_answer));
+#if !ARCH_DOESNT_NEED_ALIGNED_STRUCTS
+        struct dns_answer_srv aligned;
+        memcpy(&aligned, postqueryptr+sizeof(struct dns_answer), sizeof(aligned));
+        ans_srv = &aligned;
+#endif /* !ARCH_DOESNT_NEED_ALIGNED_STRUCTS */
+        domain = postqueryptr + sizeof(struct dns_answer) + sizeof(struct dns_answer_srv);
+        PRINTF("resolver: checking SRV record\n");
+
+        /* Check to see if we have received a PTR record for this SRV record
+         * and if we need to store this SRV record. */
+        for (i = 0; i < RESOLV_ENTRIES; i++) {
+          struct servicemap *servicemapptr = &services[i];
+          if(servicemapptr->state == STATE_NEW &&
+             dns_name_isequal(queryptr, servicemapptr->fullhostname, uip_appdata)) {
+            servicemapptr->port = uip_htons(ans_srv->port);
+            decode_name(domain, servicemapptr->hostname, uip_appdata);
+            DEBUG_PRINTF("resolver: found SRV record for %s with port=%u \
+and domain=%s\n", servicemapptr->fullhostname, servicemapptr->port,
+            servicemapptr->hostname);
+            servicemapptr->state = STATE_ASKING;
+
+            /* Need to add this host to our names list so that we can find
+             * out its IP address to actually use it. */
+            resolv_query(servicemapptr->hostname);
+            break;
+          }
+        }
+
+      } else if(ans->type == UIP_HTONS(DNS_TYPE_TXT)) {
+        domain = postqueryptr + sizeof(struct dns_answer);
+        PRINTF("resolver: checking TXT record\n");
+
+        /* Check to see if we have received a PTR and SRV record
+         * and if we need to store this TXT record. */
+        for (i = 0; i < RESOLV_ENTRIES; i++) {
+          struct servicemap *servicemapptr = &services[i];
+          if(servicemapptr->state == STATE_ASKING &&
+             dns_name_isequal(queryptr, servicemapptr->fullhostname, uip_appdata)) {
+            int length;
+            length = uip_htons(ans->len);
+            if(length > RESOLV_CONF_MAX_TXT_SIZE) {
+              length = RESOLV_CONF_MAX_TXT_SIZE;
+            }
+            memcpy(servicemapptr->txt, domain, length);
+            servicemapptr->txt[length] = '\0';
+            DEBUG_PRINTF("resolver: found TXT record for %s with value=%s\n",
+              servicemapptr->fullhostname, servicemapptr->txt);
+            servicemapptr->state = STATE_DONE;
+
+            process_post(PROCESS_BROADCAST, resolv_event_found, servicemapptr->service);
+            break;
+          }
         }
       }
     }
-#endif
+#endif /* RESOLV_CONF_SUPPORTS_MDNS && RESOLV_CONF_SUPPORTS_DNS_SD */
+
+  skip_to_next_answer:
     queryptr = (unsigned char *)skip_name(queryptr) + 10 + uip_htons(ans->len);
     --nanswers;
   }
@@ -1262,11 +1566,11 @@ newdata(void)
   /* Got to this point there's no answer, try next nameserver if available
      since this one doesn't know the answer */
 #if RESOLV_CONF_SUPPORTS_MDNS
-  if(nanswers == 0 && UIP_UDP_BUF->srcport != UIP_HTONS(MDNS_PORT) 
+  if(nanswers == 0 && UIP_UDP_BUF->srcport != UIP_HTONS(MDNS_PORT)
       && hdr->id != 0)
 #else
-  if(nanswers == 0) 
-#endif
+  if(nanswers == 0)
+#endif /* RESOLV_CONF_SUPPORTS_MDNS */
   {
     if(try_next_server(namemapptr)) {
       namemapptr->state = STATE_ASKING;
@@ -1285,9 +1589,6 @@ void
 resolv_set_hostname(const char *hostname)
 {
   strncpy(resolv_hostname, hostname, RESOLV_CONF_MAX_DOMAIN_NAME_SIZE);
-#if RESOLV_CONF_SUPPORTS_DNS_SD
-  strncpy(resolv_ownername, hostname, RESOLV_CONF_MAX_DOMAIN_NAME_SIZE / 8);
-#endif /* RESOLV_CONF_SUPPORTS_DNS_SD */
 
   /* Add the .local suffix if it isn't already there */
   if(strlen(resolv_hostname) < 7 ||
@@ -1357,17 +1658,14 @@ PROCESS_THREAD(mdns_probe_process, ev, data)
  */
 PROCESS_THREAD(resolv_process, ev, data)
 {
-#if RESOLV_CONF_SUPPORTS_MDNS && RESOLV_CONF_SUPPORTS_DNS_SD
-  static uint8_t i = 0;
-  struct servicemap *serviceptr;
-#endif
-
   PROCESS_BEGIN();
 
   memset(names, 0, sizeof(names));
 #if RESOLV_CONF_SUPPORTS_MDNS && RESOLV_CONF_SUPPORTS_DNS_SD
+  memset(services_looking, 0, sizeof(services_looking));
   memset(services, 0, sizeof(services));
-#endif
+  memset(myservices, 0, sizeof(myservices));
+#endif /* RESOLV_CONF_SUPPORTS_MDNS && RESOLV_CONF_SUPPORTS_DNS_SD */
 
   resolv_event_found = process_alloc_event();
 
@@ -1383,7 +1681,7 @@ PROCESS_THREAD(resolv_process, ev, data)
   uip_ds6_maddr_add(&resolv_mdns_addr);
 #else
   /* TODO: Is there anything we need to do here for IPv4 multicast? */
-#endif
+#endif /* NETSTACK_CONF_WITH_IPV6 */
 
   resolv_set_hostname(CONTIKI_CONF_DEFAULT_HOSTNAME);
 #endif /* RESOLV_CONF_SUPPORTS_MDNS */
@@ -1409,23 +1707,28 @@ PROCESS_THREAD(resolv_process, ev, data)
             memset(uip_appdata, 0, sizeof(struct dns_hdr));
 
 #if RESOLV_CONF_SUPPORTS_DNS_SD
-            for(i = 0; i < RESOLV_ENTRIES; ++i) {
-              serviceptr = &services[i];
-              if(serviceptr->state == STATE_NEW) {
-                len = mdns_prep_service_announce_packet(DNS_TYPE_SRV, serviceptr);
+            {
+              uint8_t i;
+              struct myservicemap *serviceptr;
+              for(i = 0; i < RESOLV_ENTRIES; ++i) {
+                serviceptr = &myservices[i];
+                if(serviceptr->state == STATE_NEW) {
+                  len = mdns_prep_service_discover_packet(serviceptr);
+                  uip_udp_packet_sendto(resolv_conn, uip_appdata, len,
+                                        &resolv_mdns_addr, UIP_HTONS(MDNS_PORT));
 
-                uip_udp_packet_sendto(resolv_conn, uip_appdata,
-                                  len, &resolv_mdns_addr, UIP_HTONS(MDNS_PORT));
+                  len = mdns_prep_service_announce_packet(DNS_TYPE_PTR, serviceptr);
+                  uip_udp_packet_sendto(resolv_conn, uip_appdata, len,
+                                        &resolv_mdns_addr, UIP_HTONS(MDNS_PORT));
 
-                len = mdns_prep_service_announce_packet(DNS_TYPE_PTR, serviceptr);
+                  len = mdns_prep_service_announce_packet(DNS_TYPE_SRV, serviceptr);
+                  uip_udp_packet_sendto(resolv_conn, uip_appdata, len,
+                                        &resolv_mdns_addr, UIP_HTONS(MDNS_PORT));
 
-                uip_udp_packet_sendto(resolv_conn, uip_appdata,
-                                  len, &resolv_mdns_addr, UIP_HTONS(MDNS_PORT));
-
-                len = mdns_prep_service_announce_packet(DNS_TYPE_TXT, serviceptr);
-
-                uip_udp_packet_sendto(resolv_conn, uip_appdata,
-                                  len, &resolv_mdns_addr, UIP_HTONS(MDNS_PORT));
+                  len = mdns_prep_service_announce_packet(DNS_TYPE_TXT, serviceptr);
+                  uip_udp_packet_sendto(resolv_conn, uip_appdata, len,
+                                        &resolv_mdns_addr, UIP_HTONS(MDNS_PORT));
+                }
               }
             }
 #endif /* RESOLV_CONF_SUPPORTS_DNS_SD */
@@ -1529,6 +1832,7 @@ resolv_query(const char *name)
   }
 
   if(i == RESOLV_ENTRIES) {
+    /* Did not find a matching entry. Need to create a new one. */
     i = lseqi;
     nameptr = &names[i];
   }
@@ -1544,6 +1848,7 @@ resolv_query(const char *name)
 
 #if RESOLV_CONF_SUPPORTS_MDNS
   {
+    /* Determine if we should use mDNS or DNS. */
     size_t name_len = strlen(name);
 
     static const char local_suffix[] = "local";
@@ -1560,7 +1865,7 @@ resolv_query(const char *name)
                       (0 == strcmp(nameptr->name, resolv_hostname));
 #endif /* RESOLV_CONF_SUPPORTS_MDNS */
 
-  /* Force check_entires() to run on our process. */
+  /* Force check_entries() to run on our process. */
   process_post(&resolv_process, PROCESS_EVENT_TIMER, 0);
 }
 /*---------------------------------------------------------------------------*/
@@ -1680,7 +1985,7 @@ resolv_found(char *name, uip_ipaddr_t * ipaddr)
      && !uip_ds6_is_my_addr(ipaddr)
 #else
      && uip_ipaddr_cmp(&uip_hostaddr, ipaddr) != 0
-#endif
+#endif /* NETSTACK_CONF_WITH_IPV6 */
     ) {
     uint8_t i;
 
@@ -1747,93 +2052,178 @@ resolv_found(char *name, uip_ipaddr_t * ipaddr)
 #if RESOLV_CONF_SUPPORTS_DNS_SD
 /*---------------------------------------------------------------------------*/
 /**
- * Look up a service in the array of known hostnames.
+ * Queues a service name so that a question for the name will be sent out.
+ *
+ * \param service The service that is to be queried.
+ */
+void
+resolv_query_service(const char *service)
+{
+  uint8_t i;
+  int8_t open_slot = -1;
+
+  struct servicelookupmap *servicelookupptr = 0;
+
+  init();
+
+  /* Remove trailing dots, if present. */
+  service = remove_trailing_dots(service);
+
+  /* Check to see if we are already looking for this service. */
+  for(i = 0; i < RESOLV_ENTRIES; ++i) {
+    servicelookupptr = &services_looking[i];
+    if(servicelookupptr->state == STATE_UNUSED) {
+      /* Make note of this open space in case we need to insert the new
+       * query into it. */
+      if(open_slot == -1) {
+        open_slot = i;
+      }
+    } else if(strcasecmp(servicelookupptr->service, service) == 0) {
+      DEBUG_PRINTF("resolver: service %s already being looked for\n", service);
+      return;
+    }
+  }
+
+  if(i == RESOLV_ENTRIES) {
+    /* Did not find a matching entry. Need to create a new one. */
+    if(open_slot == -1) {
+      /* All slots are full. For now, just overwrite the first one. */
+      open_slot = 0;
+    }
+    servicelookupptr = &services_looking[open_slot];
+  }
+
+  PRINTF("resolver: Starting query for service \"%s\".\n", service);
+
+  /* Save the service as one to look up. */
+  memset(servicelookupptr, 0, sizeof(*servicelookupptr));
+  strncpy(servicelookupptr->service, service, sizeof(servicelookupptr->service));
+  servicelookupptr->state = STATE_NEW;
+
+  /* Force check_entries() to run on our process. */
+  process_post(&resolv_process, PROCESS_EVENT_TIMER, 0);
+}
+/*---------------------------------------------------------------------------*/
+/**
+ * Look up a service in the array of known services on other devices.
  *
  * \note This function only looks in the internal array of known
  * hostnames, it does not send out a query for the service if none
- * was found. TODO The function resolv_service_query() can be used
- * to send a query for a service.
+ * was found.
+ *
+ * TODO: provide a mechanism for getting back more than one host that supports
+ *       the service.
  *
  */
 resolv_status_t
-resolv_service_lookup(const char *servicename, uip_ipaddr_t ** ipaddr, int *ipport)
+resolv_service_lookup(const char *service, uip_ipaddr_t ** ipaddr, int *port)
 {
-  resolv_status_t ret = resolv_lookup(servicename, NULL);
+  resolv_status_t ret = RESOLV_STATUS_UNCACHED;
 
-  if (ret == RESOLV_STATUS_CACHED) {
+  static uint8_t i, j;
 
-    static uint8_t i;
+  struct servicemap *serviceptr;
+  struct namemap *nameptr;
 
-    struct namemap *nameptr;
+  /* Remove trailing dots, if present. */
+  service = remove_trailing_dots(service);
 
-    /* Walk through the list to get the serice's hostname. */
-    for(i = 0; i < RESOLV_ENTRIES; ++i) {
-      nameptr = &names[i];
-      if(strcasecmp(servicename, nameptr->name) == 0) {
+  /* Walk through the services list to see if the name is in there. */
+  for(i = 0; i < RESOLV_ENTRIES; ++i) {
+    serviceptr = &services[i];
 
-        if(ipport) {
-          *ipport = nameptr->ipport;
+    if(strcasecmp(service, serviceptr->service) == 0) {
+      switch (serviceptr->state) {
+      case STATE_DONE:
+        ret = RESOLV_STATUS_CACHED;
+#if RESOLV_SUPPORTS_RECORD_EXPIRATION
+        if(clock_seconds() > serviceptr->expiration) {
+          ret = RESOLV_STATUS_EXPIRED;
         }
-
-        if(ipaddr) {
-          *ipaddr = &nameptr->ipaddr;
-        }
-
-#if VERBOSE_DEBUG
-        if(ipaddr) {
-          PRINTF("resolver: Found address for \"%s\".\n", name);
-          PRINTF
-            ("resolver: %02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x \n",
-             ((uint8_t *) ipaddr)[0], ((uint8_t *) ipaddr)[1],
-             ((uint8_t *) ipaddr)[2], ((uint8_t *) ipaddr)[3],
-             ((uint8_t *) ipaddr)[4], ((uint8_t *) ipaddr)[5],
-             ((uint8_t *) ipaddr)[6], ((uint8_t *) ipaddr)[7],
-             ((uint8_t *) ipaddr)[8], ((uint8_t *) ipaddr)[9],
-             ((uint8_t *) ipaddr)[10], ((uint8_t *) ipaddr)[11],
-             ((uint8_t *) ipaddr)[12], ((uint8_t *) ipaddr)[13],
-             ((uint8_t *) ipaddr)[14], ((uint8_t *) ipaddr)[15]);
-        } else {
-          PRINTF("resolver: Unable to retrieve address for \"%s\".\n", name);
-        }
-#endif /* VERBOSE_DEBUG */
+#endif /* RESOLV_SUPPORTS_RECORD_EXPIRATION */
+        break;
+      case STATE_NEW:
+      case STATE_ASKING:
+        ret = RESOLV_STATUS_RESOLVING;
+        break;
       }
+
+      if (ret == RESOLV_STATUS_CACHED) {
+        uint8_t found = 0;
+        /* We know this hostname matches the service, but we really want
+         * to give the caller back an IP address. Iterate the names list
+         * to find the matching name. */
+        for (j = 0; j < RESOLV_ENTRIES; j++) {
+          nameptr = &names[j];
+          if(strncmp(serviceptr->hostname, nameptr->name, RESOLV_CONF_MAX_DOMAIN_NAME_SIZE) == 0 &&
+             nameptr->state == STATE_DONE) {
+            if(ipaddr) {
+              *ipaddr = &nameptr->ipaddr;
+            }
+            if(port) {
+              *port = serviceptr->port;
+            }
+            found = 1;
+            break;
+          }
+        }
+
+        if (found) {
+          /* Exit the service finding loop as well. */
+          break;
+        }
+      }
+
+      /* If we didn't find a matching service AND host, make sure we don't
+       * return success. */
+      ret = RESOLV_STATUS_UNCACHED;
     }
   }
 
   return ret;
 }
+/*---------------------------------------------------------------------------*/
 /**
  * Queues a service that should be announced via DNS-SD.
  *
- * \param name The service name (e.g., _presence._tcp) that is to be announced.
+ * \param service The service name (e.g., _presence._tcp) that is to be announced.
  * \param txt The additional information to the service that is to be announced.
  * \param port The port of the service that is to be announced.
  */
 void
-resolv_add_service(const char *name, const char *txt, int port)
+resolv_add_service(const char *service, const char *txt, int port)
 {
   static uint8_t i;
+  register struct myservicemap *myserviceptr = 0;
 
-  register struct servicemap *serviceptr = 0;
+  DEBUG_PRINTF("resolver: adding service %s\n", service);
 
   /* Remove trailing dots, if present. */
   txt = remove_trailing_dots(txt);
 
   for(i = 0; i < RESOLV_ENTRIES; ++i) {
-    serviceptr = &services[i];
-    if(serviceptr->state != STATE_UNUSED && 0 == strcasecmp(serviceptr->name, name)) {
+    myserviceptr = &myservices[i];
+    if(myserviceptr->state != STATE_UNUSED &&
+       strcasecmp(myserviceptr->service, service) == 0) {
       return;
     }
   }
 
   for(i = 0; i < RESOLV_ENTRIES; ++i) {
-    serviceptr = &services[i];
-    if(serviceptr->state == STATE_UNUSED) {
-      memset(serviceptr, 0, sizeof(*serviceptr));
-      strncpy(serviceptr->name, name, sizeof(serviceptr->name) - 1);
-      strncpy(serviceptr->txt, txt, sizeof(serviceptr->txt) - 1);
-      serviceptr->state = STATE_NEW;
-      serviceptr->port = port;
+    myserviceptr = &myservices[i];
+    if(myserviceptr->state == STATE_UNUSED) {
+      memset(myserviceptr, 0, sizeof(*myserviceptr));
+      strncpy(myserviceptr->service, service, sizeof(myserviceptr->service) - 1);
+
+      /* Add the .local suffix if it isn't already there */
+      if(strlen(myserviceptr->service) < 7 ||
+         strcasecmp(myserviceptr->service + strlen(myserviceptr->service) - 6, ".local") != 0) {
+        strncat(myserviceptr->service, ".local", RESOLV_CONF_MAX_DOMAIN_NAME_SIZE);
+      }
+
+      strncpy(myserviceptr->txt, txt, sizeof(myserviceptr->txt) - 1);
+      myserviceptr->state = STATE_NEW;
+      myserviceptr->port = port;
       break;
     }
   }

--- a/core/net/ip/resolv.c
+++ b/core/net/ip/resolv.c
@@ -364,7 +364,7 @@ decode_name(const unsigned char *query, char *dest,
   //DEBUG_PRINTF("resolver: decoding name: \"");
 
   while(len && n) {
-    if(n & 0xc0) {
+    if((n & 0xc0) == 0xc0) {
       const uint16_t offset = query[0] + ((n & ~0xC0) << 8);
 
       //DEBUG_PRINTF("<skip-to-%d>",offset);
@@ -412,7 +412,7 @@ dns_name_isequal(const unsigned char *queryptr, const char *name,
     return 0;
 
   while(n) {
-    if(n & 0xc0) {
+    if((n & 0xc0) == 0xc0) {
       queryptr = packet + queryptr[0] + ((n & ~0xC0) << 8);
       n = *queryptr++;
     }
@@ -452,7 +452,7 @@ skip_name(unsigned char *query)
 
   do {
     n = *query;
-    if(n & 0xc0) {
+    if((n & 0xc0) == 0xc0) {
       DEBUG_PRINTF("<skip-to-%d>", query[0] + ((n & ~0xC0) << 8));
       ++query;
       break;

--- a/core/net/ip/resolv.h
+++ b/core/net/ip/resolv.h
@@ -1,18 +1,18 @@
 /*
  * Copyright (c) 2002-2003, Adam Dunkels.
- * All rights reserved. 
+ * All rights reserved.
  *
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met: 
- * 1. Redistributions of source code must retain the above copyright 
- *    notice, this list of conditions and the following disclaimer. 
- * 2. Redistributions in binary form must reproduce the above copyright 
- *    notice, this list of conditions and the following disclaimer in the 
- *    documentation and/or other materials provided with the distribution. 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
  * 3. The name of the author may not be used to endorse or promote
  *    products derived from this software without specific prior
- *    written permission.  
+ *    written permission.
  *
  * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS
  * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
@@ -24,7 +24,7 @@
  * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
  * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
  * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.  
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
  * This file is part of the uIP TCP/IP stack.
  *
@@ -108,7 +108,9 @@ CCIF void resolv_set_hostname(const char *hostname);
 CCIF const char *resolv_get_hostname(void);
 
 #if RESOLV_CONF_SUPPORTS_DNS_SD
-CCIF resolv_status_t resolv_service_lookup(const char *servicename, uip_ipaddr_t ** ipaddr, int *ipport);
+CCIF void resolv_query_service(const char *service);
+CCIF resolv_status_t resolv_service_lookup(const char *servicename,
+                                           uip_ipaddr_t ** ipaddr, int *port);
 
 CCIF void resolv_add_service(const char *name, const char *txt, int port);
 #endif /* RESOLV_CONF_SUPPORTS_DNS_SD */

--- a/core/net/ip/resolv.h
+++ b/core/net/ip/resolv.h
@@ -43,6 +43,13 @@
 #include "contiki.h"
 #include "uip.h"
 
+/* If RESOLV_CONF_SUPPORTS_DNS_SD is set, then queries
+ * for services in the local TLD will use DNS-SD.
+ */
+#ifndef RESOLV_CONF_SUPPORTS_DNS_SD
+#define RESOLV_CONF_SUPPORTS_DNS_SD   (1)
+#endif
+
 /** If RESOLV_CONF_SUPPORTS_MDNS is set, then queries
  *  for domain names in the `local` TLD will use MDNS and
  *  will respond to MDNS queries for this device's hostname,
@@ -99,6 +106,13 @@ CCIF void resolv_query(const char *name);
 CCIF void resolv_set_hostname(const char *hostname);
 
 CCIF const char *resolv_get_hostname(void);
+
+#if RESOLV_CONF_SUPPORTS_DNS_SD
+CCIF resolv_status_t resolv_service_lookup(const char *servicename, uip_ipaddr_t ** ipaddr, int *ipport);
+
+CCIF void resolv_add_service(const char *name, const char *txt, int port);
+#endif /* RESOLV_CONF_SUPPORTS_DNS_SD */
+
 #endif
 
 PROCESS_NAME(resolv_process);

--- a/examples/udp-ipv6/Makefile
+++ b/examples/udp-ipv6/Makefile
@@ -1,8 +1,5 @@
 all: udp-server udp-client
 
-#CFLAGS += -DRESOLV_CONF_SUPPORTS_MDNS=1
-#CFLAGS += -DRESOLV_CONF_SUPPORTS_DNS_SD=1
-
 CONTIKI = ../..
 CONTIKI_WITH_IPV6 = 1
 include $(CONTIKI)/Makefile.include

--- a/examples/udp-ipv6/Makefile
+++ b/examples/udp-ipv6/Makefile
@@ -1,5 +1,8 @@
 all: udp-server udp-client
 
+#CFLAGS += -DRESOLV_CONF_SUPPORTS_MDNS=1
+#CFLAGS += -DRESOLV_CONF_SUPPORTS_DNS_SD=1
+
 CONTIKI = ../..
 CONTIKI_WITH_IPV6 = 1
 include $(CONTIKI)/Makefile.include

--- a/examples/udp-ipv6/udp-client.c
+++ b/examples/udp-ipv6/udp-client.c
@@ -37,6 +37,7 @@
 
 #define DEBUG DEBUG_PRINT
 #include "net/ip/uip-debug.h"
+#include "net/uip-debug.h"
 
 #define SEND_INTERVAL		15 * CLOCK_SECOND
 #define MAX_PAYLOAD_LEN		40
@@ -54,7 +55,7 @@ tcpip_handler(void)
   if(uip_newdata()) {
     str = uip_appdata;
     str[uip_datalen()] = '\0';
-    printf("Response from the server: '%s'\n", str);
+    PRINTF("Response from the server: '%s'\n", str);
   }
 }
 /*---------------------------------------------------------------------------*/
@@ -64,10 +65,10 @@ timeout_handler(void)
 {
   static int seq_id;
 
-  printf("Client sending to: ");
+  PRINTF("Client sending to: ");
   PRINT6ADDR(&client_conn->ripaddr);
   sprintf(buf, "Hello %d from the client", ++seq_id);
-  printf(" (msg: %s)\n", buf);
+  PRINTF(" (msg: %s)\n", buf);
 #if SEND_TOO_LARGE_PACKET_TO_TEST_FRAGMENTATION
   uip_udp_packet_send(client_conn, buf, UIP_APPDATA_SIZE);
 #else /* SEND_TOO_LARGE_PACKET_TO_TEST_FRAGMENTATION */
@@ -105,16 +106,24 @@ set_global_address(void)
 #endif /* UIP_CONF_ROUTER */
 /*---------------------------------------------------------------------------*/
 static resolv_status_t
-set_connection_address(uip_ipaddr_t *ipaddr)
+set_connection_address(uip_ipaddr_t *ipaddr
+#if RESOLV_CONF_SUPPORTS_MDNS && RESOLV_CONF_SUPPORTS_DNS_SD
+                                    , int *ipport
+#endif
+)
 {
 #ifndef UDP_CONNECTION_ADDR
-#if RESOLV_CONF_SUPPORTS_MDNS
-#define UDP_CONNECTION_ADDR       contiki-udp-server.local
+#if RESOLV_CONF_SUPPORTS_MDNS && RESOLV_CONF_SUPPORTS_DNS_SD
+#define UDP_CONNECTION_ADDR       _server._udp.local
+#elif RESOLV_CONF_SUPPORTS_MDNS
+#define UDP_CONNECTION_ADDR       con-serv.local
 #elif UIP_CONF_ROUTER
 #define UDP_CONNECTION_ADDR       aaaa:0:0:0:0212:7404:0004:0404
 #else
 #define UDP_CONNECTION_ADDR       fe80:0:0:0:6466:6666:6666:6666
-#endif
+#if RESOLV_CONF_SUPPORTS_DNS_SD
+#endif /* RESOLV_CONF_SUPPORTS_DNS_SD */
+#endif /* RESOLV_CONF_SUPPORTS_MDNS */
 #endif /* !UDP_CONNECTION_ADDR */
 
 #define _QUOTEME(x) #x
@@ -124,12 +133,20 @@ set_connection_address(uip_ipaddr_t *ipaddr)
 
   if(uiplib_ipaddrconv(QUOTEME(UDP_CONNECTION_ADDR), ipaddr) == 0) {
     uip_ipaddr_t *resolved_addr = NULL;
+#if RESOLV_CONF_SUPPORTS_MDNS && RESOLV_CONF_SUPPORTS_DNS_SD
+    status = resolv_service_lookup(QUOTEME(UDP_CONNECTION_ADDR),&resolved_addr,ipport);
+#else
     status = resolv_lookup(QUOTEME(UDP_CONNECTION_ADDR),&resolved_addr);
+#endif
     if(status == RESOLV_STATUS_UNCACHED || status == RESOLV_STATUS_EXPIRED) {
       PRINTF("Attempting to look up %s\n",QUOTEME(UDP_CONNECTION_ADDR));
       resolv_query(QUOTEME(UDP_CONNECTION_ADDR));
       status = RESOLV_STATUS_RESOLVING;
-    } else if(status == RESOLV_STATUS_CACHED && resolved_addr != NULL) {
+    } else if(status == RESOLV_STATUS_CACHED && resolved_addr != NULL
+#if RESOLV_CONF_SUPPORTS_MDNS && RESOLV_CONF_SUPPORTS_DNS_SD
+              && ipport != NULL
+#endif
+    ) {
       PRINTF("Lookup of \"%s\" succeded!\n",QUOTEME(UDP_CONNECTION_ADDR));
     } else if(status == RESOLV_STATUS_RESOLVING) {
       PRINTF("Still looking up \"%s\"...\n",QUOTEME(UDP_CONNECTION_ADDR));
@@ -149,6 +166,9 @@ PROCESS_THREAD(udp_client_process, ev, data)
 {
   static struct etimer et;
   uip_ipaddr_t ipaddr;
+#if RESOLV_CONF_SUPPORTS_MDNS && RESOLV_CONF_SUPPORTS_DNS_SD
+  int ipport = 0;
+#endif
 
   PROCESS_BEGIN();
   PRINTF("UDP client process started\n");
@@ -161,7 +181,11 @@ PROCESS_THREAD(udp_client_process, ev, data)
 
   static resolv_status_t status = RESOLV_STATUS_UNCACHED;
   while(status != RESOLV_STATUS_CACHED) {
-    status = set_connection_address(&ipaddr);
+    status = set_connection_address(&ipaddr
+#if RESOLV_CONF_SUPPORTS_MDNS && RESOLV_CONF_SUPPORTS_DNS_SD
+                                    , &ipport
+#endif
+    );
 
     if(status == RESOLV_STATUS_RESOLVING) {
       PROCESS_WAIT_EVENT_UNTIL(ev == resolv_event_found);
@@ -172,8 +196,13 @@ PROCESS_THREAD(udp_client_process, ev, data)
   }
 
   /* new connection with remote host */
+#if RESOLV_CONF_SUPPORTS_MDNS && RESOLV_CONF_SUPPORTS_DNS_SD
+  client_conn = udp_new(&ipaddr, UIP_HTONS(ipport), NULL);
+  udp_bind(client_conn, UIP_HTONS(ipport + 1));
+#else
   client_conn = udp_new(&ipaddr, UIP_HTONS(3000), NULL);
   udp_bind(client_conn, UIP_HTONS(3001));
+#endif
 
   PRINTF("Created a connection with the server ");
   PRINT6ADDR(&client_conn->ripaddr);

--- a/examples/udp-ipv6/udp-server.c
+++ b/examples/udp-ipv6/udp-server.c
@@ -95,7 +95,7 @@ PROCESS_THREAD(udp_server_process, ev, data)
   PRINTF("UDP server started\n");
 
 #if RESOLV_CONF_SUPPORTS_MDNS
-  resolv_set_hostname("con-serv");
+  resolv_set_hostname("cus");
 
 #if RESOLV_CONF_SUPPORTS_DNS_SD
   resolv_add_service("_server._udp", "status=avail", 3000);

--- a/examples/udp-ipv6/udp-server.c
+++ b/examples/udp-ipv6/udp-server.c
@@ -95,7 +95,11 @@ PROCESS_THREAD(udp_server_process, ev, data)
   PRINTF("UDP server started\n");
 
 #if RESOLV_CONF_SUPPORTS_MDNS
-  resolv_set_hostname("contiki-udp-server");
+  resolv_set_hostname("con-serv");
+
+#if RESOLV_CONF_SUPPORTS_DNS_SD
+  resolv_add_service("_server._udp", "status=avail", 3000);
+#endif /* RESOLV_CONF_SUPPORTS_DNS_SD */
 #endif
 
 #if UIP_CONF_ROUTER


### PR DESCRIPTION
This PR is an update to #255. Notably, it updates resolv.c to work with avahi on Linux.

### Changes:

- Fix DNS compression.
- Keep explicit tables of the services the node provides, the services
  the node is trying to discover, and services that the node knows
  others provide. This is necessary because more than one device can
  support the same service.
- Update the packet formats to be standards compliant.
- Provide the "_services._dns-sd._udp.local" PTR so that avahi knows
  that the services the node has exist (and will show up in
  `avahi-browse --all`.
- Handle packets when other devices ask if the node supports a given
  service.
- Properly parse PTR, SRV, and TXT packets to discover devices that
  support a given service.

### Testing

I have tested this by using the minimal-net platform and avahi as the service provider (with udp-client) or listener (with udp-server).

### Notes

I cannot get this to work without hacking `uip-udp-packet.c`. See https://github.com/contiki-os/contiki/pull/255#issuecomment-100558608 for the long explanation, but it basically boils down to a problem with resolv.c building packets in uip_appdata, which the UDP library then takes and copies into the same memory, causing problems. Any help would be appreciated.