### PR TITLE
Put some uip6 temporaries on the stack

### DIFF
--- a/core/net/ipv6/uip6.c
+++ b/core/net/ipv6/uip6.c
@@ -207,11 +207,6 @@ uint8_t uip_flags;
 /* uip_conn always points to the current connection (set to NULL for UDP). */
 struct uip_conn *uip_conn;
 
-/* Temporary variables. */
-#if (UIP_TCP || UIP_UDP)
-static uint8_t c;
-#endif
-
 #if UIP_ACTIVE_OPEN || UIP_UDP
 /* Keeps track of the last port used for a new connection. */
 static uint16_t lastport;
@@ -256,8 +251,6 @@ static uint8_t iss[4];
 
 /* Temporary variables. */
 uint8_t uip_acc32[4];
-static uint8_t opt;
-static uint16_t tmp16;
 #endif /* UIP_TCP */
 /** @} */
 
@@ -432,6 +425,7 @@ uip_udpchksum(void)
 void
 uip_init(void)
 {
+  int c;
 
   uip_ds6_init();
   uip_icmp6_init();
@@ -466,6 +460,7 @@ struct uip_conn *
 uip_connect(const uip_ipaddr_t *ripaddr, uint16_t rport)
 {
   register struct uip_conn *conn, *cconn;
+  int c;
 
   /* Find an unused local port. */
   again:
@@ -560,6 +555,7 @@ remove_ext_hdr(void)
 struct uip_udp_conn *
 uip_udp_new(const uip_ipaddr_t *ripaddr, uint16_t rport)
 {
+  int c;
   register struct uip_udp_conn *conn;
 
   /* Find an unused local port. */
@@ -605,6 +601,7 @@ uip_udp_new(const uip_ipaddr_t *ripaddr, uint16_t rport)
 void
 uip_unlisten(uint16_t port)
 {
+  int c;
   for(c = 0; c < UIP_LISTENPORTS; ++c) {
     if(uip_listenports[c] == port) {
       uip_listenports[c] = 0;
@@ -616,6 +613,7 @@ uip_unlisten(uint16_t port)
 void
 uip_listen(uint16_t port)
 {
+  int c;
   for(c = 0; c < UIP_LISTENPORTS; ++c) {
     if(uip_listenports[c] == 0) {
       uip_listenports[c] = port;
@@ -941,6 +939,9 @@ void
 uip_process(uint8_t flag)
 {
 #if UIP_TCP
+  int c;
+  uint16_t tmp16;
+  uint8_t opt;
   register struct uip_conn *uip_connr = uip_conn;
 #endif /* UIP_TCP */
 #if UIP_UDP


### PR DESCRIPTION
Some "temporary" variables were declared with static storage duration for no good reason.

Replaced them with local stack variables wherever they were used.

There are still some variables that are unnecessarily given static duration which I have left alone.