### PR TITLE
End-to-End DAO and DAO ACK handling for Contiki RPL.

### DIFF
--- a/core/contiki-default-conf.h
+++ b/core/contiki-default-conf.h
@@ -148,6 +148,13 @@
 #define UIP_CONF_IPV6_RPL 1
 #endif /* UIP_CONF_IPV6_RPL */
 
+/* If RPL is enabled also enable the RPL NBR Policy */
+#if UIP_CONF_IPV6_RPL
+#ifndef NBR_TABLE_FIND_REMOVABLE
+#define NBR_TABLE_FIND_REMOVABLE rpl_nbr_policy_find_removable
+#endif /* NBR_TABLE_FIND_REMOVABLE */
+#endif /* UIP_CONF_IPV6_RPL */
+
 /* UIP_CONF_MAX_ROUTES specifies the maximum number of routes that each
    node will be able to handle. */
 #ifndef UIP_CONF_MAX_ROUTES

--- a/core/net/ip/tcpip.c
+++ b/core/net/ip/tcpip.c
@@ -644,7 +644,7 @@ tcpip_ipv6_output(void)
     nbr = uip_ds6_nbr_lookup(nexthop);
     if(nbr == NULL) {
 #if UIP_ND6_SEND_NA
-      if((nbr = uip_ds6_nbr_add(nexthop, NULL, 0, NBR_INCOMPLETE)) == NULL) {
+      if((nbr = uip_ds6_nbr_add(nexthop, NULL, 0, NBR_INCOMPLETE, NBR_TABLE_REASON_IPV6_ND, NULL)) == NULL) {
         uip_clear_buf();
         return;
       } else {

--- a/core/net/ipv6/uip-ds6-nbr.c
+++ b/core/net/ipv6/uip-ds6-nbr.c
@@ -83,7 +83,7 @@ uip_ds6_nbr_add(const uip_ipaddr_t *ipaddr, const uip_lladdr_t *lladdr,
                 void *data)
 {
   uip_ds6_nbr_t *nbr = nbr_table_add_lladdr(ds6_neighbors, (linkaddr_t*)lladdr
-                                            ,reason, data);
+                                            , reason, data);
   if(nbr) {
     uip_ipaddr_copy(&nbr->ipaddr, ipaddr);
 #if UIP_ND6_SEND_NA || UIP_ND6_SEND_RA || !UIP_CONF_ROUTER

--- a/core/net/ipv6/uip-ds6-nbr.c
+++ b/core/net/ipv6/uip-ds6-nbr.c
@@ -79,9 +79,11 @@ uip_ds6_neighbors_init(void)
 /*---------------------------------------------------------------------------*/
 uip_ds6_nbr_t *
 uip_ds6_nbr_add(const uip_ipaddr_t *ipaddr, const uip_lladdr_t *lladdr,
-                uint8_t isrouter, uint8_t state)
+                uint8_t isrouter, uint8_t state, nbr_table_reason_t reason,
+                void *data)
 {
-  uip_ds6_nbr_t *nbr = nbr_table_add_lladdr(ds6_neighbors, (linkaddr_t*)lladdr);
+  uip_ds6_nbr_t *nbr = nbr_table_add_lladdr(ds6_neighbors, (linkaddr_t*)lladdr
+                                            ,reason, data);
   if(nbr) {
     uip_ipaddr_copy(&nbr->ipaddr, ipaddr);
 #if UIP_ND6_SEND_NA || UIP_ND6_SEND_RA || !UIP_CONF_ROUTER

--- a/core/net/ipv6/uip-ds6-nbr.c
+++ b/core/net/ipv6/uip-ds6-nbr.c
@@ -115,7 +115,7 @@ uip_ds6_nbr_add(const uip_ipaddr_t *ipaddr, const uip_lladdr_t *lladdr,
 }
 
 /*---------------------------------------------------------------------------*/
-void
+int
 uip_ds6_nbr_rm(uip_ds6_nbr_t *nbr)
 {
   if(nbr != NULL) {
@@ -123,9 +123,9 @@ uip_ds6_nbr_rm(uip_ds6_nbr_t *nbr)
     uip_packetqueue_free(&nbr->packethandle);
 #endif /* UIP_CONF_IPV6_QUEUE_PKT */
     NEIGHBOR_STATE_CHANGED(nbr);
-    nbr_table_remove(ds6_neighbors, nbr);
+    return nbr_table_remove(ds6_neighbors, nbr);
   }
-  return;
+  return 0;
 }
 
 /*---------------------------------------------------------------------------*/

--- a/core/net/ipv6/uip-ds6-nbr.h
+++ b/core/net/ipv6/uip-ds6-nbr.h
@@ -86,8 +86,10 @@ typedef struct uip_ds6_nbr {
 void uip_ds6_neighbors_init(void);
 
 /** \brief Neighbor Cache basic routines */
-uip_ds6_nbr_t *uip_ds6_nbr_add(const uip_ipaddr_t *ipaddr, const uip_lladdr_t *lladdr,
-                               uint8_t isrouter, uint8_t state);
+uip_ds6_nbr_t *uip_ds6_nbr_add(const uip_ipaddr_t *ipaddr,
+                               const uip_lladdr_t *lladdr,
+                               uint8_t isrouter, uint8_t state,
+                               nbr_table_reason_t reason, void *data);
 int uip_ds6_nbr_rm(uip_ds6_nbr_t *nbr);
 const uip_lladdr_t *uip_ds6_nbr_get_ll(const uip_ds6_nbr_t *nbr);
 const uip_ipaddr_t *uip_ds6_nbr_get_ipaddr(const uip_ds6_nbr_t *nbr);

--- a/core/net/ipv6/uip-ds6-nbr.h
+++ b/core/net/ipv6/uip-ds6-nbr.h
@@ -88,7 +88,7 @@ void uip_ds6_neighbors_init(void);
 /** \brief Neighbor Cache basic routines */
 uip_ds6_nbr_t *uip_ds6_nbr_add(const uip_ipaddr_t *ipaddr, const uip_lladdr_t *lladdr,
                                uint8_t isrouter, uint8_t state);
-void uip_ds6_nbr_rm(uip_ds6_nbr_t *nbr);
+int uip_ds6_nbr_rm(uip_ds6_nbr_t *nbr);
 const uip_lladdr_t *uip_ds6_nbr_get_ll(const uip_ds6_nbr_t *nbr);
 const uip_ipaddr_t *uip_ds6_nbr_get_ipaddr(const uip_ds6_nbr_t *nbr);
 uip_ds6_nbr_t *uip_ds6_nbr_lookup(const uip_ipaddr_t *ipaddr);

--- a/core/net/ipv6/uip-ds6-route.c
+++ b/core/net/ipv6/uip-ds6-route.c
@@ -348,7 +348,8 @@ uip_ds6_route_add(uip_ipaddr_t *ipaddr, uint8_t length,
          initialize this pointer with the list of routing entries that
          are attached to this neighbor. */
       routes = nbr_table_add_lladdr(nbr_routes,
-                                    (linkaddr_t *)nexthop_lladdr);
+                                    (linkaddr_t *)nexthop_lladdr,
+                                    NBR_TABLE_REASON_ROUTE, NULL);
       if(routes == NULL) {
         /* This should not happen, as we explicitly deallocated one
            route table entry above. */

--- a/core/net/ipv6/uip-ds6-route.c
+++ b/core/net/ipv6/uip-ds6-route.c
@@ -207,6 +207,12 @@ uip_ds6_route_next(uip_ds6_route_t *r)
 }
 /*---------------------------------------------------------------------------*/
 int
+uip_ds6_route_is_nexthop(const uip_lladdr_t *lladdr)
+{
+  return nbr_table_get_from_lladdr(nbr_routes, (linkaddr_t *)lladdr) != NULL;
+}
+/*---------------------------------------------------------------------------*/
+int
 uip_ds6_route_num_routes(void)
 {
   return num_routes;
@@ -307,11 +313,16 @@ uip_ds6_route_add(uip_ipaddr_t *ipaddr, uint8_t length,
        least recently used one we have. */
 
     if(uip_ds6_route_num_routes() == UIP_DS6_ROUTE_NB) {
+      uip_ds6_route_t *oldest;
+      oldest = NULL;
+#if UIP_DS6_ROUTE_REMOVE_LEAST_RECENTLY_USED
       /* Removing the oldest route entry from the route table. The
          least recently used route is the first route on the list. */
-      uip_ds6_route_t *oldest;
-
-      oldest = list_tail(routelist); /* uip_ds6_route_head(); */
+      oldest = list_tail(routelist);
+#endif
+      if(oldest == NULL) {
+        return NULL;
+      }
       PRINTF("uip_ds6_route_add: dropping route to ");
       PRINT6ADDR(&oldest->ipaddr);
       PRINTF("\n");

--- a/core/net/ipv6/uip-ds6-route.c
+++ b/core/net/ipv6/uip-ds6-route.c
@@ -207,8 +207,15 @@ uip_ds6_route_next(uip_ds6_route_t *r)
 }
 /*---------------------------------------------------------------------------*/
 int
-uip_ds6_route_is_nexthop(const uip_lladdr_t *lladdr)
+uip_ds6_route_is_nexthop(const uip_ipaddr_t *ipaddr)
 {
+  const uip_lladdr_t *lladdr;
+  lladdr = uip_ds6_nbr_lladdr_from_ipaddr(ipaddr);
+
+  if(lladdr == NULL) {
+    return 0;
+  }
+
   return nbr_table_get_from_lladdr(nbr_routes, (linkaddr_t *)lladdr) != NULL;
 }
 /*---------------------------------------------------------------------------*/

--- a/core/net/ipv6/uip-ds6-route.h
+++ b/core/net/ipv6/uip-ds6-route.h
@@ -106,6 +106,9 @@ void uip_ds6_notification_rm(struct uip_ds6_notification *n);
 #define RPL_ROUTE_SET_NOPATH_RECEIVED(route) do {                       \
     (route)->state.state_flags |= RPL_ROUTE_ENTRY_NOPATH_RECEIVED;      \
   } while(0)
+#define RPL_ROUTE_CLEAR_NOPATH_RECEIVED(route) do {                       \
+    (route)->state.state_flags &= ~RPL_ROUTE_ENTRY_NOPATH_RECEIVED;      \
+  } while(0)
 
 #define RPL_ROUTE_IS_DAO_PENDING(route)                                 \
   ((route->state.state_flags & RPL_ROUTE_ENTRY_DAO_PENDING) != 0)

--- a/core/net/ipv6/uip-ds6-route.h
+++ b/core/net/ipv6/uip-ds6-route.h
@@ -197,7 +197,7 @@ uip_ipaddr_t *uip_ds6_route_nexthop(uip_ds6_route_t *);
 int uip_ds6_route_num_routes(void);
 uip_ds6_route_t *uip_ds6_route_head(void);
 uip_ds6_route_t *uip_ds6_route_next(uip_ds6_route_t *);
-
+int uip_ds6_route_is_nexthop(const uip_lladdr_t *lladdr);
 /** @} */
 
 #endif /* UIP_DS6_ROUTE_H */

--- a/core/net/ipv6/uip-ds6-route.h
+++ b/core/net/ipv6/uip-ds6-route.h
@@ -124,6 +124,9 @@ void uip_ds6_notification_rm(struct uip_ds6_notification *n);
 #define RPL_ROUTE_SET_DAO_NACKED(route) do {                            \
     (route)->state.state_flags |= RPL_ROUTE_ENTRY_DAO_NACK;             \
   } while(0)
+#define RPL_ROUTE_CLEAR_DAO_NACKED(route) do {                          \
+    (route)->state.state_flags &= ~RPL_ROUTE_ENTRY_DAO_NACK;            \
+  } while(0)
 
 #define RPL_ROUTE_CLEAR_DAO(route) do {                                 \
     (route)->state.state_flags &= ~(RPL_ROUTE_ENTRY_DAO_NACK|RPL_ROUTE_ENTRY_DAO_PENDING); \
@@ -200,7 +203,7 @@ uip_ipaddr_t *uip_ds6_route_nexthop(uip_ds6_route_t *);
 int uip_ds6_route_num_routes(void);
 uip_ds6_route_t *uip_ds6_route_head(void);
 uip_ds6_route_t *uip_ds6_route_next(uip_ds6_route_t *);
-int uip_ds6_route_is_nexthop(const uip_lladdr_t *lladdr);
+int uip_ds6_route_is_nexthop(const uip_ipaddr_t *ipaddr);
 /** @} */
 
 #endif /* UIP_DS6_ROUTE_H */

--- a/core/net/ipv6/uip-ds6-route.h
+++ b/core/net/ipv6/uip-ds6-route.h
@@ -97,11 +97,42 @@ void uip_ds6_notification_rm(struct uip_ds6_notification *n);
 #ifndef UIP_DS6_ROUTE_STATE_TYPE
 #define UIP_DS6_ROUTE_STATE_TYPE rpl_route_entry_t
 /* Needed for the extended route entry state when using ContikiRPL */
+#define RPL_ROUTE_ENTRY_NOPATH_RECEIVED   0x01
+#define RPL_ROUTE_ENTRY_DAO_PENDING       0x02
+#define RPL_ROUTE_ENTRY_DAO_NACK          0x04
+
+#define RPL_ROUTE_IS_NOPATH_RECEIVED(route)                             \
+  (((route)->state.state_flags & RPL_ROUTE_ENTRY_NOPATH_RECEIVED) != 0)
+#define RPL_ROUTE_SET_NOPATH_RECEIVED(route) do {                       \
+    (route)->state.state_flags |= RPL_ROUTE_ENTRY_NOPATH_RECEIVED;      \
+  } while(0)
+
+#define RPL_ROUTE_IS_DAO_PENDING(route)                                 \
+  ((route->state.state_flags & RPL_ROUTE_ENTRY_DAO_PENDING) != 0)
+#define RPL_ROUTE_SET_DAO_PENDING(route) do {                           \
+    (route)->state.state_flags |= RPL_ROUTE_ENTRY_DAO_PENDING;          \
+  } while(0)
+#define RPL_ROUTE_CLEAR_DAO_PENDING(route) do {                         \
+    (route)->state.state_flags &= ~RPL_ROUTE_ENTRY_DAO_PENDING;         \
+  } while(0)
+
+#define RPL_ROUTE_IS_DAO_NACKED(route)                                  \
+  ((route->state.state_flags & RPL_ROUTE_ENTRY_DAO_NACK) != 0)
+#define RPL_ROUTE_SET_DAO_NACKED(route) do {                            \
+    (route)->state.state_flags |= RPL_ROUTE_ENTRY_DAO_NACK;             \
+  } while(0)
+
+#define RPL_ROUTE_CLEAR_DAO(route) do {                                 \
+    (route)->state.state_flags &= ~(RPL_ROUTE_ENTRY_DAO_NACK|RPL_ROUTE_ENTRY_DAO_PENDING); \
+  } while(0)
+
+struct rpl_dag;
 typedef struct rpl_route_entry {
   uint32_t lifetime;
-  void *dag;
-  uint8_t learned_from;
-  uint8_t nopath_received;
+  struct rpl_dag *dag;
+  uint8_t dao_seqno_out;
+  uint8_t dao_seqno_in;
+  uint8_t state_flags;
 } rpl_route_entry_t;
 #endif /* UIP_DS6_ROUTE_STATE_TYPE */
 

