### PR TITLE
Fix warning introduced by https://github.com/contiki-os/contiki/pull/1133

### DIFF
--- a/core/net/rime/chameleon-bitopt.c
+++ b/core/net/rime/chameleon-bitopt.c
@@ -92,7 +92,7 @@ le16_read(const void *ptr)
   return ((uint16_t)p[1] << 8) | p[0];
 }
 /*---------------------------------------------------------------------------*/
-uint8_t CC_INLINE
+static uint8_t CC_INLINE
 get_bits_in_byte(uint8_t *from, int bitpos, int vallen)
 {
   uint16_t shifted_val;


### PR DESCRIPTION
https://github.com/contiki-os/contiki/pull/1133 introduced a warning, undetected when it was last tested for non-regression as we didn't compile with -Werror back then. This fixes the warning and should get Travis green again!