### PR TITLE
Changed RPL IPv6 NBR Callback Print Statement

### DIFF
--- a/core/net/rpl/rpl.c
+++ b/core/net/rpl/rpl.c
@@ -277,9 +277,9 @@ rpl_ipv6_neighbor_callback(uip_ds6_nbr_t *nbr)
   rpl_instance_t *instance;
   rpl_instance_t *end;
 
-  PRINTF("RPL: Removing neighbor ");
+  PRINTF("RPL: Neighbor state changed for ");
   PRINT6ADDR(&nbr->ipaddr);
-  PRINTF("\n");
+  PRINTF(", nscount=%u, state=%u\n", nbr->nscount, nbr->state);
   for(instance = &instance_table[0], end = instance + RPL_MAX_INSTANCES; instance < end; ++instance) {
     if(instance->used == 1 ) {
       p = rpl_find_parent_any_dag(instance, &nbr->ipaddr);


### PR DESCRIPTION
The function ```rpl_ipv6_neighbor_callback``` is called when a neighbour has been removed or a new one has been added to the ```ds6_neighbors``` table. However, the ```rpl_ipv6_neighbor_callback``` always prints ```RPL: Removing a neighbor ...``` when ```DEBUG``` is enabled in ```rpl.c```. This PR changes the print statement to don't misunderstand the NBR event.

Perhaps, it would be nicer to change the definition of ```NEIGHBOR_STATE_CHANGED(n)``` to ```NEIGHBOR_STATE_CHANGED(neighbor, state)``` and then within the RPL callback function we could understand if a NBR has been added or removed. I could change the functions to work that way, but in that case when removing a NBR which state should we send in the ```NEIGHBOR_STATE_CHANGED``` function? I guess we could send ```NBR_INCOMPLETE``` or create a new state for non-neighbours but AFAIK that is not specified in IPv6 ND.