### PR TITLE
Make TX power configurable for CC26XX

### DIFF
--- a/cpu/cc26xx/dev/cc26xx-rf.c
+++ b/cpu/cc26xx/dev/cc26xx-rf.c
@@ -263,9 +263,8 @@ static const output_config_t output_power[] = {
 #define OUTPUT_POWER_MAX     (output_power[0].dbm)
 #define OUTPUT_POWER_UNKNOWN 0xFFFF
 
-/* Default TX Power - position in output_power[] */
-#define CC26XX_RF_TX_POWER 0
-const output_config_t *tx_power_current = &output_power[0];
+/* TX Power Setting - position in output_power[] */
+const output_config_t *tx_power_current = &output_power[CC26XX_RF_TX_POWER];
 /*---------------------------------------------------------------------------*/
 #define RF_CORE_CLOCKS_MASK (RFC_PWR_PWMCLKEN_RFC_M | RFC_PWR_PWMCLKEN_CPE_M \
                              | RFC_PWR_PWMCLKEN_CPERAM_M)

--- a/cpu/cc26xx/dev/cc26xx-rf.h
+++ b/cpu/cc26xx/dev/cc26xx-rf.h
@@ -54,6 +54,12 @@
 /*---------------------------------------------------------------------------*/
 #include <stdint.h>
 /*---------------------------------------------------------------------------*/
+#ifdef CC26XX_RF_CONF_TX_POWER
+#define CC26XX_RF_TX_POWER CC26XX_RF_CONF_TX_POWER
+#else
+#define CC26XX_RF_TX_POWER 0
+#endif /* CC26XX_RF_CONF_TX_POWER */
+
 #ifdef CC26XX_RF_CONF_CHANNEL
 #define CC26XX_RF_CHANNEL CC26XX_RF_CONF_CHANNEL
 #else


### PR DESCRIPTION
By default the TX power cannot be modified.