### PR TITLE
AES-128 driver for the CC2538 SoC

### DIFF
--- a/core/lib/aes-128.c
+++ b/core/lib/aes-128.c
@@ -167,17 +167,6 @@ encrypt(uint8_t *state)
 }
 /*---------------------------------------------------------------------------*/
 void
-aes_128_padded_encrypt(uint8_t *plaintext_and_result, uint8_t plaintext_len)
-{
-  uint8_t block[AES_128_BLOCK_SIZE];
-  
-  memset(block, 0, AES_128_BLOCK_SIZE);
-  memcpy(block, plaintext_and_result, plaintext_len);
-  AES_128.encrypt(block);
-  memcpy(plaintext_and_result, block, plaintext_len);
-}
-/*---------------------------------------------------------------------------*/
-void
 aes_128_set_padded_key(uint8_t *key, uint8_t key_len)
 {
   uint8_t block[AES_128_BLOCK_SIZE];

--- a/core/lib/aes-128.h
+++ b/core/lib/aes-128.h
@@ -37,8 +37,8 @@
  *         Konrad Krentz <konrad.krentz@gmail.com>
  */
 
-#ifndef AES_H_
-#define AES_H_
+#ifndef AES_128_H_
+#define AES_128_H_
 
 #include "contiki.h"
 
@@ -74,4 +74,4 @@ void aes_128_set_padded_key(uint8_t *key, uint8_t key_len);
 
 extern const struct aes_128_driver AES_128;
 
-#endif /* AES_H_ */
+#endif /* AES_128_H_ */

--- a/core/lib/aes-128.h
+++ b/core/lib/aes-128.h
@@ -68,11 +68,6 @@ struct aes_128_driver {
 };
 
 /**
- * \brief Pads the plaintext with zeroes before calling AES_128.encrypt
- */
-void aes_128_padded_encrypt(uint8_t *plaintext_and_result, uint8_t plaintext_len);
-
-/**
  * \brief Pads the key with zeroes before calling AES_128.set_key
  */
 void aes_128_set_padded_key(uint8_t *key, uint8_t key_len);

--- a/core/net/netstack.c
+++ b/core/net/netstack.c
@@ -44,6 +44,7 @@ netstack_init(void)
 {
   NETSTACK_RADIO.init();
   NETSTACK_RDC.init();
+  NETSTACK_LLSEC.init();
   NETSTACK_MAC.init();
   NETSTACK_NETWORK.init();
 }

--- a/cpu/cc2538/dev/aes.h
+++ b/cpu/cc2538/dev/aes.h
@@ -50,6 +50,7 @@
 
 #include "contiki.h"
 #include "dev/crypto.h"
+#include "lib/aes-128.h"
 
 #include <stdint.h>
 /*---------------------------------------------------------------------------*/
@@ -486,6 +487,13 @@ uint8_t aes_load_keys(const void *keys, uint8_t key_size, uint8_t count,
                       uint8_t start_area);
 
 /** @} */
+/*---------------------------------------------------------------------------*/
+/** \name AES-128 driver
+ * @{
+ */
+extern const struct aes_128_driver aes_128_cc2538_driver;
+/** @} */
+/*---------------------------------------------------------------------------*/
 
 #endif /* AES_H_ */
 

--- a/platform/cc2538dk/Makefile.cc2538dk
+++ b/platform/cc2538dk/Makefile.cc2538dk
@@ -26,7 +26,7 @@ include $(CONTIKI_CPU)/Makefile.cc2538
 
 MODULES += core/net core/net/mac \
            core/net/mac/contikimac \
-           core/net/llsec
+           core/net/llsec core/net/llsec/noncoresec
 
 PYTHON = python
 BSL_FLAGS += -e -w -v

--- a/platform/cc2538dk/contiki-conf.h
+++ b/platform/cc2538dk/contiki-conf.h
@@ -500,6 +500,22 @@ typedef uint32_t rtimer_clock_t;
 #endif /* NETSTACK_CONF_WITH_IPV6 */
 /** @} */
 /*---------------------------------------------------------------------------*/
+/**
+ * \name Security
+ *
+ * @{
+ */
+
+#ifndef AES_128_CONF
+#define AES_128_CONF aes_128_cc2538_driver
+#endif /* AES_128_CONF */
+
+#ifndef CC2538_CONF_WITH_CRYPTO
+#define CC2538_CONF_WITH_CRYPTO 1
+#endif /* CC2538_CONF_WITH_CRYPTO */
+
+/** @} */
+/*---------------------------------------------------------------------------*/
 
 #endif /* CONTIKI_CONF_H_ */
 

--- a/platform/cc2538dk/contiki-main.c
+++ b/platform/cc2538dk/contiki-main.c
@@ -56,6 +56,7 @@
 #include "dev/slip.h"
 #include "dev/cc2538-rf.h"
 #include "dev/udma.h"
+#include "dev/crypto.h"
 #include "usb/usb-serial.h"
 #include "lib/random.h"
 #include "net/netstack.h"
@@ -201,6 +202,12 @@ main(void)
   ctimer_init();
 
   set_rf_params();
+
+#if CC2538_CONF_WITH_CRYPTO
+  crypto_init();
+  /* TODO do not leave the crypto engine enabled */
+#endif /* CC2538_CONF_WITH_CRYPTO */
+
   netstack_init();
 
 #if NETSTACK_CONF_WITH_IPV6


### PR DESCRIPTION
* rudimentary `aes_128_driver` for the CC2538 SoC
* deleted aes_128_padded_encrypt as suggested in #618 
* a fix for an error when including `aes-128.h`