### PR TITLE
Regression test for compiler warnings

### DIFF
--- a/regression-tests/01-compile-base/Makefile
+++ b/regression-tests/01-compile-base/Makefile
@@ -1,39 +1,41 @@
 EXAMPLESDIR=../../examples
 TOOLSDIR=../../tools
 
+ENFORCE_WARNING_COUNT = 1
+# Format: example-path:target[:warning-count]
 EXAMPLES = \
-hello-world/avr-raven \
-hello-world/exp5438 \
-hello-world/eval-adf7xxxmb4z \
-hello-world/micaz \
-hello-world/minimal-net \
-hello-world/native \
-hello-world/sky \
-hello-world/wismote \
-hello-world/z1 \
-eeprom-test/native \
-collect/sky \
-er-rest-example/wismote \
-example-shell/native \
-netperf/sky \
-powertrace/sky \
-rime/sky \
-rime/z1 \
-ravenusbstick/avr-ravenusb \
-servreg-hack/sky \
-sky/sky \
-sky-ip/sky \
-sky-shell/sky \
-sky-shell-exec/sky \
-sky-shell-webserver/sky \
-tcp-socket/minimal-net \
-telnet-server/minimal-net \
-webserver/minimal-net \
-webserver-ipv6/eval-adf7xxxmb4z \
-wget/minimal-net \
-z1/z1 \
-settings-example/avr-raven \
-ipv6/multicast/sky \
+hello-world:avr-raven:6 \
+hello-world:exp5438:8 \
+hello-world:eval-adf7xxxmb4z:1 \
+hello-world:micaz:6 \
+hello-world:minimal-net:1 \
+hello-world:native:5 \
+hello-world:sky:5 \
+hello-world:wismote:6 \
+hello-world:z1:7 \
+eeprom-test:native:6 \
+collect:sky:21 \
+er-rest-example:wismote:8 \
+example-shell:native:54 \
+netperf:sky:21 \
+powertrace:sky:7 \
+rime:sky:7 \
+rime:z1:9 \
+ravenusbstick:avr-ravenusb:11 \
+servreg-hack:sky:6 \
+sky:sky:4 \
+sky-ip:sky:24 \
+sky-shell:sky:21 \
+sky-shell-exec:sky:21 \
+sky-shell-webserver:sky:28 \
+tcp-socket:minimal-net:3 \
+telnet-server:minimal-net:40 \
+webserver:minimal-net:3 \
+webserver-ipv6:eval-adf7xxxmb4z:1 \
+wget:minimal-net:9 \
+z1:z1:25 \
+settings-example:avr-raven:3 \
+ipv6/multicast:sky:5 \
 
 TOOLS=
 

--- a/regression-tests/14-compile-8051-ports/Makefile
+++ b/regression-tests/14-compile-8051-ports/Makefile
@@ -2,12 +2,12 @@ EXAMPLESDIR=../../examples
 TOOLSDIR=../../tools
 
 EXAMPLES = \
-hello-world/cc2530dk \
-cc2530dk/cc2530dk \
-cc2530dk/border-router/cc2530dk \
-cc2530dk/udp-ipv6/cc2530dk \
-cc2530dk/sniffer/cc2530dk \
-ipv6/multicast/cc2530dk \
+hello-world:cc2530dk \
+cc2530dk:cc2530dk \
+cc2530dk/border-router:cc2530dk \
+cc2530dk/udp-ipv6:cc2530dk \
+cc2530dk/sniffer:cc2530dk \
+ipv6/multicast:cc2530dk \
 
 TOOLS=
 

--- a/regression-tests/15-compile-arm-apcs-ports/Makefile
+++ b/regression-tests/15-compile-arm-apcs-ports/Makefile
@@ -1,15 +1,17 @@
 EXAMPLESDIR=../../examples
 TOOLSDIR=../../tools
 
+ENFORCE_WARNING_COUNT = 1
+# Format: example-path:target[:warning-count]
 EXAMPLES = \
-hello-world/econotag \
-hello-world/mbxxx \
-ipv6/rpl-border-router/econotag \
-er-rest-example/econotag \
-webserver-ipv6/econotag \
-ipv6/multicast/econotag \
-econotag-flash-test/econotag \
-econotag-ecc-test/econotag \
+hello-world:econotag \
+hello-world:mbxxx:9 \
+ipv6/rpl-border-router:econotag \
+er-rest-example:econotag \
+webserver-ipv6:econotag \
+ipv6/multicast:econotag \
+econotag-flash-test:econotag \
+econotag-ecc-test:econotag \
 
 TOOLS=
 

--- a/regression-tests/16-compile-6502-ports/Makefile
+++ b/regression-tests/16-compile-6502-ports/Makefile
@@ -2,19 +2,19 @@ EXAMPLESDIR=../../examples
 TOOLSDIR=../../tools
 
 EXAMPLES = \
