### PR TITLE
Removed obsolete apps from retro distribution.

### DIFF
--- a/tools/6502/Makefile
+++ b/tools/6502/Makefile
@@ -60,16 +60,13 @@ $1-makes:
 	$(MAKE) -C ../../examples/webbrowser    TARGET=$1
 	$(MAKE) -C ../../examples/wget          TARGET=$1
 	$(MAKE) -C ../../examples/irc           TARGET=$1
-	$(MAKE) -C ../../../contikiprojects/vandenbrande.com/twitter/platform/$1
-	$(MAKE) -C ../../examples/email         TARGET=$1
-	$(MAKE) -C ../../examples/ftp           TARGET=$1
 	$(MAKE) -C ../../examples/webserver     TARGET=$1 HTTPD-CFS=1
 	$(MAKE) -C ../../examples/telnet-server TARGET=$1
 endef
 
 $(eval $(call makes,apple2enh))
 
-apple2: contiki-apple2-1.dsk contiki-apple2-2.dsk contiki-apple2-3.dsk contiki-apple2-4.dsk contiki-apple2.2mg
+apple2: contiki-apple2-1.dsk contiki-apple2-2.dsk contiki-apple2-3.dsk contiki-apple2.2mg
 
 contiki-apple2-1.dsk: apple2enh-makes
 	cp ../apple2enh/prodos.dsk $@
@@ -97,8 +94,6 @@ contiki-apple2-2.dsk: apple2enh-makes
 	java -jar $(AC) -cc65 $@ ipconfig        bin   < ../../cpu/6502/ipconfig/ipconfig.apple2enh
 	java -jar $(AC) -p    $@ irc.system      sys   < $(CC65_HOME)/targetutil/loader.system
 	java -jar $(AC) -cc65 $@ irc             bin   < ../../examples/irc/irc-client.apple2enh
-	java -jar $(AC) -p    $@ breadbox.system sys   < $(CC65_HOME)/targetutil/loader.system
-	java -jar $(AC) -cc65 $@ breadbox        bin   < ../../../contikiprojects/vandenbrande.com/twitter/platform/apple2enh/breadbox64.apple2enh
 	java -jar $(AC) -p    $@ contiki.cfg     bin 0 < ../apple2enh/default.cfg
 	java -jar $(AC) -p    $@ cs8900a.eth     rel 0 < ../../cpu/6502/ethconfig/cs8900a.eth
 	java -jar $(AC) -p    $@ lan91c96.eth    rel 0 < ../../cpu/6502/ethconfig/lan91c96.eth
@@ -106,23 +101,6 @@ contiki-apple2-2.dsk: apple2enh-makes
 	java -jar $(AC) -p    $@ contiki.mou     rel 0 < $(CC65_HOME)/mou/a2e.stdmou.mou
 
 contiki-apple2-3.dsk: apple2enh-makes
-	cp ../apple2enh/prodos.dsk $@
-	java -jar $(AC) -p    $@ menu.system     sys   < ../apple2enh/menu.system
-	java -jar $(AC) -p    $@ ethconfi.system sys   < $(CC65_HOME)/targetutil/loader.system
-	java -jar $(AC) -cc65 $@ ethconfi        bin   < ../../cpu/6502/ethconfig/ethconfig.apple2enh
-	java -jar $(AC) -p    $@ ipconfig.system sys   < $(CC65_HOME)/targetutil/loader.system
-	java -jar $(AC) -cc65 $@ ipconfig        bin   < ../../cpu/6502/ipconfig/ipconfig.apple2enh
-	java -jar $(AC) -p    $@ email.system    sys   < $(CC65_HOME)/targetutil/loader.system
-	java -jar $(AC) -cc65 $@ email           bin   < ../../examples/email/email-client.apple2enh
-	java -jar $(AC) -p    $@ ftp.system      sys   < $(CC65_HOME)/targetutil/loader.system
-	java -jar $(AC) -cc65 $@ ftp             bin   < ../../examples/ftp/ftp-client.apple2enh
-	java -jar $(AC) -p    $@ contiki.cfg     bin 0 < ../apple2enh/default.cfg
-	java -jar $(AC) -p    $@ cs8900a.eth     rel 0 < ../../cpu/6502/ethconfig/cs8900a.eth
-	java -jar $(AC) -p    $@ lan91c96.eth    rel 0 < ../../cpu/6502/ethconfig/lan91c96.eth
-	java -jar $(AC) -p    $@ w5100.eth       rel 0 < ../../cpu/6502/ethconfig/w5100.eth
-	java -jar $(AC) -p    $@ contiki.mou     rel 0 < $(CC65_HOME)/mou/a2e.stdmou.mou
-
-contiki-apple2-4.dsk: apple2enh-makes
 	cp ../apple2enh/prodos.dsk $@
 	java -jar $(AC) -p    $@ menu.system     sys   < ../apple2enh/menu.system
 	java -jar $(AC) -p    $@ ethconfi.system sys   < $(CC65_HOME)/targetutil/loader.system
