### PR TITLE
Fixed the issue with CC2520_READ_REG macro to read correct value of register.

### DIFF
--- a/dev/cc2520/cc2520.h
+++ b/dev/cc2520/cc2520.h
@@ -118,6 +118,7 @@ void cc2520_set_cca_threshold(int value);
     CC2520_SPI_ENABLE();                                                \
     SPI_WRITE((CC2520_INS_MEMRD | ((adr>>8)&0xFF)));                    \
     SPI_WRITE((adr & 0xFF));                                            \
+    (void)SPI_RXBUF;                                                    \
     SPI_READ(data);                                                     \
     CC2520_SPI_DISABLE();                                               \
   } while(0)


### PR DESCRIPTION
Fixed the issue with CC2520_READ_REG macro to read correct value of register.