### PR TITLE
Move locking of neighbors / children from RPL to uip-ds6-route module 

### DIFF
--- a/core/net/ipv6/uip-ds6-route.c
+++ b/core/net/ipv6/uip-ds6-route.c
@@ -367,6 +367,9 @@ uip_ds6_route_add(uip_ipaddr_t *ipaddr, uint8_t length,
     num_routes++;
 
     PRINTF("uip_ds6_route_add num %d\n", num_routes);
+
+    /* lock this entry so that nexthop is not removed */
+    nbr_table_lock(nbr_routes, routes);
   }
 
   uip_ipaddr_copy(&(r->ipaddr), ipaddr);
@@ -423,7 +426,7 @@ uip_ds6_route_rm(uip_ds6_route_t *route)
     list_remove(route->neighbor_routes->route_list, neighbor_route);
     if(list_head(route->neighbor_routes->route_list) == NULL) {
       /* If this was the only route using this neighbor, remove the
-         neibhor from the table */
+         neighbor from the table - this implicitly unlocks nexthop */
       PRINTF("uip_ds6_route_rm: removing neighbor too\n");
       nbr_table_remove(nbr_routes, route->neighbor_routes->route_list);
     }

--- a/core/net/rpl/rpl-dag.c
+++ b/core/net/rpl/rpl-dag.c
@@ -1408,10 +1408,4 @@ rpl_process_dio(uip_ipaddr_t *from, rpl_dio_t *dio)
   p->dtsn = dio->dtsn;
 }
 /*---------------------------------------------------------------------------*/
-void
-rpl_lock_parent(rpl_parent_t *p)
-{
-  nbr_table_lock(rpl_parents, p);
-}
-/*---------------------------------------------------------------------------*/
 /** @} */

--- a/core/net/rpl/rpl-icmp6.c
+++ b/core/net/rpl/rpl-icmp6.c
@@ -773,8 +773,6 @@ dao_input(void)
     PRINTF("RPL: Neighbor already in neighbor cache\n");
   }
 
-  rpl_lock_parent(parent);
-
   rep = rpl_add_route(dag, &prefix, prefixlen, &dao_sender_addr);
   if(rep == NULL) {
     RPL_STAT(rpl_stats.mem_overflows++);

--- a/core/net/rpl/rpl-private.h
+++ b/core/net/rpl/rpl-private.h
@@ -303,9 +303,6 @@ uip_ds6_route_t *rpl_add_route(rpl_dag_t *dag, uip_ipaddr_t *prefix,
                                int prefix_len, uip_ipaddr_t *next_hop);
 void rpl_purge_routes(void);
 
-/* Lock a parent in the neighbor cache. */
-void rpl_lock_parent(rpl_parent_t *p);
-
 /* Objective function. */
 rpl_of_t *rpl_find_of(rpl_ocp_t);
 


### PR DESCRIPTION
This PR is spawned by the discussions on the PR #1213 . The PR moves the locking when DAO is received from its location in RPL (e.g. locking an RPL parent) to the corresponding location in uip-ds6-route module. The RPL locks was never unlocked which causes risk of ending up with a lot of locked entries in the nbr-table. Moving it to the uip-ds6-route module makes it easier to get a consistent locking / unlocking behaviour as this module removes the nbr-table entry for any neighbor that is no longer a nexthop. The locking is now made for each entry that is used as nexthop.

I also added some debug printouts for the nbr-table module that are useful when debugging locking and unlocking.