### PR TITLE
Extended SOURCEDIRS variable with EXTRADIRS variable in Makefile.include

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -182,7 +182,7 @@ CONTIKI_CPU_DIRS_CONCAT    = ${addprefix $(CONTIKI_CPU)/, \
                                $(CONTIKI_CPU_DIRS)}
 
 SOURCEDIRS = . $(PROJECTDIRS) $(CONTIKI_TARGET_DIRS_CONCAT) \
-             $(CONTIKI_CPU_DIRS_CONCAT) $(CONTIKIDIRS) $(APPDS) ${dir $(target_makefile)}
+             $(CONTIKI_CPU_DIRS_CONCAT) $(CONTIKIDIRS) $(APPDS) $(EXTERNALDIRS) ${dir $(target_makefile)}
 
 vpath %.c $(SOURCEDIRS)
 vpath %.S $(SOURCEDIRS)


### PR DESCRIPTION
Directories listed in this variable are added to include and
source (vpath) search paths.

Contents of this variable aren't automatically prefixed with
Contki root. This allows for inclusion of folders that are
outside Contiki root.
