### PR TITLE
Handle possible reetrancy in contikimac protothread

### DIFF
--- a/core/net/mac/contikimac/contikimac.c
+++ b/core/net/mac/contikimac/contikimac.c
@@ -388,8 +388,8 @@ powercycle(struct rtimer *t, void *ptr)
         }
         powercycle_turn_radio_off();
       }
-      schedule_powercycle_fixed(t, RTIMER_NOW() + CCA_SLEEP_TIME);
-      PT_YIELD(&pt);
+      PT_YIELD_ON(&pt,
+                  schedule_powercycle_fixed(t, RTIMER_NOW() + CCA_SLEEP_TIME));
     }
 
     if(packet_seen) {
@@ -438,8 +438,8 @@ powercycle(struct rtimer *t, void *ptr)
           break;
         }
 
-        schedule_powercycle(t, CCA_CHECK_TIME + CCA_SLEEP_TIME);
-        PT_YIELD(&pt);
+        PT_YIELD_ON(&pt,
+                     schedule_powercycle(t, CCA_CHECK_TIME + CCA_SLEEP_TIME));
       }
       if(radio_is_on) {
         if(!(NETSTACK_RADIO.receiving_packet() ||
@@ -462,12 +462,12 @@ powercycle(struct rtimer *t, void *ptr)
         rtimer_arch_sleep(CYCLE_TIME - (RTIMER_NOW() - cycle_start));
       } else {
         sleepcycle = 0;
-        schedule_powercycle_fixed(t, CYCLE_TIME + cycle_start);
-        PT_YIELD(&pt);
+        PT_YIELD_ON(&pt,
+                    schedule_powercycle_fixed(t, CYCLE_TIME + cycle_start));
       }
 #else
-      schedule_powercycle_fixed(t, CYCLE_TIME + cycle_start);
-      PT_YIELD(&pt);
+     PT_YIELD_ON(&pt,
+                 schedule_powercycle_fixed(t, CYCLE_TIME + cycle_start));
 #endif
     }
   }

--- a/core/sys/pt.h
+++ b/core/sys/pt.h
@@ -296,6 +296,32 @@ struct pt {
   } while(0)
 
 /**
+ * Yield from the current protothread then execute a statement
+ *
+ * This function will yield the protothread, thereby allowing other
+ * processing to take place in the system.
+ *
+ * This macro should be used when there is a possibility that the given
+ * statement will cause re-entry into the protothread either directly (i.e.
+ * through recursion) or through an ISR. Without this macro, the protothread
+ * would not correctly continue from the yield point.
+ *
+ * \param pt A pointer to the protothread control structure.
+ * \param stmnt a statement to execute just before yielding
+ *
+ * \hideinitializer
+ */
+#define PT_YIELD_ON(pt,stmnt)                         \
+  do{                                                 \
+    PT_YIELD_FLAG = 0;                                \
+    LC_SET((pt)->lc);                                 \
+    if(PT_YIELD_FLAG == 0) {                          \
+      ({ stmnt ;});                                   \
+      return PT_YIELDED;                              \
+    }                                                 \
+  }while(0)
+
+/**
  * \brief      Yield from the protothread until a condition occurs.
  * \param pt   A pointer to the protothread control structure.
  * \param cond The condition.


### PR DESCRIPTION
On platforms which allow nested interrupts (I believe all of the cortex m3 based platforms fall into this category) it may be possible for the ```powercycle()``` function to be re-entered in between the ```rtimer_set```s and ``PT_YIELD``s. This will wreck the protothread's state. 

This PR fixes this problem and does so by adding the PT_YIELD_ON macro which handles statements which cause possible re-entry to the calling protothread. PT_YIELD_ON will also have utility in user app code and may find use in other parts of core Contiki.