@@ -156,12 +134,6 @@ contiki-apple2.2mg: apple2enh-makes
 	java -jar $(AC) -cc65 $@ wget            bin   < ../../examples/wget/wget.apple2enh
 	java -jar $(AC) -p    $@ irc.system      sys   < $(CC65_HOME)/targetutil/loader.system
 	java -jar $(AC) -cc65 $@ irc             bin   < ../../examples/irc/irc-client.apple2enh
-	java -jar $(AC) -p    $@ breadbox.system sys   < $(CC65_HOME)/targetutil/loader.system
-	java -jar $(AC) -cc65 $@ breadbox        bin   < ../../../contikiprojects/vandenbrande.com/twitter/platform/apple2enh/breadbox64.apple2enh
-	java -jar $(AC) -p    $@ email.system    sys   < $(CC65_HOME)/targetutil/loader.system
-	java -jar $(AC) -cc65 $@ email           bin   < ../../examples/email/email-client.apple2enh
-	java -jar $(AC) -p    $@ ftp.system      sys   < $(CC65_HOME)/targetutil/loader.system
-	java -jar $(AC) -cc65 $@ ftp             bin   < ../../examples/ftp/ftp-client.apple2enh
 	java -jar $(AC) -p    $@ webserv.system  sys   < $(CC65_HOME)/targetutil/loader.system
 	java -jar $(AC) -cc65 $@ webserv         bin   < ../../examples/webserver/webserver-example.apple2enh
 	java -jar $(AC) -p    $@ telnetd.system  sys   < $(CC65_HOME)/targetutil/loader.system
@@ -178,7 +150,7 @@ contiki-apple2.2mg: apple2enh-makes
 
 $(eval $(call makes,atarixl))
 
-atari: contiki-atari-1.atr contiki-atari-2.atr contiki-atari-3.atr contiki-atari-4.atr contiki-atari.atr
+atari: contiki-atari-1.atr contiki-atari-2.atr contiki-atari-3.atr contiki-atari.atr
 
 contiki-atari-1.atr: atarixl-makes
 	mkdir atr
@@ -199,39 +171,21 @@ contiki-atari-1.atr: atarixl-makes
 
 contiki-atari-2.atr: atarixl-makes
 	mkdir atr
-	cp ../atarixl/dos25/dos.sys                                                              atr/dos.sys
-	cp ../atarixl/dos25/dup.sys                                                              atr/dup.sys
-	cp ../../cpu/6502/ipconfig/ipconfig.atarixl                                              atr/ipconfig.com
-	cp ../../examples/irc/irc-client.atarixl                                                 atr/irc.com
-	cp ../../../contikiprojects/vandenbrande.com/twitter/platform/atarixl/breadbox64.atarixl atr/breadbox.com
-	cp ../atarixl/default.cfg                                                                atr/contiki.cfg
-	cp ../../cpu/6502/ethconfig/cs8900a.eth                                                  atr/cs8900a.eth
-	cp $(CC65_HOME)/mou/atrxst.mou                                                           atr/contiki.mou
-	cp $(CC65_HOME)/mou/atrxami.mou                                                          atr/ami.mou
-	cp $(CC65_HOME)/mou/atrxjoy.mou                                                          atr/joy.mou
-	cp $(CC65_HOME)/mou/atrxtrk.mou                                                          atr/trk.mou
-	cp $(CC65_HOME)/mou/atrxtt.mou                                                           atr/tt.mou
+	cp ../atarixl/dos25/dos.sys                 atr/dos.sys
+	cp ../atarixl/dos25/dup.sys                 atr/dup.sys
+	cp ../../cpu/6502/ipconfig/ipconfig.atarixl atr/ipconfig.com
+	cp ../../examples/irc/irc-client.atarixl    atr/irc.com
+	cp ../atarixl/default.cfg                   atr/contiki.cfg
+	cp ../../cpu/6502/ethconfig/cs8900a.eth     atr/cs8900a.eth
+	cp $(CC65_HOME)/mou/atrxst.mou              atr/contiki.mou
+	cp $(CC65_HOME)/mou/atrxami.mou             atr/ami.mou
+	cp $(CC65_HOME)/mou/atrxjoy.mou             atr/joy.mou
+	cp $(CC65_HOME)/mou/atrxtrk.mou             atr/trk.mou
+	cp $(CC65_HOME)/mou/atrxtt.mou              atr/tt.mou
 	$(DIR2ATR) -b Dos25 1040 $@ atr
 	rm -r atr
 
 contiki-atari-3.atr: atarixl-makes
