### PR TITLE
Refresh nbr reachable state after received IPv6 unicast message

### DIFF
--- a/core/net/ipv6/uip-ds6-nbr.c
+++ b/core/net/ipv6/uip-ds6-nbr.c
@@ -322,6 +322,20 @@ uip_ds6_neighbor_periodic(void)
   }
 }
 /*---------------------------------------------------------------------------*/
+#if UIP_ND6_SEND_NA
+void
+uip_ds6_nbr_refresh_reachable_state(const uip_ipaddr_t *ipaddr)
+{
+  uip_ds6_nbr_t *nbr;
+  nbr = uip_ds6_nbr_lookup(ipaddr);
+  if(nbr != NULL) {
+    nbr->state = NBR_REACHABLE;
+    nbr->nscount = 0;
+    stimer_set(&nbr->reachable, UIP_ND6_REACHABLE_TIME / 1000);
+  }
+}
+#endif /* UIP_ND6_SEND_NA */
+/*---------------------------------------------------------------------------*/
 uip_ds6_nbr_t *
 uip_ds6_get_least_lifetime_neighbor(void)
 {

--- a/core/net/ipv6/uip-ds6-nbr.c
+++ b/core/net/ipv6/uip-ds6-nbr.c
@@ -96,8 +96,12 @@ uip_ds6_nbr_add(const uip_ipaddr_t *ipaddr, const uip_lladdr_t *lladdr,
     uip_packetqueue_new(&nbr->packethandle);
 #endif /* UIP_CONF_IPV6_QUEUE_PKT */
 #if UIP_ND6_SEND_NA
-    /* timers are set separately, for now we put them in expired state */
-    stimer_set(&nbr->reachable, 0);
+    if(nbr->state == NBR_REACHABLE) {
+      stimer_set(&nbr->reachable, UIP_ND6_REACHABLE_TIME / 1000);
+    } else {
+      /* We set the timer in expired state */
+      stimer_set(&nbr->reachable, 0);
+    }
     stimer_set(&nbr->sendns, 0);
     nbr->nscount = 0;
 #endif /* UIP_ND6_SEND_NA */

--- a/core/net/ipv6/uip-ds6-nbr.h
+++ b/core/net/ipv6/uip-ds6-nbr.h
@@ -100,6 +100,17 @@ void uip_ds6_link_neighbor_callback(int status, int numtx);
 void uip_ds6_neighbor_periodic(void);
 int uip_ds6_nbr_num(void);
 
+#if UIP_ND6_SEND_NA
+/**
+ * \brief Refresh the reachable state of a neighbor. This function
+ * may be called when a node receives an IPv6 message that confirms the
+ * reachability of a neighbor.
+ * \param ipaddr pointer to the IPv6 address whose neighbor reachability state
+ * should be refreshed.
+ */
+void uip_ds6_nbr_refresh_reachable_state(const uip_ipaddr_t *ipaddr);
+#endif /* UIP_ND6_SEND_NA */
+
 /**
  * \brief
  *    This searches inside the neighbor table for the neighbor that is about to

--- a/core/net/ipv6/uip-nd6.c
+++ b/core/net/ipv6/uip-nd6.c
@@ -522,14 +522,11 @@ na_input(void)
         goto discard;
       }
 
-      if(is_solicited) {
-        nbr->state = NBR_REACHABLE;
-        nbr->nscount = 0;
-
-        /* reachable time is stored in ms */
-        stimer_set(&(nbr->reachable), uip_ds6_if.reachable_time / 1000);
-
-      } else {
+      /* Note: No need to refresh the state of the nbr here.
+       * It has already been refreshed upon receiving the unicast IPv6 ND packet.
+       * See: uip_ds6_nbr_refresh_reachable_state()
+       */
+      if(!is_solicited) {
         nbr->state = NBR_STALE;
       }
       nbr->isrouter = is_router;
@@ -552,11 +549,10 @@ na_input(void)
               goto discard;
             }
           }
-          if(is_solicited) {
-            nbr->state = NBR_REACHABLE;
-            /* reachable time is stored in ms */
-            stimer_set(&(nbr->reachable), uip_ds6_if.reachable_time / 1000);
-          }
+          /* Note: No need to refresh the state of the nbr here.
+           * It has already been refreshed upon receiving the unicast IPv6 ND packet.
+           * See: uip_ds6_nbr_refresh_reachable_state()
+           */
         }
       }
       if(nbr->isrouter && !is_router) {

--- a/core/net/ipv6/uip6.c
+++ b/core/net/ipv6/uip6.c
@@ -1156,7 +1156,9 @@ uip_process(uint8_t flag)
 
   /* Refresh neighbor state after receiving a unicast message */
 #if UIP_ND6_SEND_NA
-  uip_ds6_nbr_refresh_reachable_state(&UIP_IP_BUF->srcipaddr);
+  if(!uip_is_addr_mcast(&UIP_IP_BUF->destipaddr)) {
+    uip_ds6_nbr_refresh_reachable_state(&UIP_IP_BUF->srcipaddr);
+  }
 #endif /* UIP_ND6_SEND_NA */
 
 #if UIP_CONF_ROUTER

--- a/core/net/ipv6/uip6.c
+++ b/core/net/ipv6/uip6.c
@@ -84,6 +84,10 @@
 #include "rpl/rpl-private.h"
 #endif
 
+#if UIP_ND6_SEND_NA
+#include "net/ipv6/uip-ds6-nbr.h"
+#endif /* UIP_ND6_SEND_NA */
+
 #include <string.h>
 
 /*---------------------------------------------------------------------------*/
@@ -1149,6 +1153,11 @@ uip_process(uint8_t flag)
     PRINTF("Dropping packet, src is mcast\n");
     goto drop;
   }
+
+  /* Refresh neighbor state after receiving a unicast message */
+#if UIP_ND6_SEND_NA
+  uip_ds6_nbr_refresh_reachable_state(&UIP_IP_BUF->srcipaddr);
+#endif /* UIP_ND6_SEND_NA */
 
 #if UIP_CONF_ROUTER
   /*

--- a/core/net/rpl/rpl-icmp6.c
+++ b/core/net/rpl/rpl-icmp6.c
@@ -201,14 +201,6 @@ rpl_icmp6_update_nbr_table(uip_ipaddr_t *from, nbr_table_reason_t reason, void *
     }
   }
 
-  if(nbr != NULL) {
-#if UIP_ND6_SEND_NA
-    /* set reachable timer if we added or found the nbr entry - and update
-       neighbor entry to reachable to avoid sending NS/NA, etc.  */
-    stimer_set(&nbr->reachable, UIP_ND6_REACHABLE_TIME / 1000);
-    nbr->state = NBR_REACHABLE;
-#endif /* UIP_ND6_SEND_NA */
-  }
   return nbr;
  }
 /*---------------------------------------------------------------------------*/


### PR DESCRIPTION
This PR creates a function called `uip_ds6_nbr_refresh_reachable_state`in `uip-ds6-nbr.c` that refreshes the `Reachable` state of a neighbor. This function should be called (if NDP enabled, i.e., `UIP_ND6_SEND_NA`enabled) when the IPv6 layer or higher receives a message from a neighbor that confirms its reachability, for instance, DAO ACK or ECHO Reply messages. By refreshing the reachability of a neighbor with these messages, we may reduce the amount of traffic that NDP creates.

This PR addresses some of the comments and suggestions mentioned in [#1380](https://github.com/contiki-os/contiki/issues/1380). Let me know your suggestions/improvements.
