### PR TITLE
Small correction to cc26xx readme

### DIFF
--- a/platform/srf06-cc26xx/README.md
+++ b/platform/srf06-cc26xx/README.md
@@ -107,9 +107,9 @@ To use the port you need:
   GNU Tools for ARM Embedded Processors <https://launchpad.net/gcc-arm-embedded>.
   The port was developed and tested using this version:
 
-    $ arm-none-eabi-gcc -v
-    [...]
-    gcc version 4.9.3 20141119 (release) [ARM/embedded-4_9-branch revision 218278] (GNU Tools for ARM Embedded Processors)
+        $ arm-none-eabi-gcc -v
+        [...]
+        gcc version 4.9.3 20141119 (release) [ARM/embedded-4_9-branch revision 218278] (GNU Tools for ARM Embedded Processors)
 
 * srecord (http://srecord.sourceforge.net/)
 * You may also need other drivers so that the SmartRF can communicate with your


### PR DESCRIPTION
Code block in a list was not properly indented, so the gcc version string looked like a link leading to nowhere (because of markdown)