### PR TITLE
Replaced function pointer cast in contikimac

### DIFF
--- a/core/net/mac/contikimac/contikimac.c
+++ b/core/net/mac/contikimac/contikimac.c
@@ -269,6 +269,7 @@ off(void)
 }
 /*---------------------------------------------------------------------------*/
 static volatile rtimer_clock_t cycle_start;
+static void powercycle_wrapper(struct rtimer *t, void *ptr);
 static char powercycle(struct rtimer *t, void *ptr);
 static void
 schedule_powercycle(struct rtimer *t, rtimer_clock_t time)
@@ -281,8 +282,7 @@ schedule_powercycle(struct rtimer *t, rtimer_clock_t time)
       time = RTIMER_NOW() - RTIMER_TIME(t) + 2;
     }
 
-    r = rtimer_set(t, RTIMER_TIME(t) + time, 1,
-                   (void (*)(struct rtimer *, void *))powercycle, NULL);
+    r = rtimer_set(t, RTIMER_TIME(t) + time, 1, powercycle_wrapper, NULL);
     if(r != RTIMER_OK) {
       PRINTF("schedule_powercycle: could not set rtimer\n");
     }
@@ -300,8 +300,7 @@ schedule_powercycle_fixed(struct rtimer *t, rtimer_clock_t fixed_time)
       fixed_time = RTIMER_NOW() + 1;
     }
 
-    r = rtimer_set(t, fixed_time, 1,
-                   (void (*)(struct rtimer *, void *))powercycle, NULL);
+    r = rtimer_set(t, fixed_time, 1, powercycle_wrapper, NULL);
     if(r != RTIMER_OK) {
       PRINTF("schedule_powercycle: could not set rtimer\n");
     }
@@ -331,6 +330,12 @@ powercycle_turn_radio_on(void)
   if(we_are_sending == 0 && we_are_receiving_burst == 0) {
     on();
   }
+}
+/*---------------------------------------------------------------------------*/
+static void
+powercycle_wrapper(struct rtimer *t, void *ptr)
+{
+  powercycle(t, ptr);
 }
 /*---------------------------------------------------------------------------*/
 static char
@@ -989,8 +994,7 @@ init(void)
   radio_is_on = 0;
   PT_INIT(&pt);
 
-  rtimer_set(&rt, RTIMER_NOW() + CYCLE_TIME, 1,
-             (void (*)(struct rtimer *, void *))powercycle, NULL);
+  rtimer_set(&rt, RTIMER_NOW() + CYCLE_TIME, 1, powercycle_wrapper, NULL);
 
   contikimac_is_on = 1;
 
@@ -1006,8 +1010,7 @@ turn_on(void)
   if(contikimac_is_on == 0) {
     contikimac_is_on = 1;
     contikimac_keep_radio_on = 0;
-    rtimer_set(&rt, RTIMER_NOW() + CYCLE_TIME, 1,
-               (void (*)(struct rtimer *, void *))powercycle, NULL);
+    rtimer_set(&rt, RTIMER_NOW() + CYCLE_TIME, 1, powercycle_wrapper, NULL);
   }
   return 1;
 }


### PR DESCRIPTION
Replaced a cast of the function pointer to powercycle with a wrapper calling powercycle which has the correct signature.

The previous implementation was an instance of undefined behaviour according to the C standard.