### PR TITLE
Clarified that a newline is needed for the echo

### DIFF
--- a/examples/cc2530dk/cc2531-usb-demo/cc2531-usb-demo.c
+++ b/examples/cc2530dk/cc2531-usb-demo/cc2531-usb-demo.c
@@ -35,7 +35,7 @@
  *         USB (CDC_ACM) functionality.
  *
  *         It will print out periodically. Anything you type in the dongle's
- *         serial console will be echoed back
+ *         serial console will be echoed back after a newline.
  *
  * \author
  *         George Oikonomou - <oikonomou@users.sourceforge.net>


### PR DESCRIPTION
No code change, just a change to the descriptive comment in the cc2531 usb demo