### PR TITLE
Add option to specify make variables for regression compile tests

### DIFF
--- a/regression-tests/15-compile-arm-apcs-ports/Makefile
+++ b/regression-tests/15-compile-arm-apcs-ports/Makefile
@@ -3,7 +3,7 @@ TOOLSDIR=../../tools
 
 EXAMPLES = \
 hello-world/econotag \
-hello-world/mbxxx \
+hello-world/mbxxx:STM32W_CPUREV=CC \
 ipv6/rpl-border-router/econotag \
 er-rest-example/econotag \
 webserver-ipv6/econotag \

--- a/regression-tests/Makefile.compile-test
+++ b/regression-tests/Makefile.compile-test
@@ -42,7 +42,6 @@ get_target_vars = $(wordlist 2,15,$(subst :, ,$1))
 define dooneexample
 @echo Building example $(3): $(1) for target $(2)
 @((cd $(EXAMPLESDIR)/$(1); \
- export STM32W_CPUREV=CC; \
  make $(4) TARGET=$(2) clean && make $(4) TARGET=$(2) WERROR=1) > \
       $(3)-$(subst /,-,$(1))$(2).report 2>&1 && \
  (echo $(1) $(2): OK | tee $(3)-$(subst /,-,$(1))$(2).summary) || \

--- a/regression-tests/Makefile.compile-test
+++ b/regression-tests/Makefile.compile-test
@@ -36,12 +36,14 @@ nine := x x x x x x x x x
 max = $(subst xx,x,$(join ${1},${2}))
 gt = $(filter-out $(words ${1}),$(words $(call max,${1},${2})))
 addzero = $(if $(call gt,${nine},$(1)),$(words ${1}),0$(words ${1}))
+get_target = $(firstword $(subst :, ,$1))
+get_target_vars = $(wordlist 2,15,$(subst :, ,$1))
 
 define dooneexample
 @echo Building example $(3): $(1) for target $(2)
 @((cd $(EXAMPLESDIR)/$(1); \
  export STM32W_CPUREV=CC; \
- make TARGET=$(2) clean && make TARGET=$(2) WERROR=1) > \
+ make $(4) TARGET=$(2) clean && make $(4) TARGET=$(2) WERROR=1) > \
       $(3)-$(subst /,-,$(1))$(2).report 2>&1 && \
  (echo $(1) $(2): OK | tee $(3)-$(subst /,-,$(1))$(2).summary) || \
  (echo $(1) $(2): FAIL ಠ.ಠ | tee $(3)-$(subst /,-,$(1))$(2).summary ; \
@@ -50,7 +52,7 @@ endef
 
 define doexample
 $(eval i+=x)
-$(call dooneexample,$(dir ${1}),$(notdir ${1}),$(call addzero,${i}))
+$(call dooneexample,$(dir $(call get_target,${1})),$(notdir $(call get_target,${1})),$(call addzero,${i}),$(call get_target_vars,${1}))
 endef
 #end of GNU make magic
 


### PR DESCRIPTION
Some platforms use make variables to specify different build options such as target boards. Adding the option to specify make variables in regression compile tests makes it possible to test compiling for different boards with same target.

```
EXAMPLES = \
hello-world/stm32nucleo-spirit1:BOARD=ids01a4:SENSORBOARD=iks01a1 \
hello-world/stm32nucleo-spirit1:BOARD=ids01a5:SENSORBOARD=iks01a1 \
hello-world/srf06-cc26xx:BOARD=srf06/cc26xx \
hello-world/srf06-cc26xx:BOARD=srf06/cc13xx \
```
