### PR TITLE
made AES-128.set_key's argument const

### DIFF
--- a/core/lib/aes-128.c
+++ b/core/lib/aes-128.c
@@ -80,7 +80,7 @@ galois_mul2(uint8_t value)
 }
 /*---------------------------------------------------------------------------*/
 static void
-set_key(uint8_t *key)
+set_key(const uint8_t *key)
 {
   uint8_t i;
   uint8_t j;

--- a/core/lib/aes-128.h
+++ b/core/lib/aes-128.h
@@ -59,7 +59,7 @@ struct aes_128_driver {
   /**
    * \brief Sets the current key.
    */
-  void (* set_key)(uint8_t *key);
+  void (* set_key)(const uint8_t *key);
   
   /**
    * \brief Encrypts.


### PR DESCRIPTION
Made AES-128.set_key's argument const, thus helping to avoid compiler warnings.