### PR TITLE
Improve the stability of CC13xx/CC26xx low-power operation

### DIFF
--- a/cpu/cc26xx-cc13xx/dev/soc-rtc.c
+++ b/cpu/cc26xx-cc13xx/dev/soc-rtc.c
@@ -142,13 +142,11 @@ soc_rtc_last_isr_time(void)
 void
 soc_rtc_isr(void)
 {
-  uint32_t now, next;
+  uint32_t next;
 
   ENERGEST_ON(ENERGEST_TYPE_IRQ);
 
   last_isr_time = RTIMER_NOW();
-
-  now = ti_lib_aon_rtc_current_compare_value_get();
 
   /* Adjust the s/w tick counter irrespective of which event trigger this */
   clock_update();
@@ -161,7 +159,8 @@ soc_rtc_isr(void)
      * event on the next 512 tick boundary. If we drop to deep sleep before it
      * happens, lpm_drop() will reschedule us in the 'distant' future
      */
-    next = (now + COMPARE_INCREMENT) & MULTIPLE_512_MASK;
+    next = ((ti_lib_aon_rtc_current_compare_value_get() + 5) +
+            COMPARE_INCREMENT) & MULTIPLE_512_MASK;
     ti_lib_aon_rtc_compare_value_set(AON_RTC_CH1, next);
   }
 


### PR DESCRIPTION
This pull addresses a number of issues and applies a number of improvements to the CC13xx/CC26xx low-power logic.

_Firstly_, we make sure the AON RTC CH1 event handler always sets a valid time for the next compare event.

The current logic is to schedule CH1 events on each 512 AON RTC counter boundary while running (not when deep sleeping). However, under certain conditions the AON RTC interrupt handler will end up scheduling the next CH1 compare event too soon in the future, or on some extreme cases even in the past.

When this happens, the LPM logic gets confused thinking that there is not sufficient time to deep sleep and always chooses to put the SoC to sleep instead. The condition manifests itself by observing devices fully operational but otherwise stuck in a high power consumption state, as reported by @chenek in #1220.

AON RTC compare events cannot happen within 2 SCLK_LF cycles after a clearance (4 rtimer ticks == RTC ticks in the 16.16 format). Thus, if the next 512 boundary is too soon (5 rtimer ticks for margin), we skip it altogether. When this happens, etimers that would have expired on the skipped tick will expire 1 event later instead. Skipping a compare event has no negative impact on our s/w clock counter, since this is always read directly from the hardware counter.

_Secondly_, this pull applies a number of improvements to the logic used when trying to drop to a CC13xx/CC26xx low-power mode:
    
* We identify whether there are any pending etimers by using `etimer_pending()` instead of `etimer_next_expiration_time()`. This subsequently allows us to also identify whether an etimer is set to fire at time 0.
* We run a larger portion of the code with the global interrupt disabled. This prevents a number of messy conditions that can occur if an interrupt fires after we have started the low-power sequence.
* We check for pending events earlier in the sequence.
* We make sure to schedule a next wakeup event even when an LPM module prohibits deep sleep and forces sleep instead.
    
This fixes some of the issues discussed in #1236

Fixes #1220