### PR TITLE
Refactor tcpip.c packet input

### DIFF
--- a/core/net/ip/tcpip.c
+++ b/core/net/ip/tcpip.c
@@ -185,30 +185,17 @@ check_for_tcp_syn(void)
 static void
 packet_input(void)
 {
-#if UIP_CONF_IP_FORWARD
   if(uip_len > 0) {
+
+#if UIP_CONF_IP_FORWARD
     tcpip_is_forwarding = 1;
-    if(uip_fw_forward() == UIP_FW_LOCAL) {
+    if(uip_fw_forward() != UIP_FW_LOCAL) {
       tcpip_is_forwarding = 0;
-      check_for_tcp_syn();
-      uip_input();
-      if(uip_len > 0) {
-#if UIP_CONF_TCP_SPLIT
-        uip_split_output();
-#else /* UIP_CONF_TCP_SPLIT */
-#if NETSTACK_CONF_WITH_IPV6
-        tcpip_ipv6_output();
-#else
-	PRINTF("tcpip packet_input forward output len %d\n", uip_len);
-        tcpip_output();
-#endif
-#endif /* UIP_CONF_TCP_SPLIT */
-      }
+      return;
     }
     tcpip_is_forwarding = 0;
-  }
-#else /* UIP_CONF_IP_FORWARD */
-  if(uip_len > 0) {
+#endif /* UIP_CONF_IP_FORWARD */
+
     check_for_tcp_syn();
     uip_input();
     if(uip_len > 0) {
@@ -217,14 +204,13 @@ packet_input(void)
 #else /* UIP_CONF_TCP_SPLIT */
 #if NETSTACK_CONF_WITH_IPV6
       tcpip_ipv6_output();
-#else
+#else /* NETSTACK_CONF_WITH_IPV6 */
       PRINTF("tcpip packet_input output len %d\n", uip_len);
       tcpip_output();
-#endif
+#endif /* NETSTACK_CONF_WITH_IPV6 */
 #endif /* UIP_CONF_TCP_SPLIT */
     }
   }
-#endif /* UIP_CONF_IP_FORWARD */
 }
 /*---------------------------------------------------------------------------*/
 #if UIP_TCP


### PR DESCRIPTION
The UIP_CONF_FORWARD is now handled in a better way that the general structure
of packet_input can be clearer seen.