### PR TITLE
Use volatile access for CMD_IEEE_TX

### DIFF
--- a/cpu/cc26xx-cc13xx/rf-core/ieee-mode.c
+++ b/cpu/cc26xx-cc13xx/rf-core/ieee-mode.c
@@ -766,7 +766,7 @@ transmit(unsigned short transmit_len)
   uint16_t stat;
   uint8_t tx_active = 0;
   rtimer_clock_t t0;
-  rfc_CMD_IEEE_TX_t cmd;
+  volatile rfc_CMD_IEEE_TX_t cmd;
 
   if(!rf_is_on()) {
     was_off = 1;


### PR DESCRIPTION
As discussed very briefly in #1229, access to the data structure representing CMD_IEEE_TX should be volatile.