### PR TITLE
z1: sht25: Don't disable i2c

### DIFF
--- a/platform/z1/dev/sht25.c
+++ b/platform/z1/dev/sht25.c
@@ -51,8 +51,6 @@ configure(int type, int value)
   }
   if(value) {
     i2c_enable();
-  } else {
-    i2c_disable();
   }
   enabled = value;
   return 0;


### PR DESCRIPTION
The sht25 driver disables i2c when `SENSORS_DEACTIVATE(sht25)` is used.
This is really annoying, as a bunch of other sensors rely on i2c, and if one is in the process of reading values from other sensors everything breaks.
(Also I can't seem to find any advantages of disabling i2c - it won't save power)
Other similar devices (such as the sht11) never disable i2c, they only enable it.