### PR TITLE
resolv timer fix and other improvements

### DIFF
--- a/core/net/ip/resolv.c
+++ b/core/net/ip/resolv.c
@@ -219,25 +219,48 @@ struct dns_answer {
 };
 
 struct namemap {
+/** The entry in the name map table is not in use */
 #define STATE_UNUSED 0
+/**
+ * The name could not be resolved, either because the DNS could not be reached
+ * or because the DNS server responded with an error code
+ */
 #define STATE_ERROR  1
+/** This name will be queried with the next DNS query sent to the server */
 #define STATE_NEW    2
+/** A DNS query has been sent to the DNS server, response awaiting */
 #define STATE_ASKING 3
+/**
+ * This name was once successfully resolved, however it could have expired by
+ * now
+ */
 #define STATE_DONE   4
+  /**
+   * The state of the name map entry
+   *
+   * This must be either: STATE_UNUSED, STATE_ERROR, STATE_NEW, STATE_ASKING or
+   * STATE_DONE
+   */
   uint8_t state;
   uint8_t tmr;
+  /** The DNS request ID */
   uint16_t id;
+  /** How often it was already tried to resolve this name */
   uint8_t retries;
   uint8_t seqno;
 #if RESOLV_SUPPORTS_RECORD_EXPIRATION
   unsigned long expiration;
 #endif /* RESOLV_SUPPORTS_RECORD_EXPIRATION */
+  /** The resolved IP address */
   uip_ipaddr_t ipaddr;
+  /** The DNS error response codes */
   uint8_t err;
+  /** Index of the DNS Server to query, see \ref uip_nameserver_get */
   uint8_t server;
 #if RESOLV_CONF_SUPPORTS_MDNS
   int is_mdns:1, is_probe:1;
 #endif
+  /** The name to resolve */
   char name[RESOLV_CONF_MAX_DOMAIN_NAME_SIZE + 1];
 };
 

--- a/core/net/ip/resolv.c
+++ b/core/net/ip/resolv.c
@@ -1208,7 +1208,16 @@ PROCESS_THREAD(mdns_probe_process, ev, data)
   /* We need to wait a random (0-250ms) period of time before
    * probing to be in compliance with the MDNS spec. */
   etimer_set(&delay, CLOCK_SECOND * (random_rand() & 0xFF) / 1024);
-  PROCESS_WAIT_EVENT_UNTIL(ev == PROCESS_EVENT_TIMER);
+  do {
+    PROCESS_WAIT_EVENT();
+    switch(ev) {
+      case PROCESS_EVENT_TIMER:
+        break;
+      case PROCESS_EVENT_EXIT:
+        etimer_stop(&delay);
+        PROCESS_EXIT();
+    }
+  } while (true);
 
   /* Begin searching for our name. */
   mdns_state = MDNS_STATE_PROBING;

--- a/core/net/ip/resolv.c
+++ b/core/net/ip/resolv.c
@@ -1176,7 +1176,12 @@ PROCESS_THREAD(resolv_process, ev, data)
   /* TODO: Is there anything we need to do here for IPv4 multicast? */
 #endif
 
-  resolv_set_hostname(CONTIKI_CONF_DEFAULT_HOSTNAME);
+  /* Only set a default hostname if there is none. This prevents overwriting
+   * the hostname set by resolv_set_hostname(const char *) by the user on
+   * initialization of resolv */
+  if(0 == strlen(resolv_get_hostname())) {
+    resolv_set_hostname(CONTIKI_CONF_DEFAULT_HOSTNAME);
+  }
 #endif /* RESOLV_CONF_SUPPORTS_MDNS */
 
   while(1) {

--- a/core/net/ip/resolv.c
+++ b/core/net/ip/resolv.c
@@ -1446,6 +1446,7 @@ resolv_clear_cache(void)
   }
 }
 /*---------------------------------------------------------------------------*/
