### PR TITLE
put gcc specific stuff into seperate .h

### DIFF
--- a/core/sys/cc-gcc.h
+++ b/core/sys/cc-gcc.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2015, Scanimetrics - http://www.scanimetrics.com
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+/*---------------------------------------------------------------------------*/
+#ifndef _CC_GCC_H_
+#define _CC_GCC_H_
+#ifdef __GNUC__
+
+#ifndef CC_CONF_INLINE
+/* use __inline__ in case "inline" is not available for any reason */
+#define CC_CONF_INLINE __inline__
+#endif
+
+#define CC_CONF_ALIGN(n) __attribute__((__aligned__(n)))
+
+#endif /* __GNUC__ */
+#endif /* _CC_GCC_H_ */

--- a/core/sys/cc.h
+++ b/core/sys/cc.h
@@ -46,6 +46,7 @@
 #define CC_H_
 
 #include "contiki-conf.h"
+#include "sys/cc-gcc.h"
 
 /**
  * Configure if the C compiler supports the "register" keyword for
@@ -108,6 +109,10 @@
 #define CC_INLINE CC_CONF_INLINE
 #else /* CC_CONF_INLINE */
 #define CC_INLINE
+#endif /* CC_CONF_INLINE */
+
+#ifdef CC_CONF_ALIGN
+#define CC_ALIGN(n) CC_CONF_ALIGN(n)
 #endif /* CC_CONF_INLINE */
 
 /**

--- a/cpu/cc26xx-cc13xx/rf-core/ieee-mode.c
+++ b/cpu/cc26xx-cc13xx/rf-core/ieee-mode.c
@@ -75,12 +75,6 @@
 #include <stdio.h>
 #include <stdbool.h>
 /*---------------------------------------------------------------------------*/
-#ifdef __GNUC__
-#define CC_ALIGN_ATTR(n) __attribute__ ((aligned(n)))
-#else
-#define CC_ALIGN_ATTR(n)
-#endif
-/*---------------------------------------------------------------------------*/
 #define DEBUG 0
 #if DEBUG
 #define PRINTF(...) printf(__VA_ARGS__)
@@ -202,7 +196,7 @@ const output_config_t *tx_power_current = &output_power[0];
  * A buffer to send a CMD_IEEE_RX and to subsequently monitor its status
  * Do not use this buffer for any commands other than CMD_IEEE_RX
  */
-static uint8_t cmd_ieee_rx_buf[RF_CMD_BUFFER_SIZE] CC_ALIGN_ATTR(4);
+static uint8_t cmd_ieee_rx_buf[RF_CMD_BUFFER_SIZE] CC_ALIGN(4);
 /*---------------------------------------------------------------------------*/
 #define DATA_ENTRY_LENSZ_NONE 0
 #define DATA_ENTRY_LENSZ_BYTE 1
@@ -210,10 +204,10 @@ static uint8_t cmd_ieee_rx_buf[RF_CMD_BUFFER_SIZE] CC_ALIGN_ATTR(4);
 
 #define RX_BUF_SIZE 140
 /* Four receive buffers entries with room for 1 IEEE802.15.4 frame in each */
-static uint8_t rx_buf_0[RX_BUF_SIZE] CC_ALIGN_ATTR(4);
-static uint8_t rx_buf_1[RX_BUF_SIZE] CC_ALIGN_ATTR(4);
-static uint8_t rx_buf_2[RX_BUF_SIZE] CC_ALIGN_ATTR(4);
-static uint8_t rx_buf_3[RX_BUF_SIZE] CC_ALIGN_ATTR(4);
+static uint8_t rx_buf_0[RX_BUF_SIZE] CC_ALIGN(4);
+static uint8_t rx_buf_1[RX_BUF_SIZE] CC_ALIGN(4);
+static uint8_t rx_buf_2[RX_BUF_SIZE] CC_ALIGN(4);
+static uint8_t rx_buf_3[RX_BUF_SIZE] CC_ALIGN(4);
 
 /* The RX Data Queue */
 static dataQueue_t rx_data_queue = { 0 };
@@ -225,7 +219,7 @@ volatile static uint8_t *rx_read_entry;
 #define TX_BUF_PAYLOAD_LEN 180
 #define TX_BUF_HDR_LEN       2
 
