### PR TITLE
Removes duplicate of uip_is_addr_linklocal

### DIFF
--- a/core/net/ip/resolv.c
+++ b/core/net/ip/resolv.c
@@ -501,7 +501,7 @@ mdns_write_announce_records(unsigned char *queryptr, uint8_t *count)
   for(i = 0; i < UIP_DS6_ADDR_NB; ++i) {
     if(uip_ds6_if.addr_list[i].isused
 #if !RESOLV_CONF_MDNS_INCLUDE_GLOBAL_V6_ADDRS
-       && uip_is_addr_link_local(&uip_ds6_if.addr_list[i].ipaddr)
+       && uip_is_addr_linklocal(&uip_ds6_if.addr_list[i].ipaddr)
 #endif
       ) {
       if(!*count) {

--- a/core/net/ip/uip.h
+++ b/core/net/ip/uip.h
@@ -2016,8 +2016,9 @@ CCIF extern uip_lladdr_t uip_lladdr;
    (((a)->u8[15]) == 0x02))
 
 /**
- * \brief Checks whether the address a is link local.
- * a is of type uip_ipaddr_t
+ * \brief is addr (a) a link local unicast address, see RFC3513
+ *  i.e. is (a) on prefix FE80::/10
+ *  a is of type uip_ipaddr_t*
  */
 #define uip_is_addr_linklocal(a)                 \
   ((a)->u8[0] == 0xfe &&                         \
@@ -2069,15 +2070,6 @@ CCIF extern uip_lladdr_t uip_lladdr;
   (((b)->u8[12]) = 0xFF);                       \
   (((b)->u8[13]) = ((a)->u8[13]));              \
   (((b)->u16[7]) = ((a)->u16[7]))
-
-/**
- * \brief is addr (a) a link local unicast address, see RFC3513
- *  i.e. is (a) on prefix FE80::/10
- *  a is of type uip_ipaddr_t*
- */
-#define uip_is_addr_link_local(a) \
-  ((((a)->u8[0]) == 0xFE) && \
-  (((a)->u8[1]) == 0x80))
 
 /**
  * \brief was addr (a) forged based on the mac address m

--- a/core/net/ipv6/multicast/roll-tm.c
+++ b/core/net/ipv6/multicast/roll-tm.c
@@ -1100,7 +1100,7 @@ icmp_input()
   uint16_t val;
 
 #if UIP_CONF_IPV6_CHECKS
-  if(!uip_is_addr_link_local(&UIP_IP_BUF->srcipaddr)) {
+  if(!uip_is_addr_linklocal(&UIP_IP_BUF->srcipaddr)) {
     PRINTF("ROLL TM: ICMPv6 In, bad source ");
     PRINT6ADDR(&UIP_IP_BUF->srcipaddr);
     PRINTF(" to ");

--- a/core/net/ipv6/sicslowpan.c
+++ b/core/net/ipv6/sicslowpan.c
@@ -635,7 +635,7 @@ compress_hdr_hc06(linkaddr_t *link_destaddr)
     iphc1 |= compress_addr_64(SICSLOWPAN_IPHC_SAM_BIT,
                               &UIP_IP_BUF->srcipaddr, &uip_lladdr);
     /* No context found for this address */
-  } else if(uip_is_addr_link_local(&UIP_IP_BUF->srcipaddr) &&
+  } else if(uip_is_addr_linklocal(&UIP_IP_BUF->srcipaddr) &&
 	    UIP_IP_BUF->destipaddr.u16[1] == 0 &&
 	    UIP_IP_BUF->destipaddr.u16[2] == 0 &&
 	    UIP_IP_BUF->destipaddr.u16[3] == 0) {
@@ -686,7 +686,7 @@ compress_hdr_hc06(linkaddr_t *link_destaddr)
       iphc1 |= compress_addr_64(SICSLOWPAN_IPHC_DAM_BIT,
 	       &UIP_IP_BUF->destipaddr, (uip_lladdr_t *)link_destaddr);
       /* No context found for this address */
-    } else if(uip_is_addr_link_local(&UIP_IP_BUF->destipaddr) &&
+    } else if(uip_is_addr_linklocal(&UIP_IP_BUF->destipaddr) &&
 	      UIP_IP_BUF->destipaddr.u16[1] == 0 &&
 	      UIP_IP_BUF->destipaddr.u16[2] == 0 &&
 	      UIP_IP_BUF->destipaddr.u16[3] == 0) {
@@ -1087,9 +1087,9 @@ compress_hdr_hc1(linkaddr_t *link_destaddr)
   if(UIP_IP_BUF->vtc != 0x60 ||
      UIP_IP_BUF->tcflow != 0 ||
      UIP_IP_BUF->flow != 0 ||
-     !uip_is_addr_link_local(&UIP_IP_BUF->srcipaddr) ||
+     !uip_is_addr_linklocal(&UIP_IP_BUF->srcipaddr) ||
      !uip_is_addr_mac_addr_based(&UIP_IP_BUF->srcipaddr, &uip_lladdr) ||
-     !uip_is_addr_link_local(&UIP_IP_BUF->destipaddr) ||
+     !uip_is_addr_linklocal(&UIP_IP_BUF->destipaddr) ||
      !uip_is_addr_mac_addr_based(&UIP_IP_BUF->destipaddr,
                                  (uip_lladdr_t *)link_destaddr) ||
      (UIP_IP_BUF->proto != UIP_PROTO_ICMP6 &&

--- a/core/net/ipv6/uip-ds6.c
+++ b/core/net/ipv6/uip-ds6.c
@@ -389,7 +389,7 @@ uip_ds6_get_link_local(int8_t state)
   for(locaddr = uip_ds6_if.addr_list;
       locaddr < uip_ds6_if.addr_list + UIP_DS6_ADDR_NB; locaddr++) {
     if(locaddr->isused && (state == -1 || locaddr->state == state)
-       && (uip_is_addr_link_local(&locaddr->ipaddr))) {
+       && (uip_is_addr_linklocal(&locaddr->ipaddr))) {
       return locaddr;
     }
   }
@@ -408,7 +408,7 @@ uip_ds6_get_global(int8_t state)
   for(locaddr = uip_ds6_if.addr_list;
       locaddr < uip_ds6_if.addr_list + UIP_DS6_ADDR_NB; locaddr++) {
     if(locaddr->isused && (state == -1 || locaddr->state == state)
-       && !(uip_is_addr_link_local(&locaddr->ipaddr))) {
+       && !(uip_is_addr_linklocal(&locaddr->ipaddr))) {
       return locaddr;
     }
   }
@@ -499,13 +499,13 @@ uip_ds6_select_src(uip_ipaddr_t *src, uip_ipaddr_t *dst)
   uint8_t n = 0;
   uip_ds6_addr_t *matchaddr = NULL;
 
-  if(!uip_is_addr_link_local(dst) && !uip_is_addr_mcast(dst)) {
+  if(!uip_is_addr_linklocal(dst) && !uip_is_addr_mcast(dst)) {
     /* find longest match */
     for(locaddr = uip_ds6_if.addr_list;
         locaddr < uip_ds6_if.addr_list + UIP_DS6_ADDR_NB; locaddr++) {
       /* Only preferred global (not link-local) addresses */
       if(locaddr->isused && locaddr->state == ADDR_PREFERRED &&
-         !uip_is_addr_link_local(&locaddr->ipaddr)) {
+         !uip_is_addr_linklocal(&locaddr->ipaddr)) {
         n = get_match_length(dst, &locaddr->ipaddr);
         if(n >= best) {
           best = n;
@@ -608,7 +608,7 @@ uip_ds6_dad(uip_ds6_addr_t *addr)
 int
 uip_ds6_dad_failed(uip_ds6_addr_t *addr)
 {
-  if(uip_is_addr_link_local(&addr->ipaddr)) {
+  if(uip_is_addr_linklocal(&addr->ipaddr)) {
     PRINTF("Contiki shutdown, DAD for link local address failed\n");
     return 0;
   }

--- a/core/net/ipv6/uip-nd6.c
+++ b/core/net/ipv6/uip-nd6.c
@@ -832,7 +832,7 @@ ra_input(void)
 
 #if UIP_CONF_IPV6_CHECKS
   if((UIP_IP_BUF->ttl != UIP_ND6_HOP_LIMIT) ||
-     (!uip_is_addr_link_local(&UIP_IP_BUF->srcipaddr)) ||
+     (!uip_is_addr_linklocal(&UIP_IP_BUF->srcipaddr)) ||
      (UIP_ICMP_BUF->icode != 0)) {
     PRINTF("RA received is bad");
     goto discard;
@@ -895,7 +895,7 @@ ra_input(void)
       nd6_opt_prefix_info = (uip_nd6_opt_prefix_info *) UIP_ND6_OPT_HDR_BUF;
       if((uip_ntohl(nd6_opt_prefix_info->validlt) >=
           uip_ntohl(nd6_opt_prefix_info->preferredlt))
-         && (!uip_is_addr_link_local(&nd6_opt_prefix_info->prefix))) {
+         && (!uip_is_addr_linklocal(&nd6_opt_prefix_info->prefix))) {
         /* on-link flag related processing */
         if(nd6_opt_prefix_info->flagsreserved1 & UIP_ND6_RA_FLAG_ONLINK) {
           prefix =

--- a/core/net/ipv6/uip6.c
+++ b/core/net/ipv6/uip6.c
@@ -1203,8 +1203,8 @@ uip_process(uint8_t flag)
   if(!uip_ds6_is_my_addr(&UIP_IP_BUF->destipaddr) &&
      !uip_ds6_is_my_maddr(&UIP_IP_BUF->destipaddr)) {
     if(!uip_is_addr_mcast(&UIP_IP_BUF->destipaddr) &&
-       !uip_is_addr_link_local(&UIP_IP_BUF->destipaddr) &&
-       !uip_is_addr_link_local(&UIP_IP_BUF->srcipaddr) &&
+       !uip_is_addr_linklocal(&UIP_IP_BUF->destipaddr) &&
+       !uip_is_addr_linklocal(&UIP_IP_BUF->srcipaddr) &&
        !uip_is_addr_unspecified(&UIP_IP_BUF->srcipaddr) &&
        !uip_is_addr_loopback(&UIP_IP_BUF->destipaddr)) {
 
@@ -1238,7 +1238,7 @@ uip_process(uint8_t flag)
       UIP_STAT(++uip_stat.ip.forwarded);
       goto send;
     } else {
-      if((uip_is_addr_link_local(&UIP_IP_BUF->srcipaddr)) &&
+      if((uip_is_addr_linklocal(&UIP_IP_BUF->srcipaddr)) &&
          (!uip_is_addr_unspecified(&UIP_IP_BUF->srcipaddr)) &&
          (!uip_is_addr_loopback(&UIP_IP_BUF->destipaddr)) &&
          (!uip_is_addr_mcast(&UIP_IP_BUF->destipaddr)) &&

--- a/core/net/rpl/rpl-dag-root.c
+++ b/core/net/rpl/rpl-dag-root.c
@@ -71,7 +71,7 @@ get_global_address(void)
     state = uip_ds6_if.addr_list[i].state;
     if(uip_ds6_if.addr_list[i].isused &&
        state == ADDR_PREFERRED &&
-       !uip_is_addr_link_local(&uip_ds6_if.addr_list[i].ipaddr)) {
+       !uip_is_addr_linklocal(&uip_ds6_if.addr_list[i].ipaddr)) {
       ipaddr = &uip_ds6_if.addr_list[i].ipaddr;
     }
   }
@@ -190,7 +190,7 @@ rpl_dag_root_init_dag_immediately(void)
     state = uip_ds6_if.addr_list[i].state;
     if(uip_ds6_if.addr_list[i].isused &&
        state == ADDR_PREFERRED &&
-       !uip_is_addr_link_local(&uip_ds6_if.addr_list[i].ipaddr)) {
+       !uip_is_addr_linklocal(&uip_ds6_if.addr_list[i].ipaddr)) {
       ipaddr = &uip_ds6_if.addr_list[i].ipaddr;
     }
   }

--- a/core/net/rpl/rpl-icmp6.c
+++ b/core/net/rpl/rpl-icmp6.c
@@ -109,7 +109,7 @@ get_global_addr(uip_ipaddr_t *addr)
     state = uip_ds6_if.addr_list[i].state;
     if(uip_ds6_if.addr_list[i].isused &&
        (state == ADDR_TENTATIVE || state == ADDR_PREFERRED)) {
-      if(!uip_is_addr_link_local(&uip_ds6_if.addr_list[i].ipaddr)) {
+      if(!uip_is_addr_linklocal(&uip_ds6_if.addr_list[i].ipaddr)) {
         memcpy(addr, &uip_ds6_if.addr_list[i].ipaddr, sizeof(uip_ipaddr_t));
         return 1;
       }

--- a/tools/sky/uip6-bridge/fakeuip.c
+++ b/tools/sky/uip6-bridge/fakeuip.c
@@ -55,7 +55,7 @@ uip_ds6_get_link_local(int8_t state) {
   for(locaddr = uip_ds6_if.addr_list;
       locaddr < uip_ds6_if.addr_list + UIP_DS6_ADDR_NB; locaddr++) {
     if((locaddr->isused) && (state == - 1 || locaddr->state == state)
-       && (uip_is_addr_link_local(&locaddr->ipaddr))) {
+       && (uip_is_addr_linklocal(&locaddr->ipaddr))) {
       return locaddr;
     }
   }

--- a/tools/stm32w/uip6_bridge/fakeuip.c
+++ b/tools/stm32w/uip6_bridge/fakeuip.c
@@ -55,7 +55,7 @@ uip_ds6_get_link_local(int8_t state) {
   for(locaddr = uip_ds6_if.addr_list;
       locaddr < uip_ds6_if.addr_list + UIP_DS6_ADDR_NB; locaddr++) {
     if((locaddr->isused) && (state == - 1 || locaddr->state == state)
-       && (uip_is_addr_link_local(&locaddr->ipaddr))) {
+       && (uip_is_addr_linklocal(&locaddr->ipaddr))) {
       return locaddr;
     }
   }


### PR DESCRIPTION
A simple search and replace of `uip_is_addr_link_local` to ensure the more
commonly used `uip_is_addr_linklocal` is used consistently.