### PR TITLE
Implement the Wireshark ZEPv2 encapsualtion for the avr-ravenusb.

### DIFF
--- a/cpu/avr/radio/rf230bb/hal.h
+++ b/cpu/avr/radio/rf230bb/hal.h
@@ -11,6 +11,7 @@
  *	Nate Bohlmann nate@elfwerks.com
  *  David Kopf dak664@embarqmail.com
  *  Ivan Delamer delamer@ieee.com
+ *  Cristiano De Alti cristiano_dealti@hotmail.com
  *
  *   All rights reserved.
  *
@@ -292,8 +293,18 @@
 #else
 #define RADIO_VECT TIMER1_CAPT_vect
 // Raven and Jackdaw
+#if PLATFORM_TYPE == RAVENUSB_C
+/* Extern clock source on T1 pin. Clock on falling edge */
+#define HAL_ENABLE_RADIO_INTERRUPT( ) { TCCR1B = ( 1 << ICES1 ) | ( 1 << CS11 ) | ( 1 << CS12 ); TIFR1 |= (1 << ICF1); TIMSK1 |= ( 1 << ICIE1 ) ; }
+#else
 #define HAL_ENABLE_RADIO_INTERRUPT( ) { TCCR1B = ( 1 << ICES1 ) | ( 1 << CS10 ); TIFR1 |= (1 << ICF1); TIMSK1 |= ( 1 << ICIE1 ) ; }
+#endif
 #define HAL_DISABLE_RADIO_INTERRUPT( ) ( TIMSK1 &= ~( 1 << ICIE1 ) )
+
+#define HAL_READ_TIMER_COUNTER( ) TCNT1
+#define HAL_TIMER_OVERFLOW_PENDING( ) ( TIFR1 & ( 1 << TOV1 ) )
+#define HAL_CLEAR_TIMER_OVERFLOW( ) ( TIFR1 &= ~( 1 << TOV1 ) )
+#define TIMER_VECT TIMER1_OVF_vect
 #endif
 
 #define HAL_ENABLE_OVERFLOW_INTERRUPT( ) ( TIMSK1 |= ( 1 << TOIE1 ) )
@@ -359,6 +370,8 @@ typedef struct{
     uint8_t length;                       /**< Length of frame. */
     uint8_t data[ HAL_MAX_FRAME_LENGTH ]; /**< Actual frame data. */
     uint8_t lqi;                          /**< LQI value for received frame. */
+    uint8_t rssi;                         /**< RSSI value for received frame as an offset in dB from the minimum RSSI (-91dBm). */
+    uint32_t timestamp;                   /**< High precision timestamp (1/RF230_CONF_PRECISE_TIMESTAMP_SECONDS). */
     bool crc;                             /**< Flag - did CRC pass for received frame? */
 } hal_rx_frame_t;
 

--- a/cpu/avr/radio/rf230bb/rf230bb.c
+++ b/cpu/avr/radio/rf230bb/rf230bb.c
@@ -6,6 +6,7 @@
  *
  *  David Kopf dak664@embarqmail.com
  *  Ivan Delamer delamer@ieee.com
+ *  Cristiano De Alti cristiano_dealti@hotmail.com
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -548,6 +549,44 @@ rf230_is_ready_to_send() {
 	return true;
 }
 
+/*---------------------------------------------------------------------------*/
+/*
+ * Interrupt leaves frame intact in FIFO.
+ */
+#if RF230_CONF_TIMESTAMPS
+static volatile rtimer_clock_t interrupt_time;
+static volatile int interrupt_time_set;
+#endif /* RF230_CONF_TIMESTAMPS */
+int
+rf230_interrupt(void)
+{
+  /* Poll the receive process, unless the stack thinks the radio is off */
+#if RADIOALWAYSON
+if (RF230_receive_on) {
+  DEBUGFLOW('+');
+#endif
+#if RF230_CONF_TIMESTAMPS
+  interrupt_time = timesynch_time();
+  interrupt_time_set = 1;
+#endif /* RF230_CONF_TIMESTAMPS */
+
+  process_poll(&rf230_process);
+  
+  rf230_pending = 1;
+  
+#if RADIOSTATS //TODO:This will double count buffered packets
+  RF230_receivepackets++;
+#endif
+  RIMESTATS_ADD(llrx);
+
+#if RADIOALWAYSON
+} else {
+  DEBUGFLOW('-');
+  rxframe[rxframe_head].length=0;
+}
+#endif
+  return 1;
+}
 
 static void
 flushrx(void)