-static uint8_t tx_buf[TX_BUF_HDR_LEN + TX_BUF_PAYLOAD_LEN] CC_ALIGN_ATTR(4);
+static uint8_t tx_buf[TX_BUF_HDR_LEN + TX_BUF_PAYLOAD_LEN] CC_ALIGN(4);
 /*---------------------------------------------------------------------------*/
 /* Overrides for IEEE 802.15.4, differential mode */
 static uint32_t ieee_overrides[] = {

--- a/cpu/cc26xx-cc13xx/rf-core/prop-mode.c
+++ b/cpu/cc26xx-cc13xx/rf-core/prop-mode.c
@@ -80,12 +80,6 @@
 #include <stdio.h>
 #include <stdbool.h>
 /*---------------------------------------------------------------------------*/
-#ifdef __GNUC__
-#define CC_ALIGN_ATTR(n) __attribute__ ((aligned(n)))
-#else
-#define CC_ALIGN_ATTR(n)
-#endif
-/*---------------------------------------------------------------------------*/
 #define DEBUG 0
 #if DEBUG
 #define PRINTF(...) printf(__VA_ARGS__)
@@ -241,8 +235,8 @@ const output_config_t *tx_power_current = &output_power[1];
 
 #define RX_BUF_SIZE 140
 /* Receive buffers: 1 frame in each */
-static uint8_t rx_buf_0[RX_BUF_SIZE] CC_ALIGN_ATTR(4);
-static uint8_t rx_buf_1[RX_BUF_SIZE] CC_ALIGN_ATTR(4);
+static uint8_t rx_buf_0[RX_BUF_SIZE] CC_ALIGN(4);
+static uint8_t rx_buf_1[RX_BUF_SIZE] CC_ALIGN(4);
 
 /* The RX Data Queue */
 static dataQueue_t rx_data_queue = { 0 };
@@ -254,7 +248,7 @@ volatile static uint8_t *rx_read_entry;
 #define TX_BUF_PAYLOAD_LEN 180
 #define TX_BUF_HDR_LEN       2
 
-static uint8_t tx_buf[TX_BUF_HDR_LEN + TX_BUF_PAYLOAD_LEN] CC_ALIGN_ATTR(4);
+static uint8_t tx_buf[TX_BUF_HDR_LEN + TX_BUF_PAYLOAD_LEN] CC_ALIGN(4);
 /*---------------------------------------------------------------------------*/
 static uint8_t
 rf_is_on(void)

--- a/cpu/cc26xx-cc13xx/rf-core/rf-ble.c
+++ b/cpu/cc26xx-cc13xx/rf-core/rf-ble.c
@@ -39,6 +39,7 @@
 #include "contiki-conf.h"
 #include "sys/process.h"
 #include "sys/clock.h"
+#include "sys/cc.h"
 #include "sys/etimer.h"
 #include "net/netstack.h"
 #include "net/linkaddr.h"
@@ -52,12 +53,6 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <stdio.h>
-/*---------------------------------------------------------------------------*/
-#ifdef __GNUC__
-#define CC_ALIGN_ATTR(n) __attribute__ ((aligned(n)))
-#else
-#define CC_ALIGN_ATTR(n)
-#endif
 /*---------------------------------------------------------------------------*/
 #define DEBUG 0
 #if DEBUG
@@ -79,7 +74,7 @@
 #define BLE_ADV_PAYLOAD_BUF_LEN     64
 #define BLE_UUID_SIZE               16
 /*---------------------------------------------------------------------------*/
-static unsigned char ble_params_buf[32] CC_ALIGN_ATTR(4);
+static unsigned char ble_params_buf[32] CC_ALIGN(4);
 static uint8_t ble_mode_on = RF_BLE_IDLE;
 static struct etimer ble_adv_et;
 static uint8_t payload[BLE_ADV_PAYLOAD_BUF_LEN];

--- a/cpu/cc26xx-cc13xx/rf-core/rf-core.c
+++ b/cpu/cc26xx-cc13xx/rf-core/rf-core.c
@@ -40,6 +40,7 @@
 #include "dev/watchdog.h"
 #include "sys/process.h"
 #include "sys/energest.h"
+#include "sys/cc.h"
 #include "net/netstack.h"
 #include "net/packetbuf.h"
 #include "net/rime/rimestats.h"
@@ -71,12 +72,6 @@
 #define PRINTF(...) printf(__VA_ARGS__)
 #else
 #define PRINTF(...)
-#endif
-/*---------------------------------------------------------------------------*/
-#ifdef __GNUC__
-#define CC_ALIGN_ATTR(n) __attribute__ ((aligned(n)))
-#else
-#define CC_ALIGN_ATTR(n)
 #endif
 /*---------------------------------------------------------------------------*/
 #ifdef RF_CORE_CONF_DEBUG_CRC

--- a/doc/Doxyfile
+++ b/doc/Doxyfile
@@ -1961,7 +1961,7 @@ PREDEFINED             = CC_FUNCTION_POINTER_ARGS:=1 \
                          UIP_CONF_ICMP6:=1 \
                          WITH_LOADER_ARCH:=1 \
                          __attribute__(x):= \
-                         CC_ALIGN_ATTR(n):= \
+                         CC_ALIGN(n):= \
                          HTTPD_STRING_ATTR:= \
                          PROGMEM:= \
                          EEMEM:= \


### PR DESCRIPTION
I think that it does not make sense to define functionality specific to compilers in platform headers or as needed in C files. I'd like to propose that we have specific header files for compiler specific functionality and have created such a header for gcc.

In addition to the above, this will also have the tangible effect of defining CC_CONF_INLINE on platforms that build with gcc and which do not already define it (such as CC2538 and CC2650) without having to add more to the platform specific header files.

