### PR TITLE
CC26xx - various fixes and improvements for the watchdog module

### DIFF
--- a/cpu/cc26xx-cc13xx/dev/contiki-watchdog.c
+++ b/cpu/cc26xx-cc13xx/dev/contiki-watchdog.c
@@ -45,12 +45,58 @@
 #include "contiki.h"
 #include "dev/watchdog.h"
 #include "ti-lib.h"
+
+#include <stdbool.h>
+#include <stdint.h>
 /*---------------------------------------------------------------------------*/
 #ifdef CONTIKI_WATCHDOG_CONF_TIMER_TOP
 #define CONTIKI_WATCHDOG_TIMER_TOP CONTIKI_WATCHDOG_CONF_TIMER_TOP
 #else
 #define CONTIKI_WATCHDOG_TIMER_TOP 0xFFFFF
 #endif
+
+#ifdef  CONTIKI_WATCHDOG_CONF_LOCK_CONFIG
+#define CONTIKI_WATCHDOG_LOCK_CONFIG CONTIKI_WATCHDOG_CONF_LOCK_CONFIG
+#else
+#define CONTIKI_WATCHDOG_LOCK_CONFIG 1
+#endif
+
+#define LOCK_INTERRUPTS_DISABLED 0x01
+#define LOCK_REGISTERS_UNLOCKED  0x02
+/*---------------------------------------------------------------------------*/
+static uint32_t
+unlock_config(void)
+{
+  uint32_t ret = 0;
+  bool int_status;
+
+  if(CONTIKI_WATCHDOG_LOCK_CONFIG) {
+    int_status = ti_lib_int_master_disable();
+
+    if(ti_lib_watchdog_lock_state()) {
+      ret |= LOCK_REGISTERS_UNLOCKED;
+      ti_lib_watchdog_unlock();
+    }
+
+    ret |= (int_status) ? (0) : (LOCK_INTERRUPTS_DISABLED);
+  }
+
+  return ret;
+}
+/*---------------------------------------------------------------------------*/
+static void
+lock_config(uint32_t status)
+{
+  if(CONTIKI_WATCHDOG_LOCK_CONFIG) {
+
+    if(status & LOCK_REGISTERS_UNLOCKED) {
+      ti_lib_watchdog_lock();
+    }
+    if(status & LOCK_INTERRUPTS_DISABLED) {
+      ti_lib_int_master_enable();
+    }
+  }
+}
 /*---------------------------------------------------------------------------*/
 /**
  * \brief Initialises the CC26xx WDT
@@ -62,6 +108,7 @@ void
 watchdog_init(void)
 {
   ti_lib_watchdog_reload_set(CONTIKI_WATCHDOG_TIMER_TOP);
+  lock_config(LOCK_REGISTERS_UNLOCKED);
 }
 /*---------------------------------------------------------------------------*/
 /**
@@ -70,8 +117,12 @@ watchdog_init(void)
 void
 watchdog_start(void)
 {
+  uint32_t lock_status = unlock_config();
+
   watchdog_periodic();
   ti_lib_watchdog_reset_enable();
+
+  lock_config(lock_status);
 }
 /*---------------------------------------------------------------------------*/
 /**
@@ -90,7 +141,11 @@ watchdog_periodic(void)
 void
 watchdog_stop(void)
 {
+  uint32_t lock_status = unlock_config();
+
   ti_lib_watchdog_reset_disable();
+
+  lock_config(lock_status);
 }
 /*---------------------------------------------------------------------------*/
 /**

--- a/cpu/cc26xx-cc13xx/dev/contiki-watchdog.c
+++ b/cpu/cc26xx-cc13xx/dev/contiki-watchdog.c
@@ -42,8 +42,15 @@
  * \file
  * Implementation of the CC13xx/CC26xx watchdog driver.
  */
-#include "watchdog.h"
+#include "contiki.h"
+#include "dev/watchdog.h"
 #include "ti-lib.h"
+/*---------------------------------------------------------------------------*/
+#ifdef CONTIKI_WATCHDOG_CONF_TIMER_TOP
+#define CONTIKI_WATCHDOG_TIMER_TOP CONTIKI_WATCHDOG_CONF_TIMER_TOP
+#else
+#define CONTIKI_WATCHDOG_TIMER_TOP 0xFFFFF
+#endif
 /*---------------------------------------------------------------------------*/
 /**
  * \brief Initialises the CC26xx WDT
@@ -54,7 +61,7 @@
 void
 watchdog_init(void)
 {
-  ti_lib_watchdog_reload_set(0xFFFFF);
+  ti_lib_watchdog_reload_set(CONTIKI_WATCHDOG_TIMER_TOP);
 }
 /*---------------------------------------------------------------------------*/
 /**

--- a/cpu/cc26xx-cc13xx/dev/contiki-watchdog.c
+++ b/cpu/cc26xx-cc13xx/dev/contiki-watchdog.c
@@ -79,6 +79,7 @@ watchdog_start(void)
 void
 watchdog_periodic(void)
 {
+  ti_lib_watchdog_reload_set(CONTIKI_WATCHDOG_TIMER_TOP);
   ti_lib_watchdog_int_clear();
 }
 /*---------------------------------------------------------------------------*/

--- a/cpu/cc26xx-cc13xx/dev/contiki-watchdog.c
+++ b/cpu/cc26xx-cc13xx/dev/contiki-watchdog.c
@@ -70,6 +70,7 @@ watchdog_init(void)
 void
 watchdog_start(void)
 {
+  watchdog_periodic();
   ti_lib_watchdog_reset_enable();
 }
 /*---------------------------------------------------------------------------*/
@@ -81,6 +82,15 @@ watchdog_periodic(void)
 {
   ti_lib_watchdog_reload_set(CONTIKI_WATCHDOG_TIMER_TOP);
   ti_lib_watchdog_int_clear();
+}
+/*---------------------------------------------------------------------------*/
+/**
+ * \brief Stops the WDT such that it won't timeout and cause MCU reset
+ */
+void
+watchdog_stop(void)
+{
+  ti_lib_watchdog_reset_disable();
 }
 /*---------------------------------------------------------------------------*/
 /**


### PR DESCRIPTION
I'm pushing up several changes to the CC26xx's WDT interface from my private repo.

These include:
- Added macro to make WDT timeout configurable
- Added working watchdog_stop() implementation
- Fixed the way in which the WDT is reset in watchdog_periodic()
- Enabled configuration register locking to avoid accidental changes