### PR TITLE
Resolved Contiki error: Reading outside memory

### DIFF
--- a/core/sys/ctimer.c
+++ b/core/sys/ctimer.c
@@ -99,15 +99,8 @@ void
 ctimer_set(struct ctimer *c, clock_time_t t,
 	   void (*f)(void *), void *ptr)
 {
-  ctimer_set_with_process(c, t, f, ptr, PROCESS_CURRENT());
-}
-/*---------------------------------------------------------------------------*/
-void
-ctimer_set_with_process(struct ctimer *c, clock_time_t t,
-	   void (*f)(void *), void *ptr, struct process *p)
-{
   PRINTF("ctimer_set %p %u\n", c, (unsigned)t);
-  c->p = p;
+  c->p = PROCESS_CURRENT();
   c->f = f;
   c->ptr = ptr;
   if(initialized) {


### PR DESCRIPTION
Wismote with large memory model, rpl-border-router is generating error: "reading outside memory". Please look into attached screenshot for the same. Problem has been resolved after few changes in ctimer_set function in ctimer.c.
![screenshot from 2015-11-10 13 16 02](https://cloud.githubusercontent.com/assets/12022110/11057605/888b9062-87b2-11e5-8670-385c493687de.png)
