### PR TITLE
Fix DHCP client retries.

### DIFF
--- a/apps/dhcp/dhcp.c
+++ b/apps/dhcp/dhcp.c
@@ -97,9 +97,9 @@ makestrings(void)
 PROCESS_THREAD(dhcp_process, ev, data)
 {
   PROCESS_BEGIN();
-  
+
   ctk_window_new(&window, 28, 7, "DHCP");
-  
+
   CTK_WIDGET_ADD(&window, &getbutton);
   CTK_WIDGET_ADD(&window, &statuslabel);
   CTK_WIDGET_ADD(&window, &ipaddrlabel);
@@ -110,22 +110,21 @@ PROCESS_THREAD(dhcp_process, ev, data)
   CTK_WIDGET_ADD(&window, &gatewayentry);
   CTK_WIDGET_ADD(&window, &dnsserverlabel);
   CTK_WIDGET_ADD(&window, &dnsserverentry);
-  
+
   CTK_WIDGET_FOCUS(&window, &getbutton);
 
   ctk_window_open(&window);
   dhcpc_init(uip_lladdr.addr, sizeof(uip_lladdr.addr));
 
-
   while(1) {
     PROCESS_WAIT_EVENT();
-    
+
     if(ev == ctk_signal_widget_activate) {
       if(data == (process_data_t)&getbutton) {
 	dhcpc_request();
 	set_statustext("Requesting...");
       }
-    } else if(ev == tcpip_event) {
+    } else if(ev == tcpip_event || ev == PROCESS_EVENT_TIMER) {
       dhcpc_appcall(ev, data);
     } else if(ev == PROCESS_EVENT_EXIT ||
 	      ev == ctk_signal_window_close) {

--- a/cpu/6502/ipconfig/ipconfig.c
+++ b/cpu/6502/ipconfig/ipconfig.c
@@ -177,9 +177,9 @@ app_quit(void)
 PROCESS_THREAD(ipconfig_process, ev, data)
 {
   PROCESS_BEGIN();
-  
+
   ctk_window_new(&window, 29, 14, "IP config");
-  
+
   CTK_WIDGET_ADD(&window, &requestbutton);
   CTK_WIDGET_ADD(&window, &statuslabel);  
   CTK_WIDGET_ADD(&window, &ipaddrlabel);  
@@ -208,11 +208,11 @@ PROCESS_THREAD(ipconfig_process, ev, data)
 
   while(1) {
     PROCESS_WAIT_EVENT();
-    
+
     if(ev == PROCESS_EVENT_MSG) {
       makestrings();
       ctk_window_redraw(&window);
-    } else if(ev == tcpip_event) {
+    } else if(ev == tcpip_event || ev == PROCESS_EVENT_TIMER) {
       dhcpc_appcall(ev, data);
     } else if(ev == ctk_signal_button_activate) {   
       if(data == (process_data_t)&requestbutton) {


### PR DESCRIPTION
In order to have DHCP retries actually work dhcpc_appcall() must be called for PROCESS_EVENT_TIMER too.