### PR TITLE
Makefile.include: Remove unused MODULESSUBST

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -147,7 +147,6 @@ endif
 
 ifdef MODULES
   UNIQUEMODULES = $(call uniq,$(MODULES))
-  MODULESSUBST = ${subst /,-,$(UNIQUEMODULES)}
   MODULEDIRS = ${wildcard ${addprefix $(CONTIKI)/, $(UNIQUEMODULES)}}
   MODULES_SOURCES = ${foreach d, $(MODULEDIRS), ${subst ${d}/,,${wildcard $(d)/*.c}}}
   CONTIKI_SOURCEFILES += $(MODULES_SOURCES)


### PR DESCRIPTION
The commit bddd96d5c83323fb3f99835149af5ab1058c10bb "Removed all module
makefiles. Instead, all .c files in a module directory are compiled."
made the MODULESSUBST variable useless, but it did not remove it, so do
it now.