### PR TITLE
Add route_discovery_explicit_open()

### DIFF
--- a/core/net/rime/route-discovery.c
+++ b/core/net/rime/route-discovery.c
@@ -271,14 +271,24 @@ static const struct unicast_callbacks rrep_callbacks = {rrep_packet_received};
 static const struct netflood_callbacks rreq_callbacks = {rreq_packet_received, NULL, NULL};
 /*---------------------------------------------------------------------------*/
 void
+route_discovery_expicit_open(struct route_discovery_conn *c,
+			     clock_time_t time,
+			     uint16_t netflood_channel,
+			     uint16_t unicast_channel,
+			     const struct route_discovery_callbacks *callbacks)
+{
+  netflood_open(&c->rreqconn, time, netflood_channel, &rreq_callbacks);
+  unicast_open(&c->rrepconn, unicast_channel, &rrep_callbacks);
+  c->cb = callbacks;
+}
+/*---------------------------------------------------------------------------*/
+void
 route_discovery_open(struct route_discovery_conn *c,
 		     clock_time_t time,
 		     uint16_t channels,
 		     const struct route_discovery_callbacks *callbacks)
 {
-  netflood_open(&c->rreqconn, time, channels + 0, &rreq_callbacks);
-  unicast_open(&c->rrepconn, channels + 1, &rrep_callbacks);
-  c->cb = callbacks;
+  route_discovery_expicit_open(c, time, channels + 0, channels + 1, callbacks);
 }
 /*---------------------------------------------------------------------------*/
 void

--- a/core/net/rime/route-discovery.h
+++ b/core/net/rime/route-discovery.h
@@ -83,6 +83,10 @@ struct route_discovery_conn {
 void route_discovery_open(struct route_discovery_conn *c, clock_time_t time,
 			  uint16_t channels,
 			  const struct route_discovery_callbacks *callbacks);
+void route_discovery_explicit_open(struct route_discovery_conn *c, clock_time_t time,
+				   uint16_t netflood_channel,
+				   uint16_t unicast_channel,
+				   const struct route_discovery_callbacks *callbacks);
 int route_discovery_discover(struct route_discovery_conn *c, const linkaddr_t *dest,
 			     clock_time_t timeout);
 


### PR DESCRIPTION
For route discovery connections, 2 logical channels are used:
One channel for netflood messages, and one for unicast.

When opening a route discovery connection using
route_discovery_open(), only one channel number is specified
and used for netflood, and the unicast channel number is
hard-coded to be the next channel (+1).

This commit adds an alternative function for opening route
discovery connections, allowing the user to specify both channels
independently, to gain improved control, flexibility and readability.

The existing function (route_discovery_open()) was modified to
make use of the new function, to prevent code duplication,
without breaking the expected behavior.