### PR TITLE
Travis: improved output for failed Cooja simulation

### DIFF
--- a/regression-tests/simexec.sh
+++ b/regression-tests/simexec.sh
@@ -55,13 +55,13 @@ while (( "$#" )); do
 
 	#Verbose output when using CI
 	if [ "$CI" = "true" ]; then
-		echo "==== COOJA.log ====" ; cat COOJA.log;
+		echo "==== $BASENAME.log ====" ; cat $BASENAME.log;
 		echo "==== COOJA.testlog ====" ; cat COOJA.testlog;
 		echo "==== Files used for simulation (sha1sum) ===="
 		grep "Loading firmware from:" COOJA.log | cut -d " " -f 10 | uniq  | xargs -r sha1sum
 		grep "Creating core communicator between Java class" COOJA.log | cut -d " " -f 17 | uniq  | xargs -r sha1sum
 	else
-		tail -50 COOJA.log ;
+		tail -50 $BASENAME.log ;
 	fi;
 
 	mv COOJA.testlog $BASENAME.$RANDOMSEED.faillog


### PR DESCRIPTION
Simply print out the standard output from java instead of the Cooja log.
stdout includes the full Cooja log, but also error messages in cases the JVM crashes (e.g. native node triggers segfault).