### PR TITLE
NDP disabled: also disable uip_ds6_neighbor_periodic

### DIFF
--- a/core/net/ipv6/uip-ds6-nbr.c
+++ b/core/net/ipv6/uip-ds6-nbr.c
@@ -84,15 +84,19 @@ uip_ds6_nbr_add(const uip_ipaddr_t *ipaddr, const uip_lladdr_t *lladdr,
   uip_ds6_nbr_t *nbr = nbr_table_add_lladdr(ds6_neighbors, (linkaddr_t*)lladdr);
   if(nbr) {
     uip_ipaddr_copy(&nbr->ipaddr, ipaddr);
+#if UIP_ND6_SEND_NA || UIP_ND6_SEND_RA || !UIP_CONF_ROUTER
     nbr->isrouter = isrouter;
+#endif /* UIP_ND6_SEND_NA || UIP_ND6_SEND_RA || !UIP_CONF_ROUTER */
     nbr->state = state;
-  #if UIP_CONF_IPV6_QUEUE_PKT
+#if UIP_CONF_IPV6_QUEUE_PKT
     uip_packetqueue_new(&nbr->packethandle);
-  #endif /* UIP_CONF_IPV6_QUEUE_PKT */
+#endif /* UIP_CONF_IPV6_QUEUE_PKT */
+#if UIP_ND6_SEND_NA
     /* timers are set separately, for now we put them in expired state */
     stimer_set(&nbr->reachable, 0);
     stimer_set(&nbr->sendns, 0);
     nbr->nscount = 0;
+#endif /* UIP_ND6_SEND_NA */
     PRINTF("Adding neighbor with ip addr ");
     PRINT6ADDR(ipaddr);
     PRINTF(" link addr ");
@@ -230,6 +234,7 @@ uip_ds6_link_neighbor_callback(int status, int numtx)
 #endif /* UIP_DS6_LL_NUD */
 
 }
+#if UIP_ND6_SEND_NA
 /*---------------------------------------------------------------------------*/
 void
 uip_ds6_neighbor_periodic(void)
@@ -241,7 +246,7 @@ uip_ds6_neighbor_periodic(void)
     case NBR_REACHABLE:
       if(stimer_expired(&nbr->reachable)) {
 #if UIP_CONF_IPV6_RPL
-        /* when a neighbor leave it's REACHABLE state and is a default router,
+        /* when a neighbor leave its REACHABLE state and is a default router,
            instead of going to STALE state it enters DELAY state in order to
            force a NUD on it. Otherwise, if there is no upward traffic, the
            node never knows if the default router is still reachable. This
@@ -268,7 +273,6 @@ uip_ds6_neighbor_periodic(void)
 #endif /* UIP_CONF_IPV6_RPL */
       }
       break;
-#if UIP_ND6_SEND_NA
     case NBR_INCOMPLETE:
       if(nbr->nscount >= UIP_ND6_MAX_MULTICAST_SOLICIT) {
         uip_ds6_nbr_rm(nbr);
@@ -304,7 +308,6 @@ uip_ds6_neighbor_periodic(void)
         stimer_set(&nbr->sendns, uip_ds6_if.retrans_timer / 1000);
       }
       break;
-#endif /* UIP_ND6_SEND_NA */
     default:
       break;
     }
@@ -330,5 +333,6 @@ uip_ds6_get_least_lifetime_neighbor(void)
   }
   return nbr_expiring;
 }
+#endif /* UIP_ND6_SEND_NA */
 /*---------------------------------------------------------------------------*/
 /** @} */

