### PR TITLE
fix minor warning in cc2530-rf driver

### DIFF
--- a/cpu/cc253x/dev/cc2530-rf.c
+++ b/cpu/cc253x/dev/cc2530-rf.c
@@ -486,7 +486,7 @@ transmit(unsigned short transmit_len)
 }
 /*---------------------------------------------------------------------------*/
 static int
-send(void *payload, unsigned short payload_len)
+send(const void *payload, unsigned short payload_len)
 {
   prepare(payload, payload_len);
   return transmit(payload_len);


### PR DESCRIPTION
function pointer typesig says const, function declaration doesn't