### PR TITLE
Fixes compilation targeting c64

### DIFF
--- a/apps/webserver/httpd-cgi.c
+++ b/apps/webserver/httpd-cgi.c
@@ -155,10 +155,13 @@ make_tcp_stats(void *arg)
 {
   struct uip_conn *conn;
   struct httpd_state *s = (struct httpd_state *)arg;
+#if NETSTACK_CONF_WITH_IPV6
+  char buf[48];
+#endif
+
   conn = &uip_conns[s->u.count];
 
 #if NETSTACK_CONF_WITH_IPV6
-  char buf[48];
   httpd_sprint_ip6(conn->ripaddr, buf);
   return snprintf((char *)uip_appdata, uip_mss(),
          "<tr align=\"center\"><td>%d</td><td>%s:%u</td><td>%s</td><td>%u</td><td>%u</td><td>%c %c</td></tr>\r\n",

--- a/core/net/ipv6/uip-nd6.c
+++ b/core/net/ipv6/uip-nd6.c
@@ -662,7 +662,8 @@ rs_input(void)
         }
         if(memcmp(&nd6_opt_llao[UIP_ND6_OPT_DATA_OFFSET],
             lladdr, UIP_LLADDR_LEN) != 0) {
-          uip_ds6_nbr_t nbr_data = *nbr;
+          uip_ds6_nbr_t nbr_data;
+          nbr_data = *nbr;
           uip_ds6_nbr_rm(nbr);
           nbr = uip_ds6_nbr_add(&UIP_IP_BUF->srcipaddr, &lladdr_aligned,
                                 0, NBR_STALE, NBR_TABLE_REASON_IPV6_ND, NULL);

--- a/core/net/ipv6/uip6.c
+++ b/core/net/ipv6/uip6.c
@@ -73,6 +73,7 @@
 
 #include "sys/cc.h"
 #include "net/ip/uip.h"
+#include "net/ip/uip_arch.h"
 #include "net/ip/uipopt.h"
 #include "net/ipv6/uip-icmp6.h"
 #include "net/ipv6/uip-nd6.h"
@@ -1854,8 +1855,10 @@ uip_process(uint8_t flag)
       if((UIP_TCP_BUF->flags & TCP_SYN)) {
         if((uip_connr->tcpstateflags & UIP_TS_MASK) == UIP_SYN_RCVD) {
           goto tcp_send_synack;
+#if UIP_ACTIVE_OPEN
         } else if((uip_connr->tcpstateflags & UIP_TS_MASK) == UIP_SYN_SENT) {
           goto tcp_send_syn;
+#endif
         }
       }
       goto tcp_send_ack;

--- a/cpu/6502/net/ethernet-drv.c
+++ b/cpu/6502/net/ethernet-drv.c
@@ -34,17 +34,23 @@
 
 #include "contiki-net.h"
 #include "net/ethernet.h"
+#include "net/ip/tcpip.h"
 #include "net/ipv4/uip-neighbor.h"
 
 #include "net/ethernet-drv.h"
 
 #define BUF ((struct uip_eth_hdr *)&uip_buf[0])
+#define IPBUF ((struct uip_tcpip_hdr *)&uip_buf[UIP_LLH_LEN])
 
 PROCESS(ethernet_process, "Ethernet driver");
 
 /*---------------------------------------------------------------------------*/
 uint8_t
+#if NETSTACK_CONF_WITH_IPV6
+ethernet_output(const uip_lladdr_t *)
+#else
 ethernet_output(void)
+#endif
 {
   uip_arp_out();
   ethernet_send();
@@ -61,7 +67,7 @@ pollhandler(void)
   if(uip_len > 0) {
 #if NETSTACK_CONF_WITH_IPV6
     if(BUF->type == uip_htons(UIP_ETHTYPE_IPV6)) {
-      uip_neighbor_add(&IPBUF->srcipaddr, &BUF->src);
+      uip_neighbor_add(&IPBUF->srcipaddr, (struct uip_neighbor_addr *)&BUF->src);
       tcpip_input();
     } else
 #endif /* NETSTACK_CONF_WITH_IPV6 */

--- a/cpu/6502/net/ethernet-drv.h
+++ b/cpu/6502/net/ethernet-drv.h
@@ -42,6 +42,10 @@ struct ethernet_config {
 
 PROCESS_NAME(ethernet_process);
 
+#if NETSTACK_CONF_WITH_IPV6
+uint8_t ethernet_output(const uip_lladdr_t *);
+#else
 uint8_t ethernet_output(void);
+#endif
 
 #endif /* ETHERNET_DRV_H_ */


### PR DESCRIPTION
Adds some casts, splits declaration and non constant initialization and changes a few prototypes. The cc65 compiler wasn't happy with implicit casts.