### PR TITLE
ip64: Streamlined configuration parameters

### DIFF
--- a/core/net/ip64/ip64-conf-example.h
+++ b/core/net/ip64/ip64-conf-example.h
@@ -35,9 +35,14 @@
 #include "ip64-tap-driver.h"
 #include "ip64-eth-interface.h"
 
-#define IP64_CONF_UIP_FALLBACK_INTERFACE ip64_eth_interface
-#define IP64_CONF_INPUT                  ip64_eth_interface_input
+#define IP64_CONF_UIP_FALLBACK_INTERFACE    ip64_eth_interface
+#define IP64_CONF_INPUT                     ip64_eth_interface_input
 
-#define IP64_CONF_ETH_DRIVER             ip64_tap_driver
+#define IP64_CONF_ETH_DRIVER                ip64_tap_driver
 
+/* 
+ * In contrast to the mandatory parameters above, IP64_CONF_DHCP is an 
+ * optional configuration parameter. The default value is set in ip64.h 
+ */
+/* #define IP64_CONF_DHCP                      1 */
 #endif /* IP64_CONF_H */

--- a/core/net/ip64/ip64.c
+++ b/core/net/ip64/ip64.c
@@ -188,7 +188,7 @@ ip64_init(void)
 
   PRINTF("ip64_init\n");
   IP64_ETH_DRIVER.init();
-#if IP64_CONF_DHCP
+#if IP64_DHCP
   ip64_ipv4_dhcp_init();
 #endif /* IP64_CONF_DHCP */
 
@@ -894,14 +894,14 @@ ip64_hostaddr_is_configured(void)
 static void
 interface_init(void)
 {
-  IP64_CONF_UIP_FALLBACK_INTERFACE.init();
+  IP64_UIP_FALLBACK_INTERFACE.init();
 }
 /*---------------------------------------------------------------------------*/
 static void
 interface_output(void)
 {
   PRINTF("ip64: interface_output len %d\n", uip_len);
-  IP64_CONF_UIP_FALLBACK_INTERFACE.output();
+  IP64_UIP_FALLBACK_INTERFACE.output();
 }
 /*---------------------------------------------------------------------------*/
 const struct uip_fallback_interface ip64_uip_fallback_interface = {

--- a/core/net/ip64/ip64.h
+++ b/core/net/ip64/ip64.h
@@ -36,12 +36,12 @@
 
 void ip64_init(void);
 int ip64_6to4(const uint8_t *ipv6packet, const uint16_t ipv6len,
-	      uint8_t *resultpacket);
+              uint8_t *resultpacket);
 int ip64_4to6(const uint8_t *ipv4packet, const uint16_t ipv4len,
-	      uint8_t *resultpacket);
+              uint8_t *resultpacket);
 
 void ip64_set_ipv4_address(const uip_ip4addr_t *ipv4addr,
-			   const uip_ip4addr_t *netmask);
+                           const uip_ip4addr_t *netmask);
 void ip64_set_ipv6_address(const uip_ip6addr_t *ipv6addr);
 
 const uip_ip4addr_t *ip64_get_hostaddr(void);
@@ -71,7 +71,18 @@ extern uint16_t ip64_packet_buffer_maxlen;
 #define IP64_INPUT IP64_CONF_INPUT
 #endif /* IP64_CONF_INPUT */
 
+#ifndef IP64_CONF_UIP_FALLBACK_INTERFACE
+#error IP64_CONF_UIP_FALLBACK_INTERFACE must be #defined in ip64-conf.h
+#else /* IP64_CONF_UIP_FALLBACK_INTERFACE */
+#define IP64_UIP_FALLBACK_INTERFACE IP64_CONF_UIP_FALLBACK_INTERFACE
+#endif /* IP64_CONF_UIP_FALLBACK_INTERFACE */
 
+#ifdef IP64_CONF_DHCP
+#define IP64_DHCP IP64_CONF_DHCP
+#else /* IP64_CONF_DHCP */
+/* Enable DHCP per default */
+#define IP64_DHCP 1
+#endif /* IP64_CONF_DHCP */
 
 #endif /* IP64_H */
 


### PR DESCRIPTION
I just replaced the two defines "IP64_CONF_DHCP" and "IP64_CONF_UIP_FALLBACK_INTERFACE"
from ip64.c and moved their definition into ip64.h. In addition, i added IP64_CONF_DHCP to the example configuration file for completeness.