### PR TITLE
Improve the CC13xx sub-ghz driver

### DIFF
--- a/cpu/cc26xx-cc13xx/rf-core/prop-mode.c
+++ b/cpu/cc26xx-cc13xx/rf-core/prop-mode.c
@@ -647,6 +647,7 @@ static int
 transmit(unsigned short transmit_len)
 {
   int ret;
+  uint8_t was_off = 0;
   uint32_t cmd_status;
   volatile rfc_CMD_PROP_TX_ADV_t *cmd_tx_adv;
 
@@ -654,6 +655,7 @@ transmit(unsigned short transmit_len)
   uint16_t total_length;
 
   if(!rf_is_on()) {
+    was_off = 1;
     if(on() != RF_CORE_CMD_OK) {
       PRINTF("transmit: on() failed\n");
       return RADIO_TX_ERR;
@@ -738,6 +740,10 @@ transmit(unsigned short transmit_len)
   cmd_tx_adv->status = RF_CORE_RADIO_OP_STATUS_IDLE;
 
   rx_on_prop();
+
+  if(was_off) {
+    off();
+  }
 
   return ret;
 }

--- a/cpu/cc26xx-cc13xx/rf-core/prop-mode.c
+++ b/cpu/cc26xx-cc13xx/rf-core/prop-mode.c
@@ -1066,6 +1066,12 @@ set_value(radio_param_t param, radio_value_t value)
       return RADIO_RESULT_INVALID_VALUE;
     }
 
+    if(get_channel() == (uint8_t)value) {
+      /* We already have that very same channel configured.
+       * Nothing to do here. */
+      return RADIO_RESULT_OK;
+    }
+
     set_channel((uint8_t)value);
     break;
   case RADIO_PARAM_TXPOWER:

--- a/cpu/cc26xx-cc13xx/rf-core/prop-mode.c
+++ b/cpu/cc26xx-cc13xx/rf-core/prop-mode.c
@@ -971,6 +971,8 @@ off(void)
   rx_off_prop();
   rf_core_power_down();
 
+  ENERGEST_OFF(ENERGEST_TYPE_LISTEN);
+
   /* Switch HF clock source to the RCOSC to preserve power */
   oscillators_switch_to_hf_rc();
 


### PR DESCRIPTION
#1233 applied some improvements to the CC13xx/CC26xx IEEE mode driver. This pull replicates those improvements for the prop mode driver. In summary:

* We only switch channel if a new channel is being requested
* We turn the CC13xx RF back off after prop TX if it was off to start with
* Turn off `ENERGEST_TYPE_LISTEN` in CC13xx prop mode `off()`