### PR TITLE
Fix Wismote randon_init for link-layer addresses shorter than 8 bytes

### DIFF
--- a/platform/wismote/contiki-wismote-main.c
+++ b/platform/wismote/contiki-wismote-main.c
@@ -257,7 +257,7 @@ main(int argc, char **argv)
   init_platform();
 
   set_rime_addr();
-  random_init(linkaddr_node_addr.u8[6] + linkaddr_node_addr.u8[7]);
+  random_init(linkaddr_node_addr.u8[LINKADDR_SIZE-2] + linkaddr_node_addr.u8[LINKADDR_SIZE-1]);
 
   cc2520_init();
   {


### PR DESCRIPTION
https://github.com/contiki-os/contiki/pull/1226 was wrongly assuming link-layer addresses of 8 bytes in `random_init` for Wismote (not an issue with the z1 code, where `node_mac` always is 8 bytes long).