### PR TITLE
CoAP: Fix handling of Token Length greater than 8

### DIFF
--- a/apps/er-coap/er-coap.c
+++ b/apps/er-coap/er-coap.c
@@ -451,15 +451,18 @@ coap_parse_message(void *packet, uint8_t *data, uint16_t data_len)
     >> COAP_HEADER_VERSION_POSITION;
   coap_pkt->type = (COAP_HEADER_TYPE_MASK & coap_pkt->buffer[0])
     >> COAP_HEADER_TYPE_POSITION;
-  coap_pkt->token_len =
-    MIN(COAP_TOKEN_LEN,
-        (COAP_HEADER_TOKEN_LEN_MASK & coap_pkt->
-         buffer[0]) >> COAP_HEADER_TOKEN_LEN_POSITION);
+  coap_pkt->token_len = (COAP_HEADER_TOKEN_LEN_MASK & coap_pkt->buffer[0])
+    >> COAP_HEADER_TOKEN_LEN_POSITION;
   coap_pkt->code = coap_pkt->buffer[1];
   coap_pkt->mid = coap_pkt->buffer[2] << 8 | coap_pkt->buffer[3];
 
   if(coap_pkt->version != 1) {
     coap_error_message = "CoAP version must be 1";
+    return BAD_REQUEST_4_00;
+  }
+
+  if(coap_pkt->token_len > COAP_TOKEN_LEN) {
+    coap_error_message = "Token Length must not be more than 8";
     return BAD_REQUEST_4_00;
   }
 


### PR DESCRIPTION
According to the RFC, TKL greater than 8 MUST be processed as a message format error.