### PR TITLE
Minor fixes for the WisMote platform

### DIFF
--- a/platform/wismote/contiki-conf.h
+++ b/platform/wismote/contiki-conf.h
@@ -6,13 +6,11 @@
 #include "platform-conf.h"
 
 #ifndef NETSTACK_CONF_MAC
-/* #define NETSTACK_CONF_MAC     csma_driver */
-#define NETSTACK_CONF_MAC     nullmac_driver
+#define NETSTACK_CONF_MAC     csma_driver
 #endif /* NETSTACK_CONF_MAC */
 
 #ifndef NETSTACK_CONF_RDC
-/* #define NETSTACK_CONF_RDC     contikimac_driver */
-#define NETSTACK_CONF_RDC     nullrdc_driver
+#define NETSTACK_CONF_RDC     contikimac_driver
 #endif /* NETSTACK_CONF_RDC */
 
 #ifndef NETSTACK_CONF_RDC_CHANNEL_CHECK_RATE

--- a/platform/wismote/contiki-wismote-main.c
+++ b/platform/wismote/contiki-wismote-main.c
@@ -73,7 +73,7 @@ extern const struct uip_router UIP_ROUTER_MODULE;
 #if NETSTACK_CONF_WITH_IPV4
 #include "net/ip/uip.h"
 #include "net/ipv4/uip-fw.h"
-#include "net/uip-fw-drv.h"
+#include "net/ipv4/uip-fw-drv.h"
 #include "net/ipv4/uip-over-mesh.h"
 static struct uip_fw_netif slipif =
   {UIP_FW_NETIF(192,168,1,2, 255,255,255,255, slip_send)};


### PR DESCRIPTION
This PR changes the WisMote's default MAC and RDC layers to CSMA and ContikiMAC, respectively. Furthermore, it fixes a compilation error concerning an invalid header inclusion when the IPv4 stack is enabled.