### PR TITLE
off_t changed to signed to stay the same as POSIX

### DIFF
--- a/platform/sky/platform-conf.h
+++ b/platform/sky/platform-conf.h
@@ -71,7 +71,7 @@
 /* Types for clocks and uip_stats */
 typedef unsigned short uip_stats_t;
 typedef unsigned long clock_time_t;
-typedef unsigned long off_t;
+typedef long off_t;
 
 /* the low-level radio driver */
 #define NETSTACK_CONF_RADIO   cc2420_driver


### PR DESCRIPTION
On many other tool chains, like TI's new MSG430-GCC, the typedef will be conflict.