### PR TITLE
More flexibility for the fallback interface

### DIFF
--- a/core/net/ip/tcpip.c
+++ b/core/net/ip/tcpip.c
@@ -586,7 +586,16 @@ tcpip_ipv6_output(void)
 	    /* This should be copied from the ext header... */
 	    UIP_IP_BUF->proto = proto;
 	  }
-	  UIP_FALLBACK_INTERFACE.output();
+	  /* Inform the other end that the destination is not reachable. If it's
+	   * not informed routes might get lost unexpectedly until there's a need
+	   * to send a new packet to the peer */
+	  if(UIP_FALLBACK_INTERFACE.output() < 0) {
+	    PRINTF("FALLBACK: output error. Reporting DST UNREACH\n");
+	    uip_icmp6_error_output(ICMP6_DST_UNREACH, ICMP6_DST_UNREACH_ADDR, 0);
+	    uip_flags = 0;
+	    tcpip_ipv6_output();
+	    return;
+	  }
 #else
           PRINTF("tcpip_ipv6_output: Destination off-link but no route\n");
 #endif /* !UIP_FALLBACK_INTERFACE */

--- a/core/net/ip/uip.h
+++ b/core/net/ip/uip.h
@@ -1429,7 +1429,13 @@ extern struct uip_udp_conn uip_udp_conns[UIP_UDP_CONNS];
 
 struct uip_fallback_interface {
   void (*init)(void);
-  void (*output)(void);
+  /**
+   * \retval >=0
+   * 	in case of success
+   * \retval <0
+   *	in case of failure
+   */
+  int (*output)(void);
 };
 
 #if UIP_CONF_ICMP6

--- a/core/net/ip64/ip64-eth-interface.c
+++ b/core/net/ip64/ip64-eth-interface.c
@@ -84,7 +84,7 @@ init(void)
   printf("ip64-eth-interface: init\n");
 }
 /*---------------------------------------------------------------------------*/
-static void
+static int
 output(void)
 {
   int len, ret;
@@ -114,7 +114,7 @@ output(void)
       printf("Create request\n");
       len = ip64_arp_create_arp_request(ip64_packet_buffer,
 					&ip64_packet_buffer[sizeof(struct ip64_eth_hdr)]);
-      IP64_ETH_DRIVER.output(ip64_packet_buffer, len);
+      return IP64_ETH_DRIVER.output(ip64_packet_buffer, len);
     }
   }
 }

--- a/core/net/ip64/ip64-slip-interface.c
+++ b/core/net/ip64/ip64-slip-interface.c
@@ -115,7 +115,7 @@ init(void)
   slip_set_input_callback(input_callback);
 }
 /*---------------------------------------------------------------------------*/
-static void
+static int
 output(void)
 {
   int len;
@@ -138,8 +138,10 @@ output(void)
       memcpy(&uip_buf[UIP_LLH_LEN], ip64_packet_buffer, len);
       uip_len = len;
       slip_send();
+      return len;
     }
   }
+  return 0;
 }
 /*---------------------------------------------------------------------------*/
 const struct uip_fallback_interface ip64_slip_interface = {

--- a/cpu/native/net/wpcap.c
+++ b/cpu/native/net/wpcap.c
@@ -192,7 +192,7 @@ uint8_t wfall_send(const uip_lladdr_t *lladdr);
 static uip_ipaddr_t last_sender;
 #endif
 
-static void
+static int
 output(void)
 {
 #if FALLBACK_HAS_ETHERNET_HEADERS&&0
@@ -203,8 +203,8 @@ output(void)
   }
   uip_ipaddr_copy(&last_sender, &UIP_IP_BUF->srcipaddr);
 #endif
-    PRINTF("FUT: %u\n", uip_len);
-	wfall_send(0);
+  PRINTF("FUT: %u\n", uip_len);
+  return wfall_send(0);
 }
 
 const struct uip_fallback_interface rpl_interface = {

--- a/examples/cc2530dk/border-router/slip-bridge.c
+++ b/examples/cc2530dk/border-router/slip-bridge.c
@@ -83,7 +83,7 @@ init(void)
   slip_set_input_callback(slip_input_callback);
 }
 /*---------------------------------------------------------------------------*/
