### PR TITLE
Fix default tun/tap issue with multiple tunslip6

### DIFF
--- a/tools/tunslip6.c
+++ b/tools/tunslip6.c
@@ -852,14 +852,6 @@ exit(1);
     break;
   }
 
-  if(*tundev == '\0') {
-    /* Use default. */
-    if(tap) {
-      strcpy(tundev, "tap0");
-    } else {
-      strcpy(tundev, "tun0");
-    }
-  }
   if(host != NULL) {
     struct addrinfo hints, *servinfo, *p;
     int rv;


### PR DESCRIPTION
When running multiple tunslip6 instances, it collides with tun0 being already
used (cannot open file). However, system default is already to use "tun0" and "tap0".

By putting the default empty string as name, system automatically increment and
selects a free interface, "tun0", "tun1".