### PR TITLE
Fix default CoAP header block2 size

### DIFF
--- a/apps/er-coap/er-coap-engine.c
+++ b/apps/er-coap/er-coap-engine.c
@@ -104,7 +104,7 @@ coap_receive(void)
               coap_new_transaction(message->mid, &UIP_IP_BUF->srcipaddr,
                                    UIP_UDP_BUF->srcport))) {
           uint32_t block_num = 0;
-          uint16_t block_size = REST_MAX_CHUNK_SIZE;
+          uint16_t block_size = COAP_MAX_BLOCK_SIZE;
           uint32_t block_offset = 0;
           int32_t new_offset = 0;
 
@@ -125,8 +125,8 @@ coap_receive(void)
           if(coap_get_header_block2
                (message, &block_num, NULL, &block_size, &block_offset)) {
             PRINTF("Blockwise: block request %lu (%u/%u) @ %lu bytes\n",
-                   block_num, block_size, REST_MAX_CHUNK_SIZE, block_offset);
-            block_size = MIN(block_size, REST_MAX_CHUNK_SIZE);
+                   block_num, block_size, COAP_MAX_BLOCK_SIZE, block_offset);
+            block_size = MIN(block_size, COAP_MAX_BLOCK_SIZE);
             new_offset = block_offset;
           }
 


### PR DESCRIPTION
When a client sends a CoAP request without specifying a block2 size, the server should choose one.
The CoAP engine sets this to `REST_MAX_CHUNK_SIZE`, which is not a valid block size as it is not a power of two.
As a result, resources can return a payload that isn't a valid block size.
Some clients (Californium is affected, Cooper does not seem to be) do not check the block2 size with the actual payload size, and can therefore end up with duplicated data.

For example, on the Z1 platform:

* An initial CoAP request is sent without a block2 header
* The CoAP engine calls the resource handler with `preferred_size` set to `REST_MAX_CHUNK_SIZE`, in this case 48.
* The resource returns a payload of size 48.
* The client receives the payload, and stores all 48 bytes.
* The client sends a further CoAP block request for the rest of the payload,
with the block2 size set to 32.
* The resource returns bytes 32-64.
* The client stores the payload. Bytes 32-48 are now duplicated.