-email/c64 \
-ftp/c64 \
-irc/c64 \
-telnet-server/c64 \
-wget/c64 \
-webbrowser/c64 \
-webbrowser/c128 \
-webbrowser/atarixl \
-webbrowser/apple2enh \
-webserver/c64 \
-webserver/c128 \
-webserver/atarixl \
-webserver/apple2enh \
+email:c64 \
+ftp:c64 \
+irc:c64 \
+telnet-server:c64 \
+wget:c64 \
+webbrowser:c64 \
+webbrowser:c128 \
+webbrowser:atarixl \
+webbrowser:apple2enh \
+webserver:c64 \
+webserver:c128 \
+webserver:atarixl \
+webserver:apple2enh \
 
 TOOLS=
 

--- a/regression-tests/18-compile-arm-ports/Makefile
+++ b/regression-tests/18-compile-arm-ports/Makefile
@@ -1,23 +1,25 @@
 EXAMPLESDIR=../../examples
 TOOLSDIR=../../tools
 
+ENFORCE_WARNING_COUNT = 1
+# Format: example-path:target[:warning-count]
 EXAMPLES = \
-hello-world/ev-aducrf101mkxz \
-ipv6/rpl-border-router/ev-aducrf101mkxz \
-webserver-ipv6/ev-aducrf101mkxz \
-ipv6/multicast/ev-aducrf101mkxz \
-cc2538dk/sniffer/ev-aducrf101mkxz \
-cc26xx/cc26xx-web-demo/srf06-cc26xx \
-cc26xx/very-sleepy-demo/srf06-cc26xx \
-hello-world/cc2538dk \
-ipv6/rpl-border-router/cc2538dk \
-er-rest-example/cc2538dk \
-webserver-ipv6/cc2538dk \
-cc2538dk/cc2538dk \
-cc2538dk/udp-ipv6-echo-server/cc2538dk \
-cc2538dk/sniffer/cc2538dk \
-cc2538dk/mqtt-demo/cc2538dk \
-ipv6/multicast/cc2538dk \
+hello-world:ev-aducrf101mkxz \
+ipv6/rpl-border-router:ev-aducrf101mkxz \
+webserver-ipv6:ev-aducrf101mkxz \
+ipv6/multicast:ev-aducrf101mkxz \
+cc2538dk/sniffer:ev-aducrf101mkxz:87 \
+cc26xx/cc26xx-web-demo:srf06-cc26xx:1 \
+cc26xx/very-sleepy-demo:srf06-cc26xx:1 \
+hello-world:cc2538dk \
+ipv6/rpl-border-router:cc2538dk \
+er-rest-example:cc2538dk:4 \
+webserver-ipv6:cc2538dk \
+cc2538dk:cc2538dk \
+cc2538dk/udp-ipv6-echo-server:cc2538dk \
+cc2538dk/sniffer:cc2538dk \
+cc2538dk/mqtt-demo:cc2538dk \
+ipv6/multicast:cc2538dk \
 
 TOOLS=
 

--- a/regression-tests/22-compile-nxp-ports/Makefile
+++ b/regression-tests/22-compile-nxp-ports/Makefile
@@ -1,15 +1,16 @@
 EXAMPLESDIR=../../examples
 TOOLSDIR=../../tools
 
-# build jn516x examples, covering IPv6, RPL, CoAP, Rime, Nullrdc, Contikimac
+ENFORCE_WARNING_COUNT = 1
+# Format: example-path:target[:warning-count]
 EXAMPLES = \
-jn516x/dr1175-sensors/jn516x \
-jn516x/rime/jn516x \
-jn516x/rpl/border-router/jn516x \
-jn516x/rpl/node/jn516x \
-jn516x/rpl/coap-dongle-node/jn516x \
-jn516x/rpl/coap-dr1175-node/jn516x \
-jn516x/rpl/coap-dr1199-node/jn516x  
+jn516x/dr1175-sensors:jn516x \
+jn516x/rime:jn516x \
+jn516x/rpl/border-router:jn516x \
+jn516x/rpl/node:jn516x \
+jn516x/rpl/coap-dongle-node:jn516x:4 \
+jn516x/rpl/coap-dr1175-node:jn516x:4 \
+jn516x/rpl/coap-dr1199-node:jn516x:4
 
 TOOLS=
 

--- a/regression-tests/Makefile.compile-test
+++ b/regression-tests/Makefile.compile-test
@@ -25,6 +25,8 @@
 # OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 # SUCH DAMAGE.
 
+ENFORCE_WARNING_COUNT ?= 0
+
 all: summary
 
 build: examples tools
@@ -43,14 +45,37 @@ define dooneexample
  export STM32W_CPUREV=CC; \
  make TARGET=$(2) clean && make TARGET=$(2)) > \
       $(3)-$(subst /,-,$(1))$(2).report 2>&1 && \
