### PR TITLE
Log web browser page attributes free memory left.

### DIFF
--- a/apps/webbrowser/www.c
+++ b/apps/webbrowser/www.c
@@ -34,12 +34,14 @@
 
 #include <string.h>
 #include <stddef.h>
+#include <stdlib.h>
 
 #include "ctk/ctk.h"
 #include "ctk/ctk-textentry-cmdline.h"
 #include "contiki-net.h"
 #include "lib/petsciiconv.h"
 #include "sys/arg.h"
+#include "sys/log.h"
 #if WWW_CONF_WITH_WGET
 #include "program-handler.h"
 #endif /* WWW_CONF_WITH_WGET */
@@ -49,13 +51,6 @@
 #include "http-strings.h"
 
 #include "www.h"
-
-#if 1
-#define PRINTF(x)
-#else
-#include <stdio.h>
-#define PRINTF(x) printf x
-#endif
 
 
 /* The array that holds the current URL. */
@@ -299,6 +294,8 @@ end_page(char *status, void *focus)
   petsciiconv_topetscii(webpageptr - x, x);
   CTK_WIDGET_FOCUS(&mainwindow, focus);
   redraw_window();
+  log_message("Page attribs free: ", itoa(pageattribs + sizeof(pageattribs) - pageattribptr,
+                                          pageattribs + sizeof(pageattribs) - 4, 10));
 }
 /*-----------------------------------------------------------------------------------*/
 /* open_url():


### PR DESCRIPTION
After page loading has finished the number of free bytes left for page attributes is logged. It turns out that "usual" pages tend to get along with ~800 bytes while i.e. the Google search pages use all of the 2000 bytes of page attribute memory allocated by default (because of the long URLs with many parameters). So it seems that reducing this default isn't exactly the best way to reduce memory consumption...