### PR TITLE
Client requested close takes precedence over server initiated close.

### DIFF
--- a/apps/webbrowser/webclient.c
+++ b/apps/webbrowser/webclient.c
@@ -479,6 +479,11 @@ webclient_appcall(void *state)
 
   if(uip_closed()) {
     tcp_markconn(uip_conn, NULL);
+    /* Client requested close takes precedence over server initiated close. */
+    if(s.state == WEBCLIENT_STATE_CLOSE) {
+      webclient_closed();
+      return;
+    }
     switch(s.httpflag) {
     case HTTPFLAG_HTTPS:
       /* Send some info to the user. */

--- a/apps/webbrowser/www.c
+++ b/apps/webbrowser/www.c
@@ -292,6 +292,15 @@ show_statustext(char *text)
   CTK_WIDGET_REDRAW(&statustext);
 }
 /*-----------------------------------------------------------------------------------*/
+static void
+end_page(char *status, void *focus)
+{
+  show_statustext(status);
+  petsciiconv_topetscii(webpageptr - x, x);
+  CTK_WIDGET_FOCUS(&mainwindow, focus);
+  redraw_window();
+}
+/*-----------------------------------------------------------------------------------*/
 /* open_url():
  *
  * Called when the URL present in the global "url" variable should be
@@ -660,10 +669,7 @@ webclient_timedout(void)
 void
 webclient_closed(void)
 {
-  show_statustext("Stopped");
-  petsciiconv_topetscii(webpageptr - x, x);
-  CTK_WIDGET_FOCUS(&mainwindow, &downbutton);
-  redraw_window();
+  end_page("Stopped", &downbutton);
 }
 /*-----------------------------------------------------------------------------------*/
 /* webclient_connected():
@@ -710,6 +716,7 @@ webclient_datahandler(char *data, uint16_t len)
 	     "                       Would you like to download instead?");
       CTK_WIDGET_ADD(&mainwindow, &wgetnobutton);
       CTK_WIDGET_ADD(&mainwindow, &wgetyesbutton);
+      CTK_WIDGET_FOCUS(&mainwindow, &wgetyesbutton);
       redraw_window();
 #endif /* CTK_CONF_WINDOWS */
 #endif /* WWW_CONF_WITH_WGET || WWW_CONF_WGET_EXEC */
@@ -721,10 +728,7 @@ webclient_datahandler(char *data, uint16_t len)
 
   if(data == NULL) {
     loading = 0;
-    show_statustext("Done");
-    petsciiconv_topetscii(webpageptr - x, x);
-    CTK_WIDGET_FOCUS(&mainwindow, &urlentry);
-    redraw_window();
+    end_page("Done", &urlentry);
   }
 }
 /*-----------------------------------------------------------------------------------*/


### PR DESCRIPTION
When the client has already called webclient_close() it doesn't expect to have webclient_datahandler(NULL, 0) called just because the connection was closed by the server "at the same time". Rather it expects to always have webclient_closed() called.

Calling webclient_datahandler(NULL, 0) instead of webclient_closed() means that the web browser shows "Done" in the status line instead of "Stopped". So the user is mislead to think that he has already seen all of the page.

Note: webclient_close() is called by the client during newdata() so the already existing check for WEBCLIENT_STATE_CLOSE further above doesn't help.