### PR TITLE
Update the CC2538DK README about a Win CDC driver

### DIFF
--- a/platform/cc2538dk/README.md
+++ b/platform/cc2538dk/README.md
@@ -146,10 +146,14 @@ The CC2538 EM's USB Vendor and Product IDs are the following:
 
 The implementation in Contiki is pure CDC-ACM: The Linux and OS X kernels know exactly what to do and drivers are not required.
 
-On windows, you will need to provide a driver:
+On windows, you will need to provide a driver. You have two options:
 
-  * Download this LUFA CDC-ACM driver:
-<http://code.google.com/p/lufa-lib/source/browse/trunk/Demos/Device/LowLevel/VirtualSerial/LUFA+VirtualSerial.inf>
+  * Use the signed or unsigned driver provided by TI in [CC2538 Foundation Firmware](http://www.ti.com/tool/cc2538-sw). You will find them both under the `drivers` directory.
+  * Download a generic Virtual Serial Port driver and modify it so it works for the CC2538.
+
+For the latter option:
+
+  * Download this [LUFA CDC-ACM driver](https://raw.githubusercontent.com/abcminiuser/lufa/master/Demos/Device/LowLevel/VirtualSerial/LUFA%20VirtualSerial.inf).
   * Adjust the VID and PID near the end with the values at the start of this section.
   * Next time you get prompted for the driver, include the directory containing the .inf file in the search path and the driver will be installed.
 


### PR DESCRIPTION
* The current version of the README points to a wrong URL for the LUFA Virtual Serial driver.
* A driver is nowadays provided by TI through CC2538 Foundation Firmware

Thus, this pull updates the LUFA driver URL, documents that TI also provides a driver and adds a link to the CC2538 Foundation Firmware download page