### PR TITLE
Remove unused RPL_CONF_MAX_DAG_ENTRIES

### DIFF
--- a/platform/cc2530dk/contiki-conf.h
+++ b/platform/cc2530dk/contiki-conf.h
@@ -226,7 +226,7 @@
 #define UIP_CONF_ND6_SEND_RA                 0
 #define UIP_CONF_IP_FORWARD                  0
 #define RPL_CONF_STATS                       0
-#define RPL_CONF_MAX_DAG_ENTRIES             1
+
 #ifndef RPL_CONF_OF
 #define RPL_CONF_OF rpl_mrhof
 #endif

--- a/platform/cc2538dk/contiki-conf.h
+++ b/platform/cc2538dk/contiki-conf.h
@@ -448,7 +448,7 @@ typedef uint32_t rtimer_clock_t;
 #define UIP_CONF_ND6_SEND_RA                 0
 #define UIP_CONF_IP_FORWARD                  0
 #define RPL_CONF_STATS                       0
-#define RPL_CONF_MAX_DAG_ENTRIES             1
+
 #ifndef RPL_CONF_OF
 #define RPL_CONF_OF rpl_mrhof
 #endif

--- a/platform/remote/contiki-conf.h
+++ b/platform/remote/contiki-conf.h
@@ -452,7 +452,7 @@ typedef uint32_t rtimer_clock_t;
 #define UIP_CONF_ND6_SEND_RA                 0
 #define UIP_CONF_IP_FORWARD                  0
 #define RPL_CONF_STATS                       0
-#define RPL_CONF_MAX_DAG_ENTRIES             1
+
 #ifndef RPL_CONF_OF
 #define RPL_CONF_OF rpl_mrhof
 #endif

--- a/platform/sensinode/contiki-conf.h
+++ b/platform/sensinode/contiki-conf.h
@@ -222,7 +222,7 @@
 #define UIP_CONF_ND6_SEND_RA                 0
 #define UIP_CONF_IP_FORWARD                  0
 #define RPL_CONF_STATS                       0
-#define RPL_CONF_MAX_DAG_ENTRIES             1
+
 #ifndef RPL_CONF_OF
 #define RPL_CONF_OF rpl_mrhof
 #endif

--- a/platform/srf06-cc26xx/contiki-conf.h
+++ b/platform/srf06-cc26xx/contiki-conf.h
@@ -201,7 +201,7 @@
 #define UIP_CONF_ND6_SEND_RA                 0
 #define UIP_CONF_IP_FORWARD                  0
 #define RPL_CONF_STATS                       0
-#define RPL_CONF_MAX_DAG_ENTRIES             1
+
 #ifndef RPL_CONF_OF
 #define RPL_CONF_OF rpl_mrhof
 #endif


### PR DESCRIPTION
This pull request removes the unused `RPL_CONF_MAX_DAG_ENTRIES` of `contiki-conf.h` config file.  I couldn't find this definition anywhere else.