- (echo $(1) $(2): OK | tee $(3)-$(subst /,-,$(1))$(2).summary) || \
- (echo $(1) $(2): FAIL ಠ.ಠ | tee $(3)-$(subst /,-,$(1))$(2).summary ; \
+ (echo $(1) $(2) compilation: OK | tee $(3)-$(subst /,-,$(1))$(2).summary) || \
+ (echo $(1) $(2) compilation: FAIL ಠ.ಠ | tee $(3)-$(subst /,-,$(1))$(2).summary ; \
   tail -10 $(3)-$(subst /,-,$(1))$(2).report | tee $(3)-$(subst /,-,$(1))$(2).faillog))
+@(if [ $(ENFORCE_WARNING_COUNT) = 1 ] ; then \
+    if [ -z $(4) ] ; then warnings=0; else warnings=$(4); fi; \
+    new_warnings=`cat $(3)-$(subst /,-,$(1))$(2).report | grep -i warning | wc -l`; \
+    delta=`expr $$new_warnings - $$warnings`; \
+    if [ $$delta -eq 0 ] ; then \
+      echo "$(1) $(2) warnings (old: $$warnings new: $$new_warnings): OK" | tee -a $(3)-$(subst /,-,$(1))$(2).summary ; \
+    else \
+      echo "$(1) $(2) warnings (old: $$warnings new: $$new_warnings): FAIL ಠ_ಠ" | tee -a $(3)-$(subst /,-,$(1))$(2).summary ; \
+      if [ $$delta -lt 0 ] ; then \
+        if [ $$new_warnings -eq 0 ] ; then \
+          echo "Congratulations, you fixed all warnings! Please adjust the makefile variable EXAMPLES with the line '$(1):$(2)'"; \
+        else \
+          echo "Congratulations, you fixed `expr $$delta \"*\" -1 ` warnings. Please adjust the makefile variable EXAMPLES with the line '$(1):$(2):$$new_warnings'"; \
+        fi ; \
+      else \
+        echo "You increased the number of warnings by $$delta. Please fix these."; \
+      fi ; \
+    fi ; \
+  fi ; \
+)
 endef
 
 define doexample
 $(eval i+=x)
-$(call dooneexample,$(dir ${1}),$(notdir ${1}),$(call addzero,${i}))
+$(eval example = $(word 1, $(subst :, ,${1})))
+$(eval target = $(word 2, $(subst :, ,${1})))
+$(eval warnings = $(word 3, $(subst :, ,${1})))
+$(call dooneexample,${example},${target},$(call addzero,${i}),${warnings})
 endef
 #end of GNU make magic
 

--- a/regression-tests/scan_build/Makefile
+++ b/regression-tests/scan_build/Makefile
@@ -1,15 +1,17 @@
 EXAMPLESDIR=../../examples
 TOOLSDIR=../../tools
 
+ENFORCE_WARNING_COUNT = 1
+# Format: example-path:target[:warning-count]
 EXAMPLES = \
-hello-world:minimal-net \
-hello-world:native \
-eeprom-test:native \
-example-shell:native \
-tcp-socket:minimal-net \
-telnet-server:minimal-net \
-webserver:minimal-net \
-wget:minimal-net \
+hello-world:minimal-net:1 \
+hello-world:native:5 \
+eeprom-test:native:6 \
+example-shell:native:54 \
+tcp-socket:minimal-net:3 \
+telnet-server:minimal-net:40 \
+webserver:minimal-net:3 \
+wget:minimal-net:9 \
 
 TOOLS=
 

--- a/regression-tests/scan_build/Makefile
+++ b/regression-tests/scan_build/Makefile
@@ -2,14 +2,14 @@ EXAMPLESDIR=../../examples
 TOOLSDIR=../../tools
 
 EXAMPLES = \
-hello-world/minimal-net \
-hello-world/native \
-eeprom-test/native \
-example-shell/native \
-tcp-socket/minimal-net \
-telnet-server/minimal-net \
-webserver/minimal-net \
-wget/minimal-net \
+hello-world:minimal-net \
+hello-world:native \
+eeprom-test:native \
+example-shell:native \
+tcp-socket:minimal-net \
+telnet-server:minimal-net \
+webserver:minimal-net \
+wget:minimal-net \
 
 TOOLS=
 


### PR DESCRIPTION
The PR adds regression testing for the number of compiler warnings. It is enabled for all compilations in compile-base, the ARM and NXP ports. The makefile variable `EXAMPLES` reflects the current number of warnings for every build as follows:
`example-path:target[:warning-count]` (no `warning-count` means 0 warning)

* The test passes iff the warning count is unchanged;
* If the warning count decreases, the variable `EXAMPLES` must be update to reflect the progress;
* If the warning count increases, new warnings must be fixed.