### PR TITLE
Set Win32 file i/o to binary mode.

### DIFF
--- a/platform/win32/contiki-main.c
+++ b/platform/win32/contiki-main.c
@@ -36,6 +36,7 @@
 #include <windows.h>
 #include <winsock2.h>
 #include <stdio.h>
+#include <fcntl.h>
 
 #include "contiki-net.h"
 
@@ -101,6 +102,8 @@ char **contiki_argv;
 int
 main(int argc, char **argv)
 {
+  _set_fmode(O_BINARY);
+
   contiki_argc = argc;
   contiki_argv = argv;
 


### PR DESCRIPTION
This is i.e. necessary to have the file based webserver-example successfully read 'contiki.gif'.