### PR TITLE
Correctly set new CC26xx TX power when the RFC is powered off

### DIFF
--- a/cpu/cc26xx-cc13xx/rf-core/rf-core.c
+++ b/cpu/cc26xx-cc13xx/rf-core/rf-core.c
@@ -159,7 +159,7 @@ rf_core_send_cmd(uint32_t cmd, uint32_t *status)
 
   HWREG(RFC_DBELL_BASE + RFC_DBELL_O_CMDR) = cmd;
   do {
-    *status = HWREG(RFC_DBELL_BASE + RFC_DBELL_O_CMDSTA);
+    *status = HWREG(RFC_DBELL_BASE + RFC_DBELL_O_CMDSTA) & 0xFF;
     if(++timeout_count > 50000) {
       PRINTF("rf_core_send_cmd: 0x%08lx Timeout\n", cmd);
       if(!interrupts_disabled) {

--- a/cpu/cc26xx-cc13xx/rf-core/rf-core.c
+++ b/cpu/cc26xx-cc13xx/rf-core/rf-core.c
@@ -129,10 +129,18 @@ rf_core_send_cmd(uint32_t cmd, uint32_t *status)
   bool interrupts_disabled;
   bool is_radio_op = false;
 
-  /* If cmd is 4-byte aligned, then it's a radio OP. Clear the status field */
+  /*
+   * If cmd is 4-byte aligned, then it's either a radio OP or an immediate
+   * command. Clear the status field if it's a radio OP
+   */
   if((cmd & 0x03) == 0) {
-    is_radio_op = true;
-    ((rfc_radioOp_t *)cmd)->status = RF_CORE_RADIO_OP_STATUS_IDLE;
+    uint32_t cmd_type;
+    cmd_type = ((rfc_command_t *)cmd)->commandNo & RF_CORE_COMMAND_TYPE_MASK;
+    if(cmd_type == RF_CORE_COMMAND_TYPE_IEEE_FG_RADIO_OP ||
+       cmd_type == RF_CORE_COMMAND_TYPE_RADIO_OP) {
+      is_radio_op = true;
+      ((rfc_radioOp_t *)cmd)->status = RF_CORE_RADIO_OP_STATUS_IDLE;
+    }
   }
 
   /*

--- a/cpu/cc26xx-cc13xx/rf-core/rf-core.h
+++ b/cpu/cc26xx-cc13xx/rf-core/rf-core.h
@@ -218,7 +218,6 @@ typedef struct rf_core_primary_mode_s {
 /*---------------------------------------------------------------------------*/
 /* Command Types */
 #define RF_CORE_COMMAND_TYPE_MASK                        0x0C00
-#define RF_CORE_COMMAND_TYPE_IMMEDIATE                   0x0000
 #define RF_CORE_COMMAND_TYPE_RADIO_OP                    0x0800
 #define RF_CORE_COMMAND_TYPE_IEEE_BG_RADIO_OP            0x0800
 #define RF_CORE_COMMAND_TYPE_IEEE_FG_RADIO_OP            0x0C00


### PR DESCRIPTION
The radio driver has 2 problems:

* Firstly, detection of whether a command is a Radio Op is broken: Some immediate commands will get categorised as Radio Ops, when in reality they are not. One such command is `CMD_SET_TX_POWER`.
* Secondly: When `set_tx_power()` is called in IEEE mode, it will try to immediately apply the new setting by sending `CMD_SET_TX_POWER`. If this command fails, then the new TX power setting will not be applied at all. One reason of such failure is if the RFC is powered off.

Thus, this pull:

* Fixes the command type classification logic.
* Changes the logic in `set_tx_power()` for IEEE mode. If the new user setting is valid, it always gets saved. If the RFC happens to be powered up, the new setting gets applied immediately with `CMD_SET_TX_POWER`. If the RFC is powered off, the new power setting will get applied next time the RFC is turned on.

Fixes #1340 