### PR TITLE
Fixed DHCP client.

### DIFF
--- a/core/net/ip/dhcpc.c
+++ b/core/net/ip/dhcpc.c
@@ -300,7 +300,6 @@ PT_THREAD(handle_dhcp(process_event_t ev, void *data))
   }
   
  selecting:
-  xid++;
   s.ticks = CLOCK_SECOND;
   do {
     while(ev != tcpip_event) {
@@ -366,7 +365,6 @@ PT_THREAD(handle_dhcp(process_event_t ev, void *data))
   }
 
   /* renewing: */
-  xid++;
   do {
     while(ev != tcpip_event) {
       tcpip_poll_udp(s.conn);

--- a/core/net/ip64/ip64-dhcpc.c
+++ b/core/net/ip64/ip64-dhcpc.c
@@ -308,7 +308,6 @@ PT_THREAD(handle_dhcp(process_event_t ev, void *data))
   }
   
  selecting:
-  xid++;
   s.ticks = CLOCK_SECOND;
   do {
     while(ev != tcpip_event) {
@@ -374,7 +373,6 @@ PT_THREAD(handle_dhcp(process_event_t ev, void *data))
   }
 
   /* renewing: */
-  xid++;
   do {
     while(ev != tcpip_event) {
       tcpip_poll_udp(s.conn);


### PR DESCRIPTION
RFC2131 states on page 36 regarding DHCPREQUEST: " 'xid' from server DHCPOFFER message "

As the DHCPOFFER message uses the 'xid' from the DHCPDISCOVER message this means that the DHCP client is supposed to re-use the 'xid' from its DHCPDISCOVER for the DHCPREQUEST.