### PR TITLE
Simplified LLSEC

### DIFF
--- a/core/net/ipv6/sicslowpan.c
+++ b/core/net/ipv6/sicslowpan.c
@@ -1338,7 +1338,7 @@ send_packet(linkaddr_t *dest)
 
   /* Provide a callback function to receive the result of
      a packet transmission. */
-  NETSTACK_LLSEC.send(&packet_sent, NULL);
+  NETSTACK_MAC.send(&packet_sent, NULL);
 
   /* If we are sending multiple packets in a row, we need to let the
      watchdog know that we are still alive. */

--- a/core/net/llsec/llsec.h
+++ b/core/net/llsec/llsec.h
@@ -41,12 +41,7 @@
  * \ingroup net
  * \defgroup llsec Link Layer Security
  * 
- * Layer for implementing link layer security.
- *         
- * NETSTACK_LLSEC sits in between NETSTACK_MAC and NETSTACK_NETWORK
- * protocols. All NETSTACK_MAC protocols invoke NETSTACK_LLSEC.input()
- * for incoming packets. Likewise, all NETSTACK_NETWORK protocols
- * invoke NETSTACK_LLSEC.send(...) for outgoing packets.
+ * Link layer security driver interface.
  * 
  * @{
  */
@@ -64,15 +59,7 @@ struct llsec_driver {
   
   /** Inits link layer security. */
   void (* init)(void);
-  
-  /** Secures outgoing frames before passing them to NETSTACK_MAC. */
-  void (* send)(mac_callback_t sent_callback, void *ptr);
-  
-  /**
-   * Decrypts incoming frames;
-   * filters out injected or replayed frames.
-   */
-  void (* input)(void);
+
 };
 
 #endif /* LLSEC_H_ */

--- a/core/net/llsec/noncoresec/noncoresec.c
+++ b/core/net/llsec/noncoresec/noncoresec.c
@@ -134,12 +134,6 @@ add_security_header(void)
   }
 }
 /*---------------------------------------------------------------------------*/
-static void
-send(mac_callback_t sent, void *ptr)
-{
-  NETSTACK_MAC.send(sent, ptr);
-}
-/*---------------------------------------------------------------------------*/
 static int
 create(void)
 {
@@ -223,12 +217,6 @@ parse(void)
   return result;
 }
 /*---------------------------------------------------------------------------*/
-static void
-input(void)
-{
-  NETSTACK_NETWORK.input();
-}
-/*---------------------------------------------------------------------------*/
 static int
 length(void)
 {
@@ -245,9 +233,7 @@ init(void)
 /*---------------------------------------------------------------------------*/
 const struct llsec_driver noncoresec_driver = {
   "noncoresec",
-  init,
-  send,
-  input
+  init
 };
 /*---------------------------------------------------------------------------*/
 const struct framer noncoresec_framer = {

--- a/core/net/llsec/nullsec.c
+++ b/core/net/llsec/nullsec.c
@@ -54,24 +54,9 @@ init(void)
 
 }
 /*---------------------------------------------------------------------------*/
-static void
-send(mac_callback_t sent, void *ptr)
-{
-  packetbuf_set_attr(PACKETBUF_ATTR_FRAME_TYPE, FRAME802154_DATAFRAME);
-  NETSTACK_MAC.send(sent, ptr);
-}
-/*---------------------------------------------------------------------------*/
-static void
-input(void)
-{
-  NETSTACK_NETWORK.input();
-}
-/*---------------------------------------------------------------------------*/
 const struct llsec_driver nullsec_driver = {
   "nullsec",
-  init,
-  send,
-  input
+  init
 };
 /*---------------------------------------------------------------------------*/
 

--- a/core/net/mac/csma.c
+++ b/core/net/mac/csma.c
@@ -337,6 +337,9 @@ send_packet(mac_callback_t sent, void *ptr)
   }
   packetbuf_set_attr(PACKETBUF_ATTR_MAC_SEQNO, seqno++);
 
+  /* Frames are of type DATA by default */
+  packetbuf_set_attr(PACKETBUF_ATTR_FRAME_TYPE, FRAME802154_DATAFRAME);
+
   /* Look for the neighbor entry */
   n = neighbor_queue_from_addr(addr);
   if(n == NULL) {
@@ -417,7 +420,7 @@ send_packet(mac_callback_t sent, void *ptr)
 static void
 input_packet(void)
 {
-  NETSTACK_LLSEC.input();
+  NETSTACK_NETWORK.input();
 }
 /*---------------------------------------------------------------------------*/
 static int

--- a/core/net/mac/nullmac.c
+++ b/core/net/mac/nullmac.c
@@ -48,13 +48,15 @@
 static void
 send_packet(mac_callback_t sent, void *ptr)
 {
+  /* Frames are of type DATA by default */
+  packetbuf_set_attr(PACKETBUF_ATTR_FRAME_TYPE, FRAME802154_DATAFRAME);
   NETSTACK_RDC.send(sent, ptr);
 }
 /*---------------------------------------------------------------------------*/
 static void
 packet_input(void)
 {
-  NETSTACK_LLSEC.input();
+  NETSTACK_NETWORK.input();
 }
 /*---------------------------------------------------------------------------*/
 static int

--- a/core/net/rime/rime.c
+++ b/core/net/rime/rime.c
@@ -180,7 +180,7 @@ rime_output(struct channel *c)
   if(chameleon_create(c)) {
     packetbuf_compact();
 
-    NETSTACK_LLSEC.send(packet_sent, c);
+    NETSTACK_MAC.send(packet_sent, c);
     return 1;
   }
   return 0;

--- a/examples/ipv6/slip-radio/slip-radio.c
+++ b/examples/ipv6/slip-radio/slip-radio.c
@@ -125,7 +125,7 @@ slip_radio_cmd_handler(const uint8_t *data, int len)
 
       /* parse frame before sending to get addresses, etc. */
       no_framer.parse();
-      NETSTACK_LLSEC.send(packet_sent, &packet_ids[packet_pos]);
+      NETSTACK_MAC.send(packet_sent, &packet_ids[packet_pos]);
 
       packet_pos++;
       if(packet_pos >= sizeof(packet_ids)) {

--- a/platform/cooja/net/uip-driver.c
+++ b/platform/cooja/net/uip-driver.c
@@ -55,7 +55,7 @@ uip_driver_send(void)
 
   /* XXX we should provide a callback function that is called when the
      packet is sent. For now, we just supply a NULL pointer. */
-  NETSTACK_LLSEC.send(NULL, NULL);
+  NETSTACK_MAC.send(NULL, NULL);
   return 1;
 }
 /*--------------------------------------------------------------------*/


### PR DESCRIPTION
With https://github.com/contiki-os/contiki/pull/1146, link-layer security is now implemented as as a FRAMER, and the scope of LLSEC has reduced. Only its `name` and `init` function remain really needed, as all functionality has moved away from the `send` and `input` functions. This makes LLSEC not really a layer anymore. This PR removes LLSEC as a layer, but keeps LLSEC as a driver (for `name` and `init`) and of course the link-layer security framer. I find this to also better match what link-layer security is from an architectural point of view: a service rather than a layer.

This PR does not have any (intended!) functional impact on link-layer security; it really only is about architecture.

Am very open to suggestions and discussions. Let me solicit @kkrentz explicitly here.