### PR TITLE
Last compiler warnings

### DIFF
--- a/apps/webbrowser/www.c
+++ b/apps/webbrowser/www.c
@@ -52,6 +52,8 @@
 
 #include "www.h"
 
+/* Explicitly declare itoa as it is non-standard and not necessarily in stdlib.h */
+char *itoa(int value, char *str, int base);
 
 /* The array that holds the current URL. */
 static char url[WWW_CONF_MAX_URLLEN + 1];

--- a/examples/jn516x/rpl/border-router/slip-bridge.c
+++ b/examples/jn516x/rpl/border-router/slip-bridge.c
@@ -107,7 +107,7 @@ init(void)
   slip_set_input_callback(slip_input_callback);
 }
 /*---------------------------------------------------------------------------*/
-static void
+static int
 output(void)
 {
   if(uip_ipaddr_cmp(&last_sender, &UIP_IP_BUF->srcipaddr)) {
@@ -123,6 +123,7 @@ output(void)
     slip_send();
     printf("\n");
   }
+  return 0;
 }
 /*---------------------------------------------------------------------------*/
 #if !SLIP_BRIDGE_CONF_NO_PUTCHAR

--- a/examples/wget/wget.c
+++ b/examples/wget/wget.c
@@ -169,14 +169,14 @@ PROCESS_THREAD(wget_process, ev, data)
     strcpy(url, contiki_argv[1]);
     puts(url);
   } else {
-    gets(url);
+    fgets(url, sizeof(url), stdin);
   }
   fputs("Save as:", stdout);
   if(contiki_argc > 2) {
     strcpy(name, contiki_argv[2]);
     puts(name);
   } else {
-    gets(name);
+    fgets(name, sizeof(name), stdin);
   }
   file = cfs_open(name, CFS_WRITE);
   if(file == -1) {


### PR DESCRIPTION
This fixes three warnings that slipped in after https://github.com/contiki-os/contiki/pull/1293 was last built in Travis.