### PR TITLE
Fix serialdump.c warnings (clang)

### DIFF
--- a/tools/sky/serialdump.c
+++ b/tools/sky/serialdump.c
@@ -55,7 +55,7 @@ usage(int result)
 }
 
 static void
-print_hex_line(unsigned char *prefix, unsigned char *outbuf, int index)
+print_hex_line(char *prefix, unsigned char *outbuf, int index)
 {
   int i;
 
@@ -92,7 +92,8 @@ main(int argc, char **argv)
   char *speedname = BAUDRATE_S;
   char *device = MODEMDEVICE;
   char *timeformat = NULL;
-  unsigned char buf[BUFSIZE], outbuf[HCOLS];
+  unsigned char buf[BUFSIZE];
+  char outbuf[HCOLS];
   unsigned char mode = MODE_START_TEXT;
   int nfound, flags = 0;
   unsigned char lastc = '\0';
@@ -273,7 +274,7 @@ main(int argc, char **argv)
     }
 
     if(FD_ISSET(fd, &smask)) {
-      int i, j, n = read(fd, buf, sizeof(buf));
+      int i, n = read(fd, buf, sizeof(buf));
       if(n < 0) {
         perror("could not read");
         exit(-1);


### PR DESCRIPTION
Using clang (on osx) yields to some warnings
(conversion between signed/unsigned, unused variable)
which gcc would only produce when used with -Wall.
This commit fixes those.