### PR TITLE
Avoiding conditional directives that split up parts of statements.

### DIFF
--- a/core/net/ip/resolv.c
+++ b/core/net/ip/resolv.c
@@ -62,7 +62,6 @@
  * function with the hostname.
  */
 
-#include <stdbool.h>
 #include "net/ip/tcpip.h"
 #include "net/ip/resolv.h"
 #include "net/ip/uip-udp-packet.h"
@@ -658,8 +657,6 @@ check_entries(void)
   register struct dns_hdr *hdr;
 
   register struct namemap *namemapptr;
-  
-  bool test;
 
   for(i = 0; i < RESOLV_ENTRIES; ++i) {
     namemapptr = &names[i];
@@ -668,11 +665,11 @@ check_entries(void)
       if(namemapptr->state == STATE_ASKING) {
         if(--namemapptr->tmr == 0) {
 #if RESOLV_CONF_SUPPORTS_MDNS
-          test = ++namemapptr->retries ==
+          int test = ++namemapptr->retries ==
              (namemapptr->is_mdns ? RESOLV_CONF_MAX_MDNS_RETRIES :
               RESOLV_CONF_MAX_RETRIES);
 #else /* RESOLV_CONF_SUPPORTS_MDNS */
-          test = ++namemapptr->retries == RESOLV_CONF_MAX_RETRIES;
+          int test = ++namemapptr->retries == RESOLV_CONF_MAX_RETRIES;
 #endif /* RESOLV_CONF_SUPPORTS_MDNS */
           if (test)
           {
@@ -1067,12 +1064,11 @@ newdata(void)
 
   /* Got to this point there's no answer, try next nameserver if available
      since this one doesn't know the answer */
-  bool test;
 #if RESOLV_CONF_SUPPORTS_MDNS
-  test = nanswers == 0 && UIP_UDP_BUF->srcport != UIP_HTONS(MDNS_PORT) 
+  int test = nanswers == 0 && UIP_UDP_BUF->srcport != UIP_HTONS(MDNS_PORT) 
       && hdr->id != 0;
 #else
-  test = nanswers == 0;
+  int test = nanswers == 0;
 #endif
   if (test)
   {

--- a/cpu/stm32w108/e_stdio/src/small-dtoa.c
+++ b/cpu/stm32w108/e_stdio/src/small-dtoa.c
@@ -46,8 +46,7 @@
  
  
  
- 
-#include <stdbool.h>
+
 #include <_ansi.h>
 #include <stdlib.h>
 
@@ -323,14 +322,14 @@ _Bigint tab_blshift[BUF_LSHIFT_SIZE],tab_Slshift[BUF_LSHIFT_SIZE],tab_mhilshift[
     *sign = 0;
 
 #if defined(IEEE_Arith) + defined(VAX)
-  bool test;
+  int test;
 #ifdef IEEE_Arith
   test = (word0 (d) & Exp_mask) == Exp_mask;
 #else
   test = word0 (d) == 0x8000;
 #endif
-    if (test) 
-    {
+  if (test) 
+  {
       /* Infinity or NaN */
       *decpt = 9999;
       s =

--- a/cpu/stm32w108/e_stdio/src/small-dtoa.c
+++ b/cpu/stm32w108/e_stdio/src/small-dtoa.c
@@ -47,7 +47,7 @@
  
  
  
-
+#include <stdbool.h>
 #include <_ansi.h>
 #include <stdlib.h>
 
@@ -323,11 +323,13 @@ _Bigint tab_blshift[BUF_LSHIFT_SIZE],tab_Slshift[BUF_LSHIFT_SIZE],tab_mhilshift[
     *sign = 0;
 
 #if defined(IEEE_Arith) + defined(VAX)
+  bool test;
 #ifdef IEEE_Arith
-  if ((word0 (d) & Exp_mask) == Exp_mask)
+  test = (word0 (d) & Exp_mask) == Exp_mask;
 #else
-  if (word0 (d) == 0x8000)
+  test = word0 (d) == 0x8000;
 #endif
+    if (test) 
     {
       /* Infinity or NaN */
       *decpt = 9999;

--- a/cpu/stm32w108/e_stdio/src/small-strtod.c
+++ b/cpu/stm32w108/e_stdio/src/small-strtod.c
@@ -113,7 +113,6 @@ Supporting OS subroutines required: <<close>>, <<fstat>>, <<isatty>>,
 #include <_ansi.h>
 #include <reent.h>
 #include <string.h>
-#include <stdbool.h>
 #include "small-mprec.h"
 
 double
@@ -692,7 +691,7 @@ dig_done:
 	      /* boundary case -- decrement exponent */
 #ifdef Sudden_Underflow
 	      L = word0 (rv) & Exp_mask;
-	      bool test;
+	      int test;
 #ifdef IBM
 	      test = L < Exp_msk1;
 #else
@@ -833,9 +832,9 @@ dig_done:
 	  		adj = aadj1 * small_ulp (rv.d);
 	  		#endif
 	      rv.d += adj;
-	      bool test;
+	      int test;
 	#ifdef IBM
-	      test = (word0 (rv) & Exp_mask) < P * Exp_msk1
+	      test = (word0 (rv) & Exp_mask) < P * Exp_msk1;
 	#else
 	      test = (word0 (rv) & Exp_mask) <= P * Exp_msk1;
 	#endif

--- a/cpu/stm32w108/e_stdio/src/small-strtod.c
+++ b/cpu/stm32w108/e_stdio/src/small-strtod.c
@@ -113,6 +113,7 @@ Supporting OS subroutines required: <<close>>, <<fstat>>, <<isatty>>,
 #include <_ansi.h>
 #include <reent.h>
 #include <string.h>
+#include <stdbool.h>
 #include "small-mprec.h"
 
 double
@@ -691,12 +692,14 @@ dig_done:
 	      /* boundary case -- decrement exponent */
 #ifdef Sudden_Underflow
 	      L = word0 (rv) & Exp_mask;
+	      bool test;
 #ifdef IBM
-	      if (L < Exp_msk1)
+	      test = L < Exp_msk1;
 #else
-	      if (L <= Exp_msk1)
+	      test = L <= Exp_msk1;
 #endif
-		goto undfl;
+          if (test)
+		    goto undfl;
 	      L -= Exp_msk1;
 #else
 	      L = (word0 (rv) & Exp_mask) - Exp_msk1;
@@ -830,11 +833,13 @@ dig_done:
 	  		adj = aadj1 * small_ulp (rv.d);
 	  		#endif
 	      rv.d += adj;
+	      bool test;
 	#ifdef IBM
-	      if ((word0 (rv) & Exp_mask) < P * Exp_msk1)
+	      test = (word0 (rv) & Exp_mask) < P * Exp_msk1
 	#else
-	      if ((word0 (rv) & Exp_mask) <= P * Exp_msk1)
+	      test = (word0 (rv) & Exp_mask) <= P * Exp_msk1;
 	#endif
+	    if (test)
 		{
 		  if (word0 (rv0) == Tiny0
 		      && word1 (rv0) == Tiny1)

--- a/cpu/stm32w108/small-printf/sp-vfprintf.c
+++ b/cpu/stm32w108/small-printf/sp-vfprintf.c
@@ -193,6 +193,7 @@ static char *sccsid = "from: @(#)vfprintf.c	5.50 (Berkeley) 12/16/92";
 #include <wchar.h>
 #include <string.h>
 #include <sys/lock.h>
+#include <stdbool.h>
 
 #ifdef _HAVE_STDC
 #include <stdarg.h>
@@ -825,12 +826,14 @@ reswitch:	switch (ch) {
 			/*FALLTHROUGH*/
 		case 'd':
 		case 'i':
+		    bool test;
 			_uquad = SARG();
 #ifndef _NO_LONGLONG
-			if ((quad_t)_uquad < 0)
+			test = (quad_t)_uquad < 0;
 #else
-			if ((long) _uquad < 0)
+			test = (long) _uquad < 0;
 #endif
+            if (test)
 			{
 
 				_uquad = -_uquad;

--- a/cpu/stm32w108/small-printf/sp-vfprintf.c
+++ b/cpu/stm32w108/small-printf/sp-vfprintf.c
@@ -193,7 +193,6 @@ static char *sccsid = "from: @(#)vfprintf.c	5.50 (Berkeley) 12/16/92";
 #include <wchar.h>
 #include <string.h>
 #include <sys/lock.h>
-#include <stdbool.h>
 
 #ifdef _HAVE_STDC
 #include <stdarg.h>
@@ -826,16 +825,15 @@ reswitch:	switch (ch) {
 			/*FALLTHROUGH*/
 		case 'd':
 		case 'i':
-		    bool test;
+		        int test;
 			_uquad = SARG();
 #ifndef _NO_LONGLONG
 			test = (quad_t)_uquad < 0;
 #else
 			test = (long) _uquad < 0;
 #endif
-            if (test)
+                        if (test)
 			{
-
 				_uquad = -_uquad;
 				sign = '-';
 			}


### PR DESCRIPTION
  A suggestion to compile entire statements and expressions, as suggested by code style guidelines from the Linux Kernel and practitioners.

```
https://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/tree/Documentation/CodingStyle#n892
https://www.cqse.eu/en/blog/living-in-the-ifdef-hell/
```

It might improve code understanding, maintainability and error-proneness.
