### PR TITLE
fixed memory bug

### DIFF
--- a/core/lib/ccm-star.c
+++ b/core/lib/ccm-star.c
@@ -114,7 +114,6 @@ mic(const uint8_t *m,  uint8_t m_len,
   }
   
   if(m_len > 0) {
-    m = a + a_len;
     pos = 0;
     while(pos < m_len) {
       for(i = 0; (pos + i < m_len) && (i < AES_128_BLOCK_SIZE); i++) {


### PR DESCRIPTION
This line assumes that the plaintext directly follows the AddAuthData. But the plaintext is already at memory location m, so there is no location change needed.
