### PR TITLE
Allow for using a fixed frame header length in sicslowpan.c

### DIFF
--- a/core/net/ipv6/sicslowpan.c
+++ b/core/net/ipv6/sicslowpan.c
@@ -169,6 +169,14 @@ void uip_log(char *msg);
 #define COMPRESSION_THRESHOLD 0
 #endif
 
+/** \brief Fixed size of a frame header. This value is
+ * used in case framer returns an error or if SICSLOWPAN_USE_FIXED_HDRLEN
+ * is defined.
+ */
+#ifndef SICSLOWPAN_FIXED_HDRLEN
+#define SICSLOWPAN_FIXED_HDRLEN 21
+#endif
+
 /** \name General variables
  *  @{
  */
@@ -1345,16 +1353,15 @@ output(const uip_lladdr_t *localdest)
   /* Calculate NETSTACK_FRAMER's header length, that will be added in the NETSTACK_RDC.
    * We calculate it here only to make a better decision of whether the outgoing packet
    * needs to be fragmented or not. */
-#define USE_FRAMER_HDRLEN 1
-#if USE_FRAMER_HDRLEN
+#ifndef SICSLOWPAN_USE_FIXED_HDRLEN
   packetbuf_set_addr(PACKETBUF_ADDR_RECEIVER, &dest);
   framer_hdrlen = NETSTACK_FRAMER.length();
   if(framer_hdrlen < 0) {
     /* Framing failed, we assume the maximum header length */
-    framer_hdrlen = 21;
+    framer_hdrlen = SICSLOWPAN_FIXED_HDRLEN;
   }
 #else /* USE_FRAMER_HDRLEN */
-  framer_hdrlen = 21;
+  framer_hdrlen = SICSLOWPAN_FIXED_HDRLEN;
 #endif /* USE_FRAMER_HDRLEN */
 
   max_payload = MAC_MAX_PAYLOAD - framer_hdrlen;

--- a/core/net/ipv6/sicslowpan.c
+++ b/core/net/ipv6/sicslowpan.c
@@ -1285,11 +1285,6 @@ output(const uip_lladdr_t *localdest)
   /* The MAC address of the destination of the packet */
   linkaddr_t dest;
 
-#if SICSLOWPAN_CONF_FRAG
-  /* Number of bytes processed. */
-  uint16_t processed_ip_out_len;
-#endif /* SICSLOWPAN_CONF_FRAG */
-
   /* init */
   uncomp_hdr_len = 0;
   packetbuf_hdr_len = 0;
@@ -1367,6 +1362,9 @@ output(const uip_lladdr_t *localdest)
   max_payload = MAC_MAX_PAYLOAD - framer_hdrlen;
   if((int)uip_len - (int)uncomp_hdr_len > max_payload - (int)packetbuf_hdr_len) {
 #if SICSLOWPAN_CONF_FRAG
+    /* Number of bytes processed. */
+    uint16_t processed_ip_out_len;
+
     struct queuebuf *q;
     uint16_t frag_tag;
 


### PR DESCRIPTION
When SICSLOWPAN_FRAMER_HDRLEN is defined its value is used as a frame header length. This allows for using sicslowpan without calling a framer. This is usefull if framer is not used on a given platform or when header length is always the same. 

This PR doesn't change the default behaviour.

In addition an unused variable warning, which shows up when fragmentation isn't used, is fixed.