@@ -853,7 +892,7 @@ rf230_init(void)
 void rf230_warm_reset(void) {
 #if RF230_CONF_SNEEZER && JACKDAW
   /* Take jackdaw radio out of test mode */
-#warning Manipulating PORTB pins for RF230 Sneezer mode!
+#pragma message "Manipulating PORTB pins for RF230 Sneezer mode!"
   PORTB &= ~(1<<7);
   DDRB  &= ~(1<<7);
 #endif
@@ -1311,44 +1350,6 @@ rf230_set_pan_addr(unsigned pan,
   }
 }
 /*---------------------------------------------------------------------------*/
-/*
- * Interrupt leaves frame intact in FIFO.
- */
-#if RF230_CONF_TIMESTAMPS
-static volatile rtimer_clock_t interrupt_time;
-static volatile int interrupt_time_set;
-#endif /* RF230_CONF_TIMESTAMPS */
-int
-rf230_interrupt(void)
-{
-  /* Poll the receive process, unless the stack thinks the radio is off */
-#if RADIOALWAYSON
-if (RF230_receive_on) {
-  DEBUGFLOW('+');
-#endif
-#if RF230_CONF_TIMESTAMPS
-  interrupt_time = timesynch_time();
-  interrupt_time_set = 1;
-#endif /* RF230_CONF_TIMESTAMPS */
-
-  process_poll(&rf230_process);
-  
-  rf230_pending = 1;
-  
-#if RADIOSTATS //TODO:This will double count buffered packets
-  RF230_receivepackets++;
-#endif
-  RIMESTATS_ADD(llrx);
-
-#if RADIOALWAYSON
-} else {
-  DEBUGFLOW('-');
-  rxframe[rxframe_head].length=0;
-}
-#endif
-  return 1;
-}
-/*---------------------------------------------------------------------------*/
 /* Process to handle input packets
  * Receive interrupts cause this process to be polled
  * It calls the core MAC layer which calls rf230_read to get the packet
@@ -1419,6 +1420,7 @@ static int
 rf230_read(void *buf, unsigned short bufsize)
 {
   uint8_t len,*framep;
+  uint32_t timestamp;
 #if FOOTER_LEN
   uint8_t footer[FOOTER_LEN];
 #endif
@@ -1440,7 +1442,7 @@ rf230_read(void *buf, unsigned short bufsize)
  }
 #endif
 
-  /* The length includes the twp-byte checksum but not the LQI byte */
+  /* The length includes the two-byte checksum but not the LQI byte */
   len=rxframe[rxframe_head].length;
   if (len==0) {
 #if RADIOALWAYSON && DEBUGFLOWSIZE
@@ -1488,9 +1490,13 @@ rf230_read(void *buf, unsigned short bufsize)
   framep=&(rxframe[rxframe_head].data[0]);
   memcpy(buf,framep,len-AUX_LEN+CHECKSUM_LEN);
   rf230_last_correlation = rxframe[rxframe_head].lqi;
+  rf230_last_rssi = rxframe[rxframe_head].rssi;
+  timestamp = rxframe[rxframe_head].timestamp;
 
  /* Prepare to receive another packet */
   flushrx();
+
+ /* WARNING! do not use rxframe past this point */ 
   
  /* Point to the checksum */
   framep+=len-AUX_LEN; 
@@ -1516,19 +1522,6 @@ rf230_read(void *buf, unsigned short bufsize)
      checksum == crc16_data(buf, len - AUX_LEN, 0)) {
 #endif
 #endif /* RF230_CONF_CHECKSUM */
-
-/* Get the received signal strength for the packet, 0-84 dB above rx threshold */
-#if 0   //more general
-    rf230_last_rssi = rf230_get_raw_rssi();
-#else   //faster
-#if RF230_CONF_AUTOACK
- //   rf230_last_rssi = hal_subregister_read(SR_ED_LEVEL);  //0-84 resolution 1 dB
-    rf230_last_rssi = hal_register_read(RG_PHY_ED_LEVEL);  //0-84, resolution 1 dB
-#else
-/* last_rssi will have been set at RX_START interrupt */
-//  rf230_last_rssi = 3*hal_subregister_read(SR_RSSI);    //0-28 resolution 3 dB
-#endif
-#endif /* speed vs. generality */
 
   /* Save the smallest rssi. The display routine can reset by setting it to zero */
   if ((rf230_smallest_rssi==0) || (rf230_last_rssi<rf230_smallest_rssi))
@@ -1563,7 +1556,10 @@ rf230_read(void *buf, unsigned short bufsize)
 #endif
 
 #ifdef RF230BB_HOOK_RX_PACKET
-  RF230BB_HOOK_RX_PACKET(buf,len);
+  RF230BB_HOOK_RX_PACKET(buf, len,
+                         rf230_last_correlation,
+                         rf230_last_rssi,
+                         timestamp);
 #endif
 
   /* Here return just the data length. The checksum is however still in the buffer for packet sniffing */
@@ -1613,7 +1609,11 @@ rf230_get_raw_rssi(void)
      rssi = hal_subregister_read(SR_RSSI);      //0-28, resolution 3 dB
      rssi = (rssi << 1)  + rssi;                //*3
 #else  // 1 or 2 clock multiply, or compiler with correct optimization
-     rssi = 3 * hal_subregister_read(SR_RSSI);
+     /* See ATmega128RFA1 reference manual 9.12.10.
+        See AT86RF230 reference manual 8.4.3 */
+     rssi = hal_subregister_read(SR_RSSI);
+     if (rssi != 0)
+        rssi = 3 * (rssi - 1);
 #endif
 
   }

