### PR TITLE
RPL: fix clock_time_t calculations

### DIFF
--- a/core/net/link-stats.c
+++ b/core/net/link-stats.c
@@ -51,7 +51,7 @@
 /* Maximum value for the freshness counter */
 #define FRESHNESS_MAX                   16
 /* Statistics with no update in FRESHNESS_EXPIRATION_TIMEOUT is not fresh */
-#define FRESHNESS_EXPIRATION_TIME       (10 * 60 * CLOCK_SECOND)
+#define FRESHNESS_EXPIRATION_TIME       (10 * 60 * (clock_time_t)CLOCK_SECOND)
 
 /* EWMA (exponential moving average) used to maintain statistics over time */
 #define EWMA_SCALE            100
@@ -206,6 +206,6 @@ void
 link_stats_init(void)
 {
   nbr_table_register(link_stats, NULL);
-  ctimer_set(&periodic_timer, 60 * CLOCK_SECOND * FRESHNESS_HALF_LIFE,
+  ctimer_set(&periodic_timer, 60 * (clock_time_t)CLOCK_SECOND * FRESHNESS_HALF_LIFE,
       periodic, NULL);
 }


### PR DESCRIPTION
This issue happened with the AVR Raven. When used with the Cetic 6lbr border router, the computation of the RPL DAO lifecycle timer was incorrect due to the limited clock_time_t width of the avr-raven and the default, relatively large values, of the DIO default lifecycle and lifecycle unit used by the Cetic 6lbr (30 and 256 respectively).

Do not assume clock_time_t is wide enough on all platforms but cast to the widest type avaliable when doing calculations.
