### PR TITLE
trims resolv.c by removing unrequired static declarations

### DIFF
--- a/core/net/ip/resolv.c
+++ b/core/net/ip/resolv.c
@@ -783,9 +783,9 @@ check_entries(void)
 static void
 newdata(void)
 {
-  static uint8_t nquestions, nanswers;
+  uint8_t nquestions, nanswers;
 
-  static int8_t i;
+  int8_t i;
 
   register struct namemap *namemapptr = NULL;
 
@@ -872,7 +872,7 @@ newdata(void)
         }
         return;
       } else {
-        static uint8_t nauthrr;
+        uint8_t nauthrr;
         PRINTF("resolver: But we are still probing. Waiting...\n");
         /* We are still probing. We need to do the mDNS
          * probe race condition check here and make sure
@@ -960,7 +960,7 @@ newdata(void)
 #endif /* !ARCH_DOESNT_NEED_ALIGNED_STRUCTS */
 
 #if VERBOSE_DEBUG
-    static char debug_name[40];
+    char debug_name[40];
     decode_name(queryptr, debug_name, uip_appdata);
     DEBUG_PRINTF("resolver: Answer %d: \"%s\", type %d, class %d, ttl %d, length %d\n",
                  ++i, debug_name, uip_ntohs(ans->type),
@@ -1266,9 +1266,9 @@ remove_trailing_dots(const char *name) {
 void
 resolv_query(const char *name)
 {
-  static uint8_t i;
+  uint8_t i;
 
-  static uint8_t lseq, lseqi;
+  uint8_t lseq, lseqi;
 
   register struct namemap *nameptr = 0;
 
@@ -1315,7 +1315,7 @@ resolv_query(const char *name)
   {
     size_t name_len = strlen(name);
 
-    static const char local_suffix[] = "local";
+    const char local_suffix[] = "local";
 
     if((name_len > (sizeof(local_suffix) - 1)) &&
        (0 == strcasecmp(name + name_len - (sizeof(local_suffix) - 1), local_suffix))) {
@@ -1347,7 +1347,7 @@ resolv_lookup(const char *name, uip_ipaddr_t ** ipaddr)
 {
   resolv_status_t ret = RESOLV_STATUS_UNCACHED;
 
-  static uint8_t i;
+  uint8_t i;
 
   struct namemap *nameptr;
 


### PR DESCRIPTION
I did a quick check with a MSP430 and with a ARM based platform, here's the size diff. I'm a bit surprised to see only marginal savings in BSS, nonetheless flash savings seem to indicate it's worth to drop the `static` declarations.

| text | data | bss | dec | platform |
|------|-------|------|-------|-----------|
| -170  |    0  |   -6 | -176  |  MSP430 |
| -280  |     0 |   -12 |  -292 |   ARM |

Closes https://github.com/contiki-os/contiki/issues/1333