### PR TITLE
Check pointer in uip_debug_lladdr_print

### DIFF
--- a/core/net/ip/uip-debug.c
+++ b/core/net/ip/uip-debug.c
@@ -75,6 +75,10 @@ void
 uip_debug_lladdr_print(const uip_lladdr_t *addr)
 {
   unsigned int i;
+  if(addr == NULL) {
+    printf("(NULL LL addr)");
+    return;
+  }
   for(i = 0; i < sizeof(uip_lladdr_t); i++) {
     if(i > 0) {
       PRINTA(":");


### PR DESCRIPTION
If DEBUG is enabled in uip-ds6-nbr, the code crashes when trying to print a NULL lladdr. A NULL lladdr occurs with INCOMPLETE neighbor state.