### PR TITLE
CC26xx/CC13xx fixes

### DIFF
--- a/cpu/cc26xx-cc13xx/clock.c
+++ b/cpu/cc26xx-cc13xx/clock.c
@@ -120,31 +120,35 @@ clock_init(void)
         ((TIMER_CFG_B_ONE_SHOT >> 8) & 0xFF) | GPT_TBMR_TBPWMIE;
 }
 /*---------------------------------------------------------------------------*/
+static void
+update_clock_variable(void)
+{
+  uint32_t aon_rtc_secs_now;
+  uint32_t aon_rtc_secs_now2;
+  uint16_t aon_rtc_ticks_now;
+
+  do {
+    aon_rtc_secs_now = HWREG(AON_RTC_BASE + AON_RTC_O_SEC);
+    aon_rtc_ticks_now = HWREG(AON_RTC_BASE + AON_RTC_O_SUBSEC) >> 16;
+    aon_rtc_secs_now2 = HWREG(AON_RTC_BASE + AON_RTC_O_SEC);
+  } while(aon_rtc_secs_now != aon_rtc_secs_now2);
+
+  /* Convert AON RTC ticks to clock tick counter */
+  count = (aon_rtc_secs_now * CLOCK_SECOND) + (aon_rtc_ticks_now >> 9);
+}
+/*---------------------------------------------------------------------------*/
 CCIF clock_time_t
 clock_time(void)
 {
+  update_clock_variable();
+
   return (clock_time_t)(count & 0xFFFFFFFF);
 }
 /*---------------------------------------------------------------------------*/
 void
 clock_update(void)
 {
-  bool interrupts_disabled;
-  uint32_t aon_rtc_secs_now;
-  uint16_t aon_rtc_ticks_now;
-
-  interrupts_disabled = ti_lib_int_master_disable();
-
-  aon_rtc_secs_now = HWREG(AON_RTC_BASE + AON_RTC_O_SEC);
-  aon_rtc_ticks_now = HWREG(AON_RTC_BASE + AON_RTC_O_SUBSEC) >> 16;
-
-  /* Convert AON RTC ticks to clock tick counter */
-  count = (aon_rtc_secs_now * CLOCK_SECOND) + (aon_rtc_ticks_now >> 9);
-
-  /* Re-enable interrupts */
-  if(!interrupts_disabled) {
-    ti_lib_int_master_enable();
-  }
+  update_clock_variable();
 
   if(etimer_pending()) {
     etimer_request_poll();

--- a/cpu/cc26xx-cc13xx/dev/soc-rtc.c
+++ b/cpu/cc26xx-cc13xx/dev/soc-rtc.c
@@ -50,6 +50,8 @@
 /*---------------------------------------------------------------------------*/
 /* Prototype of a function in clock.c. Called every time the handler fires */
 void clock_update(void);
+
+static rtimer_clock_t last_isr_time;
 /*---------------------------------------------------------------------------*/
 #define COMPARE_INCREMENT (RTIMER_SECOND / CLOCK_SECOND)
 #define MULTIPLE_512_MASK 0xFFFFFE00
@@ -130,6 +132,12 @@ soc_rtc_schedule_one_shot(uint32_t channel, uint32_t ticks)
   ti_lib_aon_rtc_channel_enable(channel);
 }
 /*---------------------------------------------------------------------------*/
+rtimer_clock_t
+soc_rtc_last_isr_time(void)
+{
+  return last_isr_time;
+}
+/*---------------------------------------------------------------------------*/
 /* The AON RTC interrupt handler */
 void
 soc_rtc_isr(void)
@@ -137,6 +145,8 @@ soc_rtc_isr(void)
   uint32_t now, next;
 
   ENERGEST_ON(ENERGEST_TYPE_IRQ);
+
+  last_isr_time = RTIMER_NOW();
 
   now = ti_lib_aon_rtc_current_compare_value_get();
 

--- a/cpu/cc26xx-cc13xx/dev/soc-rtc.h
+++ b/cpu/cc26xx-cc13xx/dev/soc-rtc.h
@@ -92,6 +92,8 @@ rtimer_clock_t soc_rtc_get_next_trigger(void);
  * instead use Contiki's timer-related libraries
  */
 void soc_rtc_schedule_one_shot(uint32_t channel, uint32_t t);
+
+rtimer_clock_t soc_rtc_last_isr_time(void);
 /*---------------------------------------------------------------------------*/
 #endif /* SOC_RTC_H_ */
 /*---------------------------------------------------------------------------*/

--- a/cpu/cc26xx-cc13xx/lpm.c
+++ b/cpu/cc26xx-cc13xx/lpm.c
@@ -292,7 +292,7 @@ lpm_drop()
 
     if(next_event) {
       next_event = next_event - clock_time();
-      soc_rtc_schedule_one_shot(AON_RTC_CH1, RTIMER_NOW() +
+      soc_rtc_schedule_one_shot(AON_RTC_CH1, soc_rtc_last_isr_time() +
           (next_event * (RTIMER_SECOND / CLOCK_SECOND)));
     }
 

--- a/cpu/cc26xx-cc13xx/rf-core/ieee-mode.c
+++ b/cpu/cc26xx-cc13xx/rf-core/ieee-mode.c
@@ -1219,6 +1219,12 @@ set_value(radio_param_t param, radio_value_t value)
       return RADIO_RESULT_INVALID_VALUE;
     }
 
+    if(cmd->channel == (uint8_t)value) {
+      /* We already have that very same channel configured.
+       * Nothing to do here. */
+      return RADIO_RESULT_OK;
+    }
+
     cmd->channel = (uint8_t)value;
     break;
   case RADIO_PARAM_PAN_ID:

--- a/cpu/cc26xx-cc13xx/rf-core/ieee-mode.c
+++ b/cpu/cc26xx-cc13xx/rf-core/ieee-mode.c
@@ -853,6 +853,11 @@ transmit(unsigned short transmit_len)
    */
   rf_core_cmd_done_dis();
 
+
+  if(was_off) {
+    off();
+  }
+
   return ret;
 }
 /*---------------------------------------------------------------------------*/

--- a/cpu/cc26xx-cc13xx/rf-core/ieee-mode.c
+++ b/cpu/cc26xx-cc13xx/rf-core/ieee-mode.c
@@ -1108,6 +1108,8 @@ off(void)
 
   rf_core_power_down();
 
+  ENERGEST_OFF(ENERGEST_TYPE_LISTEN);
+
   /* Switch HF clock source to the RCOSC to preserve power */
   oscillators_switch_to_hf_rc();
 


### PR DESCRIPTION
This fixes a few bugs in the latest cc26xx/cc13xx code:

# Tickless clock

The tickless clock interrupt interrupt timing was not computed from the previous interrupt's trigger time, but from the current time (`RTIMER_NOW()`), which may have progressed significantly, causing the next timer to occur with a delay

Also, the `clock_time()` function should return an increasing time even if there hasn't been any clock interrupts. This patch recomputes the `count` variable inside the `clock_time()` call instead of on each interrupt.

# IEEE radio

A few minor fixes to the RF driver. We also have a workaround for the `lpm_sleep()` issue in #1231, which is not part of this pull request, but maybe that will be taken care of by #1231?