### PR TITLE
Remove CC2530 and CC2538 dummy watchdog_stop()

### DIFF
--- a/cpu/cc2538/dev/watchdog.c
+++ b/cpu/cc2538/dev/watchdog.c
@@ -88,15 +88,6 @@ watchdog_periodic(void)
   REG(SMWDTHROSC_WDCTL) = (SMWDTHROSC_WDCTL_CLR_2 | SMWDTHROSC_WDCTL_CLR_0);
 }
 /*---------------------------------------------------------------------------*/
-/** \brief In watchdog mode, the WDT can not be stopped. This function is
- * defined here to satisfy API requirements.
- */
-void
-watchdog_stop(void)
-{
-  return;
-}
-/*---------------------------------------------------------------------------*/
 /** \brief Keeps control until the WDT throws a reset signal. Starts the WDT
  * if not already started. */
 void

--- a/cpu/cc253x/8051def.h
+++ b/cpu/cc253x/8051def.h
@@ -14,11 +14,6 @@
 
 #include <stdint.h>
 
-/* In watchdog mode, our WDT can't be stopped once started
- * Include watchdog_stop()'s declaration and then trash it */
-#include "dev/watchdog.h"
-#define watchdog_stop() watchdog_periodic()
-
 /* This port no longer implements the legacy clock_delay. Hack its usages
  * outta the way till it gets phased out completely
  * NB: This also overwrites the prototype so delay_usec() is declared twice */


### PR DESCRIPTION
The CC2538 WDT cannot be stopped once it has been started.

The CC2530/1 WDT can be stopped if it is running in timer mode, but it cannot be stopped once it has been started in watchdog mode.

Both chips currently provide "dummy" implementations of `watchdog_stop()`, one does nothing and the other one basically re-maps `_stop()` to `_periodic()`.

This was originally done in order to provide implementations for all prototypes declared in `core/dev/watchdog.h`. In hindsight and as per the discussion in #1088, this is bad practice since, if the build succeeds, the caller will expect that the WDT has in fact been stopped, when in reality it has not.

Since the feature (stopping the WDT) is unsupported by the hardware, this pull removes those dummy implementations. Thus, we will now be able to reliably detect - at build time - attempts at using this unsupported feature.