### PR TITLE
Cooja: Track CFS file size

### DIFF
--- a/platform/cooja/cfs/cfs-cooja.c
+++ b/platform/cooja/cfs/cfs-cooja.c
@@ -50,6 +50,7 @@ const struct simInterface cfs_interface;
 // COOJA variables
 #define CFS_BUF_SIZE 4000 /* Configure CFS size here and in ContikiCFS.java */
 char simCFSData[CFS_BUF_SIZE] = { 0 };
+int simCFSSize = 0;
 char simCFSChanged = 0;
 int simCFSRead = 0;
 int simCFSWritten = 0;
@@ -61,11 +62,15 @@ cfs_open(const char *n, int f)
   if(file.flag == FLAG_FILE_CLOSED) {
     file.flag = FLAG_FILE_OPEN;
     file.access = f;
-		if(f & CFS_APPEND) {
-			file.fileptr = file.endptr;
-		} else {
-	    file.fileptr = 0;
-		}
+    file.fileptr = 0;
+    file.endptr = simCFSSize;
+    if(f & CFS_WRITE) {
+      if(f & CFS_APPEND) {
+        file.fileptr = file.endptr;
+      } else {
+        file.endptr = 0;
+      }
+    }
     return 0;
   } else {
     return -1;
@@ -109,6 +114,9 @@ cfs_write(int f, const void *buf, unsigned int len)
 		simCFSWritten += len;
 		if(file.fileptr > file.endptr) {
 			file.endptr = file.fileptr;
+		}
+		if(file.fileptr > simCFSSize) {
+			simCFSSize = file.fileptr;
 		}
     return len;
   } else {

--- a/tools/cooja/java/org/contikios/cooja/contikimote/interfaces/ContikiCFS.java
+++ b/tools/cooja/java/org/contikios/cooja/contikimote/interfaces/ContikiCFS.java
@@ -120,6 +120,7 @@ public class ContikiCFS extends MoteInterface implements ContikiMoteInterface, P
     }
 
     moteMem.setByteArray("simCFSData", data);
+    moteMem.setIntValueOf("simCFSSize", data.length);
     return true;
   }
 
@@ -129,7 +130,8 @@ public class ContikiCFS extends MoteInterface implements ContikiMoteInterface, P
    * @return Filesystem data
    */
   public byte[] getFilesystemData() {
-    return moteMem.getByteArray("simCFSData", FILESYSTEM_SIZE);
+    int size = moteMem.getIntValueOf("simCFSSize");
+    return moteMem.getByteArray("simCFSData", size);
   }
 
   /**


### PR DESCRIPTION
Previously, the Cooja mote assumed that its file was always initially empty (`file.endptr == 0`). Therefore, a file uploaded to a mote's CFS could never be read by the mote, as the mote would prevent reads from going past the EOF (indicated by `endptr`).

By tracking the file size and making it accessible to Cooja, the correct size of the uploaded file can be reported to the mote and allow it to read the uploaded file.