### PR TITLE
Initialize acknowledgment no. on establishment of outgoing TCP connection.

### DIFF
--- a/core/net/ipv4/uip.c
+++ b/core/net/ipv4/uip.c
@@ -436,6 +436,11 @@ uip_connect(const uip_ipaddr_t *ripaddr, uint16_t rport)
   conn->snd_nxt[2] = iss[2];
   conn->snd_nxt[3] = iss[3];
 
+  conn->rcv_nxt[0] = 0;
+  conn->rcv_nxt[1] = 0;
+  conn->rcv_nxt[2] = 0;
+  conn->rcv_nxt[3] = 0;
+
   conn->initialmss = conn->mss = UIP_TCP_MSS;
 
   conn->len = 1;   /* TCP length of the SYN is one. */
@@ -1367,10 +1372,10 @@ uip_process(uint8_t flag)
   uip_connr->len = 1;
 
   /* rcv_nxt should be the seqno from the incoming packet + 1. */
-  uip_connr->rcv_nxt[3] = BUF->seqno[3];
-  uip_connr->rcv_nxt[2] = BUF->seqno[2];
-  uip_connr->rcv_nxt[1] = BUF->seqno[1];
   uip_connr->rcv_nxt[0] = BUF->seqno[0];
+  uip_connr->rcv_nxt[1] = BUF->seqno[1];
+  uip_connr->rcv_nxt[2] = BUF->seqno[2];
+  uip_connr->rcv_nxt[3] = BUF->seqno[3];
   uip_add_rcv_nxt(1);
 
   /* Parse the TCP MSS option, if present. */

--- a/core/net/ipv6/uip6.c
+++ b/core/net/ipv6/uip6.c
@@ -1747,10 +1747,10 @@ uip_process(uint8_t flag)
   uip_connr->len = 1;
 
   /* rcv_nxt should be the seqno from the incoming packet + 1. */
-  uip_connr->rcv_nxt[3] = UIP_TCP_BUF->seqno[3];
-  uip_connr->rcv_nxt[2] = UIP_TCP_BUF->seqno[2];
-  uip_connr->rcv_nxt[1] = UIP_TCP_BUF->seqno[1];
   uip_connr->rcv_nxt[0] = UIP_TCP_BUF->seqno[0];
+  uip_connr->rcv_nxt[1] = UIP_TCP_BUF->seqno[1];
+  uip_connr->rcv_nxt[2] = UIP_TCP_BUF->seqno[2];
+  uip_connr->rcv_nxt[3] = UIP_TCP_BUF->seqno[3];
   uip_add_rcv_nxt(1);
 
   /* Parse the TCP MSS option, if present. */


### PR DESCRIPTION
Ported change https://github.com/contiki-os/contiki/commit/2432a8ee7da3a7cdd6c05c54d28ada85105a0b37 (set expected reception sequence no to zero - to get initial connection to avoid having ack-number other than zero) from uIPv6 to uIPv4.