### PR TITLE
RPL: check if objective function is supported before creating dag.

### DIFF
--- a/core/net/rpl/rpl-dag.c
+++ b/core/net/rpl/rpl-dag.c
@@ -938,6 +938,15 @@ rpl_join_instance(uip_ipaddr_t *from, rpl_dio_t *dio)
   rpl_parent_t *p;
   rpl_of_t *of;
 
+  /* Determine the objective function by using the
+     objective code point of the DIO. */
+  of = rpl_find_of(dio->ocp);
+  if(of == NULL) {
+    PRINTF("RPL: DIO for DAG instance %u does not specify a supported OF: %u\n",
+           dio->instance_id, dio->ocp);
+    return;
+  }
+
   dag = rpl_alloc_dag(dio->instance_id, &dio->dag_id);
   if(dag == NULL) {
     PRINTF("RPL: Failed to allocate a DAG object!\n");
@@ -957,17 +966,6 @@ rpl_join_instance(uip_ipaddr_t *from, rpl_dio_t *dio)
   }
   p->dtsn = dio->dtsn;
   PRINTF("succeeded\n");
-
-  /* Determine the objective function by using the
-     objective code point of the DIO. */
-  of = rpl_find_of(dio->ocp);
-  if(of == NULL) {
-    PRINTF("RPL: DIO for DAG instance %u does not specify a supported OF\n",
-        dio->instance_id);
-    rpl_remove_parent(p);
-    instance->used = 0;
-    return;
-  }
 
   /* Autoconfigure an address if this node does not already have an address
      with this prefix. */


### PR DESCRIPTION
Currently if Contiki RPL tries to join a network that make use of a non-supported objective function it will try to both create a DAG and a parent before realising that it is not going to be possible to join. This fix checks the OCP against the currency supported objective function before trying to allocate or create anything and fails earlier. Without this fix some examples that use a border router with a non-supported OF do crash (er-coap examples, etc).