### PR TITLE
Z1: tmp102: simple: fixed wrong cast

### DIFF
--- a/platform/z1/dev/tmp102.c
+++ b/platform/z1/dev/tmp102.c
@@ -185,5 +185,6 @@ tmp102_read_temp_x100(void)
 int8_t
 tmp102_read_temp_simple(void)
 {
-  return (int8_t)tmp102_read_temp_x100() / 100;
+  /* Casted to int8_t: We don't expect temperatures outside -128 to 127 C */
+  return tmp102_read_temp_x100() / 100;
 }


### PR DESCRIPTION
Hello,

When using this code:

    (int8_t)tmp102_read_temp_x100() / 100

Only the first value is casted into a `int8_t` type.

`tmp102_read_temp_x100()` returns the temperature in Celcius * 100. Most of
the time this value will be lower than -2^7 or higher than 2^7 (+/- 1.27°C).

Best Regards,