### PR TITLE
Cc26xx fix read frame implementation

### DIFF
--- a/cpu/cc26xx/dev/cc26xx-rf.c
+++ b/cpu/cc26xx/dev/cc26xx-rf.c
@@ -1350,15 +1350,26 @@ read_frame(void *buf, unsigned short buf_len)
     return 0;
   }
 
-  if(!rx_read_entry[8]) {
+
+  if(rx_read_entry[8] < 4) {
+    PRINTF("RF: too short\n");
+    RIMESTATS_ADD(tooshort);
+
     release_data_entry();
     return 0;
   }
 
-  memcpy(buf, (char *)&rx_read_entry[9], buf_len);
+  len = rx_read_entry[8] - 4;
 
-  /* Remove the footer */
-  len = MIN(buf_len, rx_read_entry[8] - 4);
+  if(len > buf_len) {
+    PRINTF("RF: too long\n");
+    RIMESTATS_ADD(toolong);
+
+    release_data_entry();
+    return 0;
+  }
+
+  memcpy(buf, (char *)&rx_read_entry[9], len);
 
   rssi = (int8_t)rx_read_entry[9 + len + 2];
 

--- a/cpu/cc26xx/dev/cc26xx-rf.c
+++ b/cpu/cc26xx/dev/cc26xx-rf.c
@@ -1334,8 +1334,6 @@ read_frame(void *buf, unsigned short buf_len)
   int len = 0;
 
   if(GET_FIELD_V(rx_read_entry, dataEntry, status) == DATA_ENTRY_STATUS_FINISHED) {
-    /* Set status to 0 "Pending" in element */
-    GET_FIELD_V(rx_read_entry, dataEntry, status) = DATA_ENTRY_STATUS_PENDING;
 
     if(rx_read_entry[8] > 0) {
       memcpy(buf, (char *)&rx_read_entry[9], buf_len);
@@ -1351,6 +1349,9 @@ read_frame(void *buf, unsigned short buf_len)
       /* Clear the length byte */
       rx_read_entry[8] = 0;
     }
+
+    /* Set status to 0 "Pending" in element */
+    GET_FIELD_V(rx_read_entry, dataEntry, status) = DATA_ENTRY_STATUS_PENDING;
 
     /* Move read entry pointer to next entry */
     rx_read_entry = GET_FIELD_V(rx_read_entry, dataEntry, pNextEntry);


### PR DESCRIPTION
Fixes various bugs and stylistic issues with the `read_frame` function.

In particular:
- Fixed a race condition caused by using the dataEntry after setting status to PENDING
- Fixed general misuse of the packet length
- made some stylistic changes