### PR TITLE
CC26xx - enable correct IRQ in rf_core_cmd_done_en

### DIFF
--- a/cpu/cc26xx-cc13xx/rf-core/ieee-mode.c
+++ b/cpu/cc26xx-cc13xx/rf-core/ieee-mode.c
@@ -805,7 +805,7 @@ transmit(unsigned short transmit_len)
   cmd.pPayload = &tx_buf[TX_BUF_HDR_LEN];
 
   /* Enable the LAST_FG_COMMAND_DONE interrupt, which will wake us up */
-  rf_core_cmd_done_en();
+  rf_core_cmd_done_en(true);
 
   ret = rf_core_send_cmd((uint32_t)&cmd, &cmd_status);
 

--- a/cpu/cc26xx-cc13xx/rf-core/prop-mode.c
+++ b/cpu/cc26xx-cc13xx/rf-core/prop-mode.c
@@ -687,7 +687,7 @@ transmit(unsigned short transmit_len)
   rx_off_prop();
 
   /* Enable the LAST_COMMAND_DONE interrupt to wake us up */
-  rf_core_cmd_done_en();
+  rf_core_cmd_done_en(false);
 
   ret = rf_core_send_cmd((uint32_t)cmd_tx_adv, &cmd_status);
 

--- a/cpu/cc26xx-cc13xx/rf-core/rf-core.c
+++ b/cpu/cc26xx-cc13xx/rf-core/rf-core.c
@@ -378,11 +378,12 @@ rf_core_setup_interrupts()
 }
 /*---------------------------------------------------------------------------*/
 void
-rf_core_cmd_done_en()
+rf_core_cmd_done_en(bool fg)
 {
+  uint32_t irq = fg ? IRQ_LAST_FG_COMMAND_DONE : IRQ_LAST_COMMAND_DONE;
+
   HWREG(RFC_DBELL_NONBUF_BASE + RFC_DBELL_O_RFCPEIFG) = ENABLED_IRQS;
-  HWREG(RFC_DBELL_NONBUF_BASE + RFC_DBELL_O_RFCPEIEN) = ENABLED_IRQS +
-    IRQ_LAST_COMMAND_DONE;
+  HWREG(RFC_DBELL_NONBUF_BASE + RFC_DBELL_O_RFCPEIEN) = ENABLED_IRQS | irq;
 }
 /*---------------------------------------------------------------------------*/
 void

--- a/cpu/cc26xx-cc13xx/rf-core/rf-core.h
+++ b/cpu/cc26xx-cc13xx/rf-core/rf-core.h
@@ -331,17 +331,19 @@ uint8_t rf_core_boot(void);
 void rf_core_setup_interrupts(void);
 
 /**
- * \brief Enable the LAST_CMD_DONE interrupt.
+ * \brief Enable interrupt on command done.
+ * \param fg set true to enable irq on foreground command done and false for
+ * background commands or if not in ieee mode.
  *
  * This is used within TX routines in order to be able to sleep the CM3 and
  * wake up after TX has finished
  *
  * \sa rf_core_cmd_done_dis()
  */
-void rf_core_cmd_done_en(void);
+void rf_core_cmd_done_en(bool fg);
 
 /**
- * \brief Disable the LAST_CMD_DONE interrupt.
+ * \brief Disable the LAST_CMD_DONE and LAST_FG_CMD_DONE interrupts.
  *
  * This is used within TX routines after TX has completed
  *


### PR DESCRIPTION
Fix for #1229

rf_core_cmd_done_en() was enabling the wrong irq for detecting the completion of foreground operations. This was causing cc26xx devices to not wake-up on time when calling lpm_sleep() from transmit().