-	mkdir atr
-	cp ../atarixl/dos25/dos.sys                  atr/dos.sys
-	cp ../atarixl/dos25/dup.sys                  atr/dup.sys
-	cp ../../cpu/6502/ipconfig/ipconfig.atarixl  atr/ipconfig.com
-	cp ../../examples/email/email-client.atarixl atr/email.com
-	cp ../../examples/ftp/ftp-client.atarixl     atr/ftp.com
-	cp ../atarixl/default.cfg                    atr/contiki.cfg
-	cp ../../cpu/6502/ethconfig/cs8900a.eth      atr/cs8900a.eth
-	cp $(CC65_HOME)/mou/atrxst.mou               atr/contiki.mou
-	cp $(CC65_HOME)/mou/atrxami.mou              atr/ami.mou
-	cp $(CC65_HOME)/mou/atrxjoy.mou              atr/joy.mou
-	cp $(CC65_HOME)/mou/atrxtrk.mou              atr/trk.mou
-	cp $(CC65_HOME)/mou/atrxtt.mou               atr/tt.mou
-	$(DIR2ATR) -b Dos25 1040 $@ atr
-	rm -r atr
-
-contiki-atari-4.atr: atarixl-makes
 	mkdir atr
 	cp ../atarixl/dos25/dos.sys                           atr/dos.sys
 	cp ../atarixl/dos25/dup.sys                           atr/dup.sys
@@ -254,34 +208,31 @@ contiki-atari-4.atr: atarixl-makes
 
 contiki-atari.atr: atarixl-makes
 	mkdir atr
-	cp ../atarixl/mydos4534/dos.sys                                                          atr/dos.sys
-	cp ../atarixl/mydos4534/dup.sys                                                          atr/dup.sys
-	cp ../../cpu/6502/ipconfig/ipconfig.atarixl                                              atr/ipconfig.com
-	cp ../../examples/webbrowser/webbrowser.atarixl                                          atr/webbrows.com
-	cp ../../examples/wget/wget.atarixl                                                      atr/wget.com
-	cp ../../examples/irc/irc-client.atarixl                                                 atr/irc.com
-	cp ../../../contikiprojects/vandenbrande.com/twitter/platform/atarixl/breadbox64.atarixl atr/breadbox.com
-	cp ../../examples/email/email-client.atarixl                                             atr/email.com
-	cp ../../examples/ftp/ftp-client.atarixl                                                 atr/ftp.com
-	cp ../../examples/webserver/webserver-example.atarixl                                    atr/webserv.com
-	cp ../../examples/telnet-server/telnet-server.atarixl                                    atr/telnetd.com
-	cp ../atarixl/default.cfg                                                                atr/contiki.cfg
-	cp ../../cpu/6502/ethconfig/cs8900a.eth                                                  atr/cs8900a.eth
-	cp $(CC65_HOME)/mou/atrxst.mou                                                           atr/contiki.mou
-	cp $(CC65_HOME)/mou/atrxami.mou                                                          atr/ami.mou
-	cp $(CC65_HOME)/mou/atrxjoy.mou                                                          atr/joy.mou
-	cp $(CC65_HOME)/mou/atrxtrk.mou                                                          atr/trk.mou
-	cp $(CC65_HOME)/mou/atrxtt.mou                                                           atr/tt.mou
-	cp ../../examples/webserver/httpd-cfs/index.htm                                          atr/index.htm
-	cp ../../examples/webserver/httpd-cfs/backgrnd.gif                                       atr/backgrnd.gif
-	cp ../../examples/webserver/httpd-cfs/contiki.gif                                        atr/contiki.gif
-	cp ../../examples/webserver/httpd-cfs/notfound.htm                                       atr/notfound.htm
+	cp ../atarixl/mydos4534/dos.sys                       atr/dos.sys
+	cp ../atarixl/mydos4534/dup.sys                       atr/dup.sys
+	cp ../../cpu/6502/ipconfig/ipconfig.atarixl           atr/ipconfig.com
+	cp ../../examples/webbrowser/webbrowser.atarixl       atr/webbrows.com
+	cp ../../examples/wget/wget.atarixl                   atr/wget.com
+	cp ../../examples/irc/irc-client.atarixl              atr/irc.com
+	cp ../../examples/webserver/webserver-example.atarixl atr/webserv.com
+	cp ../../examples/telnet-server/telnet-server.atarixl atr/telnetd.com
+	cp ../atarixl/default.cfg                             atr/contiki.cfg
+	cp ../../cpu/6502/ethconfig/cs8900a.eth               atr/cs8900a.eth
+	cp $(CC65_HOME)/mou/atrxst.mou                        atr/contiki.mou
+	cp $(CC65_HOME)/mou/atrxami.mou                       atr/ami.mou
+	cp $(CC65_HOME)/mou/atrxjoy.mou                       atr/joy.mou
+	cp $(CC65_HOME)/mou/atrxtrk.mou                       atr/trk.mou
+	cp $(CC65_HOME)/mou/atrxtt.mou                        atr/tt.mou
+	cp ../../examples/webserver/httpd-cfs/index.htm       atr/index.htm
+	cp ../../examples/webserver/httpd-cfs/backgrnd.gif    atr/backgrnd.gif
+	cp ../../examples/webserver/httpd-cfs/contiki.gif     atr/contiki.gif
+	cp ../../examples/webserver/httpd-cfs/notfound.htm    atr/notfound.htm
 	$(DIR2ATR) -d -b MyDos4534 3200 $@ atr
 	rm -r atr
 
 $(eval $(call makes,c64))
 
