### PR TITLE
Estimated fragments count should take into account 802.15.4 header size

### DIFF
--- a/core/net/ipv6/sicslowpan.c
+++ b/core/net/ipv6/sicslowpan.c
@@ -1455,7 +1455,7 @@ output(const uip_lladdr_t *localdest)
      * IPv6/HC1/HC06/HC_UDP dispatchs/headers.
      * The following fragments contain only the fragn dispatch.
      */
-    int estimated_fragments = ((int)uip_len) / ((int)MAC_MAX_PAYLOAD - SICSLOWPAN_FRAGN_HDR_LEN) + 1;
+    int estimated_fragments = ((int)uip_len) / (max_payload - SICSLOWPAN_FRAGN_HDR_LEN) + 1;
     int freebuf = queuebuf_numfree() - 1;
     PRINTFO("uip_len: %d, fragments: %d, free bufs: %d\n", uip_len, estimated_fragments, freebuf);
     if(freebuf < estimated_fragments) {


### PR DESCRIPTION
Since #557, MAC_MAX_PAYLOAD does not include 802.15.4 header size anymore, that means the fragments count estimation is wrong again in sicslowpan.c (it requires too few queuebuf for a given packet).

This PR add the 802.15.4 header length again as committed by the framer.