### PR TITLE
cc2538: Fix stack alignment

### DIFF
--- a/cpu/cc2538/startup-gcc.c
+++ b/cpu/cc2538/startup-gcc.c
@@ -103,7 +103,7 @@ void uart1_isr(void);
 #endif
 /*---------------------------------------------------------------------------*/
 /* Allocate stack space */
-static unsigned long stack[512] __attribute__ ((section(".stack")));
+static uint64_t stack[256] __attribute__ ((section(".stack")));
 /*---------------------------------------------------------------------------*/
 __attribute__((__section__(".vectors")))
 void(*const vectors[])(void) =


### PR DESCRIPTION
According to the Procedure Call Standard for the ARM Architecture
(AAPCS) - ABI r2.09 [1], §5.2.1.2, the stack pointer must be
double-word-aligned at a public interface. The stack implementation
being full-descending, this requires that the top of stack be
double-word-aligned too.

[1] http://infocenter.arm.com/help/topic/com.arm.doc.ihi0042e/IHI0042E_aapcs.pdf

Closes #1398.