### PR TITLE
Removed memcpy that cause inconsistency in nbr-table when adding nd6 neighbors.

### DIFF
--- a/core/net/ipv6/uip-nd6.c
+++ b/core/net/ipv6/uip-nd6.c
@@ -490,14 +490,16 @@ na_input(void)
     PRINTF("NA received is bad\n");
     goto discard;
   } else {
+    const uip_lladdr_t *lladdr;
     nbr = uip_ds6_nbr_lookup(&UIP_ND6_NA_BUF->tgtipaddr);
     if(nbr == NULL) {
       goto discard;
     }
 
+    lladdr = uip_ds6_nbr_get_ll(nbr);
     if(nd6_opt_llao != NULL) {
-      is_llchange =
-        memcmp(&nd6_opt_llao[UIP_ND6_OPT_DATA_OFFSET], uip_ds6_nbr_get_ll(nbr),
+      is_llchange = lladdr == NULL ||
+        memcmp(&nd6_opt_llao[UIP_ND6_OPT_DATA_OFFSET], lladdr,
                UIP_LLADDR_LEN);
     }
     if(nbr->state == NBR_INCOMPLETE) {

--- a/core/net/ipv6/uip-nd6.c
+++ b/core/net/ipv6/uip-nd6.c
@@ -534,9 +534,12 @@ na_input(void)
         }
         goto discard;
       } else {
-        if(is_override || (!is_override && nd6_opt_llao != NULL && !is_llchange)
-           || nd6_opt_llao == NULL) {
-          if(nd6_opt_llao != NULL) {
+        /**
+         *  If this is an cache override, or same lladdr, or no llao -
+         *  do updates of nbr states.
+         */
+        if(is_override || !is_llchange || nd6_opt_llao == NULL) {
+          if(nd6_opt_llao != NULL && is_llchange) {
             uip_lladdr_t lladdr_aligned;
             extract_lladdr_aligned(&lladdr_aligned);
 
@@ -554,10 +557,6 @@ na_input(void)
             nbr->state = NBR_REACHABLE;
             /* reachable time is stored in ms */
             stimer_set(&(nbr->reachable), uip_ds6_if.reachable_time / 1000);
-          } else {
-            if(nd6_opt_llao != NULL && is_llchange) {
-              nbr->state = NBR_STALE;
-            }
           }
         }
       }

--- a/core/net/nbr-table.c
+++ b/core/net/nbr-table.c
@@ -195,9 +195,8 @@ remove_key(nbr_table_key_t *least_used_key)
   used_map[index_from_key(least_used_key)] = 0;
   /* Remove neighbor from list */
   list_remove(nbr_table_keys, least_used_key);
-  /* Return associated key */
 }
-
+/*---------------------------------------------------------------------------*/
 static nbr_table_key_t *
 nbr_table_allocate(nbr_table_reason_t reason, void *data)
 {

--- a/core/net/nbr-table.c
+++ b/core/net/nbr-table.c
@@ -178,6 +178,26 @@ nbr_set_bit(uint8_t *bitmap, nbr_table_t *table, nbr_table_item_t *item, int val
   return 0;
 }
 /*---------------------------------------------------------------------------*/
+static void
+remove_key(nbr_table_key_t *least_used_key)
+{
+  int i;
+  for(i = 0; i < MAX_NUM_TABLES; i++) {
+    if(all_tables[i] != NULL && all_tables[i]->callback != NULL) {
+      /* Call table callback for each table that uses this item */
+      nbr_table_item_t *removed_item = item_from_key(all_tables[i], least_used_key);
+      if(nbr_get_bit(used_map, all_tables[i], removed_item) == 1) {
+        all_tables[i]->callback(removed_item);
+      }
+    }
+  }
+  /* Empty used map */
+  used_map[index_from_key(least_used_key)] = 0;
+  /* Remove neighbor from list */
+  list_remove(nbr_table_keys, least_used_key);
+  /* Return associated key */
+}
+
 static nbr_table_key_t *
 nbr_table_allocate(nbr_table_reason_t reason, void *data)
 {
@@ -253,21 +273,7 @@ nbr_table_allocate(nbr_table_reason_t reason, void *data)
       return NULL;
     } else {
       /* Reuse least used item */
-      int i;
-      for(i = 0; i<MAX_NUM_TABLES; i++) {
-        if(all_tables[i] != NULL && all_tables[i]->callback != NULL) {
-          /* Call table callback for each table that uses this item */
-          nbr_table_item_t *removed_item = item_from_key(all_tables[i], least_used_key);
-          if(nbr_get_bit(used_map, all_tables[i], removed_item) == 1) {
-            all_tables[i]->callback(removed_item);
-          }
-        }
-      }
-      /* Empty used map */
-      used_map[index_from_key(least_used_key)] = 0;
-      /* Remove neighbor from list */
-      list_remove(nbr_table_keys, least_used_key);
-      /* Return associated key */
+      remove_key(least_used_key);
       return least_used_key;
     }
   }
@@ -414,6 +420,39 @@ nbr_table_get_lladdr(nbr_table_t *table, const void *item)
 {
   nbr_table_key_t *key = key_from_item(table, item);
   return key != NULL ? &key->lladdr : NULL;
+}
+/*---------------------------------------------------------------------------*/
+/* Update link-layer address of an item */
+int
+nbr_table_update_lladdr(const linkaddr_t *old_addr, const linkaddr_t *new_addr,
+                        int remove_if_duplicate)
+{
+  int index;
+  int new_index;
+  nbr_table_key_t *key;
+  index = index_from_lladdr(old_addr);
+  if(index == -1) {
+    /* Failure to change since there is nothing to change. */
+    return 0;
+  }
+  if((new_index = index_from_lladdr(new_addr)) != -1) {
+    /* check if it is a change or not - do not remove / fail if same */
+    if(new_index == index) {
+      return 1;
+    }
+    /* This new entry already exists - failure! - remove if requested. */
+    if(remove_if_duplicate) {
+      remove_key(key_from_index(index));
+    }
+    return 0;
+  }
+  key = key_from_index(index);
+  /**
+   * Copy the new lladdr into the key - since we know that there is no
+   * conflicting entry.
+   */
+  memcpy(&key->lladdr, new_addr, sizeof(linkaddr_t));
+  return 1;
 }
 /*---------------------------------------------------------------------------*/
 #if DEBUG

--- a/core/net/nbr-table.h
+++ b/core/net/nbr-table.h
@@ -109,6 +109,7 @@ int nbr_table_unlock(nbr_table_t *table, nbr_table_item_t *item);
 /** \name Neighbor tables: address manipulation */
 /** @{ */
 linkaddr_t *nbr_table_get_lladdr(nbr_table_t *table, const nbr_table_item_t *item);
+int nbr_table_update_lladdr(const linkaddr_t *old_addr, const linkaddr_t *new_addr, int remove_if_duplicate);
 /** @} */
 
 #endif /* NBR_TABLE_H_ */


### PR DESCRIPTION
This is a fix for ND6 that makes the nbr-table have two entries with the same link layer address. This cause permant disconnect from RPL root (until global repair or reboot). The reason it happens is that the nbr table allow adding a NULL entry for the neighbor discovery to handle the case when there is not yet any know link layer address. The NA code then just do a memcopy so that NULL suddenly is a valid link layer address and when that happen to exist in the tables already - things break down. This fix removes the NULL entry and re-installs it again to avoid the problem.

This bug was found by the Intel IoT team in Malaysia that have been testing the 6LoWPAN stack significantly so many thanks for your efforts! (@jeremy-ang, @usmansarwar and @pedquarkbld).