### PR TITLE
SICSLoWMAC does not handle RADIO_TX_COLLISION at all / Introduce radio_txresult_t to avoid bugs

### DIFF
--- a/core/dev/nullradio.c
+++ b/core/dev/nullradio.c
@@ -11,16 +11,16 @@ init(void)
 static int
 prepare(const void *payload, unsigned short payload_len)
 {
-  return 1;
+  return RADIO_RESULT_OK;
 }
 /*---------------------------------------------------------------------------*/
-static int
+static radio_txresult_t
 transmit(unsigned short transmit_len)
 {
   return RADIO_TX_OK;
 }
 /*---------------------------------------------------------------------------*/
-static int
+static radio_txresult_t
 send(const void *payload, unsigned short payload_len)
 {
   prepare(payload, payload_len);

--- a/core/dev/radio.h
+++ b/core/dev/radio.h
@@ -212,12 +212,12 @@ typedef enum {
 } radio_result_t;
 
 /* Radio return values for transmissions. */
-enum {
+typedef enum {
   RADIO_TX_OK,
   RADIO_TX_ERR,
   RADIO_TX_COLLISION,
   RADIO_TX_NOACK,
-};
+} radio_txresult_t;
 
 /**
  * The structure of a device driver for a radio in Contiki.
@@ -230,10 +230,10 @@ struct radio_driver {
   int (* prepare)(const void *payload, unsigned short payload_len);
 
   /** Send the packet that has previously been prepared. */
-  int (* transmit)(unsigned short transmit_len);
+  radio_txresult_t (* transmit)(unsigned short transmit_len);
 
   /** Prepare & transmit a packet. */
-  int (* send)(const void *payload, unsigned short payload_len);
+  radio_txresult_t (* send)(const void *payload, unsigned short payload_len);
 
   /** Read a received packet into a buffer. */
   int (* read)(void *buf, unsigned short buf_len);

--- a/core/net/mac/sicslowmac/sicslowmac.c
+++ b/core/net/mac/sicslowmac/sicslowmac.c
@@ -154,7 +154,7 @@ send_packet(mac_callback_t sent, void *ptr)
   params.payload_len = packetbuf_datalen();
   len = frame802154_hdrlen(&params);
   if(packetbuf_hdralloc(len)) {
-    int ret;
+	radio_txresult_t ret;
     frame802154_create(&params, packetbuf_hdrptr());
 
     PRINTF("6MAC-UT: %2X", params.fcf.frame_type);

--- a/cpu/arm/aducrf101/dev/radio.c
+++ b/cpu/arm/aducrf101/dev/radio.c
@@ -190,7 +190,7 @@ prepare(const void *payload, unsigned short payload_len)
 }
 /*---------------------------------------------------------------------------*/
 /** Send the packet that has previously been prepared. */
-static int
+static radio_txresult_t
 transmit(unsigned short transmit_len)
 {
   if(!radio_is_on)
@@ -213,7 +213,7 @@ transmit(unsigned short transmit_len)
 }
 /*---------------------------------------------------------------------------*/
 /** Prepare & transmit a packet. */
-static int
+static radio_txresult_t
 send(const void *payload, unsigned short payload_len)
 {
   prepare(payload, payload_len);

--- a/cpu/avr/radio/rf230bb/rf230bb.c
+++ b/cpu/avr/radio/rf230bb/rf230bb.c
@@ -243,8 +243,8 @@ static int rf230_off(void);
 static int rf230_read(void *buf, unsigned short bufsize);
 
 static int rf230_prepare(const void *data, unsigned short len);
-static int rf230_transmit(unsigned short len);
-static int rf230_send(const void *data, unsigned short len);
+static radio_txresult_t rf230_transmit(unsigned short len);
+static radio_txresult_t rf230_send(const void *data, unsigned short len);
 
 static int rf230_receiving_packet(void);
 static int rf230_pending_packet(void);
@@ -910,7 +910,7 @@ void rf230_warm_reset(void) {
 /*---------------------------------------------------------------------------*/
 static uint8_t buffer[RF230_MAX_TX_FRAME_LENGTH+AUX_LEN];
 
-static int
+static radio_txresult_t
 rf230_transmit(unsigned short payload_len)
 {
   int txpower;
@@ -1171,7 +1171,7 @@ bail:
   return ret;
 }
 /*---------------------------------------------------------------------------*/
-static int
+static radio_txresult_t
 rf230_send(const void *payload, unsigned short payload_len)
 {
 	int ret = 0;

--- a/cpu/cc2430/dev/cc2430_rf.c
+++ b/cpu/cc2430/dev/cc2430_rf.c
@@ -410,7 +410,7 @@ prepare(const void *payload, unsigned short payload_len)
   return 0;
 }
 /*---------------------------------------------------------------------------*/
-static int
+static radio_txresult_t
 transmit(unsigned short transmit_len)
 {
   uint8_t counter;
@@ -469,7 +469,7 @@ transmit(unsigned short transmit_len)
   return ret;
 }
 /*---------------------------------------------------------------------------*/
-static int
+static radio_txresult_t
 send(void *payload, unsigned short payload_len)
 {
   prepare(payload, payload_len);

--- a/cpu/cc253x/dev/cc2530-rf.c
+++ b/cpu/cc253x/dev/cc2530-rf.c
@@ -420,7 +420,7 @@ prepare(const void *payload, unsigned short payload_len)
   return 0;
 }
 /*---------------------------------------------------------------------------*/
-static int
+static radio_txresult_t
 transmit(unsigned short transmit_len)
 {
   uint8_t counter;
@@ -485,7 +485,7 @@ transmit(unsigned short transmit_len)
   return ret;
 }
 /*---------------------------------------------------------------------------*/
-static int
+static radio_txresult_t
 send(const void *payload, unsigned short payload_len)
 {
   prepare(payload, payload_len);

--- a/cpu/mc1322x/contiki-maca.c
+++ b/cpu/mc1322x/contiki-maca.c
@@ -73,8 +73,8 @@ int contiki_maca_on_request(void);
 int contiki_maca_off_request(void);
 int contiki_maca_read(void *buf, unsigned short bufsize);
 int contiki_maca_prepare(const void *payload, unsigned short payload_len);
-int contiki_maca_transmit(unsigned short transmit_len);
-int contiki_maca_send(const void *payload, unsigned short payload_len);
+radio_txresult_t contiki_maca_transmit(unsigned short transmit_len);
+radio_txresult_t contiki_maca_send(const void *payload, unsigned short payload_len);
 int contiki_maca_channel_clear(void);
 int contiki_maca_receiving_packet(void);
 int contiki_maca_pending_packet(void);
@@ -273,7 +273,7 @@ int contiki_maca_prepare(const void *payload, unsigned short payload_len) {
 /* gets a packet from the radio (if available), */
 /* copies the prepared packet prepped_p */
 /* and transmits it */
-int contiki_maca_transmit(unsigned short transmit_len) {
+radio_txresult_t contiki_maca_transmit(unsigned short transmit_len) {
 	volatile packet_t *p;
 
 	PRINTF("contiki maca transmit\n\r");
@@ -298,7 +298,7 @@ int contiki_maca_transmit(unsigned short transmit_len) {
 #endif
 }
 
-int contiki_maca_send(const void *payload, unsigned short payload_len) {
+radio_txresult_t contiki_maca_send(const void *payload, unsigned short payload_len) {
 	contiki_maca_prepare(payload, payload_len);
 	contiki_maca_transmit(payload_len);
 	switch(tx_status) {

--- a/dev/cc2420/cc2420.c
+++ b/dev/cc2420/cc2420.c
@@ -147,8 +147,8 @@ int cc2420_off(void);
 static int cc2420_read(void *buf, unsigned short bufsize);
 
 static int cc2420_prepare(const void *data, unsigned short len);
-static int cc2420_transmit(unsigned short len);
-static int cc2420_send(const void *data, unsigned short len);
+static radio_txresult_t cc2420_transmit(unsigned short len);
+static radio_txresult_t cc2420_send(const void *data, unsigned short len);
 
 static int cc2420_receiving_packet(void);
 static int pending_packet(void);
@@ -618,7 +618,7 @@ cc2420_init(void)
   return 1;
 }
 /*---------------------------------------------------------------------------*/
-static int
+radio_txresult_t
 cc2420_transmit(unsigned short payload_len)
 {
   int i, txpower;
@@ -743,7 +743,7 @@ cc2420_prepare(const void *payload, unsigned short payload_len)
   return 0;
 }
 /*---------------------------------------------------------------------------*/
-static int
+static radio_txresult_t
 cc2420_send(const void *payload, unsigned short payload_len)
 {
   cc2420_prepare(payload, payload_len);


### PR DESCRIPTION
NB: This is rather an issue with a path than an actual pull-request:
SICSLoWMAC does not handle RADIO_TX_COLLISION at all. By using enumerations instead of ints, bugs can be avoided, because the compiler shows a warning in some cases (here because a switch is used).

This DOES NOT fix the issue with SICSLoWMAC and it is not complete - I only fixed the radio drivers which are covered by the regression testing.
In some why this therefore also covers insufficient regression testing.