### PR TITLE
turned on correlator in radio packet filter

### DIFF
--- a/cpu/cc26xx/dev/cc26xx-rf.c
+++ b/cpu/cc26xx/dev/cc26xx-rf.c
@@ -892,10 +892,11 @@ init_rf_params(void)
   /* Configure CCA settings */
   GET_FIELD(cmd_ieee_rx_buf, CMD_IEEE_RX, ccaOpt) =
     BITVALUE(CMD_IEEE_RX, ccaOpt, ccaEnEnergy, 1) |
-    BITVALUE(CMD_IEEE_RX, ccaOpt, ccaEnCorr, 0) |
+    BITVALUE(CMD_IEEE_RX, ccaOpt, ccaEnCorr, 1) |
     BITVALUE(CMD_IEEE_RX, ccaOpt, ccaEnSync, 0) |
-    BITVALUE(CMD_IEEE_RX, ccaOpt, ccaCorrOp, 0) |
-    BITVALUE(CMD_IEEE_RX, ccaOpt, ccaSyncOp, 0);
+    BITVALUE(CMD_IEEE_RX, ccaOpt, ccaCorrOp, 1) |
+    BITVALUE(CMD_IEEE_RX, ccaOpt, ccaSyncOp, 1) |
+    BITVALUE(CMD_IEEE_RX, ccaOpt, ccaCorrThr, 3);
   /* Set CCA RSSI Threshold, 0xA6 corresponds to -90dBm (two's comp.)*/
   GET_FIELD(cmd_ieee_rx_buf, CMD_IEEE_RX, ccaRssiThr) = 0xA6;
   GET_FIELD(cmd_ieee_rx_buf, CMD_IEEE_RX, numExtEntries) = 0x00;


### PR DESCRIPTION
After making this change I am able to get ~3x higher max data throughput when sending packets with RIME (as quickly as I can) on ContikiMAC (with duty cycling enabled on the transmitter, duty cycling disabled on the receiver and a CHANNEL_CHECK_RATE of 8) than without these changes.

This improvement seems to be caused by significantly reducing the number of false positive CCAs. These false positives then limit the TX rate by causing ContikiMAC to detect collisions before sending.

In addition, I have found that this also reduces the number of false positives in the receiver routines of ContikiMAC which will result in less power consumption on duty cycling receivers.

I am somewhat concerned that these changes will lead to less reliable operation in very noisy environments but I think that these improvements are too large to ignore so I want the community to have a look.