+#if RESOLV_CONF_SUPPORTS_MDNS && RESOLV_CONF_MDNS_PROBING
 /**
  * \brief Check if the ipaddr is mine
  * \param ipaddr The IP address to check
@@ -1465,6 +1466,7 @@ is_my_addr(uip_ipaddr_t *ipaddr)
   }
   return false;
 }
+#endif /* RESOLV_CONF_SUPPORTS_MDNS && RESOLV_CONF_MDNS_PROBING */
 /*---------------------------------------------------------------------------*/
 /** \internal
  * Callback function which is called when a hostname is found.
@@ -1473,7 +1475,7 @@ is_my_addr(uip_ipaddr_t *ipaddr)
 static void
 resolv_found(char *name, uip_ipaddr_t * ipaddr)
 {
-#if RESOLV_CONF_SUPPORTS_MDNS
+#if RESOLV_CONF_SUPPORTS_MDNS && RESOLV_CONF_MDNS_PROBING
   bool is_my_hostname = strncasecmp(resolv_hostname, name, strlen(resolv_hostname)) == 0;
   if(is_my_hostname && ipaddr && !is_my_addr(ipaddr)) {
     uint8_t i;
@@ -1514,7 +1516,7 @@ resolv_found(char *name, uip_ipaddr_t * ipaddr)
     }
 
   } else
-#endif /* RESOLV_CONF_SUPPORTS_MDNS */
+#endif /* RESOLV_CONF_SUPPORTS_MDNS && RESOLV_CONF_MDNS_PROBING */
 
 #if VERBOSE_DEBUG
   if(ipaddr) {

--- a/core/net/ip/resolv.c
+++ b/core/net/ip/resolv.c
@@ -1440,6 +1440,15 @@ resolv_lookup(const char *name, uip_ipaddr_t ** ipaddr)
   return ret;
 }
 /*---------------------------------------------------------------------------*/
+void
+resolv_clear_cache(void)
+{
+  uint32_t i;
+  for(i = 0; i < RESOLV_ENTRIES; ++i) {
+    names[i].state = STATE_UNUSED;
+  }
+}
+/*---------------------------------------------------------------------------*/
 /** \internal
  * Callback function which is called when a hostname is found.
  *

--- a/core/net/ip/resolv.c
+++ b/core/net/ip/resolv.c
@@ -115,52 +115,6 @@ strcasecmp(const char *s1, const char *s2)
 
 #define UIP_UDP_BUF ((struct uip_udpip_hdr *)&uip_buf[UIP_LLH_LEN])
 
-/* If RESOLV_CONF_SUPPORTS_MDNS is set, then queries
- * for domain names in the local TLD will use mDNS as
- * described by draft-cheshire-dnsext-multicastdns.
- */
-#ifndef RESOLV_CONF_SUPPORTS_MDNS
-#define RESOLV_CONF_SUPPORTS_MDNS 1
-#endif
-
-/**
- * Probe for duplicate names in mDNS startup.
- *
- * By default mDNS hosts are asked to query for the name they want to announce
- * in order to detect duplicate names in a network. See [1] for the exact
- * specification. However in administered networks where mDNS names are
- * guaranteed to be unique this leads to unnecessary radio transimissions that
- * drain the battery. Therefore the feature can be disabled at compile time.
- * This is in compliance with the mDNS RFC 6762:
- *
- *      If a responder knows by other means that its unique resource
- *      record set name, rrtype, and rrclass cannot already be in
- *      use by any other responder on the network, then it SHOULD
- *      skip the probing step for that resource record set.
- *
- * [1] https://tools.ietf.org/html/rfc6762#section-8
- */
-#ifndef RESOLV_CONF_MDNS_PROBING
-#define RESOLV_CONF_MDNS_PROBING 1
-#endif /* RESOLV_CONF_MDNS_PROBING */
-
-#ifndef RESOLV_CONF_MDNS_INCLUDE_GLOBAL_V6_ADDRS
-#define RESOLV_CONF_MDNS_INCLUDE_GLOBAL_V6_ADDRS 0
-#endif
-
-/** The maximum number of retries when asking for a name. */
-#ifndef RESOLV_CONF_MAX_RETRIES
-#define RESOLV_CONF_MAX_RETRIES 4
-#endif
-
-#ifndef RESOLV_CONF_MAX_MDNS_RETRIES
-#define RESOLV_CONF_MAX_MDNS_RETRIES 3
-#endif
-
-#ifndef RESOLV_CONF_MAX_DOMAIN_NAME_SIZE
-#define RESOLV_CONF_MAX_DOMAIN_NAME_SIZE 32
-#endif
-
 #ifdef RESOLV_CONF_AUTO_REMOVE_TRAILING_DOTS
 #define RESOLV_AUTO_REMOVE_TRAILING_DOTS RESOLV_CONF_AUTO_REMOVE_TRAILING_DOTS
 #else

--- a/core/net/ip/resolv.h
+++ b/core/net/ip/resolv.h
@@ -92,7 +92,12 @@ typedef uint8_t resolv_status_t;
 
 /* Functions. */
 CCIF resolv_status_t resolv_lookup(const char *name, uip_ipaddr_t ** ipaddr);
