### PR TITLE
Fix Mishandling of PENDING/Queued Packets at ContikiMAC and CSMA

### DIFF
--- a/core/net/mac/contikimac/contikimac.c
+++ b/core/net/mac/contikimac/contikimac.c
@@ -805,6 +805,7 @@ qsend_list(mac_callback_t sent, void *ptr, struct rdc_buf_list *buf_list)
   struct rdc_buf_list *next;
   int ret;
   int is_receiver_awake;
+  int pending;
   
   if(buf_list == NULL) {
     return;
@@ -849,7 +850,9 @@ qsend_list(mac_callback_t sent, void *ptr, struct rdc_buf_list *buf_list)
 
     /* Prepare the packetbuf */
     queuebuf_to_packetbuf(curr->buf);
-    
+
+    pending = packetbuf_attr(PACKETBUF_ATTR_PENDING);
+
     /* Send the current packet */
     ret = send_packet(sent, ptr, curr, is_receiver_awake);
     if(ret != MAC_TX_DEFERRED) {
@@ -866,7 +869,7 @@ qsend_list(mac_callback_t sent, void *ptr, struct rdc_buf_list *buf_list)
       /* The transmission failed, we stop the burst */
       next = NULL;
     }
-  } while((next != NULL) && packetbuf_attr(PACKETBUF_ATTR_PENDING));
+  } while((next != NULL) && pending);
 }
 /*---------------------------------------------------------------------------*/
 /* Timer callback triggered when receiving a burst, after having


### PR DESCRIPTION
Fix for #1165

This fixes this problem by storing pending status in a local variable before calling mac_call_sent_callback.

Since this is (in my opinion) the obvious way to fix this problem I have gone ahead and simply implemented (and tested) this solution.