### PR TITLE
collect-view gui: Add support for OS X serialdump and motelist

### DIFF
--- a/tools/collect-view/src/org/contikios/contiki/collect/MoteFinder.java
+++ b/tools/collect-view/src/org/contikios/contiki/collect/MoteFinder.java
@@ -54,9 +54,11 @@ public class MoteFinder {
 
   public static final String MOTELIST_WINDOWS = "./tools/motelist-windows.exe";
   public static final String MOTELIST_LINUX = "./tools/motelist-linux";
+  public static final String MOTELIST_MACOS = "./tools/motelist-macos";
 
   private final Pattern motePattern;
   private final boolean isWindows;
+  private final boolean isMacos;
   private Process moteListProcess;
 //  private boolean hasVerifiedProcess;
   private ArrayList<String> comList = new ArrayList<String>();
@@ -65,7 +67,8 @@ public class MoteFinder {
   public MoteFinder() {
     String osName = System.getProperty("os.name", "").toLowerCase();
     isWindows = osName.startsWith("win");
-    motePattern = Pattern.compile("\\s(COM|/dev/[a-zA-Z]+)(\\d+)\\s");
+    isMacos = osName.startsWith("mac");
+    motePattern = Pattern.compile("\\s(COM|/dev/[a-zA-Z]+|/dev/tty.usbserial-)(\\d+|[A-Z0-9]+)\\s");
   }
 
   public String[] getMotes() throws IOException {
@@ -87,6 +90,8 @@ public class MoteFinder {
     String fullCommand;
     if (isWindows) {
       fullCommand = MOTELIST_WINDOWS;
+    } else if (isMacos) {
+      fullCommand = MOTELIST_MACOS;
     } else {
       fullCommand = MOTELIST_LINUX;
     }

--- a/tools/collect-view/src/org/contikios/contiki/collect/SerialDumpConnection.java
+++ b/tools/collect-view/src/org/contikios/contiki/collect/SerialDumpConnection.java
@@ -46,6 +46,7 @@ public class SerialDumpConnection extends CommandConnection {
 
   public static final String SERIALDUMP_WINDOWS = "./tools/serialdump-windows.exe";
   public static final String SERIALDUMP_LINUX = "./tools/serialdump-linux";
+  public static final String SERIALDUMP_MACOS = "./tools/serialdump-macos";
 
   public SerialDumpConnection(SerialConnectionListener listener) {
     super(listener);
@@ -72,6 +73,8 @@ public class SerialDumpConnection extends CommandConnection {
     String fullCommand;
     if (osName.startsWith("win")) {
       fullCommand = SERIALDUMP_WINDOWS + " " + "-b115200" + " " + getMappedComPortForWindows(comPort);
+    } else if (osName.startsWith("mac")) {
+      fullCommand = SERIALDUMP_MACOS + " " + "-b115200" + " " + comPort;
     } else {
       fullCommand = SERIALDUMP_LINUX + " " + "-b115200" + " " + comPort;
     }


### PR DESCRIPTION
Select the tools for macos when checking for motes or opening a
serial dump connection on OS X.