### PR TITLE
Change the default IPv6 prefix from aaaa::/64 to fd00::/64

### DIFF
--- a/core/net/ipv6/sicslowpan.c
+++ b/core/net/ipv6/sicslowpan.c
@@ -1757,8 +1757,8 @@ sicslowpan_init(void)
 #ifdef SICSLOWPAN_CONF_ADDR_CONTEXT_0
   SICSLOWPAN_CONF_ADDR_CONTEXT_0;
 #else
-  addr_contexts[0].prefix[0] = 0xaa;
-  addr_contexts[0].prefix[1] = 0xaa;
+  addr_contexts[0].prefix[0] = UIP_DS6_DEFAULT_PREFIX_0;
+  addr_contexts[0].prefix[1] = UIP_DS6_DEFAULT_PREFIX_1;
 #endif
 #endif /* SICSLOWPAN_CONF_MAX_ADDR_CONTEXTS > 0 */
 

--- a/core/net/ipv6/uip-ds6.h
+++ b/core/net/ipv6/uip-ds6.h
@@ -67,6 +67,36 @@
 #endif
 #define UIP_DS6_DEFRT_NB UIP_DS6_DEFRT_NBS + UIP_DS6_DEFRT_NBU
 
+/* Default prefix */
+#ifdef UIP_CONF_DS6_DEFAULT_PREFIX
+#define UIP_DS6_DEFAULT_PREFIX UIP_CONF_DS6_DEFAULT_PREFIX
+#else
+/* From RFC4193, section 3.1:
+ *  | 7 bits |1|  40 bits   |  16 bits  |          64 bits           |
+ *  +--------+-+------------+-----------+----------------------------+
+ *  | Prefix |L| Global ID  | Subnet ID |        Interface ID        |
+ *  +--------+-+------------+-----------+----------------------------+
+ *     Prefix            FC00::/7 prefix to identify Local IPv6 unicast
+ *                       addresses.
+ *     L                 Set to 1 if the prefix is locally assigned.
+ *                       Set to 0 may be defined in the future.  See
+ *                       Section 3.2 for additional information.
+ *     Global ID         40-bit global identifier used to create a
+ *                       globally unique prefix.  See Section 3.2 for
+ *                       additional information.
+ *
+ * We set prefix to 0xfc00 and set the local bit, resulting in 0xfd00.
+ * For high probability of network uniqueness, Global ID must be generated
+ * pseudo-randomly. As this is a hard-coded default prefix, we simply use
+ * a Global ID of 0. For real deployments, make sure to install a pseudo-random
+ * Global ID, e.g. in a RPL network, by configuring it at the root.
+ */
+#define UIP_DS6_DEFAULT_PREFIX 0xfd00
+#endif /* UIP_CONF_DS6_DEFAULT_PREFIX */
+
+#define UIP_DS6_DEFAULT_PREFIX_0 ((UIP_DS6_DEFAULT_PREFIX >> 8) & 0xff)
+#define UIP_DS6_DEFAULT_PREFIX_1 (UIP_DS6_DEFAULT_PREFIX & 0xff)
+
 /* Prefix list */
 #define UIP_DS6_PREFIX_NBS  1
 #ifndef UIP_CONF_DS6_PREFIX_NBU

--- a/core/net/rpl/rpl-dag-root.c
+++ b/core/net/rpl/rpl-dag-root.c
@@ -146,7 +146,7 @@ set_global_address(void)
 
   /* Assign a unique local address (RFC4193,
      http://tools.ietf.org/html/rfc4193). */
-  uip_ip6addr(&ipaddr, 0xaaaa, 0, 0, 0, 0, 0, 0, 0);
+  uip_ip6addr(&ipaddr, UIP_DS6_DEFAULT_PREFIX, 0, 0, 0, 0, 0, 0, 0);
   uip_ds6_set_addr_iid(&ipaddr, &uip_lladdr);
   uip_ds6_addr_add(&ipaddr, 0, ADDR_AUTOCONF);
 
@@ -213,7 +213,7 @@ rpl_dag_root_init_dag_immediately(void)
         dag->instance->def_route = NULL;
       }
 
-      uip_ip6addr(&prefix, 0xaaaa, 0, 0, 0, 0, 0, 0, 0);
+      uip_ip6addr(&prefix, UIP_DS6_DEFAULT_PREFIX, 0, 0, 0, 0, 0, 0, 0);
       rpl_set_prefix(dag, &prefix, 64);
       PRINTF("rpl_dag_root_init_dag: created a new RPL dag\n");
       return 0;

--- a/cpu/native/net/wpcap.c
+++ b/cpu/native/net/wpcap.c
@@ -525,7 +525,7 @@ wpcap_init(void)
 //	  }
 #else
       addr.s_addr = inet_addr("10.10.10.10");   //prefer ipv4 default for legacy compatibility
-//    uiplib_ipaddrconv("aaaa::1",(uip_ipaddr_t*) &addr6.s6_addr);
+//    uiplib_ipaddrconv("fd00::1",(uip_ipaddr_t*) &addr6.s6_addr);
 #endif
 
 #ifdef UIP_FALLBACK_INTERFACE

--- a/examples/cc2530dk/border-router/README.md
+++ b/examples/cc2530dk/border-router/README.md
@@ -15,6 +15,6 @@ The node will use this address to obtain the network prefix
 
 For example:
 
-    sudo ./tunslip6 aaaa::1/64
+    sudo ./tunslip6 fd00::1/64
 
-This will use aaaa:: / 64 as the prefix for the 15.4 network.
+This will use fd00:: / 64 as the prefix for the 15.4 network.

--- a/examples/cc2530dk/udp-ipv6/client.c
+++ b/examples/cc2530dk/udp-ipv6/client.c
@@ -130,7 +130,7 @@ PROCESS_THREAD(udp_client_process, ev, data)
   PRINTF(" local/remote port %u/%u\n",
          UIP_HTONS(l_conn->lport), UIP_HTONS(l_conn->rport));
 
