### PR TITLE
Adjusted retro target clock to "new" DNS resolver.

### DIFF
--- a/cpu/6502/6502def.h
+++ b/cpu/6502/6502def.h
@@ -61,7 +61,7 @@ typedef int32_t  s32_t;
 #define HAVE_SNPRINTF
 #define snprintf(buf, len, ...) sprintf(buf, __VA_ARGS__)
 
-#define CLOCK_CONF_SECOND 2
+#define CLOCK_CONF_SECOND 4
 typedef unsigned short clock_time_t;
 
 typedef unsigned short uip_stats_t;

--- a/cpu/6502/sys/clock.c
+++ b/cpu/6502/sys/clock.c
@@ -45,11 +45,8 @@ clock_time(void)
    * of overhead for cc65 targets.
    * On the other hand we want to avoid wrapping around frequently so the idea
    * is to reduce the clock resolution to the bare minimum. This is defined by
-   * the TCP/IP stack using a 1/2 second periodic timer. So CLOCK_CONF_SECOND
-   * needs to be defined at least as 2.
-   * The value 2 works out especially nicely as it allows us to implement the
-   * clock frequency devider below purely in (32 bit) integer arithmetic based
-   * on the educated guess of CLK_TCK being an even value. */
+   * the DNS resolver using a 1/4 second timer. So CLOCK_CONF_SECOND needs to
+   * be defined at least as 4. */
   return clock() / (CLK_TCK / CLOCK_CONF_SECOND);
 }
 /*---------------------------------------------------------------------------*/

--- a/platform/apple2enh/sys/clock.c
+++ b/platform/apple2enh/sys/clock.c
@@ -63,7 +63,7 @@ clock_update(void)
   static unsigned int count;
 
   count += tick;
-  if(count > 2000) {
+  if(count > 1000) {
     count = 0;
     ++time;
   }


### PR DESCRIPTION
The DNS resolver requires 1/4 sec clock resolution. The retro targets had a 1/2 sec clock resolution (optimized for the 1/2 sec TCP timer) resulting in DNS resolver timeouts being 0. Therefore the retro target clock resolution is now increased to 1/4 sec.