### PR TITLE
cc2538: uart: Make uart_isr() static

### DIFF
--- a/cpu/cc2538/dev/uart.c
+++ b/cpu/cc2538/dev/uart.c
@@ -359,7 +359,7 @@ uart_write_byte(uint8_t uart, uint8_t b)
   REG(uart_base + UART_DR) = b;
 }
 /*---------------------------------------------------------------------------*/
-void
+static void
 uart_isr(uint8_t uart)
 {
   uint32_t uart_base;


### PR DESCRIPTION
This function is only supposed to be used by uart.c, so it should be
static.