### PR TITLE
Fix Travis icon in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 The Contiki Operating System
 ============================
 
-[![Build Status](https://secure.travis-ci.org/contiki-os/contiki.png)](http://travis-ci.org/contiki-os/contiki)
+[![Build Status](https://travis-ci.org/contiki-os/contiki.svg?branch=master)](https://travis-ci.org/contiki-os/contiki/branches)
 
 Contiki is an open source operating system that runs on tiny low-power
 microcontrollers and makes it possible to develop applications that


### PR DESCRIPTION
This PR updates `README.md` to show the build status of the current master rather than latest build status (can be any pull request, i.e. can show "fail" while the master does pass the test). The link also points to Contiki branches rather than latest build.
