### PR TITLE
Wait for a valid RSSI reading in CC13xx/CC26xx RF drivers

### DIFF
--- a/cpu/cc26xx-cc13xx/rf-core/prop-mode.c
+++ b/cpu/cc26xx-cc13xx/rf-core/prop-mode.c
@@ -271,6 +271,7 @@ get_rssi(void)
 {
   uint32_t cmd_status;
   int8_t rssi;
+  uint8_t attempts = 0;
   uint8_t was_off = 0;
   rfc_CMD_GET_RSSI_t cmd;
 
@@ -283,14 +284,19 @@ get_rssi(void)
     }
   }
 
-  memset(&cmd, 0x00, sizeof(cmd));
-  cmd.commandNo = CMD_GET_RSSI;
-
   rssi = RF_CMD_CCA_REQ_RSSI_UNKNOWN;
 
-  if(rf_core_send_cmd((uint32_t)&cmd, &cmd_status) == RF_CORE_CMD_OK) {
-    /* Current RSSI in bits 23:16 of cmd_status */
-    rssi = (cmd_status >> 16) & 0xFF;
+  while((rssi == RF_CMD_CCA_REQ_RSSI_UNKNOWN || rssi == 0) && ++attempts < 10) {
+    memset(&cmd, 0x00, sizeof(cmd));
+    cmd.commandNo = CMD_GET_RSSI;
+
+    if(rf_core_send_cmd((uint32_t)&cmd, &cmd_status) == RF_CORE_CMD_ERROR) {
+      PRINTF("get_rssi: CMDSTA=0x%08lx\n", cmd_status);
+      break;
+    } else {
+      /* Current RSSI in bits 23:16 of cmd_status */
+      rssi = (cmd_status >> 16) & 0xFF;
+    }
   }
 
   /* If we were off, turn back off */


### PR DESCRIPTION
As discussed in #1341, the current CC13xx/CC26xx IEEE mode driver sends `CMD_GET_RSSI` once and returns the RSSI reading uncondtionally. This happens within the `get_rssi()` function.

This logic is broken if `get_rssi()` is called with the radio off. The function will make sure to turn on the radio first, but it does not make sure the RSSI reading is valid, which only happens a number of symbol periods after the radio enters RX. The outcome is that `NETSTACK_RADIO.get_value(RADIO_PARAM_RSSI, ...)` will always return -128 (meaning that RSSI is unavailable) if the radio was off at the time of calling the function.

The same condition affects the prop mode driver.

This commit changes the logic of `get_rssi()`. If `CMD_GET_RSSI` returns an invalid RSSI, we send it again. For unknown reasons, `CMD_GET_RSSI` on occasion returns 0, so we ignore that value too.

To avoid waiting forever for an RSSI reading that may never become valid, we still return `RF_CMD_CCA_REQ_RSSI_UNKNOWN` after a number of failed attempts.

Fixes #1341 
