### PR TITLE
uIP Stats: Count sent ICMP6 packets

### DIFF
--- a/core/net/ipv6/uip-icmp6.c
+++ b/core/net/ipv6/uip-icmp6.c
@@ -38,7 +38,7 @@
 /**
  * \file
  *    ICMPv6 (RFC 4443) implementation, with message and error handling
- * \author Julien Abeille <jabeille@cisco.com> 
+ * \author Julien Abeille <jabeille@cisco.com>
  * \author Mathilde Durvy <mdurvy@cisco.com>
  */
 
@@ -313,6 +313,10 @@ uip_icmp6_send(const uip_ipaddr_t *dest, int type, int code, int payload_len)
   UIP_ICMP_BUF->icmpchksum = ~uip_icmp6chksum();
 
   uip_len = UIP_IPH_LEN + UIP_ICMPH_LEN + payload_len;
+
+  UIP_STAT(++uip_stat.icmp.sent);
+  UIP_STAT(++uip_stat.ip.sent);
+
   tcpip_ipv6_output();
 }
 /*---------------------------------------------------------------------------*/


### PR DESCRIPTION
The sent ICMP6 packets (for example from RPL) are currently
not counted towards the sum of sent ip and icmp packets.

Is there any reason behind this or is it just a bug?
Looking at the code I found no side effects of adding these two lines.

Debug output:
```
uip_stat.ip .recv 10 .sent 23 .forwared 0 .drop 0
uip_stat.icmp .recv 10 .sent 11 .drop 0
uip_stat.udp .recv 0 .sent 12 .drop 0
```
(Sum of ip.sent matches icmp.sent and udp.sent)