### PR TITLE
Add CRC to packets send by CoojaMote

### DIFF
--- a/tools/cooja/apps/mspsim/src/org/contikios/cooja/mspmote/interfaces/CC2420RadioPacketConverter.java
+++ b/tools/cooja/apps/mspsim/src/org/contikios/cooja/mspmote/interfaces/CC2420RadioPacketConverter.java
@@ -46,7 +46,7 @@ public class CC2420RadioPacketConverter {
   public static final boolean WITH_XMAC = false; /* XXX No longer supported. Cross-level requires NULLMAC */
   public static final boolean WITH_CHECKSUM = false; /* Contiki checksum. Not CC2420's built-in. */
   public static final boolean WITH_TIMESTAMP = false; /* Contiki timestamp */
-  public static final boolean WITH_FOOTER = true; /* CC2420's checksum */
+  public static final boolean WITH_FOOTER = false; /* CC2420's checksum */
 
   public static byte[] fromCoojaToCC2420(RadioPacket packet) {
     byte cc2420Data[] = new byte[6+127];

--- a/tools/cooja/java/org/contikios/cooja/contikimote/interfaces/ContikiRadio.java
+++ b/tools/cooja/java/org/contikios/cooja/contikimote/interfaces/ContikiRadio.java
@@ -48,7 +48,7 @@ import org.contikios.cooja.interfaces.Position;
 import org.contikios.cooja.interfaces.Radio;
 import org.contikios.cooja.mote.memory.VarMemory;
 import org.contikios.cooja.radiomediums.UDGM;
-
+import org.contikios.cooja.util.CCITT_CRC;
 /**
  * Packet radio transceiver mote interface.
  *
@@ -200,7 +200,7 @@ public class ContikiRadio extends Radio implements ContikiMoteInterface, PolledA
       packetToMote = null;
       myMoteMemory.setIntValueOf("simInSize", 0);
     } else {
-      myMoteMemory.setIntValueOf("simInSize", packetToMote.getPacketData().length);
+      myMoteMemory.setIntValueOf("simInSize", packetToMote.getPacketData().length - 2);
       myMoteMemory.setByteArray("simInDataBuffer", packetToMote.getPacketData());
     }
 
@@ -330,7 +330,7 @@ public class ContikiRadio extends Radio implements ContikiMoteInterface, PolledA
     /* New transmission */
     int size = myMoteMemory.getIntValueOf("simOutSize");
     if (!isTransmitting && size > 0) {
-      packetFromMote = new COOJARadioPacket(myMoteMemory.getByteArray("simOutDataBuffer", size));
+      packetFromMote = new COOJARadioPacket(myMoteMemory.getByteArray("simOutDataBuffer", size + 2));
 
       if (packetFromMote.getPacketData() == null || packetFromMote.getPacketData().length == 0) {
         logger.warn("Skipping zero sized Contiki packet (no buffer)");
@@ -338,6 +338,15 @@ public class ContikiRadio extends Radio implements ContikiMoteInterface, PolledA
         mote.requestImmediateWakeup();
         return;
       }
+
+      byte[] data = packetFromMote.getPacketData();
+      CCITT_CRC txCrc = new CCITT_CRC();
+      txCrc.setCRC(0);
+      for (int i = 0; i < size; i++) {
+        txCrc.addBitrev(data[i]);
+      }
+      data[size] = (byte)txCrc.getCRCHi();
+      data[size + 1] = (byte)txCrc.getCRCLow();
 
       isTransmitting = true;
 

--- a/tools/cooja/java/org/contikios/cooja/util/CCITT_CRC.java
+++ b/tools/cooja/java/org/contikios/cooja/util/CCITT_CRC.java
@@ -1,0 +1,89 @@
+/**
+ * Copyright (c) 2008, Swedish Institute of Computer Science.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * This file is part of MSPSim.
+ *
+ * -----------------------------------------------------------------
+ *
+ * Author  : Joakim Eriksson
+ */
+
+package org.contikios.cooja.util;
+
+/* basic CRC-CCITT code */
+public class CCITT_CRC {
+  int crc;
+
+  public int getCRC() {
+    return crc;
+  }
+
+  /* this will only work with zero... */
+  public void setCRC(int val) {
+    crc = val;
+  }
+  
+  public void clr() {
+    crc = 0xffff;
+  }
+
+  public void addBitrev(int data) {
+      add(bitrev(data));
+  }
+  
+  public int getCRCLow() {
+      return bitrev(crc & 0xff);
+  }
+
+  public int getCRCHi() {
+      return bitrev(crc >> 8);
+  }
+
+  
+  public int add(int data) {
+    int newCrc = ((crc >> 8) & 0xff) | (crc << 8) & 0xffff;
+    newCrc ^= (data & 0xff);
+    newCrc ^= (newCrc & 0xff) >> 4;
+    newCrc ^= (newCrc << 12) & 0xffff;
+    newCrc ^= (newCrc & 0xff) << 5;
+    crc = newCrc & 0xffff;
+    return crc;
+  }
+
+  public int getCRCBitrev() {
+      return getCRCLow() + (getCRCHi() << 8);
+  }
+  
+  public static final String hex = "0123456789abcdef";
+
+  private static int bitrev(int data) {
+      return ((data << 7) & 0x80) | ((data << 5) & 0x40) |
+      (data << 3) & 0x20 | (data << 1) & 0x10 |
+      (data >> 7) & 0x01 | (data >> 5) & 0x02 |
+      (data >> 3) & 0x04 | (data >> 1) & 0x08;
+  }
+}


### PR DESCRIPTION
Packets sent from CoojaMote do not have a CRC. CoojaRadio simply send the packet to the RfListener as is. Also the adaptation layer between CC2420 emulator and RfListener drops and recreates the CRC for outgoing and incoming packets.

This PR ensure that all packets have (or keep) their CRC and so are exportable into valid PCAP.

Notes: I had to copy CCITT_CRC from MSPSIM as I did not see a way to cleanly reference it from Cooja, also, other radio driver might need adaptation, so feedback is most welcome.