-c64: contiki-c64-1.d64 contiki-c64-2.d64 contiki-c64-3.d64 contiki-c64.d71 contiki-c64.d81
+c64: contiki-c64-1.d64 contiki-c64-2.d64 contiki-c64.d71 contiki-c64.d81
 
 contiki-c64-1.d64: c64-makes
 	$(C1541) -format contiki-1,00 d64 $@
@@ -299,21 +250,6 @@ contiki-c64-1.d64: c64-makes
 	$(C1541) -attach $@ -write $(CC65_HOME)/mou/c64-pot.mou             pot.mou,s
 
 contiki-c64-2.d64: c64-makes
-	$(C1541) -format contiki-2,00 d64 $@
-	$(C1541) -attach $@ -write ../../cpu/6502/ethconfig/ethconfig.c64                                        ethconfig,p
-	$(C1541) -attach $@ -write ../../cpu/6502/ipconfig/ipconfig.c64                                          ipconfig,p
-	$(C1541) -attach $@ -write ../../../contikiprojects/vandenbrande.com/twitter/platform/c64/breadbox64.c64 breadbox64,p
-	$(C1541) -attach $@ -write ../../examples/email/email-client.c64                                         email,p
-	$(C1541) -attach $@ -write ../../examples/ftp/ftp-client.c64                                             ftp,p
-	$(C1541) -attach $@ -write ../c64/default.cfg                                                            contiki.cfg,s
-	$(C1541) -attach $@ -write ../../cpu/6502/ethconfig/cs8900a.eth                                          cs8900a.eth,s
-	$(C1541) -attach $@ -write ../../cpu/6502/ethconfig/lan91c96.eth                                         lan91c96.eth,s
-	$(C1541) -attach $@ -write $(CC65_HOME)/mou/c64-1351.mou                                                 contiki.mou,s
-	$(C1541) -attach $@ -write $(CC65_HOME)/mou/c64-inkwell.mou                                              inkwell.mou,s
-	$(C1541) -attach $@ -write $(CC65_HOME)/mou/c64-joy.mou                                                  joy.mou,s
-	$(C1541) -attach $@ -write $(CC65_HOME)/mou/c64-pot.mou                                                  pot.mou,s
-
-contiki-c64-3.d64: c64-makes
 	$(C1541) -format contiki-3,00 d64 $@
 	$(C1541) -attach $@ -write ../../cpu/6502/ethconfig/ethconfig.c64          ethconfig,p
 	$(C1541) -attach $@ -write ../../cpu/6502/ipconfig/ipconfig.c64            ipconfig,p
@@ -333,55 +269,49 @@ contiki-c64-3.d64: c64-makes
 
 contiki-c64.d71: c64-makes
 	$(C1541) -format contiki,00 d71 $@
