### PR TITLE
Use a different LibreOffice ppa to install doxygen

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_script:
 
   ## Install doxygen
   - if [ ${BUILD_CATEGORY:-0} = doxygen ] ; then
-      sudo add-apt-repository ppa:libreoffice/libreoffice-4-3 -y  && sudo apt-get -qq update &&
+      sudo add-apt-repository ppa:libreoffice/libreoffice-4-4 -y && sudo apt-get -qq update &&
       sudo apt-get --no-install-suggests --no-install-recommends -qq install doxygen  &&
       doxygen --version ;
     fi


### PR DESCRIPTION
Up to now we were using the LibreOffice 4.3 ppa (ppa:libreoffice/libreoffice-4-3) to install doxygen, but the LibreOffice Packaging team appear to have removed it. As a result, our doxygen build suddenly started failing (https://travis-ci.org/contiki-os/contiki/jobs/74366993) with:

```
gpg: "tag:launchpad.net:2008:redacted" not a key ID: skipping
W: GPG error: http://ppa.launchpad.net precise Release: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY 83FBA1751378B444
WARNING: The following packages cannot be authenticated!
  doxygen
```

This changes the ppa we use to LibreOffice 4.4.x.