-  uip_ip6addr(&ipaddr, 0xaaaa, 0, 0, 0, 0x0215, 0x2000, 0x0002, 0x2145);
+  uip_ip6addr(&ipaddr, UIP_DS6_DEFAULT_PREFIX, 0, 0, 0, 0x0215, 0x2000, 0x0002, 0x2145);
   g_conn = udp_new(&ipaddr, UIP_HTONS(3000), NULL);
   if(!g_conn) {
     PRINTF("udp_new g_conn error.\n");

--- a/examples/cc2530dk/udp-ipv6/ping6.c
+++ b/examples/cc2530dk/udp-ipv6/ping6.c
@@ -105,7 +105,7 @@ PROCESS_THREAD(ping6_process, ev, data)
   PRINTF("ping6 running.\n");
   PRINTF("Button 1: 5 pings 16 byte payload.\n");
 
-  uip_ip6addr(&dest_addr, 0xaaaa, 0, 0, 0, 0x0215, 0x2000, 0x0002, 0x2145);
+  uip_ip6addr(&dest_addr, UIP_DS6_DEFAULT_PREFIX, 0, 0, 0, 0x0215, 0x2000, 0x0002, 0x2145);
   count = 0;
 
   icmp6_new(NULL);

--- a/examples/cc2530dk/udp-ipv6/server.c
+++ b/examples/cc2530dk/udp-ipv6/server.c
@@ -126,7 +126,7 @@ create_dag()
 {
   rpl_dag_t *dag;
 
-  uip_ip6addr(&ipaddr, 0xaaaa, 0, 0, 0, 0, 0, 0, 0);
+  uip_ip6addr(&ipaddr, UIP_DS6_DEFAULT_PREFIX, 0, 0, 0, 0, 0, 0, 0);
   uip_ds6_set_addr_iid(&ipaddr, &uip_lladdr);
   uip_ds6_addr_add(&ipaddr, 0, ADDR_AUTOCONF);
 
@@ -135,7 +135,7 @@ create_dag()
   dag = rpl_set_root(RPL_DEFAULT_INSTANCE,
                      &uip_ds6_get_global(ADDR_PREFERRED)->ipaddr);
   if(dag != NULL) {
-    uip_ip6addr(&ipaddr, 0xaaaa, 0, 0, 0, 0, 0, 0, 0);
+    uip_ip6addr(&ipaddr, UIP_DS6_DEFAULT_PREFIX, 0, 0, 0, 0, 0, 0, 0);
     rpl_set_prefix(dag, &ipaddr, 64);
     PRINTF("Created a new RPL dag with ID: ");
     PRINT6ADDR(&dag->dag_id);

--- a/examples/cc2538-common/mqtt-demo/project-conf.h
+++ b/examples/cc2538-common/mqtt-demo/project-conf.h
@@ -45,7 +45,7 @@
 #define MQTT_DEMO_PUBLISH_TRIGGER &button_right_sensor
 
 /* If undefined, the demo will attempt to connect to IBM's quickstart */
-#define MQTT_DEMO_BROKER_IP_ADDR "aaaa::1"
+#define MQTT_DEMO_BROKER_IP_ADDR "fd00::1"
 /*---------------------------------------------------------------------------*/
 #endif /* PROJECT_CONF_H_ */
 /*---------------------------------------------------------------------------*/

--- a/examples/er-rest-example/Makefile
+++ b/examples/er-rest-example/Makefile
@@ -57,13 +57,13 @@ $(CONTIKI)/tools/tunslip6:	$(CONTIKI)/tools/tunslip6.c
 	(cd $(CONTIKI)/tools && $(MAKE) tunslip6)
 
 connect-router:	$(CONTIKI)/tools/tunslip6
-	sudo $(CONTIKI)/tools/tunslip6 aaaa::1/64
+	sudo $(CONTIKI)/tools/tunslip6 fd00::1/64
 
 connect-router-cooja:	$(CONTIKI)/tools/tunslip6
-	sudo $(CONTIKI)/tools/tunslip6 -a 127.0.0.1 -p 60001 aaaa::1/64
+	sudo $(CONTIKI)/tools/tunslip6 -a 127.0.0.1 -p 60001 fd00::1/64
 
 connect-router-native:	$(CONTIKI)/examples/ipv6/native-border-router/border-router.native
-	sudo $(CONTIKI)/exmples/ipv6/native-border-router/border-router.native -a 127.0.0.1 -p 60001 aaaa::1/64
+	sudo $(CONTIKI)/exmples/ipv6/native-border-router/border-router.native -a 127.0.0.1 -p 60001 fd00::1/64
 
 connect-minimal:
 	sudo ip address add fdfd::1/64 dev tap0 

--- a/examples/er-rest-example/README.md
+++ b/examples/er-rest-example/README.md
@@ -23,8 +23,8 @@ PRELIMINARIES
     #define NETSTACK_CONF_RDC     nullrdc_driver
 - Alternatively, you can use the native-border-router together with the slip-radio.
 - For convenience, define the Cooja addresses in /etc/hosts
-      aaaa::0212:7401:0001:0101 cooja1
-      aaaa::0212:7402:0002:0202 cooja2
+      fd00::0212:7401:0001:0101 cooja1
+      fd00::0212:7402:0002:0202 cooja2
       ...
 - Get the Copper (Cu) CoAP user-agent from
   [https://addons.mozilla.org/en-US/firefox/addon/copper-270430](https://addons.mozilla.org/en-US/firefox/addon/copper-270430)
@@ -82,11 +82,11 @@ TMOTES HOWTO
 
 3. Start Copper and discover resources at:
 
-        coap://[aaaa::____:____:____:____]:5683/
+        coap://[fd00::____:____:____:____]:5683/
 
 ### Add a client:
 
-1. Change the hard-coded server address in er-example-client.c to aaaa::____:____:____:____
+1. Change the hard-coded server address in er-example-client.c to fd00::____:____:____:____
 2. Connect a third Tmote Sky
 
         make TARGET=sky er-example-client.upload MOTE=3

--- a/examples/hello-world/README.md
+++ b/examples/hello-world/README.md
@@ -34,7 +34,7 @@ For example, using a loopback interface with the minimal-net platform:
     make UIP_CONF_IPV6=1 TARGET=minimal-net
     ./hello-world.minimal-net
     Hello, world
-    IPV6 Address: [aaaa::206:98ff:fe00:232]
+    IPV6 Address: [fd00::206:98ff:fe00:232]
     IPV6 Address: [fe80::206:98ff:fe00:232]
     ^C
 

--- a/examples/ipv6/json-ws/json-ws.c
+++ b/examples/ipv6/json-ws/json-ws.c
@@ -78,7 +78,7 @@
 static const char http_content_type_json[] = "application/json";
 
 /* Maximum 40 chars in host name?: 5 x 8 */
-static char callback_host[40] = "[aaaa::1]";
+static char callback_host[40] = "[fd00::1]";
 static uint16_t callback_port = CALLBACK_PORT;
 static uint16_t callback_interval = SEND_INTERVAL;
 static char callback_path[80] = "/debug/";

--- a/examples/ipv6/multicast/root.c
+++ b/examples/ipv6/multicast/root.c
@@ -111,7 +111,7 @@ set_own_addresses(void)
   rpl_dag_t *dag;
   uip_ipaddr_t ipaddr;
 
-  uip_ip6addr(&ipaddr, 0xaaaa, 0, 0, 0, 0, 0, 0, 0);
+  uip_ip6addr(&ipaddr, UIP_DS6_DEFAULT_PREFIX, 0, 0, 0, 0, 0, 0, 0);
   uip_ds6_set_addr_iid(&ipaddr, &uip_lladdr);
   uip_ds6_addr_add(&ipaddr, 0, ADDR_AUTOCONF);
 

--- a/examples/ipv6/multicast/sink.c
+++ b/examples/ipv6/multicast/sink.c
@@ -84,7 +84,7 @@ join_mcast_group(void)
   uip_ds6_maddr_t *rv;
 
   /* First, set our v6 global */
-  uip_ip6addr(&addr, 0xaaaa, 0, 0, 0, 0, 0, 0, 0);
+  uip_ip6addr(&addr, UIP_DS6_DEFAULT_PREFIX, 0, 0, 0, 0, 0, 0, 0);
   uip_ds6_set_addr_iid(&addr, &uip_lladdr);
   uip_ds6_addr_add(&addr, 0, ADDR_AUTOCONF);
 

--- a/examples/ipv6/native-border-router/Makefile
+++ b/examples/ipv6/native-border-router/Makefile
@@ -24,4 +24,4 @@ CONTIKI_WITH_IPV6 = 1
 include $(CONTIKI)/Makefile.include
 
 connect-router:	border-router.native
-	sudo ./border-router.native aaaa::1/64
+	sudo ./border-router.native fd00::1/64

--- a/examples/ipv6/native-border-router/slip-config.c
+++ b/examples/ipv6/native-border-router/slip-config.c
@@ -125,7 +125,7 @@ slip_config_handle_arguments(int argc, char **argv)
     case 'h':
     default:
 fprintf(stderr,"usage:  %s [options] ipaddress\n", prog);
-fprintf(stderr,"example: border-router.native -L -v2 -s ttyUSB1 aaaa::1/64\n");
+fprintf(stderr,"example: border-router.native -L -v2 -s ttyUSB1 fd00::1/64\n");
 fprintf(stderr,"Options are:\n");
 #ifdef linux
 fprintf(stderr," -B baudrate    9600,19200,38400,57600,115200,921600 (default 115200)\n");

--- a/examples/ipv6/rpl-border-router/Makefile
+++ b/examples/ipv6/rpl-border-router/Makefile
@@ -33,7 +33,7 @@ CFLAGS += -DWEBSERVER=2
 endif
 
 ifeq ($(PREFIX),)
- PREFIX = aaaa::1/64
+ PREFIX = fd00::1/64
 endif
 
 CONTIKI_WITH_IPV6 = 1

--- a/examples/ipv6/rpl-collect/udp-sender.c
+++ b/examples/ipv6/rpl-collect/udp-sender.c
@@ -195,12 +195,12 @@ set_global_address(void)
 {
   uip_ipaddr_t ipaddr;
 
-  uip_ip6addr(&ipaddr, 0xaaaa, 0, 0, 0, 0, 0, 0, 0);
+  uip_ip6addr(&ipaddr, UIP_DS6_DEFAULT_PREFIX, 0, 0, 0, 0, 0, 0, 0);
   uip_ds6_set_addr_iid(&ipaddr, &uip_lladdr);
   uip_ds6_addr_add(&ipaddr, 0, ADDR_AUTOCONF);
 
   /* set server address */
-  uip_ip6addr(&server_ipaddr, 0xaaaa, 0, 0, 0, 0, 0, 0, 1);
+  uip_ip6addr(&server_ipaddr, UIP_DS6_DEFAULT_PREFIX, 0, 0, 0, 0, 0, 0, 1);
 
 }
 /*---------------------------------------------------------------------------*/

--- a/examples/ipv6/rpl-collect/udp-sink.c
+++ b/examples/ipv6/rpl-collect/udp-sink.c
@@ -145,14 +145,14 @@ PROCESS_THREAD(udp_server_process, ev, data)
   PRINTF("UDP server started\n");
 
 #if UIP_CONF_ROUTER
-  uip_ip6addr(&ipaddr, 0xaaaa, 0, 0, 0, 0, 0, 0, 1);
+  uip_ip6addr(&ipaddr, UIP_DS6_DEFAULT_PREFIX, 0, 0, 0, 0, 0, 0, 1);
   /* uip_ds6_set_addr_iid(&ipaddr, &uip_lladdr); */
   uip_ds6_addr_add(&ipaddr, 0, ADDR_MANUAL);
   root_if = uip_ds6_addr_lookup(&ipaddr);
   if(root_if != NULL) {
     rpl_dag_t *dag;
     dag = rpl_set_root(RPL_DEFAULT_INSTANCE,(uip_ip6addr_t *)&ipaddr);
-    uip_ip6addr(&ipaddr, 0xaaaa, 0, 0, 0, 0, 0, 0, 0);
+    uip_ip6addr(&ipaddr, UIP_DS6_DEFAULT_PREFIX, 0, 0, 0, 0, 0, 0, 0);
     rpl_set_prefix(dag, &ipaddr, 64);
     PRINTF("created a new RPL dag\n");
   } else {

--- a/examples/ipv6/rpl-udp/udp-client.c
+++ b/examples/ipv6/rpl-udp/udp-client.c
@@ -116,7 +116,7 @@ set_global_address(void)
 {
   uip_ipaddr_t ipaddr;
 
-  uip_ip6addr(&ipaddr, 0xaaaa, 0, 0, 0, 0, 0, 0, 0);
+  uip_ip6addr(&ipaddr, UIP_DS6_DEFAULT_PREFIX, 0, 0, 0, 0, 0, 0, 0);
   uip_ds6_set_addr_iid(&ipaddr, &uip_lladdr);
   uip_ds6_addr_add(&ipaddr, 0, ADDR_AUTOCONF);
 
@@ -125,21 +125,21 @@ set_global_address(void)
  * Obviously the choice made here must also be selected in udp-server.c.
  *
  * For correct Wireshark decoding using a sniffer, add the /64 prefix to the 6LowPAN protocol preferences,
- * e.g. set Context 0 to aaaa::.  At present Wireshark copies Context/128 and then overwrites it.
- * (Setting Context 0 to aaaa::1111:2222:3333:4444 will report a 16 bit compressed address of aaaa::1111:22ff:fe33:xxxx)
+ * e.g. set Context 0 to fd00::.  At present Wireshark copies Context/128 and then overwrites it.
+ * (Setting Context 0 to fd00::1111:2222:3333:4444 will report a 16 bit compressed address of fd00::1111:22ff:fe33:xxxx)
  *
  * Note the IPCMV6 checksum verification depends on the correct uncompressed addresses.
  */
  
 #if 0
 /* Mode 1 - 64 bits inline */
-   uip_ip6addr(&server_ipaddr, 0xaaaa, 0, 0, 0, 0, 0, 0, 1);
+   uip_ip6addr(&server_ipaddr, UIP_DS6_DEFAULT_PREFIX, 0, 0, 0, 0, 0, 0, 1);
 #elif 1
 /* Mode 2 - 16 bits inline */
-  uip_ip6addr(&server_ipaddr, 0xaaaa, 0, 0, 0, 0, 0x00ff, 0xfe00, 1);
+  uip_ip6addr(&server_ipaddr, UIP_DS6_DEFAULT_PREFIX, 0, 0, 0, 0, 0x00ff, 0xfe00, 1);
 #else
 /* Mode 3 - derived from server link-local (MAC) address */
-  uip_ip6addr(&server_ipaddr, 0xaaaa, 0, 0, 0, 0x0250, 0xc2ff, 0xfea8, 0xcd1a); //redbee-econotag
+  uip_ip6addr(&server_ipaddr, UIP_DS6_DEFAULT_PREFIX, 0, 0, 0, 0x0250, 0xc2ff, 0xfea8, 0xcd1a); //redbee-econotag
 #endif
 }
 /*---------------------------------------------------------------------------*/

--- a/examples/ipv6/rpl-udp/udp-server.c
+++ b/examples/ipv6/rpl-udp/udp-server.c
@@ -114,20 +114,20 @@ PROCESS_THREAD(udp_server_process, ev, data)
  * Obviously the choice made here must also be selected in udp-client.c.
  *
  * For correct Wireshark decoding using a sniffer, add the /64 prefix to the 6LowPAN protocol preferences,
- * e.g. set Context 0 to aaaa::.  At present Wireshark copies Context/128 and then overwrites it.
- * (Setting Context 0 to aaaa::1111:2222:3333:4444 will report a 16 bit compressed address of aaaa::1111:22ff:fe33:xxxx)
+ * e.g. set Context 0 to fd00::.  At present Wireshark copies Context/128 and then overwrites it.
+ * (Setting Context 0 to fd00::1111:2222:3333:4444 will report a 16 bit compressed address of fd00::1111:22ff:fe33:xxxx)
  * Note Wireshark's IPCMV6 checksum verification depends on the correct uncompressed addresses.
  */
  
 #if 0
 /* Mode 1 - 64 bits inline */
-   uip_ip6addr(&ipaddr, 0xaaaa, 0, 0, 0, 0, 0, 0, 1);
+   uip_ip6addr(&ipaddr, UIP_DS6_DEFAULT_PREFIX, 0, 0, 0, 0, 0, 0, 1);
 #elif 1
 /* Mode 2 - 16 bits inline */
-  uip_ip6addr(&ipaddr, 0xaaaa, 0, 0, 0, 0, 0x00ff, 0xfe00, 1);
+  uip_ip6addr(&ipaddr, UIP_DS6_DEFAULT_PREFIX, 0, 0, 0, 0, 0x00ff, 0xfe00, 1);
 #else
 /* Mode 3 - derived from link local (MAC) address */
-  uip_ip6addr(&ipaddr, 0xaaaa, 0, 0, 0, 0, 0, 0, 0);
+  uip_ip6addr(&ipaddr, UIP_DS6_DEFAULT_PREFIX, 0, 0, 0, 0, 0, 0, 0);
   uip_ds6_set_addr_iid(&ipaddr, &uip_lladdr);
 #endif
 
@@ -136,7 +136,7 @@ PROCESS_THREAD(udp_server_process, ev, data)
   if(root_if != NULL) {
     rpl_dag_t *dag;
     dag = rpl_set_root(RPL_DEFAULT_INSTANCE,(uip_ip6addr_t *)&ipaddr);
-    uip_ip6addr(&ipaddr, 0xaaaa, 0, 0, 0, 0, 0, 0, 0);
+    uip_ip6addr(&ipaddr, UIP_DS6_DEFAULT_PREFIX, 0, 0, 0, 0, 0, 0, 0);
     rpl_set_prefix(dag, &ipaddr, 64);
     PRINTF("created a new RPL dag\n");
   } else {

--- a/examples/ipv6/simple-udp-rpl/unicast-receiver.c
+++ b/examples/ipv6/simple-udp-rpl/unicast-receiver.c
@@ -80,7 +80,7 @@ set_global_address(void)
   int i;
   uint8_t state;
 
-  uip_ip6addr(&ipaddr, 0xaaaa, 0, 0, 0, 0, 0, 0, 0);
+  uip_ip6addr(&ipaddr, UIP_DS6_DEFAULT_PREFIX, 0, 0, 0, 0, 0, 0, 0);
   uip_ds6_set_addr_iid(&ipaddr, &uip_lladdr);
   uip_ds6_addr_add(&ipaddr, 0, ADDR_AUTOCONF);
 
@@ -109,7 +109,7 @@ create_rpl_dag(uip_ipaddr_t *ipaddr)
     
     rpl_set_root(RPL_DEFAULT_INSTANCE, ipaddr);
     dag = rpl_get_any_dag();
-    uip_ip6addr(&prefix, 0xaaaa, 0, 0, 0, 0, 0, 0, 0);
+    uip_ip6addr(&prefix, UIP_DS6_DEFAULT_PREFIX, 0, 0, 0, 0, 0, 0, 0);
     rpl_set_prefix(dag, &prefix, 64);
     PRINTF("created a new RPL dag\n");
   } else {

--- a/examples/ipv6/simple-udp-rpl/unicast-sender.c
+++ b/examples/ipv6/simple-udp-rpl/unicast-sender.c
@@ -78,7 +78,7 @@ set_global_address(void)
   int i;
   uint8_t state;
 
-  uip_ip6addr(&ipaddr, 0xaaaa, 0, 0, 0, 0, 0, 0, 0);
+  uip_ip6addr(&ipaddr, UIP_DS6_DEFAULT_PREFIX, 0, 0, 0, 0, 0, 0, 0);
   uip_ds6_set_addr_iid(&ipaddr, &uip_lladdr);
   uip_ds6_addr_add(&ipaddr, 0, ADDR_AUTOCONF);
 

--- a/examples/ipv6/sky-websense/Makefile
+++ b/examples/ipv6/sky-websense/Makefile
@@ -16,7 +16,7 @@ $(CONTIKI)/tools/tunslip6:	$(CONTIKI)/tools/tunslip6.c
 	(cd $(CONTIKI)/tools && $(MAKE) tunslip6)
 
 connect-router:	$(CONTIKI)/tools/tunslip6
-	sudo $(CONTIKI)/tools/tunslip6 aaaa::1/64
+	sudo $(CONTIKI)/tools/tunslip6 fd00::1/64
 
 connect-router-cooja:	$(CONTIKI)/tools/tunslip6
-	sudo $(CONTIKI)/tools/tunslip6 -a 127.0.0.1 aaaa::1/64
+	sudo $(CONTIKI)/tools/tunslip6 -a 127.0.0.1 fd00::1/64

--- a/examples/ipv6/sky-websense/README.md
+++ b/examples/ipv6/sky-websense/README.md
@@ -17,8 +17,8 @@ To test the example in COOJA under Linux
     make connect-router-cooja
 
 3. You should now be able to browse to the nodes using your web browser:
-   Router: http://[aaaa::0212:7401:0001:0101]/
-   Node 2: http://[aaaa::0212:7402:0002:0202]/
+   Router: http://[fd00::0212:7401:0001:0101]/
+   Node 2: http://[fd00::0212:7402:0002:0202]/
 
 
 To run the example on real nodes under Linux

--- a/examples/ipv6/sky-websense/websense-remote.c
+++ b/examples/ipv6/sky-websense/websense-remote.c
@@ -44,13 +44,13 @@
 #include <stdio.h>
 
 /* The address of the server to register the services for this node */
-#define SERVER       "[aaaa::1]"
+#define SERVER       "[fd00::1]"
 
 /* This command registers two services (/0 and /1) to turn the leds on or off */
 #define REGISTER_COMMAND "/r?p=0&d=Turn%20off%20leds&p=1&d=Turn%20on%20leds"
 
 /* The address of the other node to control */
-#define OTHER_NODE   "[aaaa::1]"
+#define OTHER_NODE   "[fd00::1]"
 
 /* The commands to send to the other node */
 #define SET_LEDS_ON  "/1"

--- a/examples/jn516x/rpl/README.md
+++ b/examples/jn516x/rpl/README.md
@@ -28,7 +28,7 @@ From a Linux terminal, go to `contiki/examples/jn516x/rpl/border-router` and do 
 or `make connect-router-sw` if you have **SW flow control**
 
 This will start a tunnel interface (tun0) on the host machine.
-All traffic towards our network (prefix aaaa::1/64) will now be routed to the border router.
+All traffic towards our network (prefix fd00::1/64) will now be routed to the border router.
 
 ## RPL Node
 

--- a/examples/jn516x/rpl/border-router/Makefile
+++ b/examples/jn516x/rpl/border-router/Makefile
@@ -14,7 +14,7 @@ CFLAGS += -DPROJECT_CONF_H=\"project-conf.h\"
 PROJECT_SOURCEFILES += slip-bridge.c slip.c
 
 ifeq ($(PREFIX),)
- PREFIX = aaaa::1/64
+ PREFIX = fd00::1/64
 endif
 
 include $(CONTIKI)/Makefile.include

--- a/examples/jn516x/rpl/coap-dongle-node/dongle-node.c
+++ b/examples/jn516x/rpl/coap-dongle-node/dongle-node.c
@@ -33,6 +33,7 @@
  */
 #include "contiki.h"
 #include "net/ip/uip.h"
+#include "net/ipv6/uip-ds6.h"
 #include "tools/rpl-tools.h"
 #include "rest-engine.h"
 #include "sys/ctimer.h"
@@ -130,7 +131,7 @@ PROCESS_THREAD(start_app, ev, data)
   /* Start net stack */
   if(is_coordinator) {
     uip_ipaddr_t prefix;
-    uip_ip6addr(&prefix, 0xaaaa, 0, 0, 0, 0, 0, 0, 0);
+    uip_ip6addr(&prefix, UIP_DS6_DEFAULT_PREFIX, 0, 0, 0, 0, 0, 0, 0);
     rpl_tools_init(&prefix);
   } else {
     rpl_tools_init(NULL);

--- a/examples/jn516x/rpl/coap-dr1175-node/dr1175-node.c
+++ b/examples/jn516x/rpl/coap-dr1175-node/dr1175-node.c
@@ -34,6 +34,7 @@
 
 #include "contiki.h"
 #include "net/ip/uip.h"
+#include "net/ipv6/uip-ds6.h"
 #include "tools/rpl-tools.h"
 #include "rest-engine.h"
 #include "light-sensor.h"
@@ -350,7 +351,7 @@ PROCESS_THREAD(start_app, ev, data)
   /* Start net stack */
   if(is_coordinator) {
     uip_ipaddr_t prefix;
-    uip_ip6addr(&prefix, 0xaaaa, 0, 0, 0, 0, 0, 0, 0);
+    uip_ip6addr(&prefix, UIP_DS6_DEFAULT_PREFIX, 0, 0, 0, 0, 0, 0, 0);
     rpl_tools_init(&prefix);
   } else {
     rpl_tools_init(NULL);

--- a/examples/jn516x/rpl/coap-dr1199-node/dr1199-node.c
+++ b/examples/jn516x/rpl/coap-dr1199-node/dr1199-node.c
@@ -33,6 +33,7 @@
  */
 #include "contiki.h"
 #include "net/ip/uip.h"
+#include "net/ipv6/uip-ds6.h"
 #include "tools/rpl-tools.h"
 #include "rest-engine.h"
 #include "dev/leds.h"
@@ -351,7 +352,7 @@ PROCESS_THREAD(start_app, ev, data)
   /* Start net stack */
   if(is_coordinator) {
     uip_ipaddr_t prefix;
-    uip_ip6addr(&prefix, 0xaaaa, 0, 0, 0, 0, 0, 0, 0);
+    uip_ip6addr(&prefix, UIP_DS6_DEFAULT_PREFIX, 0, 0, 0, 0, 0, 0, 0);
     rpl_tools_init(&prefix);
   } else {
     rpl_tools_init(NULL);

--- a/examples/jn516x/rpl/node/node.c
+++ b/examples/jn516x/rpl/node/node.c
@@ -36,6 +36,7 @@
  */
 
 #include "contiki.h"
+#include "net/ipv6/uip-ds6.h"
 #include "net/rpl/rpl.h"
 #include "tools/rpl-tools.h"
 
@@ -98,7 +99,7 @@ PROCESS_THREAD(node_process, ev, data)
 
   if(is_coordinator) {
     uip_ipaddr_t prefix;
-    uip_ip6addr(&prefix, 0xaaaa, 0, 0, 0, 0, 0, 0, 0);
+    uip_ip6addr(&prefix, UIP_DS6_DEFAULT_PREFIX, 0, 0, 0, 0, 0, 0, 0);
     rpl_tools_init(&prefix);
   } else {
     rpl_tools_init(NULL);

--- a/examples/mbxxx/mbxxx-websense/Makefile
+++ b/examples/mbxxx/mbxxx-websense/Makefile
@@ -16,7 +16,7 @@ $(CONTIKI)/tools/tunslip6:     $(CONTIKI)/tools/tunslip6.c
 	(cd $(CONTIKI)/tools && $(MAKE) tunslip6)
 
 connect-router:        $(CONTIKI)/tools/tunslip6
-	sudo $(CONTIKI)/tools/tunslip6 aaaa::1/64
+	sudo $(CONTIKI)/tools/tunslip6 fd00::1/64
 
 connect-router-cooja:  $(CONTIKI)/tools/tunslip6
-	sudo $(CONTIKI)/tools/tunslip6 -a 127.0.0.1 aaaa::1/64
+	sudo $(CONTIKI)/tools/tunslip6 -a 127.0.0.1 fd00::1/64

--- a/examples/mbxxx/udp-ipv6-sleep/udp-client.c
+++ b/examples/mbxxx/udp-ipv6-sleep/udp-client.c
@@ -107,7 +107,7 @@ set_global_address(void)
 {
   uip_ipaddr_t ipaddr;
 
-  uip_ip6addr(&ipaddr, 0xaaaa, 0, 0, 0, 0, 0, 0, 0);
+  uip_ip6addr(&ipaddr, UIP_DS6_DEFAULT_PREFIX, 0, 0, 0, 0, 0, 0, 0);
   uip_ds6_set_addr_iid(&ipaddr, &uip_lladdr);
   uip_ds6_addr_add(&ipaddr, 0, ADDR_AUTOCONF);
 }
@@ -123,7 +123,7 @@ set_connection_address(uip_ipaddr_t *ipaddr)
     PRINTF("UDP client failed to parse address '%s'\n", QUOTEME(UDP_CONNECTION_ADDR));
   }
 #elif UIP_CONF_ROUTER
-  uip_ip6addr(ipaddr,0xaaaa,0,0,0,0x0280,0xe102,0x0000,0x008a);
+  uip_ip6addr(ipaddr,UIP_DS6_DEFAULT_PREFIX,0,0,0,0x0280,0xe102,0x0000,0x008a);
 #else
   uip_ip6addr(ipaddr,0xfe80,0,0,0,0x0280,0xe102,0x0000,0x008a);
 #endif /* UDP_CONNECTION_ADDR */

--- a/examples/mbxxx/udp-ipv6-sleep/udp-server.c
+++ b/examples/mbxxx/udp-ipv6-sleep/udp-server.c
@@ -95,7 +95,7 @@ PROCESS_THREAD(udp_server_process, ev, data)
   PRINTF("UDP server started\n");
 
 #if UIP_CONF_ROUTER
-  uip_ip6addr(&ipaddr, 0xaaaa, 0, 0, 0, 0, 0, 0, 0);
+  uip_ip6addr(&ipaddr, UIP_DS6_DEFAULT_PREFIX, 0, 0, 0, 0, 0, 0, 0);
   uip_ds6_set_addr_iid(&ipaddr, &uip_lladdr);
   uip_ds6_addr_add(&ipaddr, 0, ADDR_AUTOCONF);
 #endif /* UIP_CONF_ROUTER */

--- a/examples/servreg-hack/example-servreg-client.c
+++ b/examples/servreg-hack/example-servreg-client.c
@@ -54,7 +54,7 @@ set_global_address(void)
 {
   uip_ipaddr_t ipaddr;
 
-  uip_ip6addr(&ipaddr, 0xaaaa, 0, 0, 0, 0, 0, 0, 0);
+  uip_ip6addr(&ipaddr, UIP_DS6_DEFAULT_PREFIX, 0, 0, 0, 0, 0, 0, 0);
   uip_ds6_set_addr_iid(&ipaddr, &uip_lladdr);
   uip_ds6_addr_add(&ipaddr, 0, ADDR_AUTOCONF);
 }

--- a/examples/servreg-hack/example-servreg-server.c
+++ b/examples/servreg-hack/example-servreg-server.c
@@ -53,7 +53,7 @@ PROCESS_THREAD(example_servreg_server_process, ev, data)
   PROCESS_BEGIN();
 
   /* Set a global address. */
-  uip_ip6addr(&ipaddr, 0xaaaa, 0, 0, 0, 0, 0, 0, 0);
+  uip_ip6addr(&ipaddr, UIP_DS6_DEFAULT_PREFIX, 0, 0, 0, 0, 0, 0, 0);
   uip_ds6_set_addr_iid(&ipaddr, &uip_lladdr);
   uip_ds6_addr_add(&ipaddr, 0, ADDR_AUTOCONF);
 

--- a/examples/udp-ipv6/udp-client.c
+++ b/examples/udp-ipv6/udp-client.c
@@ -98,7 +98,7 @@ set_global_address(void)
 {
   uip_ipaddr_t ipaddr;
 
-  uip_ip6addr(&ipaddr, 0xaaaa, 0, 0, 0, 0, 0, 0, 0);
+  uip_ip6addr(&ipaddr, UIP_DS6_DEFAULT_PREFIX, 0, 0, 0, 0, 0, 0, 0);
   uip_ds6_set_addr_iid(&ipaddr, &uip_lladdr);
   uip_ds6_addr_add(&ipaddr, 0, ADDR_AUTOCONF);
 }
@@ -111,7 +111,7 @@ set_connection_address(uip_ipaddr_t *ipaddr)
 #if RESOLV_CONF_SUPPORTS_MDNS
 #define UDP_CONNECTION_ADDR       contiki-udp-server.local
 #elif UIP_CONF_ROUTER
-#define UDP_CONNECTION_ADDR       aaaa:0:0:0:0212:7404:0004:0404
+#define UDP_CONNECTION_ADDR       fd00:0:0:0:0212:7404:0004:0404
 #else
 #define UDP_CONNECTION_ADDR       fe80:0:0:0:6466:6666:6666:6666
 #endif

--- a/examples/udp-ipv6/udp-server.c
+++ b/examples/udp-ipv6/udp-server.c
@@ -99,7 +99,7 @@ PROCESS_THREAD(udp_server_process, ev, data)
 #endif
 
 #if UIP_CONF_ROUTER
-  uip_ip6addr(&ipaddr, 0xaaaa, 0, 0, 0, 0, 0, 0, 0);
+  uip_ip6addr(&ipaddr, UIP_DS6_DEFAULT_PREFIX, 0, 0, 0, 0, 0, 0, 0);
   uip_ds6_set_addr_iid(&ipaddr, &uip_lladdr);
   uip_ds6_addr_add(&ipaddr, 0, ADDR_AUTOCONF);
 #endif /* UIP_CONF_ROUTER */

--- a/examples/udp-stream/udp-stream.c
+++ b/examples/udp-stream/udp-stream.c
@@ -74,7 +74,7 @@ set_global_address(void)
   int i;
   uint8_t state;
 
-  uip_ip6addr(&ipaddr, 0xaaaa, 0, 0, 0, 0, 0, 0, 0);
+  uip_ip6addr(&ipaddr, UIP_DS6_DEFAULT_PREFIX, 0, 0, 0, 0, 0, 0, 0);
   uip_ds6_set_addr_iid(&ipaddr, &uip_lladdr);
   uip_ds6_addr_add(&ipaddr, 0, ADDR_AUTOCONF);
 
@@ -102,7 +102,7 @@ create_rpl_dag(uip_ipaddr_t *ipaddr)
 
     rpl_set_root(RPL_DEFAULT_INSTANCE, ipaddr);
     dag = rpl_get_any_dag();
-    uip_ip6addr(&prefix, 0xaaaa, 0, 0, 0, 0, 0, 0, 0);
+    uip_ip6addr(&prefix, UIP_DS6_DEFAULT_PREFIX, 0, 0, 0, 0, 0, 0, 0);
     rpl_set_prefix(dag, &prefix, 64);
     printf("created a new RPL dag\n");
   } else {

--- a/examples/webserver-ipv6/README.md
+++ b/examples/webserver-ipv6/README.md
@@ -41,7 +41,7 @@ On linux you can set up router advertisements as follows:
 
 - You might need to add a route:
 
-        ip -6 route add aaaa:0000:0000:0000:0206:98ff:fe00:0232/64 dev tap0
+        ip -6 route add fd00:0000:0000:0000:0206:98ff:fe00:0232/64 dev tap0
 
 - Then configure a global address by sending a router advertisement (RA) with a
   prefix option. You can use radvd for example to generate such a packet.

--- a/examples/zolertia/z1/ipv6/z1-websense/Makefile
+++ b/examples/zolertia/z1/ipv6/z1-websense/Makefile
@@ -18,10 +18,10 @@ $(CONTIKI)/tools/tunslip6:	$(CONTIKI)/tools/tunslip6.c
 	(cd $(CONTIKI)/tools && $(MAKE) tunslip6)
 
 connect-router:	$(CONTIKI)/tools/tunslip6
-	sudo $(CONTIKI)/tools/tunslip6 aaaa::1/64
+	sudo $(CONTIKI)/tools/tunslip6 fd00::1/64
 
 connect-router-cooja:	$(CONTIKI)/tools/tunslip6
-	sudo $(CONTIKI)/tools/tunslip6 -a 127.0.0.1 aaaa::1/64
+	sudo $(CONTIKI)/tools/tunslip6 -a 127.0.0.1 fd00::1/64
 
 CUSTOM_RULE_LINK=1 
 %.$(TARGET): %.co $(PROJECT_OBJECTFILES) $(PROJECT_LIBRARIES) contiki-$(TARGET).a $(LD) $(LDFLAGS) $(TARGET_STARTFILES) ${filter-out %.a,$^} ${filter %.a,$^} $(TARGET_LIBFILES) -o $@ -lm

--- a/examples/zolertia/z1/ipv6/z1-websense/README.md
+++ b/examples/zolertia/z1/ipv6/z1-websense/README.md
@@ -19,8 +19,8 @@ To test the example in COOJA under Linux
 
 3. You should now be able to browse to the nodes using your web browser:
 
-   Router: http://[aaaa::0212:7401:0001:0101]/
-   Node 2: http://[aaaa::0212:7402:0002:0202]/
+   Router: http://[fd00::0212:7401:0001:0101]/
+   Node 2: http://[fd00::0212:7402:0002:0202]/
 
 
 To run the example on real nodes under Linux

--- a/examples/zolertia/z1/ipv6/z1-websense/websense-remote.c
+++ b/examples/zolertia/z1/ipv6/z1-websense/websense-remote.c
@@ -45,13 +45,13 @@
 #include <stdio.h>
 /*---------------------------------------------------------------------------*/
 /* The address of the server to register the services for this node */
-#define SERVER       "aaaa::1"
+#define SERVER       "fd00::1"
 
 /* This command registers two services (/0 and /1) to turn the leds on or off */
 #define REGISTER_COMMAND "/r?p=0&d=Turn%20off%20leds&p=1&d=Turn%20on%20leds"
 
 /* The address of the other node to control */
-#define OTHER_NODE   "aaaa::212:7403:3:303"
+#define OTHER_NODE   "fd00::212:7403:3:303"
 
 /* The commands to send to the other node */
 #define SET_LEDS_ON  "/1"

--- a/platform/avr-atmega128rfa1/apps/raven-ipso/raven-ipso.c
+++ b/platform/avr-atmega128rfa1/apps/raven-ipso/raven-ipso.c
@@ -95,7 +95,7 @@ raven_ping6(void)
   /* ping ipv6.google.com*/
   uip_ip6addr(&ping_addr,0x2001,0x420,0x5FFF,0x7D,0x2D0,0xB7FF,0xFE23,0xE6DB);
   //uip_ip6addr(&ping_addr, 0x2001, 0x4860, 0, 0x2001, 0, 0, 0, 0x68);
-  //uip_ip6addr(&ping_addr, 0xaaaa, 0, 0, 0, 0, 0, 0, 1);
+  //uip_ip6addr(&ping_addr, UIP_DS6_DEFAULT_PREFIX, 0, 0, 0, 0, 0, 0, 1);
   
   UIP_IP_BUF->vtc = 0x60;
   UIP_IP_BUF->tcflow = 1;

--- a/platform/avr-atmega128rfa1/contiki-conf.h
+++ b/platform/avr-atmega128rfa1/contiki-conf.h
@@ -151,10 +151,10 @@ typedef unsigned short uip_stats_t;
 #define UIP_CONF_LLH_LEN          0
 
 /* 10 bytes per stateful address context - see sicslowpan.c */
-/* Default is 1 context with prefix aaaa::/64 */
+/* Default is 1 context with prefix fd00::/64 */
 /* These must agree with all the other nodes or there will be a failure to communicate! */
 #define SICSLOWPAN_CONF_MAX_ADDR_CONTEXTS 1
-#define SICSLOWPAN_CONF_ADDR_CONTEXT_0 {addr_contexts[0].prefix[0]=0xaa;addr_contexts[0].prefix[1]=0xaa;}
+#define SICSLOWPAN_CONF_ADDR_CONTEXT_0 {addr_contexts[0].prefix[0]=UIP_DS6_DEFAULT_PREFIX_0;addr_contexts[0].prefix[1]=UIP_DS6_DEFAULT_PREFIX_1;}
 #define SICSLOWPAN_CONF_ADDR_CONTEXT_1 {addr_contexts[1].prefix[0]=0xbb;addr_contexts[1].prefix[1]=0xbb;}
 #define SICSLOWPAN_CONF_ADDR_CONTEXT_2 {addr_contexts[2].prefix[0]=0x20;addr_contexts[2].prefix[1]=0x01;addr_contexts[2].prefix[2]=0x49;addr_contexts[2].prefix[3]=0x78,addr_contexts[2].prefix[4]=0x1d;addr_contexts[2].prefix[5]=0xb1;}
 

--- a/platform/avr-atmega128rfa1/contiki-main.c
+++ b/platform/avr-atmega128rfa1/contiki-main.c
@@ -340,7 +340,7 @@ uint8_t i;
 #if 0
 {  
   uip_ip6addr_t ipaddr;
-  uip_ip6addr(&ipaddr, 0xaaaa, 0, 0, 0, 0, 0, 0, 0);
+  uip_ip6addr(&ipaddr, UIP_DS6_DEFAULT_PREFIX, 0, 0, 0, 0, 0, 0, 0);
   uip_ds6_addr_add(&ipaddr, 0, ADDR_AUTOCONF);
 //  uip_ds6_prefix_add(&ipaddr,64,0);
 }

--- a/platform/avr-raven/apps/raven-ipso/raven-ipso.c
+++ b/platform/avr-raven/apps/raven-ipso/raven-ipso.c
@@ -95,7 +95,7 @@ raven_ping6(void)
   /* ping ipv6.google.com*/
   uip_ip6addr(&ping_addr,0x2001,0x420,0x5FFF,0x7D,0x2D0,0xB7FF,0xFE23,0xE6DB);
   //uip_ip6addr(&ping_addr, 0x2001, 0x4860, 0, 0x2001, 0, 0, 0, 0x68);
-  //uip_ip6addr(&ping_addr, 0xaaaa, 0, 0, 0, 0, 0, 0, 1);
+  //uip_ip6addr(&ping_addr, UIP_DS6_DEFAULT_PREFIX, 0, 0, 0, 0, 0, 0, 1);
   
   UIP_IP_BUF->vtc = 0x60;
   UIP_IP_BUF->tcflow = 1;

--- a/platform/avr-raven/contiki-conf.h
+++ b/platform/avr-raven/contiki-conf.h
@@ -167,10 +167,10 @@ typedef unsigned short uip_stats_t;
 #define UIP_CONF_LLH_LEN         0
 
 /* 10 bytes per stateful address context - see sicslowpan.c */
-/* Default is 1 context with prefix aaaa::/64 */
+/* Default is 1 context with prefix fd00::/64 */
 /* These must agree with all the other nodes or there will be a failure to communicate! */
 #define SICSLOWPAN_CONF_MAX_ADDR_CONTEXTS 1
-#define SICSLOWPAN_CONF_ADDR_CONTEXT_0 {addr_contexts[0].prefix[0]=0xaa;addr_contexts[0].prefix[1]=0xaa;}
+#define SICSLOWPAN_CONF_ADDR_CONTEXT_0 {addr_contexts[0].prefix[0]=UIP_DS6_DEFAULT_PREFIX_0;addr_contexts[0].prefix[1]=UIP_DS6_DEFAULT_PREFIX_1;}
 #define SICSLOWPAN_CONF_ADDR_CONTEXT_1 {addr_contexts[1].prefix[0]=0xbb;addr_contexts[1].prefix[1]=0xbb;}
 #define SICSLOWPAN_CONF_ADDR_CONTEXT_2 {addr_contexts[2].prefix[0]=0x20;addr_contexts[2].prefix[1]=0x01;addr_contexts[2].prefix[2]=0x49;addr_contexts[2].prefix[3]=0x78,addr_contexts[2].prefix[4]=0x1d;addr_contexts[2].prefix[5]=0xb1;}
 

--- a/platform/avr-raven/contiki-raven-default-init-net.c
+++ b/platform/avr-raven/contiki-raven-default-init-net.c
@@ -44,7 +44,7 @@ init_net(void)
 
 /*  uip_ipaddr_t ipprefix;
 
-  uip_ip6addr(&ipprefix, 0xaaaa, 0, 0, 0, 0, 0, 0, 0);
+  uip_ip6addr(&ipprefix, UIP_DS6_DEFAULT_PREFIX, 0, 0, 0, 0, 0, 0, 0);
 
   uip_netif_addr_add(&ipprefix, UIP_DEFAULT_PREFIX_LEN, 0, AUTOCONF);
   uip_nd6_prefix_add(&ipprefix, UIP_DEFAULT_PREFIX_LEN, 0);

--- a/platform/avr-raven/contiki-raven-main.c
+++ b/platform/avr-raven/contiki-raven-main.c
@@ -357,7 +357,7 @@ uint8_t i;
 #if 0
 {  
   uip_ip6addr_t ipaddr;
-  uip_ip6addr(&ipaddr, 0xaaaa, 0, 0, 0, 0, 0, 0, 0);
+  uip_ip6addr(&ipaddr, UIP_DS6_DEFAULT_PREFIX, 0, 0, 0, 0, 0, 0, 0);
   uip_ds6_addr_add(&ipaddr, 0, ADDR_AUTOCONF);
 //  uip_ds6_prefix_add(&ipaddr,64,0);
 }

--- a/platform/avr-ravenusb/contiki-conf.h
+++ b/platform/avr-ravenusb/contiki-conf.h
@@ -236,10 +236,10 @@ extern void mac_log_802_15_4_rx(const uint8_t* buffer, size_t total_len);
 #define UIP_CONF_BUFSIZE		 UIP_LINK_MTU + UIP_LLH_LEN + 4   /* +4 for vlan on macosx */
 
 /* 10 bytes per stateful address context - see sicslowpan.c */
-/* Default is 1 context with prefix aaaa::/64 */
+/* Default is 1 context with prefix fd00::/64 */
 /* These must agree with all the other nodes or there will be a failure to communicate! */
 #//define SICSLOWPAN_CONF_MAX_ADDR_CONTEXTS 1
-#define SICSLOWPAN_CONF_ADDR_CONTEXT_0 {addr_contexts[0].prefix[0]=0xaa;addr_contexts[0].prefix[1]=0xaa;}
+#define SICSLOWPAN_CONF_ADDR_CONTEXT_0 {addr_contexts[0].prefix[0]=UIP_DS6_DEFAULT_PREFIX_0;addr_contexts[0].prefix[1]=UIP_DS6_DEFAULT_PREFIX_1;}
 #define SICSLOWPAN_CONF_ADDR_CONTEXT_1 {addr_contexts[1].prefix[0]=0xbb;addr_contexts[1].prefix[1]=0xbb;}
 #define SICSLOWPAN_CONF_ADDR_CONTEXT_2 {addr_contexts[2].prefix[0]=0x20;addr_contexts[2].prefix[1]=0x01;addr_contexts[2].prefix[2]=0x49;addr_contexts[2].prefix[3]=0x78,addr_contexts[2].prefix[4]=0x1d;addr_contexts[2].prefix[5]=0xb1;}
 

--- a/platform/cc2530dk/contiki-conf.h
+++ b/platform/cc2530dk/contiki-conf.h
@@ -259,8 +259,8 @@
 /* Define our IPv6 prefixes/contexts here */
 #define SICSLOWPAN_CONF_MAX_ADDR_CONTEXTS    1
 #define SICSLOWPAN_CONF_ADDR_CONTEXT_0 { \
-  addr_contexts[0].prefix[0] = 0xaa; \
-  addr_contexts[0].prefix[1] = 0xaa; \
+  addr_contexts[0].prefix[0] = UIP_DS6_DEFAULT_PREFIX_0; \
+  addr_contexts[0].prefix[1] = UIP_DS6_DEFAULT_PREFIX_1; \
 }
 
 #define MAC_CONF_CHANNEL_CHECK_RATE          8

--- a/platform/cc2538dk/README.md
+++ b/platform/cc2538dk/README.md
@@ -308,14 +308,14 @@ Start by building a border router from `examples/ipv6/rpl-border-router`
   * Connect device to Linux or OS X over its XDS port.
   * `cd $(CONTIKI)/tools`
   * `make tunslip6`
-  * `sudo $(CONTIKI)/tools/tunslip6 -s /dev/<device> aaaa::1/64`
+  * `sudo $(CONTIKI)/tools/tunslip6 -s /dev/<device> fd00::1/64`
   * The router will print its own IPv6 address. Use it below.
 
         Got configuration message of type P
-        Setting prefix aaaa::
+        Setting prefix fd00::
         created a new RPL dag
         Server IPv6 addresses:
-         aaaa::212:4b00:89ab:cdef
+         fd00::212:4b00:89ab:cdef
          fe80::212:4b00:89ab:cdef
 
   * `ping6 <address>`

--- a/platform/cc2538dk/contiki-conf.h
+++ b/platform/cc2538dk/contiki-conf.h
@@ -472,8 +472,8 @@ typedef uint32_t rtimer_clock_t;
 #define SICSLOWPAN_CONF_MAX_ADDR_CONTEXTS    1
 #ifndef SICSLOWPAN_CONF_ADDR_CONTEXT_0
 #define SICSLOWPAN_CONF_ADDR_CONTEXT_0 { \
-  addr_contexts[0].prefix[0] = 0xaa; \
-  addr_contexts[0].prefix[1] = 0xaa; \
+  addr_contexts[0].prefix[0] = UIP_DS6_DEFAULT_PREFIX_0; \
+  addr_contexts[0].prefix[1] = UIP_DS6_DEFAULT_PREFIX_1; \
 }
 #endif
 

--- a/platform/cooja-ip64/contiki-cooja-ip64-main.c
+++ b/platform/cooja-ip64/contiki-cooja-ip64-main.c
@@ -217,7 +217,7 @@ contiki_init(void)
   printf("%02x%02x\n", lladdr->ipaddr.u8[14],
          lladdr->ipaddr.u8[15]);
 
-  uip_ip6addr(&ipaddr, 0xaaaa, 0, 0, 0, 0, 0, 0, 0);
+  uip_ip6addr(&ipaddr, UIP_DS6_DEFAULT_PREFIX, 0, 0, 0, 0, 0, 0, 0);
   uip_ds6_set_addr_iid(&ipaddr, &uip_lladdr);
   uip_ds6_addr_add(&ipaddr, 0, ADDR_TENTATIVE);
   printf("Tentative global IPv6 address ");

--- a/platform/cooja/contiki-cooja-main.c
+++ b/platform/cooja/contiki-cooja-main.c
@@ -304,7 +304,7 @@ contiki_init()
     if(1) {
       uip_ipaddr_t ipaddr;
       int i;
-      uip_ip6addr(&ipaddr, 0xaaaa, 0, 0, 0, 0, 0, 0, 0);
+      uip_ip6addr(&ipaddr, UIP_DS6_DEFAULT_PREFIX, 0, 0, 0, 0, 0, 0, 0);
       uip_ds6_set_addr_iid(&ipaddr, &uip_lladdr);
       uip_ds6_addr_add(&ipaddr, 0, ADDR_TENTATIVE);
       printf("Tentative global IPv6 address ");

--- a/platform/ev-aducrf101mkxz/README.md
+++ b/platform/ev-aducrf101mkxz/README.md
@@ -71,9 +71,9 @@ the SLIP tunnel on the host machine:
 
     sudo contiki/tools/tunslip6 \
         -s /dev/serial/by-id/usb-SEGGER_J-Link_000541011111-if00 \
-        -B 115200 -v3 aaaa::1/64
+        -B 115200 -v3 fd00::1/64
 
-Open the border router's home page at: http://[aaaa::3230:3030:3132:3334]/
+Open the border router's home page at: http://[fd00::3230:3030:3132:3334]/
 
 #### Web Server ####
 
@@ -90,7 +90,7 @@ router:
     adi-cm3sd/cm3sd.py -a contiki/examples/webserver-ipv6/webserver6.ev-aducrf101mkxz.hex \
         /dev/serial/by-id/usb-SEGGER_J-Link_000541022222-if00
 
-Open the web server's home page at: http://[aaaa::3230:3030:3536:3738]/
+Open the web server's home page at: http://[fd00::3230:3030:3536:3738]/
 
 On Windows:
 -----------

--- a/platform/eval-adf7xxxmb4z/README.md
+++ b/platform/eval-adf7xxxmb4z/README.md
@@ -51,9 +51,9 @@ Build and run the SLIP tunnel on the host machine.
 Here it is assumed that the Secondary UART USB port (J3) is attached to /dev/ttyUSB1:
 
 	make -C contiki/tools tunslip6
-	sudo contiki/tools/tunslip6 -B 38400 -s /dev/ttyUSB1 -v3 aaaa::1/64
+	sudo contiki/tools/tunslip6 -B 38400 -s /dev/ttyUSB1 -v3 fd00::1/64
 
-Open the border router home page at http://[aaaa::302:304:506:708]/
+Open the border router home page at http://[fd00::302:304:506:708]/
 
 Build and run the IPv6 web server example on another eval board.
 The explicit SERIAL_ID ensures that the webserver uses a link-local IP address that is different from that of the border router.
@@ -61,7 +61,7 @@ The explicit SERIAL_ID ensures that the webserver uses a link-local IP address t
 	make -C contiki/examples/webserver-ipv6 TARGET=eval-adf7xxxmb4z SERIAL_ID='"\x01\x02\x03\x04\x05\x06\x07\x09"' webserver6.eval-adf7xxxmb4z.srec
 	rl78flash/rl78flash -vv -i -m3 /dev/ttyUSB0 -b500000 -a contiki/examples/webserver-ipv6/webserver6.eval-adf7xxxmb4z.srec
 
-Open the web server's home page at http://[aaaa::7a30:3178:3032:7830]
+Open the web server's home page at http://[fd00::7a30:3178:3032:7830]
 
 
 On Windows:

--- a/platform/exp5438/contiki-exp5438-main.c
+++ b/platform/exp5438/contiki-exp5438-main.c
@@ -236,7 +236,7 @@ main(int argc, char **argv)
   if(!UIP_CONF_IPV6_RPL) {
     uip_ipaddr_t ipaddr;
     int i;
-    uip_ip6addr(&ipaddr, 0xaaaa, 0, 0, 0, 0, 0, 0, 0);
+    uip_ip6addr(&ipaddr, UIP_DS6_DEFAULT_PREFIX, 0, 0, 0, 0, 0, 0, 0);
     uip_ds6_set_addr_iid(&ipaddr, &uip_lladdr);
     uip_ds6_addr_add(&ipaddr, 0, ADDR_TENTATIVE);
     printf("Tentative global IPv6 address ");

--- a/platform/jn516x/contiki-jn516x-main.c
+++ b/platform/jn516x/contiki-jn516x-main.c
@@ -226,7 +226,7 @@ start_uip6(void)
   if(!UIP_CONF_IPV6_RPL) {
     uip_ipaddr_t ipaddr;
     int i;
-    uip_ip6addr(&ipaddr, 0xaaaa, 0, 0, 0, 0, 0, 0, 0);
+    uip_ip6addr(&ipaddr, UIP_DS6_DEFAULT_PREFIX, 0, 0, 0, 0, 0, 0, 0);
     uip_ds6_set_addr_iid(&ipaddr, &uip_lladdr);
     uip_ds6_addr_add(&ipaddr, 0, ADDR_TENTATIVE);
     PRINTF("Tentative global IPv6 address ");

--- a/platform/mbxxx/contiki-main.c
+++ b/platform/mbxxx/contiki-main.c
@@ -214,7 +214,7 @@ main(void)
   if(!UIP_CONF_IPV6_RPL) {
     uip_ipaddr_t ipaddr;
     int i;
-    uip_ip6addr(&ipaddr, 0xaaaa, 0, 0, 0, 0, 0, 0, 0);
+    uip_ip6addr(&ipaddr, UIP_DS6_DEFAULT_PREFIX, 0, 0, 0, 0, 0, 0, 0);
     uip_ds6_set_addr_iid(&ipaddr, &uip_lladdr);
     uip_ds6_addr_add(&ipaddr, 0, ADDR_TENTATIVE);
     printf("Tentative global IPv6 address ");

--- a/platform/micaz/init-net.c
+++ b/platform/micaz/init-net.c
@@ -177,7 +177,7 @@ init_net(void)
   if(!UIP_CONF_IPV6_RPL) {
     uip_ipaddr_t ipaddr;
     int i;
-    uip_ip6addr(&ipaddr, 0xaaaa, 0, 0, 0, 0, 0, 0, 0);
+    uip_ip6addr(&ipaddr, UIP_DS6_DEFAULT_PREFIX, 0, 0, 0, 0, 0, 0, 0);
     uip_ds6_set_addr_iid(&ipaddr, &uip_lladdr);
     uip_ds6_addr_add(&ipaddr, 0, ADDR_TENTATIVE);
     printf_P(PSTR("Tentative global IPv6 address "));

--- a/platform/minimal-net/contiki-main.c
+++ b/platform/minimal-net/contiki-main.c
@@ -289,7 +289,7 @@ main(int argc, char **argv)
 #ifdef HARD_CODED_ADDRESS
     uiplib_ipaddrconv(HARD_CODED_ADDRESS, &ipaddr);
 #else
-    uip_ip6addr(&ipaddr, 0xaaaa, 0, 0, 0, 0, 0, 0, 0);
+    uip_ip6addr(&ipaddr, UIP_DS6_DEFAULT_PREFIX, 0, 0, 0, 0, 0, 0, 0);
 #endif
     if((ipaddr.u16[0] != 0) ||
        (ipaddr.u16[1] != 0) ||

--- a/platform/sky/contiki-sky-main.c
+++ b/platform/sky/contiki-sky-main.c
@@ -330,7 +330,7 @@ main(int argc, char **argv)
   if(!UIP_CONF_IPV6_RPL) {
     uip_ipaddr_t ipaddr;
     int i;
-    uip_ip6addr(&ipaddr, 0xaaaa, 0, 0, 0, 0, 0, 0, 0);
+    uip_ip6addr(&ipaddr, UIP_DS6_DEFAULT_PREFIX, 0, 0, 0, 0, 0, 0, 0);
     uip_ds6_set_addr_iid(&ipaddr, &uip_lladdr);
     uip_ds6_addr_add(&ipaddr, 0, ADDR_TENTATIVE);
     PRINTF("Tentative global IPv6 address ");

--- a/platform/wismote/contiki-wismote-main.c
+++ b/platform/wismote/contiki-wismote-main.c
@@ -324,7 +324,7 @@ main(int argc, char **argv)
   if(!UIP_CONF_IPV6_RPL) {
     uip_ipaddr_t ipaddr;
     int i;
-    uip_ip6addr(&ipaddr, 0xaaaa, 0, 0, 0, 0, 0, 0, 0);
+    uip_ip6addr(&ipaddr, UIP_DS6_DEFAULT_PREFIX, 0, 0, 0, 0, 0, 0, 0);
     uip_ds6_set_addr_iid(&ipaddr, &uip_lladdr);
     uip_ds6_addr_add(&ipaddr, 0, ADDR_TENTATIVE);
     printf("Tentative global IPv6 address ");

--- a/platform/z1/contiki-z1-main.c
+++ b/platform/z1/contiki-z1-main.c
@@ -345,7 +345,7 @@ main(int argc, char **argv)
   if(!UIP_CONF_IPV6_RPL) {
     uip_ipaddr_t ipaddr;
     int i;
-    uip_ip6addr(&ipaddr, 0xaaaa, 0, 0, 0, 0, 0, 0, 0);
+    uip_ip6addr(&ipaddr, UIP_DS6_DEFAULT_PREFIX, 0, 0, 0, 0, 0, 0, 0);
     uip_ds6_set_addr_iid(&ipaddr, &uip_lladdr);
     uip_ds6_addr_add(&ipaddr, 0, ADDR_TENTATIVE);
     printf("Tentative global IPv6 address ");

--- a/platform/zoul/contiki-conf.h
+++ b/platform/zoul/contiki-conf.h
@@ -540,8 +540,8 @@ typedef uint32_t rtimer_clock_t;
 #define SICSLOWPAN_CONF_MAX_ADDR_CONTEXTS    1
 #ifndef SICSLOWPAN_CONF_ADDR_CONTEXT_0
 #define SICSLOWPAN_CONF_ADDR_CONTEXT_0 { \
-  addr_contexts[0].prefix[0] = 0xaa; \
-  addr_contexts[0].prefix[1] = 0xaa; \
+  addr_contexts[0].prefix[0] = UIP_DS6_DEFAULT_PREFIX_0; \
+  addr_contexts[0].prefix[1] = UIP_DS6_DEFAULT_PREFIX_1; \
 }
 #endif
 

--- a/regression-tests/11-ipv6/code/receiver/udp-receiver.c
+++ b/regression-tests/11-ipv6/code/receiver/udp-receiver.c
@@ -39,7 +39,7 @@ PROCESS_THREAD(udp_process, ev, data)
 
   PROCESS_BEGIN();
 
-  uip_ip6addr(&addr, 0xaaaa, 0, 0, 0, 0, 0, 0, 2);
+  uip_ip6addr(&addr, UIP_DS6_DEFAULT_PREFIX, 0, 0, 0, 0, 0, 0, 2);
   uip_ds6_addr_add(&addr, 0, ADDR_AUTOCONF);
 
   simple_udp_register(&broadcast_connection, UDP_PORT,

--- a/regression-tests/11-ipv6/code/sender/unicast-sender.c
+++ b/regression-tests/11-ipv6/code/sender/unicast-sender.c
@@ -40,12 +40,12 @@ PROCESS_THREAD(udp_process, ev, data)
 
   PROCESS_BEGIN();
 
-  uip_ip6addr(&addr, 0xaaaa, 0, 0, 0, 0, 0, 0, 3);
+  uip_ip6addr(&addr, UIP_DS6_DEFAULT_PREFIX, 0, 0, 0, 0, 0, 0, 3);
   uip_ds6_addr_add(&addr, 0, ADDR_AUTOCONF);
 
   rpl_set_root(RPL_DEFAULT_INSTANCE, &addr);
   /*  dag = rpl_get_any_dag();
-  uip_ip6addr(&prefix, 0xaaaa, 0, 0, 0, 0, 0, 0, 0);
+  uip_ip6addr(&prefix, UIP_DS6_DEFAULT_PREFIX, 0, 0, 0, 0, 0, 0, 0);
   rpl_set_prefix(dag, &prefix, 64);*/
 
 
@@ -63,7 +63,7 @@ PROCESS_THREAD(udp_process, ev, data)
     etimer_reset(&periodic_timer);
 
     printf("Sending unicast\n");
-    uip_ip6addr(&addr, 0xaaaa, 0, 0, 0, 0, 0, 0, 2);
+    uip_ip6addr(&addr, UIP_DS6_DEFAULT_PREFIX, 0, 0, 0, 0, 0, 0, 2);
     simple_udp_sendto(&broadcast_connection, buf, sizeof(buf), &addr);
   }
 

--- a/regression-tests/12-rpl/code/receiver-node.c
+++ b/regression-tests/12-rpl/code/receiver-node.c
@@ -73,7 +73,7 @@ set_global_address(void)
   int i;
   uint8_t state;
 
-  uip_ip6addr(&ipaddr, 0xaaaa, 0, 0, 0, 0, 0, 0, 0);
+  uip_ip6addr(&ipaddr, UIP_DS6_DEFAULT_PREFIX, 0, 0, 0, 0, 0, 0, 0);
   uip_ds6_set_addr_iid(&ipaddr, &uip_lladdr);
   uip_ds6_addr_add(&ipaddr, 0, ADDR_AUTOCONF);
 

--- a/regression-tests/12-rpl/code/root-node.c
+++ b/regression-tests/12-rpl/code/root-node.c
@@ -77,7 +77,7 @@ set_global_address(void)
   int i;
   uint8_t state;
 
-  uip_ip6addr(&ipaddr, 0xaaaa, 0, 0, 0, 0, 0, 0, 0);
+  uip_ip6addr(&ipaddr, UIP_DS6_DEFAULT_PREFIX, 0, 0, 0, 0, 0, 0, 0);
   uip_ds6_set_addr_iid(&ipaddr, &uip_lladdr);
   uip_ds6_addr_add(&ipaddr, 0, ADDR_AUTOCONF);
 
@@ -106,7 +106,7 @@ create_rpl_dag(uip_ipaddr_t *ipaddr)
     
     rpl_set_root(RPL_DEFAULT_INSTANCE, ipaddr);
     dag = rpl_get_any_dag();
-    uip_ip6addr(&prefix, 0xaaaa, 0, 0, 0, 0, 0, 0, 0);
+    uip_ip6addr(&prefix, UIP_DS6_DEFAULT_PREFIX, 0, 0, 0, 0, 0, 0, 0);
     rpl_set_prefix(dag, &prefix, 64);
     PRINTF("created a new RPL dag\n");
   } else {

--- a/regression-tests/12-rpl/code/sender-node.c
+++ b/regression-tests/12-rpl/code/sender-node.c
@@ -72,7 +72,7 @@ set_global_address(void)
   int i;
   uint8_t state;
 
-  uip_ip6addr(&ipaddr, 0xaaaa, 0, 0, 0, 0, 0, 0, 0);
+  uip_ip6addr(&ipaddr, UIP_DS6_DEFAULT_PREFIX, 0, 0, 0, 0, 0, 0, 0);
   uip_ds6_set_addr_iid(&ipaddr, &uip_lladdr);
   uip_ds6_addr_add(&ipaddr, 0, ADDR_AUTOCONF);
 
@@ -109,7 +109,7 @@ PROCESS_THREAD(sender_node_process, ev, data)
 
     PROCESS_WAIT_EVENT_UNTIL(etimer_expired(&send_timer));
 
-    uip_ip6addr(&addr, 0xaaaa, 0, 0, 0, 0x0201, 0x001, 0x001, 0x001);
+    uip_ip6addr(&addr, UIP_DS6_DEFAULT_PREFIX, 0, 0, 0, 0x0201, 0x001, 0x001, 0x001);
 
     {
       static unsigned int message_number;

--- a/regression-tests/13-ipv6-apps/x02-sky-coap.csc
+++ b/regression-tests/13-ipv6-apps/x02-sky-coap.csc
@@ -181,14 +181,14 @@ PROCESS_CONF_NO_PROCESS_NAMES=1
 
 The test script communicates with the REST server via the RPL border router using external commands.
 (* $ make connect-router-cooja)
-* $ ping6 -c 10 -I tun0 aaaa::212:7401:1:101
-* $ ping6 -c 10 -I tun0 aaaa::212:7402:2:202
-* $ wget -t 1 -T 10 -O - http://[aaaa::212:7402:2:202]
+* $ ping6 -c 10 -I tun0 fd00::212:7401:1:101
+* $ ping6 -c 10 -I tun0 fd00::212:7402:2:202
+* $ wget -t 1 -T 10 -O - http://[fd00::212:7402:2:202]
 
 The final test uses the CoAP Java implementation by Matthias Kovatsch, downloaded from:
 https://github.com/mkovatsc/Californium/blob/master/run/ExampleClient.jar
-* $ java -jar ExampleClient.jar DISCOVER coap://[aaaa::212:7402:2:202]
-* $ java -jar ExampleClient.jar GET coap://[aaaa::212:7402:2:202]/hello</notes>
+* $ java -jar ExampleClient.jar DISCOVER coap://[fd00::212:7402:2:202]
+* $ java -jar ExampleClient.jar GET coap://[fd00::212:7402:2:202]/hello</notes>
       <decorations>true</decorations>
     </plugin_config>
     <width>751</width>

--- a/tools/sky/uip6-bridge/Makefile
+++ b/tools/sky/uip6-bridge/Makefile
@@ -36,5 +36,5 @@ connect: ../../tapslip6
 
 bridge:
 	@sudo service radvd restart || echo radvd could not be restarted
-	sudo route add -6 aaaa::/64 tap0
-	sudo ip -6 address add aaaa::1/64 dev tap0
+	sudo route add -6 fd00::/64 tap0
+	sudo ip -6 address add fd00::1/64 dev tap0

--- a/tools/stm32w/wpcapslip6/README.md
+++ b/tools/stm32w/wpcapslip6/README.md
@@ -14,9 +14,9 @@ rpl-border-router (the latter on Windows Vista and later only).
 
 An example of usage with the RPL border router:
 
-    wpcapslip6 -s COMXX -b aaaa:: -a aaaa:1::1/128 02-00-00-00-00-01
+    wpcapslip6 -s COMXX -b fd00:: -a fd00:1::1/128 02-00-00-00-00-01
 
 where 02-00-00-00-00-01 is the MAC address of the local network adapter.
 
--a aaaa:1::1/128 can be omitted if an IP address is already set to the network
+-a fd00:1::1/128 can be omitted if an IP address is already set to the network
 adapter.

--- a/tools/tunslip6.c
+++ b/tools/tunslip6.c
@@ -837,7 +837,7 @@ main(int argc, char **argv)
     case 'h':
     default:
 fprintf(stderr,"usage:  %s [options] ipaddress\n", prog);
-fprintf(stderr,"example: tunslip6 -L -v2 -s ttyUSB1 aaaa::1/64\n");
+fprintf(stderr,"example: tunslip6 -L -v2 -s ttyUSB1 fd00::1/64\n");
 fprintf(stderr,"Options are:\n");
 #ifndef __APPLE__
 fprintf(stderr," -B baudrate    9600,19200,38400,57600,115200 (default),230400,460800,921600\n");


### PR DESCRIPTION
This PR brings https://github.com/contiki-os/contiki/pull/712 back to life, now with `fd00` rather than `fc00`. As mentioned [here](https://github.com/contiki-os/contiki/pull/712#issuecomment-137351534) I (and some others) believe `fd00` to be a better alternative than the Sixxs prefix.