-	$(C1541) -attach $@ -write ../../cpu/6502/ethconfig/ethconfig.c64                                        ethconfig,p
-	$(C1541) -attach $@ -write ../../cpu/6502/ipconfig/ipconfig.c64                                          ipconfig,p
-	$(C1541) -attach $@ -write ../../examples/webbrowser/webbrowser.c64                                      webbrowser,p
-	$(C1541) -attach $@ -write ../../examples/wget/wget.c64                                                  wget,p
-	$(C1541) -attach $@ -write ../../examples/irc/irc-client.c64                                             irc,p
-	$(C1541) -attach $@ -write ../../../contikiprojects/vandenbrande.com/twitter/platform/c64/breadbox64.c64 breadbox64,p
-	$(C1541) -attach $@ -write ../../examples/email/email-client.c64                                         email,p
-	$(C1541) -attach $@ -write ../../examples/ftp/ftp-client.c64                                             ftp,p
-	$(C1541) -attach $@ -write ../../examples/webserver/webserver-example.c64                                webserver,p
-	$(C1541) -attach $@ -write ../../examples/telnet-server/telnet-server.c64                                telnetd,p
-	$(C1541) -attach $@ -write ../c64/default.cfg                                                            contiki.cfg,s
-	$(C1541) -attach $@ -write ../../cpu/6502/ethconfig/cs8900a.eth                                          cs8900a.eth,s
-	$(C1541) -attach $@ -write ../../cpu/6502/ethconfig/lan91c96.eth                                         lan91c96.eth,s
-	$(C1541) -attach $@ -write $(CC65_HOME)/mou/c64-1351.mou                                                 contiki.mou,s
-	$(C1541) -attach $@ -write $(CC65_HOME)/mou/c64-inkwell.mou                                              inkwell.mou,s
-	$(C1541) -attach $@ -write $(CC65_HOME)/mou/c64-joy.mou                                                  joy.mou,s
-	$(C1541) -attach $@ -write $(CC65_HOME)/mou/c64-pot.mou                                                  pot.mou,s
-	$(C1541) -attach $@ -write ../../examples/webserver/httpd-cfs/index.htm                                  index.htm,s
-	$(C1541) -attach $@ -write ../../examples/webserver/httpd-cfs/backgrnd.gif                               backgrnd.gif,s
-	$(C1541) -attach $@ -write ../../examples/webserver/httpd-cfs/contiki.gif                                contiki.gif,s
-	$(C1541) -attach $@ -write ../../examples/webserver/httpd-cfs/notfound.htm                               notfound.htm,s
+	$(C1541) -attach $@ -write ../../cpu/6502/ethconfig/ethconfig.c64          ethconfig,p
+	$(C1541) -attach $@ -write ../../cpu/6502/ipconfig/ipconfig.c64            ipconfig,p
+	$(C1541) -attach $@ -write ../../examples/webbrowser/webbrowser.c64        webbrowser,p
+	$(C1541) -attach $@ -write ../../examples/wget/wget.c64                    wget,p
+	$(C1541) -attach $@ -write ../../examples/irc/irc-client.c64               irc,p
+	$(C1541) -attach $@ -write ../../examples/webserver/webserver-example.c64  webserver,p
+	$(C1541) -attach $@ -write ../../examples/telnet-server/telnet-server.c64  telnetd,p
+	$(C1541) -attach $@ -write ../c64/default.cfg                              contiki.cfg,s
+	$(C1541) -attach $@ -write ../../cpu/6502/ethconfig/cs8900a.eth            cs8900a.eth,s
+	$(C1541) -attach $@ -write ../../cpu/6502/ethconfig/lan91c96.eth           lan91c96.eth,s
+	$(C1541) -attach $@ -write $(CC65_HOME)/mou/c64-1351.mou                   contiki.mou,s
+	$(C1541) -attach $@ -write $(CC65_HOME)/mou/c64-inkwell.mou                inkwell.mou,s
+	$(C1541) -attach $@ -write $(CC65_HOME)/mou/c64-joy.mou                    joy.mou,s
+	$(C1541) -attach $@ -write $(CC65_HOME)/mou/c64-pot.mou                    pot.mou,s
+	$(C1541) -attach $@ -write ../../examples/webserver/httpd-cfs/index.htm    index.htm,s
+	$(C1541) -attach $@ -write ../../examples/webserver/httpd-cfs/backgrnd.gif backgrnd.gif,s
+	$(C1541) -attach $@ -write ../../examples/webserver/httpd-cfs/contiki.gif  contiki.gif,s
+	$(C1541) -attach $@ -write ../../examples/webserver/httpd-cfs/notfound.htm notfound.htm,s
 
 contiki-c64.d81: c64-makes
 	$(C1541) -format contiki,00 d81 $@
