### PR TITLE
changed tcpip static temporaries to stack vars

### DIFF
--- a/core/net/ip/tcpip.c
+++ b/core/net/ip/tcpip.c
@@ -249,7 +249,7 @@ tcp_connect(const uip_ipaddr_t *ripaddr, uint16_t port, void *appstate)
 void
 tcp_unlisten(uint16_t port)
 {
-  static unsigned char i;
+  unsigned char i;
   struct listenport *l;
 
   l = s.listenports;
@@ -267,7 +267,7 @@ tcp_unlisten(uint16_t port)
 void
 tcp_listen(uint16_t port)
 {
-  static unsigned char i;
+  unsigned char i;
   struct listenport *l;
 
   l = s.listenports;
@@ -371,7 +371,7 @@ static void
 eventhandler(process_event_t ev, process_data_t data)
 {
 #if UIP_TCP
-  static unsigned char i;
+  unsigned char i;
   register struct listenport *l;
 #endif /*UIP_TCP*/
   struct process *p;
@@ -764,9 +764,9 @@ tcpip_uipcall(void)
 
 #if UIP_TCP
  {
-   static unsigned char i;
+   unsigned char i;
    struct listenport *l;
-   
+
    /* If this is a connection request for a listening port, we must
       mark the connection with the right process ID. */
    if(uip_connected()) {
@@ -795,11 +795,11 @@ tcpip_uipcall(void)
 PROCESS_THREAD(tcpip_process, ev, data)
 {
   PROCESS_BEGIN();
-  
+
 #if UIP_TCP
  {
-   static unsigned char i;
-   
+   unsigned char i;
+
    for(i = 0; i < UIP_LISTENPORTS; ++i) {
      s.listenports[i].port = 0;
    }


### PR DESCRIPTION
A number of local variables in tcpip.c were declared with static storage for no good reason (they do not ever preserve state between function calls).

This patch removes static declaration from these variables.