### PR TITLE
Added Exception to symbols.h inside core/loader.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ summary
 .DS_Store
 obj_*
 symbols.*
+!core/loader/symbols.h
 Makefile.target
 doc/html
 patches-*


### PR DESCRIPTION
symbols.h is available in source code of contiki-OS. Hence when we clone this repository, we are able to do a normal make inside any example. However, when we push our cloned folder to another repository, we do not push core/loader/symbols.h, which generates error.
Hence, i do request this pull to create an exception only to this file, allowing easy operations of contiki-OS, as in the case of avr compilations.
Thanks.