-	$(C1541) -attach $@ -write ../../cpu/6502/ethconfig/ethconfig.c64                                        ethconfig,p
-	$(C1541) -attach $@ -write ../../cpu/6502/ipconfig/ipconfig.c64                                          ipconfig,p
-	$(C1541) -attach $@ -write ../../examples/webbrowser/webbrowser.c64                                      webbrowser,p
-	$(C1541) -attach $@ -write ../../examples/wget/wget.c64                                                  wget,p
-	$(C1541) -attach $@ -write ../../examples/irc/irc-client.c64                                             irc,p
-	$(C1541) -attach $@ -write ../../../contikiprojects/vandenbrande.com/twitter/platform/c64/breadbox64.c64 breadbox64,p
-	$(C1541) -attach $@ -write ../../examples/email/email-client.c64                                         email,p
-	$(C1541) -attach $@ -write ../../examples/ftp/ftp-client.c64                                             ftp,p
-	$(C1541) -attach $@ -write ../../examples/webserver/webserver-example.c64                                webserver,p
-	$(C1541) -attach $@ -write ../../examples/telnet-server/telnet-server.c64                                telnetd,p
-	$(C1541) -attach $@ -write ../c64/default.cfg                                                            contiki.cfg,s
-	$(C1541) -attach $@ -write ../../cpu/6502/ethconfig/cs8900a.eth                                          cs8900a.eth,s
-	$(C1541) -attach $@ -write ../../cpu/6502/ethconfig/lan91c96.eth                                         lan91c96.eth,s
-	$(C1541) -attach $@ -write $(CC65_HOME)/mou/c64-1351.mou                                                 contiki.mou,s
-	$(C1541) -attach $@ -write $(CC65_HOME)/mou/c64-inkwell.mou                                              inkwell.mou,s
-	$(C1541) -attach $@ -write $(CC65_HOME)/mou/c64-joy.mou                                                  joy.mou,s
-	$(C1541) -attach $@ -write $(CC65_HOME)/mou/c64-pot.mou                                                  pot.mou,s
-	$(C1541) -attach $@ -write ../../examples/webserver/httpd-cfs/index.htm                                  index.htm,s
-	$(C1541) -attach $@ -write ../../examples/webserver/httpd-cfs/backgrnd.gif                               backgrnd.gif,s
-	$(C1541) -attach $@ -write ../../examples/webserver/httpd-cfs/contiki.gif                                contiki.gif,s
-	$(C1541) -attach $@ -write ../../examples/webserver/httpd-cfs/notfound.htm                               notfound.htm,s
+	$(C1541) -attach $@ -write ../../cpu/6502/ethconfig/ethconfig.c64          ethconfig,p
+	$(C1541) -attach $@ -write ../../cpu/6502/ipconfig/ipconfig.c64            ipconfig,p
+	$(C1541) -attach $@ -write ../../examples/webbrowser/webbrowser.c64        webbrowser,p
+	$(C1541) -attach $@ -write ../../examples/wget/wget.c64                    wget,p
+	$(C1541) -attach $@ -write ../../examples/irc/irc-client.c64               irc,p
+	$(C1541) -attach $@ -write ../../examples/webserver/webserver-example.c64  webserver,p
+	$(C1541) -attach $@ -write ../../examples/telnet-server/telnet-server.c64  telnetd,p
+	$(C1541) -attach $@ -write ../c64/default.cfg                              contiki.cfg,s
+	$(C1541) -attach $@ -write ../../cpu/6502/ethconfig/cs8900a.eth            cs8900a.eth,s
+	$(C1541) -attach $@ -write ../../cpu/6502/ethconfig/lan91c96.eth           lan91c96.eth,s
+	$(C1541) -attach $@ -write $(CC65_HOME)/mou/c64-1351.mou                   contiki.mou,s
+	$(C1541) -attach $@ -write $(CC65_HOME)/mou/c64-inkwell.mou                inkwell.mou,s
+	$(C1541) -attach $@ -write $(CC65_HOME)/mou/c64-joy.mou                    joy.mou,s
+	$(C1541) -attach $@ -write $(CC65_HOME)/mou/c64-pot.mou                    pot.mou,s
+	$(C1541) -attach $@ -write ../../examples/webserver/httpd-cfs/index.htm    index.htm,s
+	$(C1541) -attach $@ -write ../../examples/webserver/httpd-cfs/backgrnd.gif backgrnd.gif,s
+	$(C1541) -attach $@ -write ../../examples/webserver/httpd-cfs/contiki.gif  contiki.gif,s
+	$(C1541) -attach $@ -write ../../examples/webserver/httpd-cfs/notfound.htm notfound.htm,s
 
 $(eval $(call makes,c128))
 
-c128: contiki-c128-1.d64 contiki-c128-2.d64 contiki-c128-3.d64 contiki-c128.d71 contiki-c128.d81
+c128: contiki-c128-1.d64 contiki-c128-2.d64 contiki-c128.d71 contiki-c128.d81
 
 contiki-c128-1.d64: c128-makes
 	$(C1541) -format contiki-1,00 d64 $@
@@ -395,17 +325,6 @@ contiki-c128-1.d64: c128-makes
 	$(C1541) -attach $@ -write ../../cpu/6502/ethconfig/lan91c96.eth     lan91c96.eth,s
 
 contiki-c128-2.d64: c128-makes