-
+/**
+ * Clear the resolv cache.
+ *
+ * Any previously resolved name will be forgotten and has to be resolved again.
+ */
+CCIF void resolv_clear_cache(void);
 CCIF void resolv_query(const char *name);
 
 #if RESOLV_CONF_SUPPORTS_MDNS

--- a/core/net/ip/resolv.h
+++ b/core/net/ip/resolv.h
@@ -42,16 +42,51 @@
 
 #include "contiki.h"
 #include "uip.h"
-
-/** If RESOLV_CONF_SUPPORTS_MDNS is set, then queries
- *  for domain names in the `local` TLD will use MDNS and
- *  will respond to MDNS queries for this device's hostname,
- *  as described by draft-cheshire-dnsext-multicastdns.
+/*---------------------------------------------------------------------------*/
+#ifndef RESOLV_CONF_MAX_DOMAIN_NAME_SIZE
+  #define RESOLV_CONF_MAX_DOMAIN_NAME_SIZE 32
+#endif
+#ifndef RESOLV_CONF_MAX_MDNS_RETRIES
+  #define RESOLV_CONF_MAX_MDNS_RETRIES 3
+#endif
+/**
+ * The maximum number of retries when asking for a name.
+ */
+#ifndef RESOLV_CONF_MAX_RETRIES
+  #define RESOLV_CONF_MAX_RETRIES 4
+#endif
+#ifndef RESOLV_CONF_MDNS_INCLUDE_GLOBAL_V6_ADDRS
+  #define RESOLV_CONF_MDNS_INCLUDE_GLOBAL_V6_ADDRS 0
+#endif
+/**
+ * Probe for duplicate names in mDNS startup.
+ *
+ * By default mDNS hosts are asked to query for the name they want to announce
+ * in order to detect duplicate names in a network. See [1] for the exact
+ * specification. However in administered networks where mDNS names are
+ * guaranteed to be unique this leads to unnecessary radio transimissions that
+ * drain the battery. Therefore the feature can be disabled at compile time.
+ * This is in compliance with the mDNS RFC 6762:
+ *
+ *      If a responder knows by other means that its unique resource
+ *      record set name, rrtype, and rrclass cannot already be in
+ *      use by any other responder on the network, then it SHOULD
+ *      skip the probing step for that resource record set.
+ *
+ * [1] https://tools.ietf.org/html/rfc6762#section-8
+ */
+#ifndef RESOLV_CONF_MDNS_PROBING
+  #define RESOLV_CONF_MDNS_PROBING 1
+#endif /* RESOLV_CONF_MDNS_PROBING */
+/**
+ * If RESOLV_CONF_SUPPORTS_MDNS is set, then queries for domain names in the
+ * `local` TLD will use MDNS and will respond to MDNS queries for this device's
+ * hostname, as described by draft-cheshire-dnsext-multicastdns.
  */
 #ifndef RESOLV_CONF_SUPPORTS_MDNS
-#define RESOLV_CONF_SUPPORTS_MDNS     (1)
-#endif
-
+  #define RESOLV_CONF_SUPPORTS_MDNS 1
+#endif /* RESOLV_CONF_SUPPORTS_MDNS */
+/*---------------------------------------------------------------------------*/
 /**
  * Event that is broadcasted when a DNS name has been resolved.
  */


### PR DESCRIPTION
This closes https://github.com/contiki-os/contiki/issues/1263 and makes https://github.com/contiki-os/contiki/pull/1245 obsolete.

Highlight commits are:

1. [resolv: Only set a default hostname if there is none](https://github.com/contiki-os/contiki/commit/6edc045222a8d8278d53b71af9acc9e539ec138f)
2. [Resolv: Adds ability to clear cache](https://github.com/contiki-os/contiki/commit/5ffc75aa68e172a1e5aecccca5cfa57dea04ae80)
3. [resolv: Allows to disable mDNS Probing at compile time](https://github.com/contiki-os/contiki/commit/6a61fdf5b4cb39e8b34a3c21d69a4dc381eae83a)
4. [resolv: Fixes query retransmission times](https://github.com/contiki-os/contiki/commit/ea1ec0db3e392265ea200c345d1c06c9ae028b8e)
5. [resolv: Ensure mDNS process can be stopped during probing](https://github.com/contiki-os/contiki/commit/6f3e41cb673c17b71badcb5d218843a3df48efd4)

The rest is mostly refactoring