### PR TITLE
Ignore various build and temporary files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ obj_*
 symbols.*
 Makefile.target
 doc/html
+doc/latex
 patches-*
 tools/tunslip
 tools/tunslip6
@@ -86,8 +87,14 @@ contiki-cc2530dk.lib
 *.d71
 *.d81
 
+# Cooja Build Artifacts
+*.cooja
+
 #regression tests artifacts
 *.testlog
+*.log.prog
+regression-tests/[0-9][0-9]-*/report
+regression-tests/[0-9][0-9]-*/org/
 
 # rl78 build artifacts
 *.eval-adf7xxxmb4z


### PR DESCRIPTION
Ignore:
- .cooja (elf files generated by cooja builds)
- .swp (vim editor temporary files)
- doc/latex/ (generate with ```make -C doc pdf```)
- various build & temporary files generated in regression-tests
