### PR TITLE
Fix RPL use of `acceptable_rank`

### DIFF
--- a/core/net/rpl/rpl-dag.c
+++ b/core/net/rpl/rpl-dag.c
@@ -1352,15 +1352,12 @@ rpl_recalculate_ranks(void)
 int
 rpl_process_parent_event(rpl_instance_t *instance, rpl_parent_t *p)
 {
-  int return_value;
   rpl_parent_t *last_parent = instance->current_dag->preferred_parent;
 
 #if DEBUG
   rpl_rank_t old_rank;
   old_rank = instance->current_dag->rank;
 #endif /* DEBUG */
-
-  return_value = 1;
 
   if(RPL_IS_STORING(instance)
       && uip_ds6_route_is_nexthop(rpl_get_parent_ipaddr(p))
@@ -1369,19 +1366,6 @@ rpl_process_parent_event(rpl_instance_t *instance, rpl_parent_t *p)
     PRINT6ADDR(rpl_get_parent_ipaddr(p));
     PRINTF("\n");
     rpl_remove_routes_by_nexthop(rpl_get_parent_ipaddr(p), p->dag);
-  }
-
-  if(!acceptable_rank(p->dag, p->rank)) {
-    /* The candidate parent is no longer valid: the rank increase resulting
-       from the choice of it as a parent would be too high. */
-    PRINTF("RPL: Unacceptable rank %u (Current min %u, MaxRankInc %u)\n", (unsigned)p->rank,
-        p->dag->min_rank, p->dag->instance->max_rankinc);
-    rpl_nullify_parent(p);
-    if(p != instance->current_dag->preferred_parent) {
-      return 0;
-    } else {
-      return_value = 0;
-    }
   }
 
   if(rpl_select_dag(instance, p->dag) == NULL) {
@@ -1408,7 +1392,7 @@ rpl_process_parent_event(rpl_instance_t *instance, rpl_parent_t *p)
   }
 #endif /* DEBUG */
 
-  return return_value;
+  return 1;
 }
 /*---------------------------------------------------------------------------*/
 static int

--- a/core/net/rpl/rpl-dag.c
+++ b/core/net/rpl/rpl-dag.c
@@ -80,7 +80,11 @@ static rpl_of_t * const objective_functions[] = RPL_SUPPORTED_OFS;
 #endif /* !RPL_CONF_GROUNDED */
 
 /*---------------------------------------------------------------------------*/
-/* Per-parent RPL information */
+/* A table containing information about all nodes in our candidate neighbor set,
+ * as defined in https://tools.ietf.org/html/rfc6550#section-8.2.1
+ * In this implementation, nodes have a single parent in their parent set at all
+ * times, always used as preferred parent. This table contains the preferred parent,
+ * possible future preferred parents, siblings and children. */
 NBR_TABLE_GLOBAL(rpl_parent_t, rpl_parents);
 /*---------------------------------------------------------------------------*/
 /* Allocate instance table. */

--- a/core/net/rpl/rpl-dag.c
+++ b/core/net/rpl/rpl-dag.c
@@ -325,6 +325,7 @@ acceptable_rank(rpl_dag_t *dag, rpl_rank_t rank)
 {
   return rank != INFINITE_RANK &&
     ((dag->instance->max_rankinc == 0) ||
+     (dag->min_rank == INFINITE_RANK)  ||
      DAG_RANK(rank, dag->instance) <= DAG_RANK(dag->min_rank + dag->instance->max_rankinc, dag->instance));
 }
 /*---------------------------------------------------------------------------*/

--- a/core/net/rpl/rpl-ext-header.c
+++ b/core/net/rpl/rpl-ext-header.c
@@ -135,7 +135,7 @@ rpl_verify_hbh_header(int uip_ext_opt_offset)
       /* Select DAG and preferred parent only in non-storing mode. In storing mode,
        * a parent switch would result in an immediate No-path DAO transmission, dropping
        * current incoming packet. */
-      rpl_select_dag(instance, sender);
+      rpl_select_dag(instance, sender->dag);
     }
   }
 

--- a/core/net/rpl/rpl-private.h
+++ b/core/net/rpl/rpl-private.h
@@ -370,7 +370,7 @@ void rpl_nullify_parent(rpl_parent_t *);
 void rpl_remove_parent(rpl_parent_t *);
 void rpl_move_parent(rpl_dag_t *dag_src, rpl_dag_t *dag_dst, rpl_parent_t *parent);
 rpl_parent_t *rpl_select_parent(rpl_dag_t *dag);
-rpl_dag_t *rpl_select_dag(rpl_instance_t *instance,rpl_parent_t *parent);
+rpl_dag_t *rpl_select_dag(rpl_instance_t *instance, rpl_dag_t *dag);
 void rpl_recalculate_ranks(void);
 
 /* RPL routing table functions. */

--- a/core/net/rpl/rpl.h
+++ b/core/net/rpl/rpl.h
@@ -134,7 +134,7 @@ typedef struct rpl_prefix rpl_prefix_t;
 /* Directed Acyclic Graph */
 struct rpl_dag {
   uip_ipaddr_t dag_id;
-  rpl_rank_t min_rank; /* should be reset per DAG iteration! */
+  rpl_rank_t min_rank; /* is reset at every DAG iteration */
   uint8_t version;
   uint8_t grounded;
   uint8_t preference;


### PR DESCRIPTION
In RFC6550 there are three sets of neighbors (see https://tools.ietf.org/html/rfc6550#section-8.2.1):
- **candidate neighbor set:** neighbors reachable with link-local multicast. May become parent, sibling or child;
- **parent set:** nodes above in the DODAG. With the following property: `A node's Rank MUST be greater than all elements of its DODAG parent set.`;
- **preferred parent:** selected one among the parent set, this is the parent currently in use.

Now Contiki's neighbor table `rpl_parents` has a misleading name; it is the candidate neighbor set, not the parent set. We have all sorts of nodes in the table, including with rank higher than us, and including children. That's actually ok, as we want to keep track of the rank and metric of all neighbors, in part as they might one day move to the parent set or as a preferred parent.

This PR removes the filtering out of nodes leading to a rank above `MaxRankIncrease`, which should be done on the parent set, not the candidate neighbor set.

The PR also includes the following fixes:
- adds a sanity check to `acceptable_rank` (needed because `min_rank` is set to infinite at every version update);
- clarifies `rpl_select_dag`, which actually operates on an instance and a dag, not an instance and a parent.
