### PR TITLE
Fix multiple warnings (TCPIP, coap-observe, msp430, z1/tmp102, ContikiMAC)

### DIFF
--- a/apps/er-coap/er-coap-observe.c
+++ b/apps/er-coap/er-coap-observe.c
@@ -234,8 +234,6 @@ coap_observe_handler(resource_t *resource, void *request, void *response)
   coap_packet_t *const coap_res = (coap_packet_t *)response;
   coap_observer_t * obs;
 
-  static char content[16];
-
   if(coap_req->code == COAP_GET && coap_res->code < 128) { /* GET request and response without error code */
     if(IS_OPTION(coap_req, COAP_OPTION_OBSERVE)) {
       if(coap_req->observe == 0) {
@@ -249,13 +247,14 @@ coap_observe_handler(resource_t *resource, void *request, void *response)
            * A subscription should return the same representation as a normal GET.
            * Uncomment if you want an information about the avaiable observers.
            */
-          /*
-           * coap_set_payload(coap_res,
-           *                  content,
-           *                  snprintf(content, sizeof(content), "Added %u/%u",
-           *                           list_length(observers_list),
-           *                           COAP_MAX_OBSERVERS));
-           */
+#if 0
+          static char content[16];
+          coap_set_payload(coap_res,
+                           content,
+                           snprintf(content, sizeof(content), "Added %u/%u",
+                                    list_length(observers_list),
+                                    COAP_MAX_OBSERVERS));
+#endif
         } else {
           coap_res->code = SERVICE_UNAVAILABLE_5_03;
           coap_set_payload(coap_res, "TooManyObservers", 16);

--- a/core/net/ip/tcpip.c
+++ b/core/net/ip/tcpip.c
@@ -155,6 +155,7 @@ unsigned char tcpip_is_forwarding; /* Forwarding right now? */
 PROCESS(tcpip_process, "TCP/IP stack");
 
 /*---------------------------------------------------------------------------*/
+#if UIP_TCP || UIP_CONF_IP_FORWARD
 static void
 start_periodic_tcp_timer(void)
 {
@@ -162,6 +163,7 @@ start_periodic_tcp_timer(void)
     etimer_restart(&periodic);
   }
 }
+#endif /* UIP_TCP || UIP_CONF_IP_FORWARD */
 /*---------------------------------------------------------------------------*/
 static void
 check_for_tcp_syn(void)

--- a/core/net/mac/contikimac/contikimac.c
+++ b/core/net/mac/contikimac/contikimac.c
@@ -493,14 +493,16 @@ send_packet(mac_callback_t mac_callback, void *mac_callback_ptr,
 #endif
   int strobes;
   uint8_t got_strobe_ack = 0;
-  int len;
   uint8_t is_broadcast = 0;
   uint8_t is_known_receiver = 0;
   uint8_t collisions;
   int transmit_len;
   int ret;
   uint8_t contikimac_was_on;
+#if !RDC_CONF_HARDWARE_ACK
+  int len;
   uint8_t seqno;
+#endif
   
   /* Exit if RDC and radio were explicitly turned off */
    if(!contikimac_is_on && !contikimac_keep_radio_on) {
@@ -641,11 +643,11 @@ send_packet(mac_callback_t mac_callback, void *mac_callback_ptr,
        or rx cycle */
      on();
   }
+  seqno = packetbuf_attr(PACKETBUF_ATTR_MAC_SEQNO);
 #endif
 
   watchdog_periodic();
   t0 = RTIMER_NOW();
-  seqno = packetbuf_attr(PACKETBUF_ATTR_MAC_SEQNO);
   for(strobes = 0, collisions = 0;
       got_strobe_ack == 0 && collisions == 0 &&
       RTIMER_CLOCK_LT(RTIMER_NOW(), t0 + STROBE_TIME); strobes++) {
@@ -658,7 +660,9 @@ send_packet(mac_callback_t mac_callback, void *mac_callback_ptr,
       break;
     }
 
+#if !RDC_CONF_HARDWARE_ACK
     len = 0;
+#endif
 
     {
       rtimer_clock_t wt;


### PR DESCRIPTION
These 5 commits fix compiler warnings for TCPIP, coap-observe, msp430 mtarch, z1/tmp102 driver, and ContikiMAC.
Details are included in the commit messages.

I can submit these all as separate PRs if that's preferred.