-	$(C1541) -format contiki-2,00 d64 $@
-	$(C1541) -attach $@ -write ../../cpu/6502/ethconfig/ethconfig.c128                                         ethconfig,p
-	$(C1541) -attach $@ -write ../../cpu/6502/ipconfig/ipconfig.c128                                           ipconfig,p
-	$(C1541) -attach $@ -write ../../../contikiprojects/vandenbrande.com/twitter/platform/c128/breadbox64.c128 breadbox64,p
-	$(C1541) -attach $@ -write ../../examples/email/email-client.c128                                          email,p
-	$(C1541) -attach $@ -write ../../examples/ftp/ftp-client.c128                                              ftp,p
-	$(C1541) -attach $@ -write ../c128/default.cfg                                                             contiki.cfg,s
-	$(C1541) -attach $@ -write ../../cpu/6502/ethconfig/cs8900a.eth                                            cs8900a.eth,s
-	$(C1541) -attach $@ -write ../../cpu/6502/ethconfig/lan91c96.eth                                           lan91c96.eth,s
-
-contiki-c128-3.d64: c128-makes
 	$(C1541) -format contiki-3,00 d64 $@
 	$(C1541) -attach $@ -write ../../cpu/6502/ethconfig/ethconfig.c128         ethconfig,p
 	$(C1541) -attach $@ -write ../../cpu/6502/ipconfig/ipconfig.c128           ipconfig,p
@@ -421,40 +340,34 @@ contiki-c128-3.d64: c128-makes
 
 contiki-c128.d71: c128-makes
 	$(C1541) -format contiki,00 d71 $@
-	$(C1541) -attach $@ -write ../../cpu/6502/ethconfig/ethconfig.c128                                         ethconfig,p
-	$(C1541) -attach $@ -write ../../cpu/6502/ipconfig/ipconfig.c128                                           ipconfig,p
-	$(C1541) -attach $@ -write ../../examples/webbrowser/webbrowser.c128                                       webbrowser,p
-	$(C1541) -attach $@ -write ../../examples/wget/wget.c128                                                   wget,p
-	$(C1541) -attach $@ -write ../../examples/irc/irc-client.c128                                              irc,p
-	$(C1541) -attach $@ -write ../../../contikiprojects/vandenbrande.com/twitter/platform/c128/breadbox64.c128 breadbox64,p
-	$(C1541) -attach $@ -write ../../examples/email/email-client.c128                                          email,p
-	$(C1541) -attach $@ -write ../../examples/ftp/ftp-client.c128                                              ftp,p
-	$(C1541) -attach $@ -write ../../examples/webserver/webserver-example.c128                                 webserver,p
-	$(C1541) -attach $@ -write ../../examples/telnet-server/telnet-server.c128                                 telnetd,p
-	$(C1541) -attach $@ -write ../c128/default.cfg                                                             contiki.cfg,s
-	$(C1541) -attach $@ -write ../../cpu/6502/ethconfig/cs8900a.eth                                            cs8900a.eth,s
-	$(C1541) -attach $@ -write ../../cpu/6502/ethconfig/lan91c96.eth                                           lan91c96.eth,s
-	$(C1541) -attach $@ -write ../../examples/webserver/httpd-cfs/index.htm                                    index.htm,s
-	$(C1541) -attach $@ -write ../../examples/webserver/httpd-cfs/backgrnd.gif                                 backgrnd.gif,s
-	$(C1541) -attach $@ -write ../../examples/webserver/httpd-cfs/contiki.gif                                  contiki.gif,s
-	$(C1541) -attach $@ -write ../../examples/webserver/httpd-cfs/notfound.htm                                 notfound.htm,s
+	$(C1541) -attach $@ -write ../../cpu/6502/ethconfig/ethconfig.c128         ethconfig,p
+	$(C1541) -attach $@ -write ../../cpu/6502/ipconfig/ipconfig.c128           ipconfig,p
+	$(C1541) -attach $@ -write ../../examples/webbrowser/webbrowser.c128       webbrowser,p
+	$(C1541) -attach $@ -write ../../examples/wget/wget.c128                   wget,p
+	$(C1541) -attach $@ -write ../../examples/irc/irc-client.c128              irc,p
+	$(C1541) -attach $@ -write ../../examples/webserver/webserver-example.c128 webserver,p
+	$(C1541) -attach $@ -write ../../examples/telnet-server/telnet-server.c128 telnetd,p
+	$(C1541) -attach $@ -write ../c128/default.cfg                             contiki.cfg,s
+	$(C1541) -attach $@ -write ../../cpu/6502/ethconfig/cs8900a.eth            cs8900a.eth,s
+	$(C1541) -attach $@ -write ../../cpu/6502/ethconfig/lan91c96.eth           lan91c96.eth,s
+	$(C1541) -attach $@ -write ../../examples/webserver/httpd-cfs/index.htm    index.htm,s
+	$(C1541) -attach $@ -write ../../examples/webserver/httpd-cfs/backgrnd.gif backgrnd.gif,s
+	$(C1541) -attach $@ -write ../../examples/webserver/httpd-cfs/contiki.gif  contiki.gif,s
+	$(C1541) -attach $@ -write ../../examples/webserver/httpd-cfs/notfound.htm notfound.htm,s
 
 contiki-c128.d81: c128-makes
 	$(C1541) -format contiki,00 d81 $@
