### PR TITLE
Minor fixes to Z1 and Wismote

### DIFF
--- a/platform/wismote/contiki-wismote-main.c
+++ b/platform/wismote/contiki-wismote-main.c
@@ -257,6 +257,7 @@ main(int argc, char **argv)
   init_platform();
 
   set_rime_addr();
+  random_init(linkaddr_node_addr.u8[6] + linkaddr_node_addr.u8[7]);
 
   cc2520_init();
   {

--- a/platform/z1/contiki-z1-main.c
+++ b/platform/z1/contiki-z1-main.c
@@ -268,6 +268,7 @@ main(int argc, char **argv)
   /*
    * Initialize Contiki and our processes.
    */
+  random_init(node_mac[6] + node_mac[7]);
   process_init();
   process_start(&etimer_process, NULL);
 

--- a/platform/z1/dev/cc2420-arch.c
+++ b/platform/z1/dev/cc2420-arch.c
@@ -34,13 +34,17 @@
 #include "cc2420.h"
 #include "isr_compat.h"
 
+#ifdef CC2420_CONF_SFD_TIMESTAMPS
+#define CONF_SFD_TIMESTAMPS CC2420_CONF_SFD_TIMESTAMPS
+#endif /* CC2420_CONF_SFD_TIMESTAMPS */
+
 #ifndef CONF_SFD_TIMESTAMPS
 #define CONF_SFD_TIMESTAMPS 0
 #endif /* CONF_SFD_TIMESTAMPS */
 
 #ifdef CONF_SFD_TIMESTAMPS
 #include "cc2420-arch-sfd.h"
-#endif
+#endif /* CONF_SFD_TIMESTAMPS */
 
 /*---------------------------------------------------------------------------*/
 #if 0
@@ -67,7 +71,7 @@ cc2420_arch_init(void)
 
 #if CONF_SFD_TIMESTAMPS
   cc2420_arch_sfd_init();
-#endif
+#endif /* CONF_SFD_TIMESTAMPS */
 
   CC2420_SPI_DISABLE();                /* Unselect radio. */
 }


### PR DESCRIPTION
This PR initializes the random seed on Z1 and Wismote, and fixes CC2420 SFD timestamp configuration on Z1 (to now use the flag `CC2420_CONF_SFD_TIMESTAMPS`, as other cc2420 platforms do).