--- a/core/net/ipv6/uip-ds6-nbr.h
+++ b/core/net/ipv6/uip-ds6-nbr.h
@@ -69,12 +69,14 @@ NBR_TABLE_DECLARE(ds6_neighbors);
 /** \brief An entry in the nbr cache */
 typedef struct uip_ds6_nbr {
   uip_ipaddr_t ipaddr;
-  struct stimer reachable;
-  struct stimer sendns;
-  uint8_t nscount;
   uint8_t isrouter;
   uint8_t state;
   uint16_t link_metric;
+#if UIP_ND6_SEND_NA || UIP_ND6_SEND_RA
+  struct stimer reachable;
+  struct stimer sendns;
+  uint8_t nscount;
+#endif /* UIP_ND6_SEND_NA || UIP_ND6_SEND_RA */
 #if UIP_CONF_IPV6_QUEUE_PKT
   struct uip_packetqueue_handle packethandle;
 #define UIP_DS6_NBR_PACKET_LIFETIME CLOCK_SECOND * 4

--- a/core/net/ipv6/uip-ds6.c
+++ b/core/net/ipv6/uip-ds6.c
@@ -186,7 +186,9 @@ uip_ds6_periodic(void)
   }
 #endif /* !UIP_CONF_ROUTER */
 
+#if UIP_ND6_SEND_NA
   uip_ds6_neighbor_periodic();
+#endif /* UIP_ND6_SEND_RA */
 
 #if UIP_CONF_ROUTER && UIP_ND6_SEND_RA
   /* Periodic RA sending */

--- a/core/net/rpl/rpl-icmp6.c
+++ b/core/net/rpl/rpl-icmp6.c
@@ -243,8 +243,10 @@ dio_input(void)
     if((nbr = uip_ds6_nbr_add(&from, (uip_lladdr_t *)
                               packetbuf_addr(PACKETBUF_ADDR_SENDER),
                               0, NBR_REACHABLE)) != NULL) {
+#if UIP_ND6_SEND_NA
       /* set reachable timer */
       stimer_set(&nbr->reachable, UIP_ND6_REACHABLE_TIME / 1000);
+#endif /* UIP_ND6_SEND_NA */
       PRINTF("RPL: Neighbor added to neighbor cache ");
       PRINT6ADDR(&from);
       PRINTF(", ");
@@ -754,8 +756,10 @@ dao_input(void)
     if((nbr = uip_ds6_nbr_add(&dao_sender_addr,
                               (uip_lladdr_t *)packetbuf_addr(PACKETBUF_ADDR_SENDER),
                               0, NBR_REACHABLE)) != NULL) {
+#if UIP_ND6_SEND_NA
       /* set reachable timer */
       stimer_set(&nbr->reachable, UIP_ND6_REACHABLE_TIME / 1000);
+#endif /* UIP_ND6_SEND_NA */
       PRINTF("RPL: Neighbor added to neighbor cache ");
       PRINT6ADDR(&dao_sender_addr);
       PRINTF(", ");

--- a/core/net/rpl/rpl.c
+++ b/core/net/rpl/rpl.c
@@ -285,7 +285,11 @@ rpl_ipv6_neighbor_callback(uip_ds6_nbr_t *nbr)
 
   PRINTF("RPL: Neighbor state changed for ");
   PRINT6ADDR(&nbr->ipaddr);
+#if UIP_ND6_SEND_NA || UIP_ND6_SEND_RA
   PRINTF(", nscount=%u, state=%u\n", nbr->nscount, nbr->state);
+#else /* UIP_ND6_SEND_NA || UIP_ND6_SEND_RA */
+  PRINTF(", state=%u\n", nbr->state);
+#endif /* UIP_ND6_SEND_NA || UIP_ND6_SEND_RA */
   for(instance = &instance_table[0], end = instance + RPL_MAX_INSTANCES; instance < end; ++instance) {
     if(instance->used == 1 ) {
       p = rpl_find_parent_any_dag(instance, &nbr->ipaddr);


### PR DESCRIPTION
Addresses one of the issues in https://github.com/contiki-os/contiki/issues/1380
Nodes running RPL with NDP disabled will now remain in REACHABLE state.
Removing some state in `uip-ds6-nbr` also results in about 20 bytes saved per neighbor.