### PR TITLE
Improved RPL debugging

### DIFF
--- a/core/net/ipv6/uip-ds6-route.c
+++ b/core/net/ipv6/uip-ds6-route.c
@@ -427,6 +427,12 @@ uip_ds6_route_rm(uip_ds6_route_t *route)
     if(list_head(route->neighbor_routes->route_list) == NULL) {
       /* If this was the only route using this neighbor, remove the
          neighbor from the table - this implicitly unlocks nexthop */
+#if (DEBUG) & DEBUG_ANNOTATE
+      uip_ipaddr_t *nexthop = uip_ds6_route_nexthop(route);
+      if(nexthop != NULL) {
+        ANNOTATE("#L %u 0\n", nexthop->u8[sizeof(uip_ipaddr_t) - 1]);
+      }
+#endif /* (DEBUG) & DEBUG_ANNOTATE */
       PRINTF("uip_ds6_route_rm: removing neighbor too\n");
       nbr_table_remove(nbr_routes, route->neighbor_routes->route_list);
     }
@@ -440,25 +446,6 @@ uip_ds6_route_rm(uip_ds6_route_t *route)
 #if UIP_DS6_NOTIFICATIONS
     call_route_callback(UIP_DS6_NOTIFICATION_ROUTE_RM,
         &route->ipaddr, uip_ds6_route_nexthop(route));
-#endif
-#if 0 //(DEBUG & DEBUG_ANNOTATE) == DEBUG_ANNOTATE
-    /* we need to check if this was the last route towards "nexthop" */
-    /* if so - remove that link (annotation) */
-    uip_ds6_route_t *r;
-    for(r = uip_ds6_route_head();
-        r != NULL;
-        r = uip_ds6_route_next(r)) {
-      uip_ipaddr_t *nextr, *nextroute;
-      nextr = uip_ds6_route_nexthop(r);
-      nextroute = uip_ds6_route_nexthop(route);
-      if(nextr != NULL &&
-         nextroute != NULL &&
-         uip_ipaddr_cmp(nextr, nextroute)) {
-        /* we found another link using the specific nexthop, so keep the #L */
-        return;
-      }
-    }
-    ANNOTATE("#L %u 0\n", uip_ds6_route_nexthop(route)->u8[sizeof(uip_ipaddr_t) - 1]);
 #endif
   }
 

--- a/core/net/rpl/rpl-dag.c
+++ b/core/net/rpl/rpl-dag.c
@@ -849,7 +849,7 @@ rpl_nullify_parent(rpl_parent_t *parent)
         uip_ds6_defrt_rm(dag->instance->def_route);
         dag->instance->def_route = NULL;
       }
-      /* Send no-path DAO only to preferred parent, if any */
+      /* Send No-Path DAO only to preferred parent, if any */
       if(parent == dag->preferred_parent) {
         dao_output(parent, RPL_ZERO_LIFETIME);
         rpl_set_preferred_parent(dag, NULL);

--- a/core/net/rpl/rpl-icmp6.c
+++ b/core/net/rpl/rpl-icmp6.c
@@ -731,11 +731,11 @@ dao_input(void)
       rep->state.nopath_received = 1;
       rep->state.lifetime = RPL_NOPATH_REMOVAL_DELAY;
 
-      /* We forward the incoming no-path DAO to our parent, if we have
+      /* We forward the incoming No-Path DAO to our parent, if we have
          one. */
       if(dag->preferred_parent != NULL &&
          rpl_get_parent_ipaddr(dag->preferred_parent) != NULL) {
-        PRINTF("RPL: Forwarding no-path DAO to parent ");
+        PRINTF("RPL: Forwarding No-Path DAO to parent ");
         PRINT6ADDR(rpl_get_parent_ipaddr(dag->preferred_parent));
         PRINTF("\n");
         uip_icmp6_send(rpl_get_parent_ipaddr(dag->preferred_parent),
@@ -900,7 +900,7 @@ dao_output_target(rpl_parent_t *parent, uip_ipaddr_t *prefix, uint8_t lifetime)
   buffer[pos++] = 0; /* path seq - ignored */
   buffer[pos++] = lifetime;
 
-  PRINTF("RPL: Sending DAO with prefix ");
+  PRINTF("RPL: Sending %sDAO with prefix ", lifetime == RPL_ZERO_LIFETIME ? "No-Path " : "");
   PRINT6ADDR(prefix);
   PRINTF(" to ");
   PRINT6ADDR(rpl_get_parent_ipaddr(parent));


### PR DESCRIPTION
This PR simplifies and re-enabled the annotation of removed routes in `uip-ds6-route.c`, extends the printouts of DAO sending to specify whether this is No-Path or not, and uses consistent case for No-Path throughout.