-	$(C1541) -attach $@ -write ../../cpu/6502/ethconfig/ethconfig.c128                                         ethconfig,p
-	$(C1541) -attach $@ -write ../../cpu/6502/ipconfig/ipconfig.c128                                           ipconfig,p
-	$(C1541) -attach $@ -write ../../examples/webbrowser/webbrowser.c128                                       webbrowser,p
-	$(C1541) -attach $@ -write ../../examples/wget/wget.c128                                                   wget,p
-	$(C1541) -attach $@ -write ../../examples/irc/irc-client.c128                                              irc,p
-	$(C1541) -attach $@ -write ../../../contikiprojects/vandenbrande.com/twitter/platform/c128/breadbox64.c128 breadbox64,p
-	$(C1541) -attach $@ -write ../../examples/email/email-client.c128                                          email,p
-	$(C1541) -attach $@ -write ../../examples/ftp/ftp-client.c128                                              ftp,p
-	$(C1541) -attach $@ -write ../../examples/webserver/webserver-example.c128                                 webserver,p
-	$(C1541) -attach $@ -write ../../examples/telnet-server/telnet-server.c128                                 telnetd,p
-	$(C1541) -attach $@ -write ../c128/default.cfg                                                             contiki.cfg,s
-	$(C1541) -attach $@ -write ../../cpu/6502/ethconfig/cs8900a.eth                                            cs8900a.eth,s
-	$(C1541) -attach $@ -write ../../cpu/6502/ethconfig/lan91c96.eth                                           lan91c96.eth,s
-	$(C1541) -attach $@ -write ../../examples/webserver/httpd-cfs/index.htm                                    index.htm,s
-	$(C1541) -attach $@ -write ../../examples/webserver/httpd-cfs/backgrnd.gif                                 backgrnd.gif,s
-	$(C1541) -attach $@ -write ../../examples/webserver/httpd-cfs/contiki.gif                                  contiki.gif,s
-	$(C1541) -attach $@ -write ../../examples/webserver/httpd-cfs/notfound.htm                                 notfound.htm,s
+	$(C1541) -attach $@ -write ../../cpu/6502/ethconfig/ethconfig.c128         ethconfig,p
+	$(C1541) -attach $@ -write ../../cpu/6502/ipconfig/ipconfig.c128           ipconfig,p
+	$(C1541) -attach $@ -write ../../examples/webbrowser/webbrowser.c128       webbrowser,p
+	$(C1541) -attach $@ -write ../../examples/wget/wget.c128                   wget,p
+	$(C1541) -attach $@ -write ../../examples/irc/irc-client.c128              irc,p
+	$(C1541) -attach $@ -write ../../examples/webserver/webserver-example.c128 webserver,p
+	$(C1541) -attach $@ -write ../../examples/telnet-server/telnet-server.c128 telnetd,p
+	$(C1541) -attach $@ -write ../c128/default.cfg                             contiki.cfg,s
+	$(C1541) -attach $@ -write ../../cpu/6502/ethconfig/cs8900a.eth            cs8900a.eth,s
+	$(C1541) -attach $@ -write ../../cpu/6502/ethconfig/lan91c96.eth           lan91c96.eth,s
+	$(C1541) -attach $@ -write ../../examples/webserver/httpd-cfs/index.htm    index.htm,s
+	$(C1541) -attach $@ -write ../../examples/webserver/httpd-cfs/backgrnd.gif backgrnd.gif,s
+	$(C1541) -attach $@ -write ../../examples/webserver/httpd-cfs/contiki.gif  contiki.gif,s
+	$(C1541) -attach $@ -write ../../examples/webserver/httpd-cfs/notfound.htm notfound.htm,s


### PR DESCRIPTION
- By end of Jan 2014 SuperTweet.net was shut down (http://supertweetnews.140plus.com/). So Breadbox64 has come to an end for sure :-(

- The email app - or rather email sending app as it is SMTP only - can't be used anymore since nowadays everybody uses some "strong" authentication for SMTP session logon (thanks NSA).

- The ftp client app isn't very useful as it supports only download - for which the WGET app is almost always more useful for. But more important it doesn't support PASV which is more or less the only supported mode nowadays (especially over NAT).