-static void
+static int
 output(void)
 {
   if(uip_ipaddr_cmp(&last_sender, &UIP_IP_BUF->srcipaddr)) {
@@ -94,6 +94,7 @@ output(void)
     PRINTF("SUT: %u\n", uip_len);
     slip_send();
   }
+  return 0;
 }
 /*---------------------------------------------------------------------------*/
 struct uip_fallback_interface slip_interface = {

--- a/examples/ipv6/native-border-router/tun-bridge.c
+++ b/examples/ipv6/native-border-router/tun-bridge.c
@@ -228,7 +228,7 @@ tun_output(uint8_t *data, int len)
   /* fprintf(stderr, "*** Writing to tun...%d\n", len); */
   if(write(tunfd, data, len) != len) {
     err(1, "serial_to_tun: write");
-    return 1;
+    return -1;
   }
   return 0;
 }

--- a/examples/ipv6/native-border-router/tun-bridge.c
+++ b/examples/ipv6/native-border-router/tun-bridge.c
@@ -222,13 +222,15 @@ tun_init()
 }
 
 /*---------------------------------------------------------------------------*/
-void
+static int
 tun_output(uint8_t *data, int len)
 {
   /* fprintf(stderr, "*** Writing to tun...%d\n", len); */
   if(write(tunfd, data, len) != len) {
     err(1, "serial_to_tun: write");
+    return 1;
   }
+  return 0;
 }
 /*---------------------------------------------------------------------------*/
 int
@@ -246,13 +248,14 @@ init(void)
 {
 }
 /*---------------------------------------------------------------------------*/
-static void
+static int
 output(void)
 {
   PRINTF("SUT: %u\n", uip_len);
   if(uip_len > 0) {
-    tun_output(&uip_buf[UIP_LLH_LEN], uip_len);
+    return tun_output(&uip_buf[UIP_LLH_LEN], uip_len);
   }
+  return 0;
 }
 
 

--- a/examples/ipv6/rpl-border-router/slip-bridge.c
+++ b/examples/ipv6/rpl-border-router/slip-bridge.c
@@ -100,7 +100,7 @@ init(void)
   slip_set_input_callback(slip_input_callback);
 }
 /*---------------------------------------------------------------------------*/
-static void
+static int
 output(void)
 {
   if(uip_ipaddr_cmp(&last_sender, &UIP_IP_BUF->srcipaddr)) {
@@ -115,6 +115,7 @@ output(void)
  //   PRINTF("SUT: %u\n", uip_len);
     slip_send();
   }
+  return 0;
 }
 
 /*---------------------------------------------------------------------------*/

--- a/examples/sensinode/border-router/slip-bridge.c
+++ b/examples/sensinode/border-router/slip-bridge.c
@@ -84,7 +84,7 @@ init(void)
   slip_set_input_callback(slip_input_callback);
 }
 /*---------------------------------------------------------------------------*/
-static void
+static int
 output(void)
 {
   if(uip_ipaddr_cmp(&last_sender, &UIP_IP_BUF->srcipaddr)) {
@@ -95,6 +95,7 @@ output(void)
     PRINTF("SUT: %u\n", uip_len);
     slip_send();
   }
+  return 0;
 }
 /*---------------------------------------------------------------------------*/
 const struct uip_fallback_interface slip_interface = {

--- a/platform/avr-ravenusb/contiki-raven-main.c
+++ b/platform/avr-ravenusb/contiki-raven-main.c
@@ -132,7 +132,7 @@ init(void)
 {
 }
 void mac_LowpanToEthernet(void);
-static void
+static int
 output(void)
 {
 //  if(uip_ipaddr_cmp(&last_sender, &UIP_IP_BUF->srcipaddr)) {
@@ -142,6 +142,7 @@ output(void)
     PRINTD("SUT: %u\n", uip_len);
     mac_LowpanToEthernet();  //bounceback trap is done in lowpanToEthernet
 //  }
+    return 0;
 }
 const struct uip_fallback_interface rpl_interface = {
   init, output


### PR DESCRIPTION
When there's a failure to send a packet in the fallback interface the
destination is unreachable and therefore the source should be notified.

This is a rebase of #222 as the original author did not respond within 27 days.