### PR TITLE
Change all printf into PRINTA in uip-debug.c and remove compilation warnings

### DIFF
--- a/core/net/ip/uip-debug.c
+++ b/core/net/ip/uip-debug.c
@@ -43,14 +43,16 @@
 void
 uip_debug_ipaddr_print(const uip_ipaddr_t *addr)
 {
-  if(addr == NULL || addr->u8 == NULL) {
-    printf("(NULL IP addr)");
-    return;
-  }
 #if NETSTACK_CONF_WITH_IPV6
   uint16_t a;
   unsigned int i;
   int f;
+#endif /* NETSTACK_CONF_WITH_IPV6 */
+  if(addr == NULL) {
+    PRINTA("(NULL IP addr)");
+    return;
+  }
+#if NETSTACK_CONF_WITH_IPV6
   for(i = 0, f = 0; i < sizeof(uip_ipaddr_t); i += 2) {
     a = (addr->u8[i] << 8) + addr->u8[i + 1];
     if(a == 0 && f >= 0) {
@@ -76,7 +78,7 @@ uip_debug_lladdr_print(const uip_lladdr_t *addr)
 {
   unsigned int i;
   if(addr == NULL) {
-    printf("(NULL LL addr)");
+    PRINTA("(NULL LL addr)");
     return;
   }
   for(i = 0; i < sizeof(uip_lladdr_t); i++) {


### PR DESCRIPTION
Change all printf into PRINTA in uip-debug.c; remove compilation warning (an array can never be a NULL pointer) and move addr check after local variables definition in uip_debug_ipaddr_print() for older compiler.