--- a/core/net/ipv6/uip-nd6.c
+++ b/core/net/ipv6/uip-nd6.c
@@ -201,6 +201,8 @@ ns_input(void)
 #endif /*UIP_CONF_IPV6_CHECKS */
         nbr = uip_ds6_nbr_lookup(&UIP_IP_BUF->srcipaddr);
         if(nbr == NULL) {
+          uip_lladdr_t lladdr_aligned;
+          extract_lladdr_aligned(&lladdr_aligned);
           uip_ds6_nbr_add(&UIP_IP_BUF->srcipaddr, &lladdr_aligned,
 			  0, NBR_STALE, NBR_TABLE_REASON_IPV6_ND, NULL);
         } else {
@@ -638,12 +640,11 @@ rs_input(void)
       } else {
         /* If LL address changed, set neighbor state to stale */
         if(memcmp(&nd6_opt_llao[UIP_ND6_OPT_DATA_OFFSET],
-            uip_ds6_nbr_get_ll(nbr), UIP_LLADDR_LEN) != 0) {
+                  uip_ds6_nbr_get_ll(nbr), UIP_LLADDR_LEN) != 0) {
           uip_ds6_nbr_t nbr_data = *nbr;
           uip_ds6_nbr_rm(nbr);
           nbr = uip_ds6_nbr_add(&UIP_IP_BUF->srcipaddr, &lladdr_aligned,
-          nbr = uip_ds6_nbr_add(&UIP_IP_BUF->srcipaddr, 0, NBR_STALE,
-                                NBR_TABLE_REASON_IPV6_ND, NULL);
+                                0, NBR_STALE, NBR_TABLE_REASON_IPV6_ND, NULL);
           nbr->reachable = nbr_data.reachable;
           nbr->sendns = nbr_data.sendns;
           nbr->nscount = nbr_data.nscount;
@@ -872,8 +873,8 @@ ra_input(void)
       if(nbr == NULL) {
         uip_lladdr_t lladdr_aligned;
         extract_lladdr_aligned(&lladdr_aligned);
-        nbr = uip_ds6_nbr_add(&UIP_IP_BUF->srcipaddr, &lladdr_aligned, 1,
-                              NBR_STALE, NBR_TABLE_REASON_IPV6_ND, NULL);
+        nbr = uip_ds6_nbr_add(&UIP_IP_BUF->srcipaddr, &lladdr_aligned,
+                              1, NBR_STALE, NBR_TABLE_REASON_IPV6_ND, NULL);
       } else {
         uip_lladdr_t *lladdr = (uip_lladdr_t *)uip_ds6_nbr_get_ll(nbr);
         if(nbr->state == NBR_INCOMPLETE) {

--- a/core/net/ipv6/uip-nd6.c
+++ b/core/net/ipv6/uip-nd6.c
@@ -201,9 +201,8 @@ ns_input(void)
 #endif /*UIP_CONF_IPV6_CHECKS */
         nbr = uip_ds6_nbr_lookup(&UIP_IP_BUF->srcipaddr);
         if(nbr == NULL) {
-          uip_lladdr_t lladdr_aligned;
-          extract_lladdr_aligned(&lladdr_aligned);
-          uip_ds6_nbr_add(&UIP_IP_BUF->srcipaddr, &lladdr_aligned, 0, NBR_STALE);
+          uip_ds6_nbr_add(&UIP_IP_BUF->srcipaddr, &lladdr_aligned,
+			  0, NBR_STALE, NBR_TABLE_REASON_IPV6_ND, NULL);
         } else {
           uip_lladdr_t *lladdr = (uip_lladdr_t *)uip_ds6_nbr_get_ll(nbr);
           if(memcmp(&nd6_opt_llao[UIP_ND6_OPT_DATA_OFFSET],
@@ -634,14 +633,17 @@ rs_input(void)
       extract_lladdr_aligned(&lladdr_aligned);
       if((nbr = uip_ds6_nbr_lookup(&UIP_IP_BUF->srcipaddr)) == NULL) {
         /* we need to add the neighbor */
-        uip_ds6_nbr_add(&UIP_IP_BUF->srcipaddr, &lladdr_aligned, 0, NBR_STALE);
+        uip_ds6_nbr_add(&UIP_IP_BUF->srcipaddr, &lladdr_aligned,
+                        0, NBR_STALE, NBR_TABLE_REASON_IPV6_ND, NULL);
       } else {
         /* If LL address changed, set neighbor state to stale */
         if(memcmp(&nd6_opt_llao[UIP_ND6_OPT_DATA_OFFSET],
             uip_ds6_nbr_get_ll(nbr), UIP_LLADDR_LEN) != 0) {
           uip_ds6_nbr_t nbr_data = *nbr;
           uip_ds6_nbr_rm(nbr);
-          nbr = uip_ds6_nbr_add(&UIP_IP_BUF->srcipaddr, &lladdr_aligned, 0, NBR_STALE);
+          nbr = uip_ds6_nbr_add(&UIP_IP_BUF->srcipaddr, &lladdr_aligned,
+          nbr = uip_ds6_nbr_add(&UIP_IP_BUF->srcipaddr, 0, NBR_STALE,
+                                NBR_TABLE_REASON_IPV6_ND, NULL);
           nbr->reachable = nbr_data.reachable;
           nbr->sendns = nbr_data.sendns;
           nbr->nscount = nbr_data.nscount;
@@ -870,7 +872,8 @@ ra_input(void)
       if(nbr == NULL) {
         uip_lladdr_t lladdr_aligned;
         extract_lladdr_aligned(&lladdr_aligned);
-        nbr = uip_ds6_nbr_add(&UIP_IP_BUF->srcipaddr, &lladdr_aligned, 1, NBR_STALE);
+        nbr = uip_ds6_nbr_add(&UIP_IP_BUF->srcipaddr, &lladdr_aligned, 1,
+                              NBR_STALE, NBR_TABLE_REASON_IPV6_ND, NULL);
       } else {
         uip_lladdr_t *lladdr = (uip_lladdr_t *)uip_ds6_nbr_get_ll(nbr);
         if(nbr->state == NBR_INCOMPLETE) {

--- a/core/net/llsec/noncoresec/noncoresec.c
+++ b/core/net/llsec/noncoresec/noncoresec.c
@@ -188,7 +188,7 @@ parse(void)
   
   info = nbr_table_get_from_lladdr(anti_replay_table, sender);
   if(!info) {
-    info = nbr_table_add_lladdr(anti_replay_table, sender);
+    info = nbr_table_add_lladdr(anti_replay_table, sender, NBR_TABLE_REASON_LLSEC, NULL);
     if(!info) {
       PRINTF("noncoresec: could not get nbr_table_item\n");
       return FRAMER_FAILED;

--- a/core/net/mac/phase.c
+++ b/core/net/mac/phase.c
@@ -122,7 +122,7 @@ phase_update(const linkaddr_t *neighbor, rtimer_clock_t time,
   } else {
     /* No matching phase was found, so we allocate a new one. */
     if(mac_status == MAC_TX_OK && e == NULL) {
-      e = nbr_table_add_lladdr(nbr_phase, neighbor);
+      e = nbr_table_add_lladdr(nbr_phase, neighbor, NBR_TABLE_REASON_MAC, NULL);
       if(e) {
         e->time = time;
 #if PHASE_DRIFT_CORRECT

--- a/core/net/nbr-table.c
+++ b/core/net/nbr-table.c
@@ -47,10 +47,19 @@
 static void handle_periodic_timer(void *ptr);
 static struct ctimer periodic_timer;
 static uint8_t initialized = 0;
+static void print_table();
 #define PRINTF(...) printf(__VA_ARGS__)
 #else
 #define PRINTF(...)
 #endif
+
+/* This is the callback function that will be called when there is a
+ *  nbr-policy active
+ **/
+#ifdef NBR_TABLE_FIND_REMOVABLE
+const linkaddr_t *NBR_TABLE_FIND_REMOVABLE(nbr_table_reason_t reason, void *data);
+#endif /* NBR_TABLE_FIND_REMOVABLE */
+
 
 /* List of link-layer addresses of the neighbors, used as key in the tables */
 typedef struct nbr_table_key {
@@ -170,7 +179,7 @@ nbr_set_bit(uint8_t *bitmap, nbr_table_t *table, nbr_table_item_t *item, int val
 }
 /*---------------------------------------------------------------------------*/
 static nbr_table_key_t *
-nbr_table_allocate(void)
+nbr_table_allocate(nbr_table_reason_t reason, void *data)
 {
   nbr_table_key_t *key;
   int least_used_count = 0;
@@ -179,39 +188,66 @@ nbr_table_allocate(void)
   key = memb_alloc(&neighbor_addr_mem);
   if(key != NULL) {
     return key;
-  } else { /* No more space, try to free a neighbor.
-            * The replacement policy is the following: remove neighbor that is:
-            * (1) not locked
-            * (2) used by fewest tables
-            * (3) oldest (the list is ordered by insertion time)
-            * */
-    /* Get item from first key */
-    key = list_head(nbr_table_keys);
-    while(key != NULL) {
-      int item_index = index_from_key(key);
-      int locked = locked_map[item_index];
-      /* Never delete a locked item */
-      if(!locked) {
-        int used = used_map[item_index];
-        int used_count = 0;
-        /* Count how many tables are using this item */
-        while(used != 0) {
-          if((used & 1) == 1) {
-            used_count++;
-          }
-          used >>= 1;
-        }
-        /* Find least used item */
-        if(least_used_key == NULL || used_count < least_used_count) {
-          least_used_key = key;
-          least_used_count = used_count;
-          if(used_count == 0) { /* We won't find any least used item */
-            break;
-          }
-        }
+  } else {
+#ifdef NBR_TABLE_FIND_REMOVABLE
+    const linkaddr_t *lladdr;
+    lladdr = NBR_TABLE_FIND_REMOVABLE(reason, data);
+    if(lladdr == NULL) {
+      /* Nothing found that can be deleted - return NULL to indicate failure */
+      PRINTF("*** Not removing entry to allocate new\n");
+      return NULL;
+    } else {
+      /* used least_used_key to indicate what is the least useful entry */
+      int index;
+      int locked;
+      if((index = index_from_lladdr(lladdr)) != -1) {
+        least_used_key = key_from_index(index);
+        locked = locked_map[index];
       }
-      key = list_item_next(key);
+      /* Allow delete of locked item? */
+      if(least_used_key != NULL && locked) {
+        PRINTF("Deleting locked item!\n");
+        locked_map[index] = 0;
+      }
     }
+#endif /* NBR_TABLE_FIND_REMOVABLE */
+
+    if(least_used_key == NULL) {
+      /* No more space, try to free a neighbor.
+       * The replacement policy is the following: remove neighbor that is:
+       * (1) not locked
+       * (2) used by fewest tables
+       * (3) oldest (the list is ordered by insertion time)
+       * */
+      /* Get item from first key */
+      key = list_head(nbr_table_keys);
+      while(key != NULL) {
+        int item_index = index_from_key(key);
+        int locked = locked_map[item_index];
+        /* Never delete a locked item */
+        if(!locked) {
+          int used = used_map[item_index];
+          int used_count = 0;
+          /* Count how many tables are using this item */
+          while(used != 0) {
+            if((used & 1) == 1) {
+              used_count++;
+            }
+          used >>= 1;
+          }
+          /* Find least used item */
+          if(least_used_key == NULL || used_count < least_used_count) {
+            least_used_key = key;
+            least_used_count = used_count;
+            if(used_count == 0) { /* We won't find any least used item */
+              break;
+            }
+          }
+        }
+        key = list_item_next(key);
+      }
+    }
+
     if(least_used_key == NULL) {
       /* We haven't found any unlocked item, allocation fails */
       return NULL;
@@ -289,7 +325,7 @@ nbr_table_next(nbr_table_t *table, nbr_table_item_t *item)
 /*---------------------------------------------------------------------------*/
 /* Add a neighbor indexed with its link-layer address */
 nbr_table_item_t *
-nbr_table_add_lladdr(nbr_table_t *table, const linkaddr_t *lladdr)
+nbr_table_add_lladdr(nbr_table_t *table, const linkaddr_t *lladdr, nbr_table_reason_t reason, void *data)
 {
   int index;
   nbr_table_item_t *item;
@@ -303,7 +339,7 @@ nbr_table_add_lladdr(nbr_table_t *table, const linkaddr_t *lladdr)
 
   if((index = index_from_lladdr(lladdr)) == -1) {
      /* Neighbor not yet in table, let's try to allocate one */
-    key = nbr_table_allocate();
+    key = nbr_table_allocate(reason, data);
 
     /* No space available for new entry */
     if(key == NULL) {
@@ -327,6 +363,9 @@ nbr_table_add_lladdr(nbr_table_t *table, const linkaddr_t *lladdr)
   memset(item, 0, table->item_size);
   nbr_set_bit(used_map, table, item, 1);
 
+#if DEBUG
+  print_table();
+#endif
   return item;
 }
 /*---------------------------------------------------------------------------*/
@@ -379,7 +418,7 @@ nbr_table_get_lladdr(nbr_table_t *table, const void *item)
 /*---------------------------------------------------------------------------*/
 #if DEBUG
 static void
-handle_periodic_timer(void *ptr)
+print_table()
 {
   int i, j;
   /* Printout all neighbors and which tables they are used in */
@@ -394,6 +433,12 @@ handle_periodic_timer(void *ptr)
       PRINTF("\n");
     }
   }
+}
+/*---------------------------------------------------------------------------*/
+static void
+handle_periodic_timer(void *ptr)
+{
+  print_table();
   ctimer_reset(&periodic_timer);
 }
 #endif

--- a/core/net/nbr-table.c
+++ b/core/net/nbr-table.c
@@ -199,7 +199,7 @@ nbr_table_allocate(nbr_table_reason_t reason, void *data)
     } else {
       /* used least_used_key to indicate what is the least useful entry */
       int index;
-      int locked;
+      int locked = 0;
       if((index = index_from_lladdr(lladdr)) != -1) {
         least_used_key = key_from_index(index);
         locked = locked_map[index];

--- a/core/net/nbr-table.h
+++ b/core/net/nbr-table.h
@@ -83,7 +83,7 @@ typedef enum {
 	NBR_TABLE_REASON_ROUTE,
 	NBR_TABLE_REASON_IPV6_ND,
 	NBR_TABLE_REASON_MAC,
-        NBR_TABLE_REASON_LLSEC
+	NBR_TABLE_REASON_LLSEC
 } nbr_table_reason_t;
 
 /** \name Neighbor tables: register and loop through table elements */

--- a/core/net/nbr-table.h
+++ b/core/net/nbr-table.h
@@ -75,6 +75,17 @@ typedef struct nbr_table {
 /** \brief Declaration of non-static neighbor tables */
 #define NBR_TABLE_DECLARE(name) extern nbr_table_t *name
 
+typedef enum {
+	NBR_TABLE_REASON_UNDEFINED,
+	NBR_TABLE_REASON_RPL_DIO,
+	NBR_TABLE_REASON_RPL_DAO,
+	NBR_TABLE_REASON_RPL_DIS,
+	NBR_TABLE_REASON_ROUTE,
+	NBR_TABLE_REASON_IPV6_ND,
+	NBR_TABLE_REASON_MAC,
+        NBR_TABLE_REASON_LLSEC
+} nbr_table_reason_t;
+
 /** \name Neighbor tables: register and loop through table elements */
 /** @{ */
 int nbr_table_register(nbr_table_t *table, nbr_table_callback *callback);
@@ -84,7 +95,7 @@ nbr_table_item_t *nbr_table_next(nbr_table_t *table, nbr_table_item_t *item);
 
 /** \name Neighbor tables: add and get data */
 /** @{ */
-nbr_table_item_t *nbr_table_add_lladdr(nbr_table_t *table, const linkaddr_t *lladdr);
+nbr_table_item_t *nbr_table_add_lladdr(nbr_table_t *table, const linkaddr_t *lladdr, nbr_table_reason_t reason, void *data);
 nbr_table_item_t *nbr_table_get_from_lladdr(nbr_table_t *table, const linkaddr_t *lladdr);
 /** @} */
 

--- a/core/net/rpl/rpl-conf.h
+++ b/core/net/rpl/rpl-conf.h
@@ -246,6 +246,18 @@
 #endif /* RPL_CONF_WITH_DAO_ACK */
 
 /*
+ * Setting the DIO_REFRESH_DAO_ROUTES will make RPL always increase
+ * the DTSN (Destination Advertisement Trigger Sequence Number) when
+ * sending broadcast DIO. This is to get all children to re-register
+ * their DAO route.
+ * */
+#ifdef RPL_CONF_DIO_REFRESH_DAO_ROUTES
+#define RPL_DIO_REFRESH_DAO_ROUTES RPL_CONF_DIO_REFRESH_DAO_ROUTES
+#else
+#define RPL_DIO_REFRESH_DAO_ROUTES 0
+#endif /* RPL_CONF_DIO_REFRESH_DAO_ROUTES */
+
+/*
  * RPL probing. When enabled, probes will be sent periodically to keep
  * parent link estimates up to date.
  */

--- a/core/net/rpl/rpl-conf.h
+++ b/core/net/rpl/rpl-conf.h
@@ -118,7 +118,7 @@
 #ifdef RPL_CONF_DEFAULT_ROUTE_INFINITE_LIFETIME
 #define RPL_DEFAULT_ROUTE_INFINITE_LIFETIME                    RPL_CONF_DEFAULT_ROUTE_INFINITE_LIFETIME
 #else
-#define RPL_DEFAULT_ROUTE_INFINITE_LIFETIME                    0
+#define RPL_DEFAULT_ROUTE_INFINITE_LIFETIME                    1
 #endif /* RPL_CONF_DEFAULT_ROUTE_INFINITE_LIFETIME */
 
 /*
@@ -200,7 +200,7 @@
  * used in RPL lifetime values, in seconds.
  */
 #ifndef RPL_CONF_DEFAULT_LIFETIME_UNIT
-#define RPL_DEFAULT_LIFETIME_UNIT       0xffff
+#define RPL_DEFAULT_LIFETIME_UNIT       0x60
 #else
 #define RPL_DEFAULT_LIFETIME_UNIT       RPL_CONF_DEFAULT_LIFETIME_UNIT
 #endif
@@ -209,7 +209,7 @@
  * Default route lifetime as a multiple of the lifetime unit.
  */
 #ifndef RPL_CONF_DEFAULT_LIFETIME
-#define RPL_DEFAULT_LIFETIME            0xff
+#define RPL_DEFAULT_LIFETIME            0x30
 #else
 #define RPL_DEFAULT_LIFETIME            RPL_CONF_DEFAULT_LIFETIME
 #endif

--- a/core/net/rpl/rpl-conf.h
+++ b/core/net/rpl/rpl-conf.h
@@ -246,6 +246,17 @@
 #endif /* RPL_CONF_WITH_DAO_ACK */
 
 /*
+ * RPL REPAIR ON DAO NACK. When enabled, DAO NACK will trigger a local
+ * repair in order to quickly find a new parent to send DAO's to.
+ * NOTE: this is too agressive in some cases so use with care.
+ * */
+#ifdef RPL_CONF_RPL_REPAIR_ON_DAO_NACK
+#define RPL_REPAIR_ON_DAO_NACK RPL_CONF_RPL_REPAIR_ON_DAO_NACK
+#else
+#define RPL_REPAIR_ON_DAO_NACK 0
+#endif /* RPL_CONF_RPL_REPAIR_ON_DAO_NACK */
+
+/*
  * Setting the DIO_REFRESH_DAO_ROUTES will make RPL always increase
  * the DTSN (Destination Advertisement Trigger Sequence Number) when
  * sending broadcast DIO. This is to get all children to re-register

--- a/core/net/rpl/rpl-conf.h
+++ b/core/net/rpl/rpl-conf.h
@@ -236,6 +236,16 @@
 #endif
 
 /*
+ * RPL DAO ACK support. When enabled, DAO ACK will be sent and requested.
+ * This will also enable retransmission of DAO when no ack is received.
+ * */
+#ifdef RPL_CONF_WITH_DAO_ACK
+#define RPL_WITH_DAO_ACK RPL_CONF_WITH_DAO_ACK
+#else
+#define RPL_WITH_DAO_ACK 1
+#endif /* RPL_CONF_WITH_DAO_ACK */
+
+/*
  * RPL probing. When enabled, probes will be sent periodically to keep
  * parent link estimates up to date.
  */

--- a/core/net/rpl/rpl-dag.c
+++ b/core/net/rpl/rpl-dag.c
@@ -1156,6 +1156,9 @@ global_repair(uip_ipaddr_t *from, rpl_dag_t *dag, rpl_dio_t *dio)
 
   RPL_STAT(rpl_stats.global_repairs++);
 }
+
+void rpl_set_downward_link(uint8_t link);
+
 /*---------------------------------------------------------------------------*/
 void
 rpl_local_repair(rpl_instance_t *instance)
@@ -1173,6 +1176,9 @@ rpl_local_repair(rpl_instance_t *instance)
       nullify_parents(&instance->dag_table[i], 0);
     }
   }
+
+  /* no downward link anymore */
+  rpl_set_downward_link(0);
 
   rpl_reset_dio_timer(instance);
   /* Request refresh of DAO registrations next DIO */

--- a/core/net/rpl/rpl-dag.c
+++ b/core/net/rpl/rpl-dag.c
@@ -1028,7 +1028,7 @@ rpl_join_instance(uip_ipaddr_t *from, rpl_dio_t *dio)
   rpl_set_default_route(instance, from);
 
   if(instance->mop != RPL_MOP_NO_DOWNWARD_ROUTES) {
-    rpl_schedule_dao(instance);
+    rpl_schedule_dao_immediately(instance);
   } else {
     PRINTF("RPL: The DIO does not meet the prerequisites for sending a DAO\n");
   }

--- a/core/net/rpl/rpl-dag.c
+++ b/core/net/rpl/rpl-dag.c
@@ -899,6 +899,18 @@ rpl_move_parent(rpl_dag_t *dag_src, rpl_dag_t *dag_dst, rpl_parent_t *parent)
   parent->dag = dag_dst;
 }
 /*---------------------------------------------------------------------------*/
+int
+rpl_has_downward_route(void)
+{
+  int i;
+  for(i = 0; i < RPL_MAX_INSTANCES; ++i) {
+    if(instance_table[i].used && instance_table[i].has_downward_route) {
+      return 1;
+    }
+  }
+  return 0;
+}
+/*---------------------------------------------------------------------------*/
 rpl_dag_t *
 rpl_get_any_dag(void)
 {
@@ -1157,8 +1169,6 @@ global_repair(uip_ipaddr_t *from, rpl_dag_t *dag, rpl_dio_t *dio)
   RPL_STAT(rpl_stats.global_repairs++);
 }
 
-void rpl_set_downward_link(uint8_t link);
-
 /*---------------------------------------------------------------------------*/
 void
 rpl_local_repair(rpl_instance_t *instance)
@@ -1177,8 +1187,8 @@ rpl_local_repair(rpl_instance_t *instance)
     }
   }
 
-  /* no downward link anymore */
-  rpl_set_downward_link(0);
+  /* no downward route anymore */
+  instance->has_downward_route = 0;
 
   rpl_reset_dio_timer(instance);
   /* Request refresh of DAO registrations next DIO */

--- a/core/net/rpl/rpl-icmp6.c
+++ b/core/net/rpl/rpl-icmp6.c
@@ -671,11 +671,6 @@ dao_input(void)
 
   uip_ipaddr_copy(&dao_sender_addr, &UIP_IP_BUF->srcipaddr);
 
-  /* Destination Advertisement Object */
-  PRINTF("RPL: Received a DAO from ");
-  PRINT6ADDR(&dao_sender_addr);
-  PRINTF("\n");
-
   buffer = UIP_ICMP_PAYLOAD;
   buffer_length = uip_len - uip_l3_icmp_hdr_len;
 
@@ -711,8 +706,12 @@ dao_input(void)
   learned_from = uip_is_addr_mcast(&dao_sender_addr) ?
                  RPL_ROUTE_FROM_MULTICAST_DAO : RPL_ROUTE_FROM_UNICAST_DAO;
 
-  PRINTF("RPL: DAO from %s\n",
-         learned_from == RPL_ROUTE_FROM_UNICAST_DAO? "unicast": "multicast");
+  /* Destination Advertisement Object */
+  PRINTF("RPL: Received a (%s) DAO with sequence number %u from ",
+      learned_from == RPL_ROUTE_FROM_UNICAST_DAO? "unicast": "multicast", sequence);
+  PRINT6ADDR(&dao_sender_addr);
+  PRINTF("\n");
+
   if(learned_from == RPL_ROUTE_FROM_UNICAST_DAO) {
     /* Check whether this is a DAO forwarding loop. */
     parent = rpl_find_parent(dag, &dao_sender_addr);
@@ -822,7 +821,7 @@ dao_input(void)
     goto discard;
   }
 
-  PRINTF("RPL: adding DAO route\n");
+  PRINTF("RPL: Adding DAO route\n");
 
   /* Update and add neighbor - if no room - fail. */
   if((nbr = rpl_icmp6_update_nbr_table(&dao_sender_addr, NBR_TABLE_REASON_RPL_DAO, instance)) == NULL) {
@@ -897,7 +896,7 @@ fwd_dao:
     }
 
     if(should_ack) {
-      PRINTF("RPL: sending DAO ACK\n");
+      PRINTF("RPL: Sending DAO ACK\n");
       dao_ack_output(instance, &dao_sender_addr, sequence,
                      RPL_DAO_ACK_UNCONDITIONAL_ACCEPT);
     }
@@ -1081,7 +1080,8 @@ dao_output_target_seq(rpl_parent_t *parent, uip_ipaddr_t *prefix,
   buffer[pos++] = 0; /* path seq - ignored */
   buffer[pos++] = lifetime;
 
-  PRINTF("RPL: Sending %sDAO with prefix ", lifetime == RPL_ZERO_LIFETIME ? "No-Path " : "");
+  PRINTF("RPL: Sending a %sDAO with sequence number %u, lifetime %u, prefix ",
+      lifetime == RPL_ZERO_LIFETIME ? "No-Path " : "", seq_no, lifetime);
   PRINT6ADDR(prefix);
   PRINTF(" to ");
   PRINT6ADDR(rpl_get_parent_ipaddr(parent));
@@ -1125,14 +1125,13 @@ dao_ack_input(void)
     return;
   }
 
-  PRINTF("RPL: Received a DAO ACK with sequence number %d (%d) and status %d from ",
+  PRINTF("RPL: Received a DAO %s with sequence number %d (%d) and status %d from ",
+   status < 128 ? "ACK" : "NACK",
 	 sequence, instance->my_dao_seqno, status);
   PRINT6ADDR(&UIP_IP_BUF->srcipaddr);
   PRINTF("\n");
 
   if(sequence == instance->my_dao_seqno) {
-    PRINTF("RPL: DAO %s for me!\n", status < 128 ? "ACK" : "NACK");
-
     rpl_set_downward_link(status < 128);
 
     /* always stop the retransmit timer when the ACK arrived */
@@ -1152,7 +1151,7 @@ dao_ack_input(void)
 #endif
 
   } else {
-    /* this DAO should be forwarded to another recently registered route */
+    /* this DAO ACK should be forwarded to another recently registered route */
     uip_ds6_route_t *re;
     uip_ipaddr_t *nexthop;
     if((re = find_route_entry_by_dao_ack(sequence)) != NULL) {
@@ -1162,9 +1161,9 @@ dao_ack_input(void)
 
       nexthop = uip_ds6_route_nexthop(re);
       if(nexthop == NULL) {
-        PRINTF("No next hop to fwd DAO ACK to\n");
+        PRINTF("RPL: No next hop to fwd DAO ACK to\n");
       } else {
-        PRINTF("Fwd DAO ACK to:");
+        PRINTF("RPL: Fwd DAO ACK to:");
         PRINT6ADDR(nexthop);
         PRINTF("\n");
         buffer[2] = re->state.dao_seqno_in;
@@ -1176,7 +1175,7 @@ dao_ack_input(void)
         uip_ds6_route_rm(re);
       }
     } else {
-      PRINTF("No route entry to fwd DAO ACK to\n");
+      PRINTF("RPL: No route entry to fwd DAO ACK to\n");
     }
   }
 #endif /* RPL_WITH_DAO_ACK */
@@ -1190,7 +1189,7 @@ dao_ack_output(rpl_instance_t *instance, uip_ipaddr_t *dest, uint8_t sequence,
 #if RPL_WITH_DAO_ACK
   unsigned char *buffer;
 
-  PRINTF("RPL: Sending a DAO ACK with sequence number %d to ", sequence);
+  PRINTF("RPL: Sending a DAO %s with sequence number %d to ", status < 128 ? "ACK" : "NACK", sequence);
   PRINT6ADDR(dest);
   PRINTF(" with status %d\n", status);
 

--- a/core/net/rpl/rpl-icmp6.c
+++ b/core/net/rpl/rpl-icmp6.c
@@ -802,7 +802,7 @@ dao_input(void)
         uint8_t out_seq;
         out_seq = prepare_for_dao_fwd(sequence, rep);
 
-        PRINTF("RPL: Forwarding no-path DAO to parent - out_seq:%d",
+        PRINTF("RPL: Forwarding No-path DAO to parent - out_seq:%d",
 	       out_seq);
         PRINT6ADDR(rpl_get_parent_ipaddr(dag->preferred_parent));
         PRINTF("\n");

--- a/core/net/rpl/rpl-icmp6.c
+++ b/core/net/rpl/rpl-icmp6.c
@@ -515,7 +515,7 @@ dio_output(rpl_instance_t *instance, uip_ipaddr_t *uc_addr)
 
   buffer[pos++] = instance->dtsn_out;
 
-  if(uc_addr == NULL) {
+  if(RPL_DIO_REFRESH_DAO_ROUTES && uc_addr == NULL) {
     /* Request new DAO to refresh route. We do not do this for unicast DIO
      * in order to avoid DAO messages after a DIS-DIO update,
      * or upon unicast DIO probing. */

--- a/core/net/rpl/rpl-icmp6.c
+++ b/core/net/rpl/rpl-icmp6.c
@@ -966,7 +966,6 @@ dao_output(rpl_parent_t *parent, uint8_t lifetime)
 {
   /* Destination Advertisement Object */
   uip_ipaddr_t prefix;
-  rpl_instance_t *instance;
 
   if(get_global_addr(&prefix) == 0) {
     PRINTF("RPL: No global address set for this node - suppressing DAO\n");
@@ -976,23 +975,9 @@ dao_output(rpl_parent_t *parent, uint8_t lifetime)
   if(parent == NULL || parent->dag == NULL || parent->dag->instance == NULL) {
     return;
   }
-  instance = parent->dag->instance;
 
   /* Sending a DAO with own prefix as target */
   dao_output_target(parent, &prefix, lifetime);
-#if RPL_WITH_DAO_ACK
-  /* keep track of my own sending of DAO for handling ack and loss of ack */
-  if(lifetime != RPL_ZERO_LIFETIME) {
-    instance->my_dao_seqno = dao_sequence;
-    instance->my_dao_transmissions = 1;
-    ctimer_set(&instance->dao_retransmit_timer, RPL_DAO_RETRANSMISSION_TIMEOUT,
-	       handle_dao_retransmission, parent);
-  }
-#else
-  /* We know that we have tried to register so now we are assuming
-     that we have a down-link - unless this is a zero lifetime one */
-  rpl_set_downward_link(lifetime != RPL_ZERO_LIFETIME);
-#endif /* RPL_WITH_DAO_ACK */
 }
 /*---------------------------------------------------------------------------*/
 void
@@ -1089,6 +1074,19 @@ dao_output_target_seq(rpl_parent_t *parent, uip_ipaddr_t *prefix,
 
   if(rpl_get_parent_ipaddr(parent) != NULL) {
     uip_icmp6_send(rpl_get_parent_ipaddr(parent), ICMP6_RPL, RPL_CODE_DAO, pos);
+#if RPL_WITH_DAO_ACK
+    if(lifetime != RPL_ZERO_LIFETIME) {
+      /* keep track of my own sending of DAO for handling ack and loss of ack */
+      instance->my_dao_seqno = dao_sequence;
+      instance->my_dao_transmissions = 1;
+      ctimer_set(&instance->dao_retransmit_timer, RPL_DAO_RETRANSMISSION_TIMEOUT,
+          handle_dao_retransmission, parent);
+    }
+#else /* RPL_WITH_DAO_ACK */
+    /* We know that we have tried to register so now we are assuming
+    that we have a down-link - unless this is a zero lifetime one */
+    rpl_set_downward_link(lifetime != RPL_ZERO_LIFETIME);
+#endif /* RPL_WITH_DAO_ACK */
   }
 }
 /*---------------------------------------------------------------------------*/

--- a/core/net/rpl/rpl-icmp6.c
+++ b/core/net/rpl/rpl-icmp6.c
@@ -820,7 +820,7 @@ dao_input(void)
   PRINTF("RPL: adding DAO route\n");
 
   /* Update and add neighbor - if no room - fail. */
-  if((nbr = rpl_icmp6_update_nbr_table(&dao_sender_addr, NBR_TABLE_REASON_RPL_DAO, NULL)) == NULL) {
+  if((nbr = rpl_icmp6_update_nbr_table(&dao_sender_addr, NBR_TABLE_REASON_RPL_DAO, instance)) == NULL) {
     PRINTF("RPL: Out of Memory, dropping DAO from ");
     PRINT6ADDR(&dao_sender_addr);
     PRINTF(", ");

--- a/core/net/rpl/rpl-icmp6.c
+++ b/core/net/rpl/rpl-icmp6.c
@@ -663,6 +663,7 @@ dao_input(void)
   int learned_from;
   rpl_parent_t *parent;
   uip_ds6_nbr_t *nbr;
+  int is_root;
 
   prefixlen = 0;
   parent = NULL;
@@ -695,6 +696,8 @@ dao_input(void)
   sequence = buffer[pos++];
 
   dag = instance->current_dag;
+  is_root = (dag->rank == ROOT_RANK(instance));
+
   /* Is the DAG ID present? */
   if(flags & RPL_DAO_D_FLAG) {
     if(memcmp(&dag->dag_id, &buffer[pos], sizeof(dag->dag_id))) {
@@ -829,7 +832,8 @@ dao_input(void)
     if(flags & RPL_DAO_K_FLAG) {
       /* signal the failure to add the node */
       dao_ack_output(instance, &dao_sender_addr, sequence,
-             RPL_DAO_ACK_UNABLE_TO_ACCEPT);
+		     is_root ? RPL_DAO_ACK_UNABLE_TO_ACCEPT_ROOT :
+		     RPL_DAO_ACK_UNABLE_TO_ACCEPT);
     }
     goto discard;
   }
@@ -838,11 +842,11 @@ dao_input(void)
   if(rep == NULL) {
     RPL_STAT(rpl_stats.mem_overflows++);
     PRINTF("RPL: Could not add a route after receiving a DAO\n");
-
     if(flags & RPL_DAO_K_FLAG) {
       /* signal the failure to add the node */
       dao_ack_output(instance, &dao_sender_addr, sequence,
-             RPL_DAO_ACK_UNABLE_TO_ACCEPT);
+		     is_root ? RPL_DAO_ACK_UNABLE_TO_ACCEPT_ROOT :
+		     RPL_DAO_ACK_UNABLE_TO_ACCEPT);
     }
     goto discard;
   }

--- a/core/net/rpl/rpl-icmp6.c
+++ b/core/net/rpl/rpl-icmp6.c
@@ -1084,6 +1084,7 @@ dao_ack_input(void)
 
   instance = rpl_get_instance(instance_id);
   if(instance == NULL) {
+    uip_clear_buf();
     return;
   }
 
@@ -1092,6 +1093,7 @@ dao_ack_input(void)
     /* not a known instance - did we switch?? */
     //    PRINTF("RPL: Received a DAO ACK from a not joined instance: %d",
     //	   instance_id);
+    uip_clear_buf();
     return;
   }
 
@@ -1099,7 +1101,6 @@ dao_ack_input(void)
 	 sequence, instance->my_dao_seqno, status);
   PRINT6ADDR(&UIP_IP_BUF->srcipaddr);
   PRINTF("\n");
-#endif /* DEBUG */
 
   if(sequence == instance->my_dao_seqno) {
     PRINTF("RPL: DAO %s for me!\n", status < 128 ? "ACK" : "NACK");

--- a/core/net/rpl/rpl-mrhof.c
+++ b/core/net/rpl/rpl-mrhof.c
@@ -54,6 +54,7 @@
 
 static void reset(rpl_dag_t *);
 static void neighbor_link_callback(rpl_parent_t *, int, int);
+static void dao_ack_callback(rpl_parent_t *, int);
 static rpl_parent_t *best_parent(rpl_parent_t *, rpl_parent_t *);
 static rpl_dag_t *best_dag(rpl_dag_t *, rpl_dag_t *);
 static rpl_rank_t calculate_rank(rpl_parent_t *, rpl_rank_t);
@@ -62,6 +63,7 @@ static void update_metric_container(rpl_instance_t *);
 rpl_of_t rpl_mrhof = {
   reset,
   neighbor_link_callback,
+  dao_ack_callback,
   best_parent,
   best_dag,
   calculate_rank,
@@ -115,6 +117,20 @@ static void
 reset(rpl_dag_t *dag)
 {
   PRINTF("RPL: Reset MRHOF\n");
+}
+
+static void
+dao_ack_callback(rpl_parent_t *p, int status)
+{
+  /* here we need to handle failed DAO's and other stuff */
+  PRINTF("RPL: MRHOF - DAO ACK received with status: %d", status);
+  if(status >= RPL_DAO_ACK_UNABLE_TO_ACCEPT) {
+    /* punish the ETX as if this was 10 packets lost */
+    neighbor_link_callback(p, MAC_TX_OK, 10);
+  } else if(status == RPL_DAO_ACK_TIMEOUT) { /* timeout = no ack */
+    /* punish the total lack of ACK with a similar punishment */
+    neighbor_link_callback(p, MAC_TX_OK, 10);
+  }
 }
 
 static void

--- a/core/net/rpl/rpl-mrhof.c
+++ b/core/net/rpl/rpl-mrhof.c
@@ -122,8 +122,11 @@ reset(rpl_dag_t *dag)
 static void
 dao_ack_callback(rpl_parent_t *p, int status)
 {
+  if(status == RPL_DAO_ACK_UNABLE_TO_ACCEPT_ROOT) {
+    return;
+  }
   /* here we need to handle failed DAO's and other stuff */
-  PRINTF("RPL: MRHOF - DAO ACK received with status: %d", status);
+  PRINTF("RPL: MRHOF - DAO ACK received with status: %d\n", status);
   if(status >= RPL_DAO_ACK_UNABLE_TO_ACCEPT) {
     /* punish the ETX as if this was 10 packets lost */
     neighbor_link_callback(p, MAC_TX_OK, 10);

--- a/core/net/rpl/rpl-mrhof.c
+++ b/core/net/rpl/rpl-mrhof.c
@@ -54,7 +54,9 @@
 
 static void reset(rpl_dag_t *);
 static void neighbor_link_callback(rpl_parent_t *, int, int);
+#if RPL_WITH_DAO_ACK
 static void dao_ack_callback(rpl_parent_t *, int);
+#endif
 static rpl_parent_t *best_parent(rpl_parent_t *, rpl_parent_t *);
 static rpl_dag_t *best_dag(rpl_dag_t *, rpl_dag_t *);
 static rpl_rank_t calculate_rank(rpl_parent_t *, rpl_rank_t);
@@ -63,7 +65,9 @@ static void update_metric_container(rpl_instance_t *);
 rpl_of_t rpl_mrhof = {
   reset,
   neighbor_link_callback,
+#if RPL_WITH_DAO_ACK
   dao_ack_callback,
+#endif
   best_parent,
   best_dag,
   calculate_rank,
@@ -119,10 +123,11 @@ reset(rpl_dag_t *dag)
   PRINTF("RPL: Reset MRHOF\n");
 }
 
+#if RPL_WITH_DAO_ACK
 static void
 dao_ack_callback(rpl_parent_t *p, int status)
 {
-  if(status == RPL_DAO_ACK_UNABLE_TO_ACCEPT_ROOT) {
+  if(status == RPL_DAO_ACK_UNABLE_TO_ADD_ROUTE_AT_ROOT) {
     return;
   }
   /* here we need to handle failed DAO's and other stuff */
@@ -135,6 +140,7 @@ dao_ack_callback(rpl_parent_t *p, int status)
     neighbor_link_callback(p, MAC_TX_OK, 10);
   }
 }
+#endif /* RPL_WITH_DAO_ACK */
 
 static void
 neighbor_link_callback(rpl_parent_t *p, int status, int numtx)

--- a/core/net/rpl/rpl-nbr-policy.c
+++ b/core/net/rpl/rpl-nbr-policy.c
@@ -49,7 +49,7 @@
 #include "net/ipv6/uip-ds6-nbr.h"
 #include "net/ipv6/uip-ds6-route.h"
 
-#define DEBUG DEBUG_NONE
+#define DEBUG DEBUG_FULL
 #include "net/ip/uip-debug.h"
 
 /*
@@ -58,14 +58,18 @@
  * - max X children (nexthops)
  * - max Y "best parents"
  * => at least MAX_NBRS - (Y + X + 1) free slots for other.
+ *
+ * NOTE: this policy assumes that all neighbors end up being IPv6
+ * neighbors and are not only MAC neighbors.
  */
 
 #define MAX_CHILDREN (NBR_TABLE_MAX_NEIGHBORS - 3)
+#define UIP_IP_BUF       ((struct uip_ip_hdr *)&uip_buf[UIP_LLH_LEN])
 
 static int num_parents; /* any node that are possible parents */
 static int num_children;  /* all children that we have as nexthop */
 static int num_free;
-static uip_ds6_nbr_t *worst_rank_nbr; /* the parent that has the worst rank */
+static linkaddr_t *worst_rank_nbr; /* the parent that has the worst rank */
 static rpl_rank_t worst_rank;
 /*---------------------------------------------------------------------------*/
 #if DEBUG == DEBUG_FULL
@@ -124,8 +128,12 @@ update_nbr(void)
                 parent->dag->instance != NULL &&
                 (rank = parent->dag->instance->of->calculate_rank(parent, 0)) > worst_rank) {
         /* This is the worst-rank neighbor - this is a good candidate for removal */
-        worst_rank = rank;
-        worst_rank_nbr = nbr;
+        if(uip_ds6_route_is_nexthop((uip_lladdr_t *)lladdr) == 0) {
+          worst_rank = rank;
+          worst_rank_nbr = lladdr;
+        } else {
+          printf("*** Can not use this as worst rank as it is a next hop\n");
+        }
       }
     }
 
@@ -138,10 +146,9 @@ update_nbr(void)
 
     if(is_used == 0) {
       /* This neighbor is neither parent or child and can be safely removed */
-      worst_rank_nbr = nbr;
+      worst_rank_nbr = lladdr;
       worst_rank = INFINITE_RANK;
     } else if(is_used > 1) {
-      /* Both parent and child - this should never happen! */
       PRINTF("NBR-POLICY: *** Neighbor is both child and candidate parent: ");
       PRINTLLADDR((uip_lladdr_t *)lladdr);
       PRINTF("\n");
@@ -157,67 +164,36 @@ update_nbr(void)
 	 num_free, num_children, num_parents, uip_ds6_route_num_routes());
 }
 /*---------------------------------------------------------------------------*/
-static int
-remove_worst_nbr(void)
-{
-  /* we assume that it is possible to remove the worst parent at the moment */
-  if(worst_rank_nbr != NULL) {
-    PRINTF("Removing worst ranked nbr ");
-    PRINTLLADDR((uip_lladdr_t*)nbr_table_get_lladdr(ds6_neighbors, worst_rank_nbr));
-    PRINTF(" with rank %d\n", worst_rank);
-    if(uip_ds6_nbr_rm(worst_rank_nbr)) {
-      worst_rank_nbr = NULL;
-      return 1;
-    }
-    PRINTF("FAILED to remove worst ranked nbr!\n");
-    return 0;
-  }
-  PRINTF("FAILED to remove worst rank nbr - no found\n");
-  return 0;
-}
-/*---------------------------------------------------------------------------*/
 /* Called whenever we get a unicast DIS - e.g. someone that already
    have this node in its table - since it is a unicast */
-static int
-check_add_from_dis(uip_ipaddr_t *from)
+const linkaddr_t *
+find_removable_dis(uip_ipaddr_t *from)
 {
 
-  /* do a lookup to see if it is alread there - then allow add/update */
-  if(uip_ds6_nbr_lookup(from)) {
-    return 1;
-  }
   update_nbr();
   if(num_free > 0) {
-    return 1;
+    printf("num-free > 0 = %d", num_free);
+    printf("**** Should remove unused elements but can not... \n");
+    /*    return 1; */
   }
   if(num_children < MAX_CHILDREN) {
-    return remove_worst_nbr();
+    return worst_rank_nbr;
   }
-  return 0;
+  return NULL;
 }
 /*---------------------------------------------------------------------------*/
-static int
-check_add_from_dio(uip_ipaddr_t *from, rpl_dio_t *dio)
+const linkaddr_t *
+find_removable_dio(uip_ipaddr_t *from, rpl_dio_t *dio)
 {
   rpl_instance_t *instance;
   rpl_rank_t rank;
 
-  /* Do a lookup to see if it is already there - then allow add/update. */
-  if(uip_ds6_nbr_lookup(from)) {
-    return 1;
-  }
-
   update_nbr();
-
-  /* If there is room for this neighbor just add it. */
-  if(num_free > 0) {
-    return 1;
-  }
 
   instance = rpl_get_instance(dio->instance_id);
   if(instance == NULL || instance->current_dag == NULL) {
     PRINTF("Did not find instance id: %d\n", dio->instance_id);
-    return 0;
+    return NULL;
   }
 
   /* Add the new neighbor only if it is better than the preferred parent. */
@@ -227,38 +203,43 @@ check_add_from_dio(uip_ipaddr_t *from, rpl_dio_t *dio)
     PRINTF("Found better neighbor %d < %d - add to cache...\n",
            rank, worst_rank);
 
-    return remove_worst_nbr();
+    return worst_rank_nbr;
   }
 
   PRINTF("Found worse neighbor with new %d and old %d - NOT add to cache.\n",
          rank, worst_rank);
-  return 0;
+  return NULL;
 }
 /*---------------------------------------------------------------------------*/
-static int
-check_add_from_dao(uip_ipaddr_t *from)
+const linkaddr_t *
+find_removable_dao(uip_ipaddr_t *from)
 {
-  /* Do a lookup to see if it is alread there - then allow add/update. */
-  if(uip_ds6_nbr_lookup(from)) {
-    return 1;
-  }
-
   update_nbr();
 
   /* Check if this DAO sender is not yet neighbor and there is already too
      many children. */
   if(num_children >= MAX_CHILDREN) {
     PRINTF("Can not add another child - already at max.\n");
-    return 0;
+    return NULL;
   }
-
-  return 1;
+  /* remove the worst ranked nbr */
+  return worst_rank_nbr;
 }
 /*---------------------------------------------------------------------------*/
-const struct nbr_policy rpl_nbr_policy = {
-  check_add_from_dis,
-  check_add_from_dio,
-  check_add_from_dao
-};
+const linkaddr_t *
+rpl_nbr_policy_find_removable(nbr_table_reason_t reason,void * data) {
+  /* When we get the DIO/DAO/DIS we know that UIP contains the
+     incoming packet */
+  switch(reason) {
+  case NBR_TABLE_REASON_RPL_DIO:
+    return find_removable_dio(&UIP_IP_BUF->srcipaddr, data);
+  case NBR_TABLE_REASON_RPL_DAO:
+    return find_removable_dao(&UIP_IP_BUF->srcipaddr);
+  case NBR_TABLE_REASON_RPL_DIS:
+    return find_removable_dis(&UIP_IP_BUF->srcipaddr);
+  default:
+    return NULL;
+  }
+}
 /*---------------------------------------------------------------------------*/
 /** @}*/

--- a/core/net/rpl/rpl-nbr-policy.c
+++ b/core/net/rpl/rpl-nbr-policy.c
@@ -49,7 +49,7 @@
 #include "net/ipv6/uip-ds6-nbr.h"
 #include "net/ipv6/uip-ds6-route.h"
 
-#define DEBUG DEBUG_FULL
+#define DEBUG DEBUG_NONE
 #include "net/ip/uip-debug.h"
 
 /*
@@ -63,7 +63,7 @@
  * neighbors and are not only MAC neighbors.
  */
 
-#define MAX_CHILDREN (NBR_TABLE_MAX_NEIGHBORS - 3)
+#define MAX_CHILDREN (NBR_TABLE_MAX_NEIGHBORS - 2)
 #define UIP_IP_BUF       ((struct uip_ip_hdr *)&uip_buf[UIP_LLH_LEN])
 
 static int num_parents; /* any node that are possible parents */

--- a/core/net/rpl/rpl-nbr-policy.c
+++ b/core/net/rpl/rpl-nbr-policy.c
@@ -1,0 +1,244 @@
+/*
+ * Copyright (c) 2014-2015, Yanzi Networks AB.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *    1. Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *    3. Neither the name of the copyright holders nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ * USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ */
+/**
+ * \addtogroup uip6
+ * @{
+ */
+
+
+/**
+ * \file
+ *
+ * Default RPL NBR policy
+ * decides when to add a new discovered node to the nbr table from RPL.
+ *
+ * \author Joakim Eriksson <joakime@sics.se>
+ * Contributors: Niclas Finne <nfi@sics.se>, Oriol Piñol <oriol@yanzi.se>,
+ *
+ */
+
+#include "net/rpl/rpl-private.h"
+#include "net/nbr-table.h"
+#include "net/ipv6/uip-ds6-nbr.h"
+#include "net/ipv6/uip-ds6-route.h"
+
+#define DEBUG DEBUG_NONE
+#include "net/ip/uip-debug.h"
+
+/*
+ * Policy for neighbor adds
+ * - one node is locked (default route)
+ * - max X children (nexthops)
+ * - max Y "best parents"
+ * => at least MAX_NBRS - (Y + X + 1) free slots for other.
+ */
+
+#define MAX_CHILDREN (NBR_TABLE_MAX_NEIGHBORS - 3)
+
+static int num_parents; /* any node that are possible parents */
+static int num_children;  /* all children that we have as nexthop */
+static int num_free;
+static uip_ds6_nbr_t *worst_rank_nbr; /* the parent that has the worst rank */
+static rpl_rank_t worst_rank;
+/*---------------------------------------------------------------------------*/
+static void
+update_nbr(void)
+{
+  uip_ds6_nbr_t *nbr;
+  rpl_parent_t *parent;
+  int num_used;
+  int is_used;
+  rpl_rank_t rank;
+
+  worst_rank = 0;
+  worst_rank_nbr = NULL;
+  num_used = 0;
+  num_parents = 0;
+  num_children = 0;
+
+  nbr = nbr_table_head(ds6_neighbors);
+  while(nbr != NULL) {
+    linkaddr_t *lladdr = nbr_table_get_lladdr(ds6_neighbors, nbr);
+    is_used = 0;
+
+    parent = rpl_get_parent((uip_lladdr_t *)lladdr);
+    if(parent != NULL) {
+      num_parents++;
+      is_used++;
+
+      if(parent->dag != NULL && parent->dag->preferred_parent == parent) {
+        /* This is the preferred parent for the DAG and must not be removed */
+
+        /* Note: this assumes that only RPL adds default routes. */
+
+      } else if(worst_rank < INFINITE_RANK &&
+                parent->rank > 0 &&
+                parent->dag != NULL &&
+                parent->dag->instance != NULL &&
+                (rank = parent->dag->instance->of->calculate_rank(parent, 0)) > worst_rank) {
+        /* This is the worst-rank neighbor - this is a good candidate for removal */
+        worst_rank = rank;
+        worst_rank_nbr = nbr;
+      }
+    }
+
+    /* Check if this neighbor is used as nexthop and therefor being a
+       RPL child. */
+    if(uip_ds6_route_is_nexthop((uip_lladdr_t *)lladdr) != 0) {
+      is_used++;
+      num_children++;
+    }
+
+    if(is_used == 0) {
+      /* This neighbor is neither parent or child and can be safely removed */
+      worst_rank_nbr = nbr;
+      worst_rank = INFINITE_RANK;
+    } else if(is_used > 1) {
+      /* Both parent and child - this should never happen! */
+      PRINTF("NBR-POLICY: *** Neighbor is both child and candidate parent: ");
+      PRINTLLADDR((uip_lladdr_t *)lladdr);
+      PRINTF("\n");
+    }
+
+    nbr = nbr_table_next(ds6_neighbors, nbr);
+    num_used++;
+  }
+  /* how many more IP neighbors can be have? */
+  num_free = NBR_TABLE_MAX_NEIGHBORS - num_used;
+
+  PRINTF("NBR-POLICY: Free: %d, Children: %d, Parents: %d Routes: %d\n",
+	 num_free, num_children, num_parents, uip_ds6_route_num_routes());
+}
+/*---------------------------------------------------------------------------*/
+static int
+remove_worst_nbr(void)
+{
+  /* we assume that it is possible to remove the worst parent at the moment */
+  if(worst_rank_nbr != NULL) {
+    PRINTF("Removing worst ranked nbr ");
+    PRINTLLADDR((uip_lladdr_t*)nbr_table_get_lladdr(ds6_neighbors, worst_rank_nbr));
+    PRINTF(" with rank %d\n", worst_rank);
+    if(uip_ds6_nbr_rm(worst_rank_nbr)) {
+      worst_rank_nbr = NULL;
+      return 1;
+    }
+    PRINTF("FAILED to remove worst ranked nbr!\n");
+    return 0;
+  }
+  PRINTF("FAILED to remove worst rank nbr - no found\n");
+  return 0;
+}
+/*---------------------------------------------------------------------------*/
+/* Called whenever we get a unicast DIS - e.g. someone that already
+   have this node in its table - since it is a unicast */
+static int
+check_add_from_dis(uip_ipaddr_t *from)
+{
+
+  /* do a lookup to see if it is alread there - then allow add/update */
+  if(uip_ds6_nbr_lookup(from)) {
+    return 1;
+  }
+  update_nbr();
+  if(num_free > 0) {
+    return 1;
+  }
+  if(num_children < MAX_CHILDREN) {
+    return remove_worst_nbr();
+  }
+  return 0;
+}
+/*---------------------------------------------------------------------------*/
+static int
+check_add_from_dio(uip_ipaddr_t *from, rpl_dio_t *dio)
+{
+  rpl_instance_t *instance;
+  rpl_rank_t rank;
+
+  /* Do a lookup to see if it is already there - then allow add/update. */
+  if(uip_ds6_nbr_lookup(from)) {
+    return 1;
+  }
+
+  update_nbr();
+
+  /* If there is room for this neighbor just add it. */
+  if(num_free > 0) {
+    return 1;
+  }
+
+  instance = rpl_get_instance(dio->instance_id);
+  if(instance == NULL || instance->current_dag == NULL) {
+    PRINTF("Did not find instance id: %d\n", dio->instance_id);
+    return 0;
+  }
+
+  /* Add the new neighbor only if it is better than the preferred parent. */
+  rank = instance->of->calculate_rank(NULL, dio->rank);
+  if(rank < worst_rank - instance->min_hoprankinc / 2) {
+    /* Found *great* neighbor - add! */
+    PRINTF("Found better neighbor %d < %d - add to cache...\n",
+           rank, worst_rank);
+
+    return remove_worst_nbr();
+  }
+
+  PRINTF("Found worse neighbor with new %d and old %d - NOT add to cache.\n",
+         rank, worst_rank);
+  return 0;
+}
+/*---------------------------------------------------------------------------*/
+static int
+check_add_from_dao(uip_ipaddr_t *from)
+{
+  /* Do a lookup to see if it is alread there - then allow add/update. */
+  if(uip_ds6_nbr_lookup(from)) {
+    return 1;
+  }
+
+  update_nbr();
+
+  /* Check if this DAO sender is not yet neighbor and there is already too
+     many children. */
+  if(num_children >= MAX_CHILDREN) {
+    PRINTF("Can not add another child - already at max.\n");
+    return 0;
+  }
+
+  return 1;
+}
+/*---------------------------------------------------------------------------*/
+const struct nbr_policy rpl_nbr_policy = {
+  check_add_from_dis,
+  check_add_from_dio,
+  check_add_from_dao
+};
+/*---------------------------------------------------------------------------*/
+/** @}*/

--- a/core/net/rpl/rpl-nbr-policy.c
+++ b/core/net/rpl/rpl-nbr-policy.c
@@ -68,6 +68,18 @@ static int num_free;
 static uip_ds6_nbr_t *worst_rank_nbr; /* the parent that has the worst rank */
 static rpl_rank_t worst_rank;
 /*---------------------------------------------------------------------------*/
+#if DEBUG == DEBUG_FULL
+static void update_nbr(void);
+static struct ctimer periodic_timer;
+static int timer_init = 0;
+static void
+handle_periodic_timer(void *ptr)
+{
+  update_nbr();
+  ctimer_restart(&periodic_timer);
+}
+#endif /* DEBUG == DEBUG_FULL */
+/*---------------------------------------------------------------------------*/
 static void
 update_nbr(void)
 {
@@ -76,6 +88,14 @@ update_nbr(void)
   int num_used;
   int is_used;
   rpl_rank_t rank;
+
+#if DEBUG == DEBUG_FULL
+  if(!timer_init) {
+    timer_init = 1;
+    ctimer_set(&periodic_timer, 60 * CLOCK_SECOND,
+               &handle_periodic_timer, NULL);
+  }
+#endif /* DEBUG == DEBUG_FULL */
 
   worst_rank = 0;
   worst_rank_nbr = NULL;

--- a/core/net/rpl/rpl-of0.c
+++ b/core/net/rpl/rpl-of0.c
@@ -55,7 +55,9 @@ static void update_metric_container(rpl_instance_t *);
 rpl_of_t rpl_of0 = {
   reset,
   NULL,
+#if RPL_WITH_DAO_ACK
   NULL,
+#endif
   best_parent,
   best_dag,
   calculate_rank,

--- a/core/net/rpl/rpl-of0.c
+++ b/core/net/rpl/rpl-of0.c
@@ -55,6 +55,7 @@ static void update_metric_container(rpl_instance_t *);
 rpl_of_t rpl_of0 = {
   reset,
   NULL,
+  NULL,
   best_parent,
   best_dag,
   calculate_rank,

--- a/core/net/rpl/rpl-private.h
+++ b/core/net/rpl/rpl-private.h
@@ -94,7 +94,7 @@
 #define RPL_DAO_ACK_UNCONDITIONAL_ACCEPT 0
 #define RPL_DAO_ACK_ACCEPT               1   /* 1 - 127 is OK but not good */
 #define RPL_DAO_ACK_UNABLE_TO_ACCEPT     128 /* >127 is fail */
-#define RPL_DAO_ACK_UNABLE_TO_ACCEPT_ROOT 255 /* root can not accept */
+#define RPL_DAO_ACK_UNABLE_TO_ADD_ROUTE_AT_ROOT 255 /* root can not accept */
 
 #define RPL_DAO_ACK_TIMEOUT              -1
 

--- a/core/net/rpl/rpl-private.h
+++ b/core/net/rpl/rpl-private.h
@@ -90,6 +90,13 @@
 
 #define RPL_DAO_K_FLAG                   0x80 /* DAO ACK requested */
 #define RPL_DAO_D_FLAG                   0x40 /* DODAG ID present */
+
+#define RPL_DAO_ACK_UNCONDITIONAL_ACCEPT 0
+#define RPL_DAO_ACK_ACCEPT               1   /* 1 - 127 is OK but not good */
+#define RPL_DAO_ACK_UNABLE_TO_ACCEPT     128 /* >127 is fail */
+
+#define RPL_DAO_ACK_TIMEOUT              -1
+
 /*---------------------------------------------------------------------------*/
 /* RPL IPv6 extension header option. */
 #define RPL_HDR_OPT_LEN			4
@@ -116,6 +123,9 @@
 #else /* RPL_CONF_NOPATH_REMOVAL_DELAY */
 #define RPL_NOPATH_REMOVAL_DELAY          60
 #endif /* RPL_CONF_NOPATH_REMOVAL_DELAY */
+
+#define RPL_DAO_MAX_RETRANSMISSIONS     5
+#define RPL_DAO_RETRANSMISSION_TIMEOUT  (5 * CLOCK_SECOND)
 
 /* Special value indicating immediate removal. */
 #define RPL_ZERO_LIFETIME               0
@@ -268,7 +278,7 @@ void dis_output(uip_ipaddr_t *addr);
 void dio_output(rpl_instance_t *, uip_ipaddr_t *uc_addr);
 void dao_output(rpl_parent_t *, uint8_t lifetime);
 void dao_output_target(rpl_parent_t *, uip_ipaddr_t *, uint8_t lifetime);
-void dao_ack_output(rpl_instance_t *, uip_ipaddr_t *, uint8_t);
+void dao_ack_output(rpl_instance_t *, uip_ipaddr_t *, uint8_t, uint8_t);
 void rpl_icmp6_register_handlers(void);
 
 /* RPL logic functions. */

--- a/core/net/rpl/rpl-private.h
+++ b/core/net/rpl/rpl-private.h
@@ -94,6 +94,7 @@
 #define RPL_DAO_ACK_UNCONDITIONAL_ACCEPT 0
 #define RPL_DAO_ACK_ACCEPT               1   /* 1 - 127 is OK but not good */
 #define RPL_DAO_ACK_UNABLE_TO_ACCEPT     128 /* >127 is fail */
+#define RPL_DAO_ACK_UNABLE_TO_ACCEPT_ROOT 255 /* root can not accept */
 
 #define RPL_DAO_ACK_TIMEOUT              -1
 

--- a/core/net/rpl/rpl-private.h
+++ b/core/net/rpl/rpl-private.h
@@ -270,22 +270,6 @@ typedef struct rpl_stats rpl_stats_t;
 extern rpl_stats_t rpl_stats;
 #endif
 
-struct nbr_policy {
-  /** check if it is ok to add a nbr via UC DIS - positive => ok */
-  int (* check_add_from_dis)(uip_ipaddr_t *from);
-  int (* check_add_from_dio)(uip_ipaddr_t *from, rpl_dio_t *dio);
-  int (* check_add_from_dao)(uip_ipaddr_t *from);
-};
-
-
-#ifdef RPL_CONF_NBR_POLICY
-#define RPL_NBR_POLICY RPL_CONF_NBR_POLICY
-#else /* RPL_CONF_NBR_POLICY */
-#define RPL_NBR_POLICY rpl_nbr_policy
-#endif /* RPL_CONF_NBR_POLICY */
-
-extern const struct nbr_policy RPL_NBR_POLICY;
-
 
 /*---------------------------------------------------------------------------*/
 /* RPL macros. */
@@ -307,7 +291,8 @@ void dao_output(rpl_parent_t *, uint8_t lifetime);
 void dao_output_target(rpl_parent_t *, uip_ipaddr_t *, uint8_t lifetime);
 void dao_ack_output(rpl_instance_t *, uip_ipaddr_t *, uint8_t, uint8_t);
 void rpl_icmp6_register_handlers(void);
-uip_ds6_nbr_t *rpl_icmp6_update_nbr_table(uip_ipaddr_t *from);
+uip_ds6_nbr_t *rpl_icmp6_update_nbr_table(uip_ipaddr_t *from,
+                                          nbr_table_reason_t r, void *data);
 
 /* RPL logic functions. */
 void rpl_join_dag(uip_ipaddr_t *from, rpl_dio_t *dio);

--- a/core/net/rpl/rpl-private.h
+++ b/core/net/rpl/rpl-private.h
@@ -124,8 +124,17 @@
 #define RPL_NOPATH_REMOVAL_DELAY          60
 #endif /* RPL_CONF_NOPATH_REMOVAL_DELAY */
 
+#ifdef RPL_CONF_DAO_MAX_RETRANSMISSIONS
+#define RPL_DAO_MAX_RETRANSMISSIONS RPL_CONF_DAO_MAX_RETRANSMISSIONS
+#else
 #define RPL_DAO_MAX_RETRANSMISSIONS     5
+#endif /* RPL_CONF_DAO_MAX_RETRANSMISSIONS */
+
+#ifdef RPL_CONF_DAO_RETRANSMISSION_TIMEOUT
+#define RPL_DAO_RETRANSMISSION_TIMEOUT RPL_CONF_DAO_RETRANSMISSION_TIMEOUT
+#else
 #define RPL_DAO_RETRANSMISSION_TIMEOUT  (5 * CLOCK_SECOND)
+#endif /* RPL_CONF_DAO_RETRANSMISSION_TIMEOUT */
 
 /* Special value indicating immediate removal. */
 #define RPL_ZERO_LIFETIME               0
@@ -260,6 +269,24 @@ typedef struct rpl_stats rpl_stats_t;
 
 extern rpl_stats_t rpl_stats;
 #endif
+
+struct nbr_policy {
+  /** check if it is ok to add a nbr via UC DIS - positive => ok */
+  int (* check_add_from_dis)(uip_ipaddr_t *from);
+  int (* check_add_from_dio)(uip_ipaddr_t *from, rpl_dio_t *dio);
+  int (* check_add_from_dao)(uip_ipaddr_t *from);
+};
+
+
+#ifdef RPL_CONF_NBR_POLICY
+#define RPL_NBR_POLICY RPL_CONF_NBR_POLICY
+#else /* RPL_CONF_NBR_POLICY */
+#define RPL_NBR_POLICY rpl_nbr_policy
+#endif /* RPL_CONF_NBR_POLICY */
+
+extern const struct nbr_policy RPL_NBR_POLICY;
+
+
 /*---------------------------------------------------------------------------*/
 /* RPL macros. */
 
@@ -280,6 +307,7 @@ void dao_output(rpl_parent_t *, uint8_t lifetime);
 void dao_output_target(rpl_parent_t *, uip_ipaddr_t *, uint8_t lifetime);
 void dao_ack_output(rpl_instance_t *, uip_ipaddr_t *, uint8_t, uint8_t);
 void rpl_icmp6_register_handlers(void);
+uip_ds6_nbr_t *rpl_icmp6_update_nbr_table(uip_ipaddr_t *from);
 
 /* RPL logic functions. */
 void rpl_join_dag(uip_ipaddr_t *from, rpl_dio_t *dio);

--- a/core/net/rpl/rpl-timers.c
+++ b/core/net/rpl/rpl-timers.c
@@ -224,6 +224,8 @@ set_dao_lifetime_timer(rpl_instance_t *instance)
     expiration_time = (clock_time_t)instance->default_lifetime *
       (clock_time_t)instance->lifetime_unit *
       CLOCK_SECOND / 2;
+    /* make the time for the re registration be betwen 1/2 - 3/4 of lifetime */
+    expiration_time = expiration_time + (random_rand() % (expiration_time / 2));
     PRINTF("RPL: Scheduling DAO lifetime timer %u ticks in the future\n",
            (unsigned)expiration_time);
     ctimer_set(&instance->dao_lifetime_timer, expiration_time,

--- a/core/net/rpl/rpl.c
+++ b/core/net/rpl/rpl.c
@@ -238,7 +238,6 @@ rpl_add_route(rpl_dag_t *dag, uip_ipaddr_t *prefix, int prefix_len,
 
   rep->state.dag = dag;
   rep->state.lifetime = RPL_LIFETIME(dag->instance, dag->instance->default_lifetime);
-  /* rep->state.learned_from = RPL_ROUTE_FROM_INTERNAL; */
 
   PRINTF("RPL: Added a route to ");
   PRINT6ADDR(prefix);

--- a/core/net/rpl/rpl.c
+++ b/core/net/rpl/rpl.c
@@ -238,7 +238,7 @@ rpl_add_route(rpl_dag_t *dag, uip_ipaddr_t *prefix, int prefix_len,
 
   rep->state.dag = dag;
   rep->state.lifetime = RPL_LIFETIME(dag->instance, dag->instance->default_lifetime);
-  rep->state.learned_from = RPL_ROUTE_FROM_INTERNAL;
+  /* rep->state.learned_from = RPL_ROUTE_FROM_INTERNAL; */
 
   PRINTF("RPL: Added a route to ");
   PRINT6ADDR(prefix);

--- a/core/net/rpl/rpl.c
+++ b/core/net/rpl/rpl.c
@@ -238,6 +238,8 @@ rpl_add_route(rpl_dag_t *dag, uip_ipaddr_t *prefix, int prefix_len,
 
   rep->state.dag = dag;
   rep->state.lifetime = RPL_LIFETIME(dag->instance, dag->instance->default_lifetime);
+  /* always clear state flags for the no-path received when adding/refreshing */
+  RPL_ROUTE_CLEAR_NOPATH_RECEIVED(rep);
 
   PRINTF("RPL: Added a route to ");
   PRINT6ADDR(prefix);

--- a/core/net/rpl/rpl.h
+++ b/core/net/rpl/rpl.h
@@ -300,5 +300,13 @@ enum rpl_mode rpl_set_mode(enum rpl_mode mode);
  */
 enum rpl_mode rpl_get_mode(void);
 
+
+/**
+ * Get the RPL's best guess on if we have downward link or not.
+ *
+ * \retval 1 if we have a downward link, 0 if not.
+ */
+int rpl_has_downward_link(void);
+
 /*---------------------------------------------------------------------------*/
 #endif /* RPL_H */

--- a/core/net/rpl/rpl.h
+++ b/core/net/rpl/rpl.h
@@ -181,11 +181,19 @@ typedef struct rpl_instance rpl_instance_t;
  *  Updates the metric container for outgoing DIOs in a certain DAG.
  *  If the objective function of the DAG does not use metric containers,
  *  the function should set the object type to RPL_DAG_MC_NONE.
+ *
+ * dao_ack_callback(parent, status)
+ *
+ * A callback on the result of the DAO ACK. Similar to the neighbor link
+ * callback. A failed DAO_ACK (NACK) can be used for switching to another
+ * parent via changed link metric or other mechanisms.
  */
 struct rpl_of {
   void (*reset)(struct rpl_dag *);
   void (*neighbor_link_callback)(rpl_parent_t *, int, int);
+#if RPL_WITH_DAO_ACK
   void (*dao_ack_callback)(rpl_parent_t *, int status);
+#endif
   rpl_parent_t *(*best_parent)(rpl_parent_t *, rpl_parent_t *);
   rpl_dag_t *(*best_dag)(rpl_dag_t *, rpl_dag_t *);
   rpl_rank_t (*calculate_rank)(rpl_parent_t *, rpl_rank_t);
@@ -220,6 +228,8 @@ struct rpl_instance {
   /* my last registered DAO that I might be waiting for ACK on */
   uint8_t my_dao_seqno;
   uint8_t my_dao_transmissions;
+  /* this is intended to keep track if this instance have a route downward */
+  uint8_t has_downward_route;
   rpl_rank_t max_rankinc;
   rpl_rank_t min_hoprankinc;
   uint16_t lifetime_unit; /* lifetime in seconds = l_u * d_l */
@@ -302,11 +312,11 @@ enum rpl_mode rpl_get_mode(void);
 
 
 /**
- * Get the RPL's best guess on if we have downward link or not.
+ * Get the RPL's best guess on if we have downward route or not.
  *
- * \retval 1 if we have a downward link, 0 if not.
+ * \retval 1 if we have a downward route from RPL Root, 0 if not.
  */
-int rpl_has_downward_link(void);
+int rpl_has_downward_route(void);
 
 /*---------------------------------------------------------------------------*/
 #endif /* RPL_H */

--- a/core/net/rpl/rpl.h
+++ b/core/net/rpl/rpl.h
@@ -185,6 +185,7 @@ typedef struct rpl_instance rpl_instance_t;
 struct rpl_of {
   void (*reset)(struct rpl_dag *);
   void (*neighbor_link_callback)(rpl_parent_t *, int, int);
+  void (*dao_ack_callback)(rpl_parent_t *, int status);
   rpl_parent_t *(*best_parent)(rpl_parent_t *, rpl_parent_t *);
   rpl_dag_t *(*best_dag)(rpl_dag_t *, rpl_dag_t *);
   rpl_rank_t (*calculate_rank)(rpl_parent_t *, rpl_rank_t);
@@ -216,6 +217,9 @@ struct rpl_instance {
   uint8_t dio_intcurrent;
   uint8_t dio_send; /* for keeping track of which mode the timer is in */
   uint8_t dio_counter;
+  /* my last registered DAO that I might be waiting for ACK on */
+  uint8_t my_dao_seqno;
+  uint8_t my_dao_transmissions;
   rpl_rank_t max_rankinc;
   rpl_rank_t min_hoprankinc;
   uint16_t lifetime_unit; /* lifetime in seconds = l_u * d_l */
@@ -233,6 +237,9 @@ struct rpl_instance {
   struct ctimer dao_lifetime_timer;
   struct ctimer unicast_dio_timer;
   rpl_parent_t *unicast_dio_target;
+#if RPL_WITH_DAO_ACK
+  struct ctimer dao_retransmit_timer;
+#endif /* RPL_WITH_DAO_ACK */
 };
 
 /*---------------------------------------------------------------------------*/

--- a/examples/er-rest-example/project-conf.h
+++ b/examples/er-rest-example/project-conf.h
@@ -60,6 +60,9 @@
 #undef NETSTACK_CONF_RDC
 #define NETSTACK_CONF_RDC              nullrdc_driver
 
+#undef RPL_CONF_MAX_DAG_PER_INSTANCE
+#define RPL_CONF_MAX_DAG_PER_INSTANCE     1
+
 /* Disabling TCP on CoAP nodes. */
 #undef UIP_CONF_TCP
 #define UIP_CONF_TCP                   0
@@ -92,6 +95,10 @@
 #define COAP_LINK_FORMAT_FILTERING     0
 #undef COAP_PROXY_OPTION_PROCESSING
 #define COAP_PROXY_OPTION_PROCESSING   0
+
+/* Turn of DAO ACK to make code smaller */
+#undef RPL_CONF_WITH_DAO_ACK
+#define RPL_CONF_WITH_DAO_ACK          0
 
 /* Enable client-side support for COAP observe */
 #define COAP_OBSERVE_CLIENT 1

--- a/examples/er-rest-example/project-conf.h
+++ b/examples/er-rest-example/project-conf.h
@@ -100,6 +100,9 @@
 #undef RPL_CONF_WITH_DAO_ACK
 #define RPL_CONF_WITH_DAO_ACK          0
 
+#undef RPL_CONF_OF
+#define RPL_CONF_OF                    rpl_of0
+
 /* Enable client-side support for COAP observe */
 #define COAP_OBSERVE_CLIENT 1
 #endif /* __PROJECT_ERBIUM_CONF_H__ */

--- a/examples/ipv6/rpl-collect/Makefile
+++ b/examples/ipv6/rpl-collect/Makefile
@@ -3,6 +3,8 @@ APPS = powertrace collect-view
 CONTIKI_PROJECT = udp-sender udp-sink
 PROJECT_SOURCEFILES += collect-common.c
 
+CFLAGS += -DPROJECT_CONF_H=\"project-conf.h\"
+
 ifdef PERIOD
 CFLAGS=-DPERIOD=$(PERIOD)
 endif

--- a/examples/ipv6/rpl-collect/project-conf.h
+++ b/examples/ipv6/rpl-collect/project-conf.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2015, Swedish Institute of Computer Science.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#ifndef PROJECT_CONF_H_
+#define PROJECT_CONF_H_
+
+#undef NBR_TABLE_CONF_MAX_NEIGHBORS
+#undef UIP_CONF_MAX_ROUTES
+
+#ifdef TEST_MORE_ROUTES
+/* configure number of neighbors and routes */
+#define NBR_TABLE_CONF_MAX_NEIGHBORS     10
+#define UIP_CONF_MAX_ROUTES   30
+#else
+/* configure number of neighbors and routes */
+#define NBR_TABLE_CONF_MAX_NEIGHBORS     10
+#define UIP_CONF_MAX_ROUTES   10
+#endif /* TEST_MORE_ROUTES */
+
+#undef NETSTACK_CONF_RDC
+#define NETSTACK_CONF_RDC     nullrdc_driver
+#undef NULLRDC_CONF_802154_AUTOACK
+#define NULLRDC_CONF_802154_AUTOACK       1
+
+/* Define as minutes */
+#define RPL_CONF_DEFAULT_LIFETIME_UNIT   60
+
+/* 10 minutes lifetime of routes */
+#define RPL_CONF_DEFAULT_LIFETIME        10
+
+#define RPL_CONF_DEFAULT_ROUTE_INFINITE_LIFETIME 1
+
+#endif /* PROJECT_CONF_H_ */

--- a/examples/ipv6/rpl-udp/Makefile
+++ b/examples/ipv6/rpl-udp/Makefile
@@ -1,6 +1,7 @@
 all: udp-client udp-server
-APPS=servreg-hack
 CONTIKI=../../..
+
+CFLAGS += -DPROJECT_CONF_H=\"project-conf.h\"
 
 ifdef WITH_COMPOWER
 APPS+=powertrace

--- a/examples/ipv6/rpl-udp/project-conf.h
+++ b/examples/ipv6/rpl-udp/project-conf.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2015, Swedish Institute of Computer Science.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#ifndef PROJECT_CONF_H_
+#define PROJECT_CONF_H_
+
+#undef NBR_TABLE_CONF_MAX_NEIGHBORS
+#undef UIP_CONF_MAX_ROUTES
+
+#ifdef TEST_MORE_ROUTES
+/* configure number of neighbors and routes */
+#define NBR_TABLE_CONF_MAX_NEIGHBORS     10
+#define UIP_CONF_MAX_ROUTES   30
+#else
+/* configure number of neighbors and routes */
+#define NBR_TABLE_CONF_MAX_NEIGHBORS     10
+#define UIP_CONF_MAX_ROUTES   10
+#endif /* TEST_MORE_ROUTES */
+
+#undef NETSTACK_CONF_RDC
+#define NETSTACK_CONF_RDC     nullrdc_driver
+#undef NULLRDC_CONF_802154_AUTOACK
+#define NULLRDC_CONF_802154_AUTOACK       1
+
+/* Define as minutes */
+#define RPL_CONF_DEFAULT_LIFETIME_UNIT   60
+
+/* 10 minutes lifetime of routes */
+#define RPL_CONF_DEFAULT_LIFETIME        10
+
+#define RPL_CONF_DEFAULT_ROUTE_INFINITE_LIFETIME 1
+
+#endif /* PROJECT_CONF_H_ */

--- a/examples/ipv6/rpl-udp/rpl-udp-scale-wismote.csc
+++ b/examples/ipv6/rpl-udp/rpl-udp-scale-wismote.csc
@@ -1,0 +1,721 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<simconf>
+  <project EXPORT="discard">[APPS_DIR]/mrm</project>
+  <project EXPORT="discard">[APPS_DIR]/mspsim</project>
+  <project EXPORT="discard">[APPS_DIR]/avrora</project>
+  <project EXPORT="discard">[APPS_DIR]/serial_socket</project>
+  <project EXPORT="discard">[APPS_DIR]/collect-view</project>
+  <project EXPORT="discard">[APPS_DIR]/powertracker</project>
+  <simulation>
+    <title>RPL up and downstream scaleability test network using IPv6 and RPL</title>
+    <randomseed>generated</randomseed>
+    <motedelay_us>5000000</motedelay_us>
+    <radiomedium>
+      org.contikios.cooja.radiomediums.UDGM
+      <transmitting_range>150.0</transmitting_range>
+      <interference_range>150.0</interference_range>
+      <success_ratio_tx>1.0</success_ratio_tx>
+      <success_ratio_rx>1.0</success_ratio_rx>
+    </radiomedium>
+    <events>
+      <logoutput>40000</logoutput>
+    </events>
+    <motetype>
+      org.contikios.cooja.mspmote.WismoteMoteType
+      <identifier>sky1</identifier>
+      <description>WisMote Type #sky1</description>
+      <source EXPORT="discard">[CONTIKI_DIR]/examples/ipv6/rpl-udp/udp-server.c</source>
+      <commands EXPORT="discard">make SERVER_REPLY=1 clean udp-server.wismote TARGET=wismote DEFINES=TEST_MORE_ROUTES=1</commands>
+      <firmware EXPORT="copy">[CONTIKI_DIR]/examples/ipv6/rpl-udp/udp-server.wismote</firmware>
+      <moteinterface>org.contikios.cooja.interfaces.Position</moteinterface>
+      <moteinterface>org.contikios.cooja.interfaces.RimeAddress</moteinterface>
+      <moteinterface>org.contikios.cooja.interfaces.IPAddress</moteinterface>
+      <moteinterface>org.contikios.cooja.interfaces.Mote2MoteRelations</moteinterface>
+      <moteinterface>org.contikios.cooja.interfaces.MoteAttributes</moteinterface>
+      <moteinterface>org.contikios.cooja.mspmote.interfaces.MspClock</moteinterface>
+      <moteinterface>org.contikios.cooja.mspmote.interfaces.MspMoteID</moteinterface>
+      <moteinterface>org.contikios.cooja.mspmote.interfaces.MspButton</moteinterface>
+      <moteinterface>org.contikios.cooja.mspmote.interfaces.Msp802154Radio</moteinterface>
+      <moteinterface>org.contikios.cooja.mspmote.interfaces.MspDefaultSerial</moteinterface>
+      <moteinterface>org.contikios.cooja.mspmote.interfaces.MspLED</moteinterface>
+      <moteinterface>org.contikios.cooja.mspmote.interfaces.MspDebugOutput</moteinterface>
+    </motetype>
+    <motetype>
+      org.contikios.cooja.mspmote.WismoteMoteType
+      <identifier>sky2</identifier>
+      <description>WisMote Type #sky2</description>
+      <source EXPORT="discard">[CONTIKI_DIR]/examples/ipv6/rpl-udp/udp-client.c</source>
+      <commands EXPORT="discard">make SERVER_REPLY=1 clean udp-client.wismote TARGET=wismote</commands>
+      <firmware EXPORT="copy">[CONTIKI_DIR]/examples/ipv6/rpl-udp/udp-client.wismote</firmware>
+      <moteinterface>org.contikios.cooja.interfaces.Position</moteinterface>
+      <moteinterface>org.contikios.cooja.interfaces.RimeAddress</moteinterface>
+      <moteinterface>org.contikios.cooja.interfaces.IPAddress</moteinterface>
+      <moteinterface>org.contikios.cooja.interfaces.Mote2MoteRelations</moteinterface>
+      <moteinterface>org.contikios.cooja.interfaces.MoteAttributes</moteinterface>
+      <moteinterface>org.contikios.cooja.mspmote.interfaces.MspClock</moteinterface>
+      <moteinterface>org.contikios.cooja.mspmote.interfaces.MspMoteID</moteinterface>
+      <moteinterface>org.contikios.cooja.mspmote.interfaces.MspButton</moteinterface>
+      <moteinterface>org.contikios.cooja.mspmote.interfaces.Msp802154Radio</moteinterface>
+      <moteinterface>org.contikios.cooja.mspmote.interfaces.MspDefaultSerial</moteinterface>
+      <moteinterface>org.contikios.cooja.mspmote.interfaces.MspLED</moteinterface>
+      <moteinterface>org.contikios.cooja.mspmote.interfaces.MspDebugOutput</moteinterface>
+    </motetype>
+    <mote>
+      <breakpoints />
+      <interface_config>
+        org.contikios.cooja.interfaces.Position
+        <x>48.435974731198804</x>
+        <y>-66.16503914182063</y>
+        <z>0.0</z>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspClock
+        <deviation>1.0</deviation>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspMoteID
+        <id>1</id>
+      </interface_config>
+      <motetype_identifier>sky1</motetype_identifier>
+    </mote>
+    <mote>
+      <breakpoints />
+      <interface_config>
+        org.contikios.cooja.interfaces.Position
+        <x>-65.3176930733124</x>
+        <y>17.4304162608286</y>
+        <z>0.0</z>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspClock
+        <deviation>1.0</deviation>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspMoteID
+        <id>2</id>
+      </interface_config>
+      <motetype_identifier>sky2</motetype_identifier>
+    </mote>
+    <mote>
+      <breakpoints />
+      <interface_config>
+        org.contikios.cooja.interfaces.Position
+        <x>127.9689727848476</x>
+        <y>91.71883780610729</y>
+        <z>0.0</z>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspClock
+        <deviation>1.0</deviation>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspMoteID
+        <id>3</id>
+      </interface_config>
+      <motetype_identifier>sky2</motetype_identifier>
+    </mote>
+    <mote>
+      <breakpoints />
+      <interface_config>
+        org.contikios.cooja.interfaces.Position
+        <x>154.92605604103275</x>
+        <y>40.97896551774433</y>
+        <z>0.0</z>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspClock
+        <deviation>1.0</deviation>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspMoteID
+        <id>4</id>
+      </interface_config>
+      <motetype_identifier>sky2</motetype_identifier>
+    </mote>
+    <mote>
+      <breakpoints />
+      <interface_config>
+        org.contikios.cooja.interfaces.Position
+        <x>47.34887596588397</x>
+        <y>-30.341495695501195</y>
+        <z>0.0</z>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspClock
+        <deviation>1.0</deviation>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspMoteID
+        <id>5</id>
+      </interface_config>
+      <motetype_identifier>sky2</motetype_identifier>
+    </mote>
+    <mote>
+      <breakpoints />
+      <interface_config>
+        org.contikios.cooja.interfaces.Position
+        <x>47.13486576528276</x>
+        <y>32.944481932122315</y>
+        <z>0.0</z>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspClock
+        <deviation>1.0</deviation>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspMoteID
+        <id>6</id>
+      </interface_config>
+      <motetype_identifier>sky2</motetype_identifier>
+    </mote>
+    <mote>
+      <breakpoints />
+      <interface_config>
+        org.contikios.cooja.interfaces.Position
+        <x>-11.42091423859419</x>
+        <y>17.879870626121914</y>
+        <z>0.0</z>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspClock
+        <deviation>1.0</deviation>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspMoteID
+        <id>7</id>
+      </interface_config>
+      <motetype_identifier>sky2</motetype_identifier>
+    </mote>
+    <mote>
+      <breakpoints />
+      <interface_config>
+        org.contikios.cooja.interfaces.Position
+        <x>118.92746659954325</x>
+        <y>57.05973076244069</y>
+        <z>0.0</z>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspClock
+        <deviation>1.0</deviation>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspMoteID
+        <id>8</id>
+      </interface_config>
+      <motetype_identifier>sky2</motetype_identifier>
+    </mote>
+    <mote>
+      <breakpoints />
+      <interface_config>
+        org.contikios.cooja.interfaces.Position
+        <x>56.66768196114595</x>
+        <y>74.35652008990945</y>
+        <z>0.0</z>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspClock
+        <deviation>1.0</deviation>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspMoteID
+        <id>9</id>
+      </interface_config>
+      <motetype_identifier>sky2</motetype_identifier>
+    </mote>
+    <mote>
+      <breakpoints />
+      <interface_config>
+        org.contikios.cooja.interfaces.Position
+        <x>16.45706316609417</x>
+        <y>23.9075414163248</y>
+        <z>0.0</z>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspClock
+        <deviation>1.0</deviation>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspMoteID
+        <id>10</id>
+      </interface_config>
+      <motetype_identifier>sky2</motetype_identifier>
+    </mote>
+    <mote>
+      <breakpoints />
+      <interface_config>
+        org.contikios.cooja.interfaces.Position
+        <x>-13.423161364506493</x>
+        <y>-38.483037144768275</y>
+        <z>0.0</z>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspClock
+        <deviation>1.0</deviation>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspMoteID
+        <id>11</id>
+      </interface_config>
+      <motetype_identifier>sky2</motetype_identifier>
+    </mote>
+    <mote>
+      <breakpoints />
+      <interface_config>
+        org.contikios.cooja.interfaces.Position
+        <x>-9.034961217472201</x>
+        <y>44.411389162165406</y>
+        <z>0.0</z>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspClock
+        <deviation>1.0</deviation>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspMoteID
+        <id>12</id>
+      </interface_config>
+      <motetype_identifier>sky2</motetype_identifier>
+    </mote>
+    <mote>
+      <breakpoints />
+      <interface_config>
+        org.contikios.cooja.interfaces.Position
+        <x>35.60049910164592</x>
+        <y>87.95154356223047</y>
+        <z>0.0</z>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspClock
+        <deviation>1.0</deviation>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspMoteID
+        <id>13</id>
+      </interface_config>
+      <motetype_identifier>sky2</motetype_identifier>
+    </mote>
+    <mote>
+      <breakpoints />
+      <interface_config>
+        org.contikios.cooja.interfaces.Position
+        <x>66.93880603404335</x>
+        <y>-42.39683727590697</y>
+        <z>0.0</z>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspClock
+        <deviation>1.0</deviation>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspMoteID
+        <id>14</id>
+      </interface_config>
+      <motetype_identifier>sky2</motetype_identifier>
+    </mote>
+    <mote>
+      <breakpoints />
+      <interface_config>
+        org.contikios.cooja.interfaces.Position
+        <x>94.81678343873172</x>
+        <y>26.921376811426246</y>
+        <z>0.0</z>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspClock
+        <deviation>1.0</deviation>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspMoteID
+        <id>15</id>
+      </interface_config>
+      <motetype_identifier>sky2</motetype_identifier>
+    </mote>
+    <mote>
+      <breakpoints />
+      <interface_config>
+        org.contikios.cooja.interfaces.Position
+        <x>-49.449656689283934</x>
+        <y>57.924813144367945</y>
+        <z>0.0</z>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspClock
+        <deviation>1.0</deviation>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspMoteID
+        <id>16</id>
+      </interface_config>
+      <motetype_identifier>sky2</motetype_identifier>
+    </mote>
+    <mote>
+      <breakpoints />
+      <interface_config>
+        org.contikios.cooja.interfaces.Position
+        <x>-34.02467970185502</x>
+        <y>-24.313824905298304</y>
+        <z>0.0</z>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspClock
+        <deviation>1.0</deviation>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspMoteID
+        <id>17</id>
+      </interface_config>
+      <motetype_identifier>sky2</motetype_identifier>
+    </mote>
+    <mote>
+      <breakpoints />
+      <interface_config>
+        org.contikios.cooja.interfaces.Position
+        <x>-28.750467760427494</x>
+        <y>48.01822457713635</y>
+        <z>0.0</z>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspClock
+        <deviation>1.0</deviation>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspMoteID
+        <id>18</id>
+      </interface_config>
+      <motetype_identifier>sky2</motetype_identifier>
+    </mote>
+    <mote>
+      <breakpoints />
+      <interface_config>
+        org.contikios.cooja.interfaces.Position
+        <x>124.95513738974614</x>
+        <y>20.140247172447996</y>
+        <z>0.0</z>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspClock
+        <deviation>1.0</deviation>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspMoteID
+        <id>19</id>
+      </interface_config>
+      <motetype_identifier>sky2</motetype_identifier>
+    </mote>
+    <mote>
+      <breakpoints />
+      <interface_config>
+        org.contikios.cooja.interfaces.Position
+        <x>14.85247487703553</x>
+        <y>-34.478542892943686</y>
+        <z>0.0</z>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspClock
+        <deviation>1.0</deviation>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspMoteID
+        <id>20</id>
+      </interface_config>
+      <motetype_identifier>sky2</motetype_identifier>
+    </mote>
+    <mote>
+      <breakpoints />
+      <interface_config>
+        org.contikios.cooja.interfaces.Position
+        <x>154.43072661267115</x>
+        <y>-3.279765376986134</y>
+        <z>0.0</z>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspClock
+        <deviation>1.0</deviation>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspMoteID
+        <id>21</id>
+      </interface_config>
+      <motetype_identifier>sky2</motetype_identifier>
+    </mote>
+    <mote>
+      <breakpoints />
+      <interface_config>
+        org.contikios.cooja.interfaces.Position
+        <x>99.90960713878738</x>
+        <y>-21.76043658444847</y>
+        <z>0.0</z>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspClock
+        <deviation>1.0</deviation>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspMoteID
+        <id>22</id>
+      </interface_config>
+      <motetype_identifier>sky2</motetype_identifier>
+    </mote>
+    <mote>
+      <breakpoints />
+      <interface_config>
+        org.contikios.cooja.interfaces.Position
+        <x>88.4612185198951</x>
+        <y>-49.763990463932714</y>
+        <z>0.0</z>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspClock
+        <deviation>1.0</deviation>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspMoteID
+        <id>23</id>
+      </interface_config>
+      <motetype_identifier>sky2</motetype_identifier>
+    </mote>
+    <mote>
+      <breakpoints />
+      <interface_config>
+        org.contikios.cooja.interfaces.Position
+        <x>24.745110502623138</x>
+        <y>-1.7100594420374744</y>
+        <z>0.0</z>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspClock
+        <deviation>1.0</deviation>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspMoteID
+        <id>24</id>
+      </interface_config>
+      <motetype_identifier>sky2</motetype_identifier>
+    </mote>
+    <mote>
+      <breakpoints />
+      <interface_config>
+        org.contikios.cooja.interfaces.Position
+        <x>94.06332458995635</x>
+        <y>-2.4635182908128352</y>
+        <z>0.0</z>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspClock
+        <deviation>1.0</deviation>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspMoteID
+        <id>25</id>
+      </interface_config>
+      <motetype_identifier>sky2</motetype_identifier>
+    </mote>
+    <mote>
+      <breakpoints />
+      <interface_config>
+        org.contikios.cooja.interfaces.Position
+        <x>-4.639784599615941</x>
+        <y>-10.849236218849724</y>
+        <z>0.0</z>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspClock
+        <deviation>1.0</deviation>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspMoteID
+        <id>26</id>
+      </interface_config>
+      <motetype_identifier>sky2</motetype_identifier>
+    </mote>
+    <mote>
+      <breakpoints />
+      <interface_config>
+        org.contikios.cooja.interfaces.Position
+        <x>2.4901685804620115</x>
+        <y>-60.89843789583528</y>
+        <z>0.0</z>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspClock
+        <deviation>1.0</deviation>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspMoteID
+        <id>27</id>
+      </interface_config>
+      <motetype_identifier>sky2</motetype_identifier>
+    </mote>
+    <mote>
+      <breakpoints />
+      <interface_config>
+        org.contikios.cooja.interfaces.Position
+        <x>100.55144245441083</x>
+        <y>97.41861446767646</y>
+        <z>0.0</z>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspClock
+        <deviation>1.0</deviation>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspMoteID
+        <id>28</id>
+      </interface_config>
+      <motetype_identifier>sky2</motetype_identifier>
+    </mote>
+    <mote>
+      <breakpoints />
+      <interface_config>
+        org.contikios.cooja.interfaces.Position
+        <x>-12.355761328741393</x>
+        <y>82.72616691655692</y>
+        <z>0.0</z>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspClock
+        <deviation>1.0</deviation>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspMoteID
+        <id>29</id>
+      </interface_config>
+      <motetype_identifier>sky2</motetype_identifier>
+    </mote>
+    <mote>
+      <breakpoints />
+      <interface_config>
+        org.contikios.cooja.interfaces.Position
+        <x>57.79962925723111</x>
+        <y>0.6828700499064966</y>
+        <z>0.0</z>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspClock
+        <deviation>1.0</deviation>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspMoteID
+        <id>30</id>
+      </interface_config>
+      <motetype_identifier>sky2</motetype_identifier>
+    </mote>
+    <mote>
+      <breakpoints />
+      <interface_config>
+        org.contikios.cooja.interfaces.Position
+        <x>76.5550413097159</x>
+        <y>77.33875258624342</y>
+        <z>0.0</z>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspClock
+        <deviation>1.0</deviation>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspMoteID
+        <id>31</id>
+      </interface_config>
+      <motetype_identifier>sky2</motetype_identifier>
+    </mote>
+  </simulation>
+  <plugin>
+    org.contikios.cooja.plugins.SimControl
+    <width>289</width>
+    <z>4</z>
+    <height>184</height>
+    <location_x>31</location_x>
+    <location_y>41</location_y>
+  </plugin>
+  <plugin>
+    org.contikios.cooja.plugins.Visualizer
+    <plugin_config>
+      <moterelations>true</moterelations>
+      <skin>org.contikios.cooja.plugins.skins.IDVisualizerSkin</skin>
+      <skin>org.contikios.cooja.plugins.skins.UDGMVisualizerSkin</skin>
+      <skin>org.contikios.cooja.plugins.skins.AttributeVisualizerSkin</skin>
+      <viewport>2.349818846983307 0.0 0.0 2.349818846983307 187.19773526533345 190.95275613586946</viewport>
+    </plugin_config>
+    <width>659</width>
+    <z>2</z>
+    <height>622</height>
+    <location_x>296</location_x>
+    <location_y>11</location_y>
+  </plugin>
+  <plugin>
+    org.contikios.cooja.plugins.LogListener
+    <plugin_config>
+      <filter>ID:22.*DAO</filter>
+      <formatted_time />
+      <coloring />
+    </plugin_config>
+    <width>937</width>
+    <z>3</z>
+    <height>442</height>
+    <location_x>20</location_x>
+    <location_y>297</location_y>
+  </plugin>
+  <plugin>
+    org.contikios.cooja.plugins.ScriptRunner
+    <plugin_config>
+      <script>TIMEOUT(12000000, log.log("Total PRR " + totalPRR + "\n"));
+packetsReceived= new Array();
+packetsSent = new Array();
+serverID = 1;
+nodeCount = 31;
+totalPRR = 0;
+
+for(i = 0; i &lt;= nodeCount; i++) {
+	packetsReceived[i] = 0;
+	packetsSent[i] = 0;
+}
+
+while(1) {
+	YIELD();
+
+	msgArray = msg.split(' ');
+	if(msgArray[0].equals("#A")) {
+		if(msgArray[1].charAt(0) == 'r') {
+			// Received packet
+			senderID = id;
+            arr2 = msgArray[1].split(',')[0].slice(2).split('/');
+            recv = parseInt(arr2[0]);
+            sent = parseInt(arr2[1]);
+            log.log("Sent:" + sent + " Recv:" + recv + "\n");
+            packetsSent[senderID] = sent;
+			packetsReceived[senderID] = recv;
+
+			log.log("SenderID " + senderID + " PRR " + packetsReceived[senderID] / packetsSent[senderID] + "\n");
+			totalReceived = totalSent = 0;
+			for(i = serverID + 1; i &lt;= nodeCount; i++) {
+				totalReceived += packetsReceived[i];
+				totalSent += packetsSent[i];
+			}
+			totalPRR = totalReceived / totalSent;
+			log.log("Total PRR " + totalPRR + " recv " + totalReceived + " sent " + totalSent + "\n");
+		}
+	}
+}</script>
+      <active>true</active>
+    </plugin_config>
+    <width>600</width>
+    <z>5</z>
+    <height>700</height>
+    <location_x>946</location_x>
+    <location_y>6</location_y>
+  </plugin>
+  <plugin>
+    org.contikios.cooja.plugins.MoteInterfaceViewer
+    <mote_arg>3</mote_arg>
+    <plugin_config>
+      <interface>Position</interface>
+      <scrollpos>0,0</scrollpos>
+    </plugin_config>
+    <width>350</width>
+    <z>6</z>
+    <height>300</height>
+    <location_x>976</location_x>
+    <location_y>36</location_y>
+  </plugin>
+</simconf>
+

--- a/examples/ipv6/rpl-udp/rpl-udp-scale.csc
+++ b/examples/ipv6/rpl-udp/rpl-udp-scale.csc
@@ -7,7 +7,7 @@
   <project EXPORT="discard">[APPS_DIR]/collect-view</project>
   <project EXPORT="discard">[APPS_DIR]/powertracker</project>
   <simulation>
-    <title>Data collection network using IPv6 and RPL</title>
+    <title>RPL up and downstream scaleability test network using IPv6 and RPL</title>
     <randomseed>generated</randomseed>
     <motedelay_us>5000000</motedelay_us>
     <radiomedium>
@@ -25,7 +25,7 @@
       <identifier>sky1</identifier>
       <description>Sky Mote Type #sky1</description>
       <source EXPORT="discard">[CONTIKI_DIR]/examples/ipv6/rpl-udp/udp-server.c</source>
-      <commands EXPORT="discard">make clean udp-server.sky TARGET=sky DEFINES=TEST_MORE_ROUTES=1</commands>
+      <commands EXPORT="discard">make SERVER_REPLY=1 clean udp-server.sky TARGET=sky DEFINES=TEST_MORE_ROUTES=1</commands>
       <firmware EXPORT="copy">[CONTIKI_DIR]/examples/ipv6/rpl-udp/udp-server.sky</firmware>
       <moteinterface>org.contikios.cooja.interfaces.Position</moteinterface>
       <moteinterface>org.contikios.cooja.interfaces.RimeAddress</moteinterface>
@@ -48,7 +48,7 @@
       <identifier>sky2</identifier>
       <description>Sky Mote Type #sky2</description>
       <source EXPORT="discard">[CONTIKI_DIR]/examples/ipv6/rpl-udp/udp-client.c</source>
-      <commands EXPORT="discard">make clean udp-client.sky TARGET=sky</commands>
+      <commands EXPORT="discard">make SERVER_REPLY=1 clean udp-client.sky TARGET=sky</commands>
       <firmware EXPORT="copy">[CONTIKI_DIR]/examples/ipv6/rpl-udp/udp-client.sky</firmware>
       <moteinterface>org.contikios.cooja.interfaces.Position</moteinterface>
       <moteinterface>org.contikios.cooja.interfaces.RimeAddress</moteinterface>
@@ -88,8 +88,8 @@
       <breakpoints />
       <interface_config>
         org.contikios.cooja.interfaces.Position
-        <x>4.049356309774755</x>
-        <y>98.28771308774003</y>
+        <x>-39.78380986481406</x>
+        <y>-48.10655064098382</y>
         <z>0.0</z>
       </interface_config>
       <interface_config>
@@ -124,8 +124,8 @@
       <breakpoints />
       <interface_config>
         org.contikios.cooja.interfaces.Position
-        <x>57.897299848739024</x>
-        <y>92.47229665488265</y>
+        <x>154.92605604103275</x>
+        <y>40.97896551774433</y>
         <z>0.0</z>
       </interface_config>
       <interface_config>
@@ -135,6 +135,10 @@
       <interface_config>
         org.contikios.cooja.mspmote.interfaces.MspMoteID
         <id>4</id>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.mspmote.interfaces.MspSerial
+        <history>r~;</history>
       </interface_config>
       <motetype_identifier>sky2</motetype_identifier>
     </mote>
@@ -250,8 +254,8 @@
       <breakpoints />
       <interface_config>
         org.contikios.cooja.interfaces.Position
-        <x>-18.9555027263478</x>
-        <y>75.14274313304935</y>
+        <x>-13.423161364506493</x>
+        <y>-38.483037144768275</y>
         <z>0.0</z>
       </interface_config>
       <interface_config>
@@ -268,8 +272,8 @@
       <breakpoints />
       <interface_config>
         org.contikios.cooja.interfaces.Position
-        <x>29.265863595275306</x>
-        <y>85.6911670159044</y>
+        <x>-9.034961217472201</x>
+        <y>44.411389162165406</y>
         <z>0.0</z>
       </interface_config>
       <interface_config>
@@ -430,8 +434,8 @@
       <breakpoints />
       <interface_config>
         org.contikios.cooja.interfaces.Position
-        <x>-40.05235049205791</x>
-        <y>92.47229665488265</y>
+        <x>154.43072661267115</x>
+        <y>-3.279765376986134</y>
         <z>0.0</z>
       </interface_config>
       <interface_config>
@@ -466,8 +470,8 @@
       <breakpoints />
       <interface_config>
         org.contikios.cooja.interfaces.Position
-        <x>88.03565379975346</x>
-        <y>-44.657213822233054</y>
+        <x>88.4612185198951</x>
+        <y>-49.763990463932714</y>
         <z>0.0</z>
       </interface_config>
       <interface_config>
@@ -538,8 +542,8 @@
       <breakpoints />
       <interface_config>
         org.contikios.cooja.interfaces.Position
-        <x>-13.681290784920272</x>
-        <y>-50.684884612435944</y>
+        <x>2.4901685804620115</x>
+        <y>-60.89843789583528</y>
         <z>0.0</z>
       </interface_config>
       <interface_config>
@@ -627,11 +631,11 @@
   </simulation>
   <plugin>
     org.contikios.cooja.plugins.SimControl
-    <width>259</width>
-    <z>3</z>
+    <width>289</width>
+    <z>1</z>
     <height>184</height>
-    <location_x>3</location_x>
-    <location_y>15</location_y>
+    <location_x>31</location_x>
+    <location_y>41</location_y>
   </plugin>
   <plugin>
     org.contikios.cooja.plugins.Visualizer
@@ -639,13 +643,13 @@
       <skin>org.contikios.cooja.plugins.skins.IDVisualizerSkin</skin>
       <skin>org.contikios.cooja.plugins.skins.UDGMVisualizerSkin</skin>
       <skin>org.contikios.cooja.plugins.skins.AttributeVisualizerSkin</skin>
-      <viewport>2.349818846983307 0.0 0.0 2.349818846983307 150.19773526533348 176.95275613586946</viewport>
+      <viewport>2.349818846983307 0.0 0.0 2.349818846983307 187.19773526533345 190.95275613586946</viewport>
     </plugin_config>
-    <width>520</width>
-    <z>2</z>
+    <width>659</width>
+    <z>3</z>
     <height>523</height>
-    <location_x>14</location_x>
-    <location_y>210</location_y>
+    <location_x>296</location_x>
+    <location_y>11</location_y>
   </plugin>
   <plugin>
     org.contikios.cooja.plugins.LogListener
@@ -655,10 +659,10 @@
       <coloring />
     </plugin_config>
     <width>937</width>
-    <z>0</z>
-    <height>213</height>
-    <location_x>265</location_x>
-    <location_y>16</location_y>
+    <z>4</z>
+    <height>349</height>
+    <location_x>21</location_x>
+    <location_y>464</location_y>
   </plugin>
   <plugin>
     org.contikios.cooja.plugins.ScriptRunner
@@ -679,11 +683,16 @@ while(1) {
 	YIELD();
 
 	msgArray = msg.split(' ');
-	if(msgArray[0].equals("DATA")) {
-		if(msgArray.length == 9) {
+	if(msgArray[0].equals("#A")) {
+		if(msgArray[1].charAt(0) == 'r') {
 			// Received packet
-			senderID = parseInt(msgArray[8]);
-			packetsReceived[senderID]++;
+			senderID = id;
+            arr2 = msgArray[1].split(',')[0].slice(2).split('/');
+            recv = parseInt(arr2[0]);
+            sent = parseInt(arr2[1]);
+            log.log("Sent:" + sent + " Recv:" + recv + "\n");
+            packetsSent[senderID] = sent;
+			packetsReceived[senderID] = recv;
 
 			log.log("SenderID " + senderID + " PRR " + packetsReceived[senderID] / packetsSent[senderID] + "\n");
 			totalReceived = totalSent = 0;
@@ -693,19 +702,28 @@ while(1) {
 			}
 			totalPRR = totalReceived / totalSent;
 			log.log("Total PRR " + totalPRR + " recv " + totalReceived + " sent " + totalSent + "\n");
-		} else if(msgArray.length == 6) {
-			// Sent packet
-			packetsSent[id]++;
 		}
 	}
 }</script>
       <active>true</active>
     </plugin_config>
-    <width>651</width>
-    <z>1</z>
-    <height>550</height>
-    <location_x>547</location_x>
-    <location_y>181</location_y>
+    <width>600</width>
+    <z>0</z>
+    <height>700</height>
+    <location_x>946</location_x>
+    <location_y>6</location_y>
+  </plugin>
+  <plugin>
+    org.contikios.cooja.plugins.MoteInterfaceViewer
+    <mote_arg>3</mote_arg>
+    <plugin_config>
+      <interface>Serial port</interface>
+      <scrollpos>0,0</scrollpos>
+    </plugin_config>
+    <width>350</width>
+    <z>2</z>
+    <height>300</height>
+    <location_x>976</location_x>
+    <location_y>36</location_y>
   </plugin>
 </simconf>
-

--- a/examples/ipv6/rpl-udp/udp-server.c
+++ b/examples/ipv6/rpl-udp/udp-server.c
@@ -107,7 +107,8 @@ PROCESS_THREAD(udp_server_process, ev, data)
 
   SENSORS_ACTIVATE(button_sensor);
 
-  PRINTF("UDP server started\n");
+  PRINTF("UDP server started. nbr:%d routes:%d\n",
+         NBR_TABLE_CONF_MAX_NEIGHBORS, UIP_CONF_MAX_ROUTES);
 
 #if UIP_CONF_ROUTER
 /* The choice of server address determines its 6LoPAN header compression.

--- a/platform/cc2530dk/viztool.c
+++ b/platform/cc2530dk/viztool.c
@@ -127,8 +127,8 @@ process_request() CC_NON_BANKED
       if(rt != NULL) {
         entry_size = sizeof(i) + sizeof(rt->ipaddr)
           + sizeof(rt->length)
-          + sizeof(rt->state.lifetime)
-          + sizeof(rt->state.learned_from);
+          + sizeof(rt->state.lifetime);
+          /* + sizeof(rt->state.learned_from); */
 
         memcpy(buf + len, &i, sizeof(i));
         len += sizeof(i);
@@ -147,11 +147,11 @@ process_request() CC_NON_BANKED
         len += sizeof(flip);
         PRINTF(" - %08lx", rt->state.lifetime);
 
-        memcpy(buf + len, &rt->state.learned_from,
-               sizeof(rt->state.learned_from));
-        len += sizeof(rt->state.learned_from);
+        /* memcpy(buf + len, &rt->state.learned_from, */
+        /*        sizeof(rt->state.learned_from)); */
+        /* len += sizeof(rt->state.learned_from); */
 
-        PRINTF(" - %02x [%u]\n", rt->state.learned_from, entry_size);
+        PRINTF(" - [%u]\n", entry_size);
 
         count++;
         left -= entry_size;

--- a/platform/micaz/contiki-conf.h
+++ b/platform/micaz/contiki-conf.h
@@ -125,10 +125,11 @@
 #define UIP_CONF_ROUTER                 0
 
 /* configure number of neighbors and routes */
-#define NBR_TABLE_CONF_MAX_NEIGHBORS     5
-#define UIP_CONF_MAX_ROUTES   5
+#define NBR_TABLE_CONF_MAX_NEIGHBORS    5
+#define UIP_CONF_MAX_ROUTES             5
 
-#define RPL_CONF_MAX_PARENTS         4
+#define RPL_CONF_MAX_PARENTS            4
+#define RPL_CONF_MAX_DAG_PER_INSTANCE   1
 
 #define UIP_CONF_ND6_SEND_RA		0
 #define UIP_CONF_ND6_REACHABLE_TIME     600000
@@ -140,12 +141,12 @@
 #define UIP_CONF_IPV6_REASSEMBLY        0
 #define UIP_CONF_NETIF_MAX_ADDRESSES    3
 #define UIP_CONF_IP_FORWARD             0
-#define UIP_CONF_BUFFER_SIZE		    240
+#define UIP_CONF_BUFFER_SIZE            200
 
 #define SICSLOWPAN_CONF_COMPRESSION             SICSLOWPAN_COMPRESSION_HC06
 #ifndef SICSLOWPAN_CONF_FRAG
 #define SICSLOWPAN_CONF_FRAG                    1
-#define SICSLOWPAN_CONF_FRAGMENT_BUFFERS        4
+#define SICSLOWPAN_CONF_FRAGMENT_BUFFERS        3
 #define SICSLOWPAN_CONF_MAXAGE                  8
 #endif /* SICSLOWPAN_CONF_FRAG */
 #define SICSLOWPAN_CONF_MAX_ADDR_CONTEXTS       2

--- a/regression-tests/12-rpl/04-rpl-large-network.csc
+++ b/regression-tests/12-rpl/04-rpl-large-network.csc
@@ -1,4 +1,3 @@
-<<<<<<< 1d90b9290e293eedcb6451dd86c474ec168f688c
 <?xml version="1.0" encoding="UTF-8"?>
 <simconf>
   <project EXPORT="discard">[APPS_DIR]/mrm</project>

--- a/regression-tests/12-rpl/04-rpl-large-network.csc
+++ b/regression-tests/12-rpl/04-rpl-large-network.csc
@@ -1,3 +1,4 @@
+<<<<<<< 1d90b9290e293eedcb6451dd86c474ec168f688c
 <?xml version="1.0" encoding="UTF-8"?>
 <simconf>
   <project EXPORT="discard">[APPS_DIR]/mrm</project>
@@ -7058,4 +7059,3 @@ while(true) {&#xD;
     <location_y>43</location_y>
   </plugin>
 </simconf>
-

--- a/regression-tests/21-large-rpl/code/node/client.c
+++ b/regression-tests/21-large-rpl/code/node/client.c
@@ -100,7 +100,7 @@ PROCESS_THREAD(http_example_process, ev, data)
   while(1) {
     PROCESS_WAIT_EVENT_UNTIL(etimer_expired(&et));
     etimer_reset(&et);
-    if(connect && rpl_has_downward_link()) {
+    if(connect && rpl_has_downward_route()) {
       printf("#A color=green\n");
       http_socket_get(&s, "http://www.contiki-os.org/", 0, 0,
 		      callback, NULL);

--- a/regression-tests/21-large-rpl/code/node/client.c
+++ b/regression-tests/21-large-rpl/code/node/client.c
@@ -105,6 +105,13 @@ PROCESS_THREAD(http_example_process, ev, data)
       http_socket_get(&s, "http://www.contiki-os.org/", 0, 0,
 		      callback, NULL);
       connect = 0;
+    } else if(connect) {
+      connect++;
+      /* If connect have been "tried" 5 timer we quit trying now... */
+      if(connect > 5)  {
+	restart();
+	connect = 0;
+      }
     }
   }
 

--- a/regression-tests/21-large-rpl/code/node/client.c
+++ b/regression-tests/21-large-rpl/code/node/client.c
@@ -10,6 +10,7 @@ static struct http_socket s;
 static int bytes_received = 0;
 static int restarts;
 static struct ctimer reconnect_timer;
+static int connect = 0;
 
 static void callback(struct http_socket *s, void *ptr,
                      http_socket_event_t e,
@@ -22,9 +23,9 @@ AUTOSTART_PROCESSES(&http_example_process);
 static void
 reconnect(void *dummy)
 {
+  printf("#A color=orange\n");
   rpl_set_mode(RPL_MODE_MESH);
-  http_socket_get(&s, "http://www.contiki-os.org/", 0, 0,
-                  callback, NULL);
+  connect = 1;
 }
 /*---------------------------------------------------------------------------*/
 static void
@@ -33,6 +34,8 @@ restart(void)
   int scale;
   restarts++;
   printf("restart %d\n", restarts);
+  rpl_set_mode(RPL_MODE_FEATHER);
+  printf("#A color=red\n");
 
   scale = restarts;
   if(scale > 5) {
@@ -62,6 +65,7 @@ callback(struct http_socket *s, void *ptr,
     if(bytes_received > 0) {
       printf("HTTP socket closed, %d bytes received\n", bytes_received);
       leds_off(LEDS_RED);
+      printf("#A color=blue\n");
       rpl_set_mode(RPL_MODE_FEATHER);
     } else {
       restart();
@@ -72,6 +76,7 @@ callback(struct http_socket *s, void *ptr,
   }
 }
 /*---------------------------------------------------------------------------*/
+
 PROCESS_THREAD(http_example_process, ev, data)
 {
   static struct etimer et;
@@ -88,14 +93,19 @@ PROCESS_THREAD(http_example_process, ev, data)
   PROCESS_WAIT_EVENT_UNTIL(etimer_expired(&et));
 
   http_socket_init(&s);
-  http_socket_get(&s, "http://www.contiki-os.org/", 0, 0,
-                  callback, NULL);
+  connect = 1;
   leds_on(LEDS_RED);
   restarts = 0;
-  etimer_set(&et, CLOCK_SECOND);
+  etimer_set(&et, CLOCK_SECOND * 5);
   while(1) {
     PROCESS_WAIT_EVENT_UNTIL(etimer_expired(&et));
     etimer_reset(&et);
+    if(connect && rpl_has_downward_link()) {
+      printf("#A color=green\n");
+      http_socket_get(&s, "http://www.contiki-os.org/", 0, 0,
+		      callback, NULL);
+      connect = 0;
+    }
   }
 
   PROCESS_END();

--- a/regression-tests/21-large-rpl/code/router/project-conf.h
+++ b/regression-tests/21-large-rpl/code/router/project-conf.h
@@ -7,5 +7,5 @@
 #undef NBR_TABLE_CONF_MAX_NEIGHBORS
 #define NBR_TABLE_CONF_MAX_NEIGHBORS             8
 
-#define RPL_CONF_DEFAULT_LIFETIME_UNIT           60
-#define RPL_CONF_DEFAULT_LIFETIME                3
+/* #define RPL_CONF_DEFAULT_LIFETIME_UNIT           60 */
+/* #define RPL_CONF_DEFAULT_LIFETIME                10 */

--- a/regression-tests/21-large-rpl/code/router/project-conf.h
+++ b/regression-tests/21-large-rpl/code/router/project-conf.h
@@ -7,5 +7,5 @@
 #undef NBR_TABLE_CONF_MAX_NEIGHBORS
 #define NBR_TABLE_CONF_MAX_NEIGHBORS             8
 
-/*#define RPL_CONF_DEFAULT_LIFETIME_UNIT           10
-  #define RPL_CONF_DEFAULT_LIFETIME                10*/
+#define RPL_CONF_DEFAULT_LIFETIME_UNIT           60
+#define RPL_CONF_DEFAULT_LIFETIME                5

--- a/regression-tests/21-large-rpl/code/router/project-conf.h
+++ b/regression-tests/21-large-rpl/code/router/project-conf.h
@@ -8,4 +8,4 @@
 #define NBR_TABLE_CONF_MAX_NEIGHBORS             8
 
 #define RPL_CONF_DEFAULT_LIFETIME_UNIT           60
-#define RPL_CONF_DEFAULT_LIFETIME                5
+#define RPL_CONF_DEFAULT_LIFETIME                3

--- a/regression-tests/21-large-rpl/code/router/router.c
+++ b/regression-tests/21-large-rpl/code/router/router.c
@@ -3,13 +3,23 @@
 #include "ip64.h"
 #include "net/netstack.h"
 #include "net/rpl/rpl-dag-root.h"
-
+#include "net/rpl/rpl.h"
+#include "net/ipv6/uip-ds6-route.h"
+#include <stdio.h>
 /*---------------------------------------------------------------------------*/
 PROCESS(router_node_process, "Router node");
 AUTOSTART_PROCESSES(&router_node_process);
 /*---------------------------------------------------------------------------*/
+uip_lladdr_t * uip_ds6_route_nexthop_lladdr(uip_ds6_route_t *route);
+
+
 PROCESS_THREAD(router_node_process, ev, data)
 {
+  uip_ipaddr_t *nexthop = NULL;
+  uip_ds6_defrt_t *defrt;
+  uip_ipaddr_t *ipaddr;
+  uip_ds6_route_t *r;
+  static struct etimer et;
   PROCESS_BEGIN();
 
   /* Set us up as a RPL root node. */
@@ -18,9 +28,41 @@ PROCESS_THREAD(router_node_process, ev, data)
   /* Initialize the IP64 module so we'll start translating packets */
   ip64_init();
 
+  /* etimer_set(&et, CLOCK_SECOND * 60); */
+  /* PROCESS_WAIT_EVENT_UNTIL(etimer_expired(&et)); */
+
   /* ... and do nothing more. */
   while(1) {
-    PROCESS_WAIT_EVENT();
+    etimer_set(&et, CLOCK_SECOND * 20);
+    PROCESS_WAIT_EVENT_UNTIL(etimer_expired(&et));
+
+    defrt = NULL;
+    if((ipaddr = uip_ds6_defrt_choose()) != NULL) {
+      defrt = uip_ds6_defrt_lookup(ipaddr);
+    }
+    if(defrt != NULL) {
+      printf("DefRT: :: -> %02d", defrt->ipaddr.u8[15]);
+      printf(" lt:%lu inf:%d\n", stimer_remaining(&defrt->lifetime),
+    	     defrt->isinfinite);
+    } else {
+      printf("DefRT: :: -> NULL\n");
+    }
+
+    if(uip_ds6_route_head() != NULL) {
+      printf("found head\n");
+      for(r = uip_ds6_route_head();
+    	  r != NULL;
+    	  r = uip_ds6_route_next(r)) {
+    	nexthop = uip_ds6_route_nexthop(r);
+    	if(nexthop != NULL) {
+	  printf("Route: %02d -> %02d", r->ipaddr.u8[15], nexthop->u8[15]);
+    	} else {
+    	  //printf("Route: %p %02d -> ? nbr-routes:%p", r, r->ipaddr.u8[15],
+	  //r->neighbor_routes);
+    	}
+    	printf(" lt:%lu\n", r->state.lifetime);
+      }
+    }
   }
 
   PROCESS_END();


### PR DESCRIPTION
This PR adds full handling of end-to-end DAO and DAO ACK for
Contiki RPL and makes Contiki RPL significantly more stable and
scalable. The PR includes the changes needed to how neighbors and
routes are handled to enable DAO ACK and DAO NACK. The baseline
of this work have been tested in small and large networks and is
work done at Yanzi Networks.

- Full handling of DAO and DAO_ACK with end-to-end ACK all the
  way up to the RPL ROOT to ensure that the route is installed
  all the way (including retransmission of DAO when no ACK is
  received).
- Neighbor policy that decides when it is ok to add a new
  neighbor (to avoid throwing out neighbors that are useful).
- Configuration option on the routing module so that it is
  possible to select either remove least recently used route or
  only remove when route entry times out (needed for proper
  handling of DAO_ACK/NACK).
- Added automatical renewal of DAO routes from the registering node
  rather than forcing renewal at each broadcast DIO.
- Change the way DTSN is increased so that it is only increased
  when local repair occurs.
- Updated RPL configuration and other related configuration to
  make use of the new features (30 minutes routing lifetime for
  GC of routes over time).

The new default behavior of the Contiki RPL is to make use of
DAO_ACK/NACK for more stable and scalable networks.

There is also a few other needed changes for things to work like
making some erbium tests a bit smaller and increasing number of
routes in the RPL ROOT of the large network test for RPL.

The PR represents work done by the authors (Joakim, Niclas, Oriol)
but the design is a team effort - contributors include Lars and
Flag at Yanzi Networks.
