### PR TITLE
sicslowpan should not set max mac transmits

### DIFF
--- a/core/net/ipv6/sicslowpan.c
+++ b/core/net/ipv6/sicslowpan.c
@@ -98,12 +98,6 @@ void uip_log(char *msg);
 #define UIP_LOG(m)
 #endif /* UIP_LOGGING == 1 */
 
-#ifdef SICSLOWPAN_CONF_MAX_MAC_TRANSMISSIONS
-#define SICSLOWPAN_MAX_MAC_TRANSMISSIONS SICSLOWPAN_CONF_MAX_MAC_TRANSMISSIONS
-#else
-#define SICSLOWPAN_MAX_MAC_TRANSMISSIONS 4
-#endif
-
 #ifndef SICSLOWPAN_COMPRESSION
 #ifdef SICSLOWPAN_CONF_COMPRESSION
 #define SICSLOWPAN_COMPRESSION SICSLOWPAN_CONF_COMPRESSION
@@ -1373,9 +1367,6 @@ output(const uip_lladdr_t *localdest)
   /* reset packetbuf buffer */
   packetbuf_clear();
   packetbuf_ptr = packetbuf_dataptr();
-
-  packetbuf_set_attr(PACKETBUF_ATTR_MAX_MAC_TRANSMISSIONS,
-                     SICSLOWPAN_MAX_MAC_TRANSMISSIONS);
 
   if(callback) {
     /* call the attribution when the callback comes, but set attributes


### PR DESCRIPTION
In the actual implementation sicslowpan is setting the max mac transmission value of a packet to sent to a configurable value. But this is not needed because the mac layer has a default value which will be used if sicslowpan would not set this value.
In fact changing the max mac transmits setting at the mac layer will therefore not have any effect because of sicslowpan setting a value by itself. This is not a behaviour you would expect or find within a short time without thorough debugging the whole network stack.

Have been searching for this bug a long time because of network with an insanely high collision percentage and increasing the maximum mac transmit of csma did not have any effect.