### PR TITLE
Travis: compile er-rest-example for the Wismote platform rather than Sky

### DIFF
--- a/regression-tests/01-compile-base/Makefile
+++ b/regression-tests/01-compile-base/Makefile
@@ -13,7 +13,7 @@ hello-world/wismote \
 hello-world/z1 \
 eeprom-test/native \
 collect/sky \
-er-rest-example/sky \
+er-rest-example/wismote \
 example-shell/native \
 netperf/sky \
 powertrace/sky \


### PR DESCRIPTION
Because we don't want to restrain ourselves with 700 bytes of new features!