### PR TITLE
RPL: clearer naming and documentation of DAO delay constants

### DIFF
--- a/core/net/rpl/rpl-icmp6.c
+++ b/core/net/rpl/rpl-icmp6.c
@@ -729,7 +729,7 @@ dao_input(void)
       PRINT6ADDR(&prefix);
       PRINTF("\n");
       rep->state.nopath_received = 1;
-      rep->state.lifetime = DAO_EXPIRATION_TIMEOUT;
+      rep->state.lifetime = RPL_NOPATH_REMOVAL_DELAY;
 
       /* We forward the incoming no-path DAO to our parent, if we have
          one. */

--- a/core/net/rpl/rpl-private.h
+++ b/core/net/rpl/rpl-private.h
@@ -103,12 +103,19 @@
 /*---------------------------------------------------------------------------*/
 /* Default values for RPL constants and variables. */
 
-/* The default value for the DAO timer. */
-#ifdef RPL_CONF_DAO_LATENCY
-#define RPL_DAO_LATENCY                 RPL_CONF_DAO_LATENCY
-#else /* RPL_CONF_DAO_LATENCY */
-#define RPL_DAO_LATENCY                 (CLOCK_SECOND * 4)
-#endif /* RPL_DAO_LATENCY */
+/* DAO transmissions are always delayed by RPL_DAO_DELAY +/- RPL_DAO_DELAY/2 */
+#ifdef RPL_CONF_DAO_DELAY
+#define RPL_DAO_DELAY                 RPL_CONF_DAO_DELAY
+#else /* RPL_CONF_DAO_DELAY */
+#define RPL_DAO_DELAY                 (CLOCK_SECOND * 4)
+#endif /* RPL_CONF_DAO_DELAY */
+
+/* Delay between reception of a no-path DAO and actual route removal */
+#ifdef RPL_CONF_NOPATH_REMOVAL_DELAY
+#define RPL_NOPATH_REMOVAL_DELAY          RPL_CONF_NOPATH_REMOVAL_DELAY
+#else /* RPL_CONF_NOPATH_REMOVAL_DELAY */
+#define RPL_NOPATH_REMOVAL_DELAY          60
+#endif /* RPL_CONF_NOPATH_REMOVAL_DELAY */
 
 /* Special value indicating immediate removal. */
 #define RPL_ZERO_LIFETIME               0
@@ -134,9 +141,6 @@
 
 #define INFINITE_RANK                   0xffff
 
-
-/* Expire DAOs from neighbors that do not respond in this time. (seconds) */
-#define DAO_EXPIRATION_TIMEOUT          60
 /*---------------------------------------------------------------------------*/
 #define RPL_INSTANCE_LOCAL_FLAG         0x80
 #define RPL_INSTANCE_D_FLAG             0x40

--- a/core/net/rpl/rpl-timers.c
+++ b/core/net/rpl/rpl-timers.c
@@ -312,7 +312,7 @@ schedule_dao(rpl_instance_t *instance, clock_time_t latency)
 void
 rpl_schedule_dao(rpl_instance_t *instance)
 {
-  schedule_dao(instance, RPL_DAO_LATENCY);
+  schedule_dao(instance, RPL_DAO_DELAY);
 }
 /*---------------------------------------------------------------------------*/
 void


### PR DESCRIPTION
`DAO_EXPIRATION_TIMEOUT` is renamed to `RPL_NOPATH_REMOVAL_DELAY` to reflect what it actually is.

`RPL_DAO_LATENCY` is renamed ti `RPL_DAO_DELAY` for consistency with the terminology in RFC6550 and other RPL and IPv6 constants in Contiki.

Both are now documented and configurable.