### PR TITLE
Cooja: Clone packet data before modifying it in packet analyser

### DIFF
--- a/tools/cooja/java/org/contikios/cooja/plugins/analyzers/PacketAnalyzer.java
+++ b/tools/cooja/java/org/contikios/cooja/plugins/analyzers/PacketAnalyzer.java
@@ -27,7 +27,7 @@ public abstract class PacketAnalyzer {
 
     public Packet(byte[] data, int level) {
       this.level = level;
-      this.data = data;
+      this.data = data.clone();
       this.size = data.length;
     }
 


### PR DESCRIPTION
THe packet analyser plugin is modifying the original packet data instead of working on it's own copy. This leads to broken cap files when more than one packet analyser is running.