### PR TITLE
Cooja: Make sure motes are always removed from the list of unintialized motes

### DIFF
--- a/tools/cooja/java/org/contikios/cooja/Simulation.java
+++ b/tools/cooja/java/org/contikios/cooja/Simulation.java
@@ -847,6 +847,9 @@ public class Simulation extends Observable implements Runnable {
       }
     };
 
+    //Add to list of uninitialized motes
+    motesUninit.add(mote);
+
     if (!isRunning()) {
       /* Simulation is stopped, add mote immediately */
       addMote.run();
@@ -854,8 +857,6 @@ public class Simulation extends Observable implements Runnable {
       /* Add mote from simulation thread */
       invokeSimulationThread(addMote);
     }
-    //Add to list of uninitialized motes
-    motesUninit.add(mote);
     
   }
 


### PR DESCRIPTION
This is an old bug of mine. As mine was the only plug-in that actually needed this, and only because it always added nodes from the simulation-thread, this never popped up.