### PR TITLE
Stunicast timer fix

### DIFF
--- a/core/net/rime/stunicast.c
+++ b/core/net/rime/stunicast.c
@@ -112,10 +112,10 @@ send(void *ptr)
   PRINTF("%d.%d: stunicast: resend to %d.%d\n",
 	 linkaddr_node_addr.u8[0],linkaddr_node_addr.u8[1],
 	 c->receiver.u8[0], c->receiver.u8[1]);
-	 if(c->buf) {
-  	queuebuf_to_packetbuf(c->buf);
-  	unicast_send(&c->c, &c->receiver);
-  	stunicast_set_timer(c, CLOCK_SECOND);
+  if(c->buf) {
+    queuebuf_to_packetbuf(c->buf);
+    unicast_send(&c->c, &c->receiver);
+    stunicast_set_timer(c, CLOCK_SECOND);
   }
   /*  if(c->u->sent != NULL) {
     c->u->sent(c);

--- a/core/net/rime/stunicast.c
+++ b/core/net/rime/stunicast.c
@@ -115,7 +115,7 @@ send(void *ptr)
   if(c->buf) {
     queuebuf_to_packetbuf(c->buf);
     unicast_send(&c->c, &c->receiver);
-    stunicast_set_timer(c, CLOCK_SECOND);
+    ctimer_restart(&c->t);
   }
   /*  if(c->u->sent != NULL) {
     c->u->sent(c);


### PR DESCRIPTION
In core/net/rime/stunicast.c:

When calling stunicast_send_stubborn, a clock_time_t argument is passed to determine re-transmission time. The connection's ctimer is set with this time to call the send function.
When the timer expires for the first time and the send function is called, it sets the re-transmission timer to CLOCK_SECOND, regardless of the time that was passed to  stunicast_send_stubborn.

In this fix, I simply restart the connection's ctimer, i.e. setting it to the same given clock_time_t argument as passed to stunicast_send_stubborn.