### PR TITLE
RPL probing enhancement

### DIFF
--- a/core/net/rpl/rpl-timers.c
+++ b/core/net/rpl/rpl-timers.c
@@ -332,20 +332,18 @@ rpl_cancel_dao(rpl_instance_t *instance)
 static rpl_parent_t *
 get_probing_target(rpl_dag_t *dag)
 {
-  /* Returns the next probing target. The current implementation probes the current
-   * preferred parent if we have not updated its link for RPL_PROBING_EXPIRATION_TIME.
+  /* Returns the next probing target. This implementation probes the current
+   * preferred parent if we have not transmitted to it for RPL_PROBING_EXPIRATION_TIME.
    * Otherwise, it picks at random between:
-   * (1) selecting the best parent not updated for RPL_PROBING_EXPIRATION_TIME
+   * (1) selecting the best parent (lowest rank) not updated for RPL_PROBING_EXPIRATION_TIME
    * (2) selecting the least recently updated parent
    */
 
   rpl_parent_t *p;
   rpl_parent_t *probing_target = NULL;
   rpl_rank_t probing_target_rank = INFINITE_RANK;
-  /* min_last_tx is the clock time RPL_PROBING_EXPIRATION_TIME in the past */
-  clock_time_t min_last_tx = clock_time();
-  min_last_tx = min_last_tx > 2 * RPL_PROBING_EXPIRATION_TIME
-      ? min_last_tx - RPL_PROBING_EXPIRATION_TIME : 1;
+  clock_time_t probing_target_age = 0;
+  clock_time_t clock_now = clock_time();
 
   if(dag == NULL ||
       dag->instance == NULL ||
@@ -354,15 +352,15 @@ get_probing_target(rpl_dag_t *dag)
   }
 
   /* Our preferred parent needs probing */
-  if(dag->preferred_parent->last_tx_time < min_last_tx) {
-    probing_target = dag->preferred_parent;
+  if(clock_now - dag->preferred_parent->last_tx_time > RPL_PROBING_EXPIRATION_TIME) {
+    return dag->preferred_parent;
   }
 
   /* With 50% probability: probe best parent not updated for RPL_PROBING_EXPIRATION_TIME */
-  if(probing_target == NULL && (random_rand() % 2) == 0) {
+  if(random_rand() % 2 == 0) {
     p = nbr_table_head(rpl_parents);
     while(p != NULL) {
-      if(p->dag == dag && p->last_tx_time < min_last_tx) {
+      if(p->dag == dag && (clock_now - p->last_tx_time > RPL_PROBING_EXPIRATION_TIME)) {
         /* p is in our dag and needs probing */
         rpl_rank_t p_rank = dag->instance->of->calculate_rank(p, 0);
         if(probing_target == NULL
@@ -375,14 +373,15 @@ get_probing_target(rpl_dag_t *dag)
     }
   }
 
-  /* The default probing target is the least recently updated parent */
+  /* If we still do not have a probing target: pick the least recently updated parent */
   if(probing_target == NULL) {
     p = nbr_table_head(rpl_parents);
     while(p != NULL) {
       if(p->dag == dag) {
         if(probing_target == NULL
-            || p->last_tx_time < probing_target->last_tx_time) {
+            || clock_now - p->last_tx_time > probing_target_age) {
           probing_target = p;
+          probing_target_age = clock_now - p->last_tx_time;
         }
       }
       p = nbr_table_next(rpl_parents, p);


### PR DESCRIPTION
This PR used relative clock diffs rather than absolute clock comparison, for consistent operation across clock_time_t wrap boundaries.