--- a/cpu/avr/radio/rf230bb/rf230bb.h
+++ b/cpu/avr/radio/rf230bb/rf230bb.h
@@ -11,6 +11,7 @@
  *	Nate Bohlmann nate@elfwerks.com
  *  David Kopf dak664@embarqmail.com
  *  Ivan Delamer delamer@ieee.com
+ *  Cristiano De Alti cristiano_dealti@hotmail.com
  *
  *   All rights reserved.
  *
@@ -193,7 +194,7 @@ typedef void (*radio_rx_callback) (uint16_t data);
 **	
 **	Sniffing Hooks:
 **		RF230BB_HOOK_TX_PACKET(buffer,total_len)
-**		RF230BB_HOOK_RX_PACKET(buf,len)
+**		RF230BB_HOOK_RX_PACKET(buf,len,lqi,rssi,timestamp)
 **
 **	RF230BB_HOOK_IS_SEND_ENABLED()
 **	RF230BB_HOOK_RADIO_ON()

--- a/examples/ravenusbstick/Makefile.ravenusbstick
+++ b/examples/ravenusbstick/Makefile.ravenusbstick
@@ -6,6 +6,8 @@ all: ravenusbstick
 CONTIKI_NO_NET=1
 CONTIKI_WITH_IPV6=0
 
+CFLAGS += -DJACKDAW_CONF_RAW_MODE_ZEP=1 -DRF230_CONF_RX_BUFFERS=5 -DRF230_CONF_PRECISE_TIMESTAMP_SECONDS=1000000
+
 CONTIKI = ../..
 
 MODULES+=core/net/mac/sicslowmac core/net/mac core/net/llsec

--- a/examples/ravenusbstick/fakeuip.c
+++ b/examples/ravenusbstick/fakeuip.c
@@ -19,7 +19,7 @@ struct uip_stats uip_stat;
 
 uip_lladdr_t uip_lladdr;
 
-static uint8_t (* output)(uip_lladdr_t *);
+static uint8_t (* output)(const uip_lladdr_t *);
 extern void mac_LowpanToEthernet(void);
 void tcpip_input( void )
 {

--- a/platform/avr-ravenusb/contiki-conf.h
+++ b/platform/avr-ravenusb/contiki-conf.h
@@ -161,11 +161,12 @@ static inline uint8_t radio_is_ready_to_send_() {
 //#define RF230BB_HOOK_RADIO_OFF()	Led1_off()
 //#define RF230BB_HOOK_RADIO_ON()		Led1_on()
 #define RF230BB_HOOK_TX_PACKET(buffer,total_len) mac_log_802_15_4_tx(buffer,total_len)
-#define RF230BB_HOOK_RX_PACKET(buffer,total_len) mac_log_802_15_4_rx(buffer,total_len)
+#define RF230BB_HOOK_RX_PACKET(buffer,total_len,lqi,rssi,timestamp) mac_log_802_15_4_rx(buffer,total_len,lqi,rssi,timestamp)
 #define	RF230BB_HOOK_IS_SEND_ENABLED()	mac_is_send_enabled()
 extern bool mac_is_send_enabled(void);
-extern void mac_log_802_15_4_tx(const uint8_t* buffer, size_t total_len);
-extern void mac_log_802_15_4_rx(const uint8_t* buffer, size_t total_len);
+extern void mac_log_802_15_4_tx(const uint8_t* buffer, uint8_t total_len);
+extern void mac_log_802_15_4_rx(const uint8_t* buffer, uint8_t total_len,
+                                uint8_t lqi, uint8_t rssi, uint32_t timestamp);
 
 
 /* ************************************************************************** */


### PR DESCRIPTION

![zep](https://cloud.githubusercontent.com/assets/3309585/10985235/e1066e10-841f-11e5-956d-13aa16d8d1c1.png)
With this encapsulation Wireshark will display the channel, RSSI,
LQI, frame sequence number the precise frame reception timestamp.
The timestamp is in the NTP format but due to the implementation
it will rollback after about one hour. It is meant for relative
time differences and clocked by the high precision reference clock
of the RF230 (1MHz).
I've also fixed, refactored and removed compiler warnings from
the radio driver.