### PR TITLE
Enhanced TSL2563 driver for the Zoul module (RE-Mote/Firefly)

### DIFF
--- a/examples/zolertia/zoul/project-conf.h
+++ b/examples/zolertia/zoul/project-conf.h
@@ -39,6 +39,7 @@
 #define PROJECT_CONF_H_
 
 #define BROADCAST_CHANNEL     129
+#define NETSTACK_CONF_RDC     nullrdc_driver
 
 #endif /* PROJECT_CONF_H_ */
 

--- a/examples/zolertia/zoul/test-tsl2563.c
+++ b/examples/zolertia/zoul/test-tsl2563.c
@@ -50,13 +50,8 @@
 #include "dev/i2c.h"
 #include "dev/tsl2563.h"
 /*---------------------------------------------------------------------------*/
-#if 1
-#define PRINTF(...) printf(__VA_ARGS__)
-#else
-#define PRINTF(...)
-#endif
-/*---------------------------------------------------------------------------*/
-#define SENSOR_READ_INTERVAL (CLOCK_SECOND / 2)
+/* Default sensor's integration cycle is 402ms */
+#define SENSOR_READ_INTERVAL (CLOCK_SECOND/2)
 /*---------------------------------------------------------------------------*/
 PROCESS(remote_tsl2563_process, "TSL2563 test process");
 AUTOSTART_PROCESSES(&remote_tsl2563_process);
@@ -66,14 +61,21 @@ static struct etimer et;
 PROCESS_THREAD(remote_tsl2563_process, ev, data)
 {
   PROCESS_BEGIN();
-  int light;
+  static uint16_t light;
+
+  /* Use Contiki's sensor macro to enable the sensor */
   SENSORS_ACTIVATE(tsl2563);
+
+  /* Default integration time is 402ms with 1x gain, use the below call to 
+   * change the gain and timming, see tsl2563.h for more options
+   */
+  // tsl2563.configure(TSL2563_TIMMING_CFG, TSL2563_G16X_402MS);
 
   while(1) {
     etimer_set(&et, SENSOR_READ_INTERVAL);
     PROCESS_WAIT_EVENT_UNTIL(etimer_expired(&et));
     light = tsl2563.value(TSL2563_VAL_READ);
-    PRINTF("Light = %u\n", light);
+    printf("Light = %u\n", (uint16_t) light);
   }
   PROCESS_END();
 }

--- a/examples/zolertia/zoul/test-tsl2563.c
+++ b/examples/zolertia/zoul/test-tsl2563.c
@@ -102,6 +102,7 @@ PROCESS_THREAD(remote_tsl2563_process, ev, data)
     } else {
       printf("Error, enable the DEBUG flag in the tsl2563 driver for info, ");
       printf("or check if the sensor is properly connected\n");
+      PROCESS_EXIT();
     }
   }
   PROCESS_END();

--- a/examples/zolertia/zoul/test-tsl2563.c
+++ b/examples/zolertia/zoul/test-tsl2563.c
@@ -48,15 +48,23 @@
 #include <stdio.h>
 #include "contiki.h"
 #include "dev/i2c.h"
+#include "dev/leds.h"
 #include "dev/tsl2563.h"
 /*---------------------------------------------------------------------------*/
 /* Default sensor's integration cycle is 402ms */
-#define SENSOR_READ_INTERVAL (CLOCK_SECOND/2)
+#define SENSOR_READ_INTERVAL (CLOCK_SECOND)
 /*---------------------------------------------------------------------------*/
 PROCESS(remote_tsl2563_process, "TSL2563 test process");
 AUTOSTART_PROCESSES(&remote_tsl2563_process);
 /*---------------------------------------------------------------------------*/
 static struct etimer et;
+/*---------------------------------------------------------------------------*/
+void
+light_interrupt_callback(uint8_t value)
+{
+  printf("* Light sensor interrupt!\n");
+  leds_toggle(LEDS_PURPLE);
+}
 /*---------------------------------------------------------------------------*/
 PROCESS_THREAD(remote_tsl2563_process, ev, data)
 {
@@ -66,16 +74,35 @@ PROCESS_THREAD(remote_tsl2563_process, ev, data)
   /* Use Contiki's sensor macro to enable the sensor */
   SENSORS_ACTIVATE(tsl2563);
 
-  /* Default integration time is 402ms with 1x gain, use the below call to 
+  /* Default integration time is 402ms with 1x gain, use the below call to
    * change the gain and timming, see tsl2563.h for more options
    */
-  // tsl2563.configure(TSL2563_TIMMING_CFG, TSL2563_G16X_402MS);
+  /* tsl2563.configure(TSL2563_TIMMING_CFG, TSL2563_G16X_402MS); */
+
+  /* Register the interrupt handler */
+  TSL2563_REGISTER_INT(light_interrupt_callback);
+
+  /* Enable the interrupt source for values over the threshold.  The sensor
+   * compares against the value of CH0, one way to find out the required
+   * threshold for a given lux quantity is to enable the DEBUG flag and see
+   * the CH0 value for a given measurement.  The other is to reverse the
+   * calculations done in the calculate_lux() function.  The below value roughly
+   * represents a 2500 lux threshold, same as pointing a flashlight directly
+   */
+  tsl2563.configure(TSL2563_INT_OVER, 0x15B8);
+
+  /* And periodically poll the sensor */
 
   while(1) {
     etimer_set(&et, SENSOR_READ_INTERVAL);
     PROCESS_WAIT_EVENT_UNTIL(etimer_expired(&et));
     light = tsl2563.value(TSL2563_VAL_READ);
-    printf("Light = %u\n", (uint16_t) light);
+    if(light != TSL2563_ERROR) {
+      printf("Light = %u\n", (uint16_t)light);
+    } else {
+      printf("Error, enable the DEBUG flag in the tsl2563 driver for info, ");
+      printf("or check if the sensor is properly connected\n");
+    }
   }
   PROCESS_END();
 }

--- a/platform/zoul/dev/tsl2563.c
+++ b/platform/zoul/dev/tsl2563.c
@@ -47,7 +47,7 @@
 #include "lib/sensors.h"
 #include "tsl2563.h"
 /*---------------------------------------------------------------------------*/
-#define DEBUG 1
+#define DEBUG 0
 #if DEBUG
 #define PRINTF(...) printf(__VA_ARGS__)
 #else
@@ -66,9 +66,9 @@ void (*tsl2563_int_callback)(uint8_t value);
 static uint16_t
 calculate_lux(uint8_t *buf)
 {
-  uint32_t ch0, ch1 = 0;
-  uint32_t chscale;
-  uint32_t ratio, lratio, tmp = 0;
+  uint32_t ch0, ch1, chscale = 0;
+  uint32_t ratio = 0;
+  uint32_t lratio, tmp = 0;
   uint16_t buffer[2];
 
   /* The calculations below assume the integration time is 402ms and the gain
@@ -80,15 +80,15 @@ calculate_lux(uint8_t *buf)
   buffer[1] = (buf[3] << 8 | (buf[2]));
 
   switch(timming) {
-    case TSL2563_TIMMING_INTEG_402MS:
-      chscale = (1 << CH_SCALE);
-      break;
-    case TSL2563_TIMMING_INTEG_101MS:
-      chscale = CHSCALE_TINT1;
-      break;
-    case TSL2563_TIMMING_INTEG_13_7MS:
-      chscale = CHSCALE_TINT0;
-      break;
+  case TSL2563_TIMMING_INTEG_402MS:
+    chscale = (1 << CH_SCALE);
+    break;
+  case TSL2563_TIMMING_INTEG_101MS:
+    chscale = CHSCALE_TINT1;
+    break;
+  case TSL2563_TIMMING_INTEG_13_7MS:
+    chscale = CHSCALE_TINT0;
+    break;
   }
 
   if(!gain) {
@@ -183,7 +183,7 @@ static int
 tsl2563_id_register(uint8_t *buf)
 {
   if(tsl2563_read_reg((TSL2563_COMMAND + TSL2563_ID_REG),
-                       buf, 1) == TSL2563_SUCCESS) {
+                      buf, 1) == TSL2563_SUCCESS) {
     PRINTF("TSL2563: partnum/revnum 0x%02X\n", *buf);
     return TSL2563_SUCCESS;
   }
@@ -208,6 +208,17 @@ tsl2563_off(void)
 }
 /*---------------------------------------------------------------------------*/
 static int
+tsl2563_clear_interrupt(void)
+{
+  uint8_t buf = (TSL2563_COMMAND + TSL2563_CLEAR_INTERRUPT);
+  if(tsl2563_write_reg(&buf, 1) != I2C_MASTER_ERR_NONE) {
+    PRINTF("TSL2563: failed to clear the interrupt\n");
+    return TSL2563_ERROR;
+  }
+  return TSL2563_SUCCESS;
+}
+/*---------------------------------------------------------------------------*/
+static int
 tsl2563_read_sensor(uint16_t *lux)
 {
   uint8_t buf[4];
@@ -217,6 +228,9 @@ tsl2563_read_sensor(uint16_t *lux)
                       &buf[0], 2) == TSL2563_SUCCESS) {
     if(tsl2563_read_reg((TSL2563_COMMAND + TSL2563_D1LOW),
                         &buf[2], 2) == TSL2563_SUCCESS) {
+
+      PRINTF("TSL2563: CH0 0x%02X%02X CH1 0x%02X%02X\n", buf[1], buf[0],
+             buf[3], buf[2]);
       *lux = calculate_lux(buf);
       return TSL2563_SUCCESS;
     }
@@ -231,31 +245,32 @@ PROCESS_THREAD(tsl2563_int_process, ev, data)
 {
   PROCESS_EXITHANDLER();
   PROCESS_BEGIN();
+
   while(1) {
     PROCESS_YIELD_UNTIL(ev == PROCESS_EVENT_POLL);
-
-    /* FIXME: Read interrupt source and clear */
+    tsl2563_clear_interrupt();
     tsl2563_int_callback(0);
   }
   PROCESS_END();
 }
-
 /*---------------------------------------------------------------------------*/
 static void
 tsl2563_interrupt_handler(uint8_t port, uint8_t pin)
 {
-  /* FIXME: Check if the interrupt is ours */
+  /* There's no alert/interruption flag to check, clear the interruption by
+   * writting to the CLEAR bit in the COMMAND register
+   */
   process_poll(&tsl2563_int_process);
 }
 /*---------------------------------------------------------------------------*/
 static int
 configure(int type, int value)
 {
-  uint8_t buf[2];
+  uint8_t buf[3];
 
   if((type != TSL2563_ACTIVE) && (type != TSL2563_INT_OVER) &&
-    (type != TSL2563_INT_BELOW) && (type != TSL2563_INT_DISABLE) && 
-    (type != TSL2563_TIMMING_CFG)) {
+     (type != TSL2563_INT_BELOW) && (type != TSL2563_INT_DISABLE) &&
+     (type != TSL2563_TIMMING_CFG)) {
     PRINTF("TSL2563: invalid start value\n");
     return TSL2563_ERROR;
   }
@@ -264,10 +279,13 @@ configure(int type, int value)
    * time (not nominal), with manual control disabled
    */
 
-  if(type == TSL2563_ACTIVE) {   
+  if(type == TSL2563_ACTIVE) {
     if(value) {
       i2c_init(I2C_SDA_PORT, I2C_SDA_PIN, I2C_SCL_PORT, I2C_SCL_PIN,
                I2C_SCL_NORMAL_BUS_SPEED);
+
+      /*  Initialize interrupts handlers */
+      tsl2563_int_callback = NULL;
 
       /* Power on the sensor and check for the part number */
       if(tsl2563_on() == TSL2563_SUCCESS) {
@@ -276,17 +294,20 @@ configure(int type, int value)
 
             /* Read the timming/gain configuration */
             if(tsl2563_read_reg((TSL2563_COMMAND + TSL2563_TIMMING),
-                      &buf[0], 1) == TSL2563_SUCCESS) {
+                                &buf[0], 1) == TSL2563_SUCCESS) {
               gain = buf[0] & TSL2563_TIMMING_GAIN;
               timming = buf[0] & TSL2563_TIMMING_INTEG_MASK;
               PRINTF("TSL2563: enabled, timming %u gain %u\n", timming, gain);
-              return TSL2563_SUCCESS;
+
+              /* Clear any pending interrupt */
+              if(tsl2563_clear_interrupt() == TSL2563_SUCCESS) {
+                return TSL2563_SUCCESS;
+              }
             }
           }
         }
       }
       return TSL2563_ERROR;
-
     } else {
       if(tsl2563_off() == TSL2563_SUCCESS) {
         PRINTF("TSL2563: stopped\n");
@@ -297,15 +318,30 @@ configure(int type, int value)
   }
 
   if(type == TSL2563_INT_DISABLE) {
-    /* FIXME: disable interrupt */
+
+    /* Ensure the GPIO doesn't generate more interrupts, this may affect others
+     * I2C digital sensors using the bus and sharing this pin, so an user may
+     * comment the line below
+     */
     GPIO_DISABLE_INTERRUPT(TSL2563_INT_PORT_BASE, TSL2563_INT_PIN_MASK);
+
+    /* This also wipes out the persistance value, to be reconfigured when
+     * enabling back the interruption
+     */
+    buf[0] = (TSL2563_COMMAND + TSL2563_INTERRUPT);
+    buf[1] = TSL2563_INTR_DISABLED;
+
+    if(tsl2563_write_reg(buf, 2) != TSL2563_SUCCESS) {
+      PRINTF("TSL2563: failed to disable the interrupt\n");
+      return TSL2563_ERROR;
+    }
     return TSL2563_SUCCESS;
   }
 
   /* Configure the timming and gain */
   if(type == TSL2563_TIMMING_CFG) {
     if((value != TSL2563_G16X_402MS) && (value != TSL2563_G1X_402MS) &&
-      (value != TSL2563_G1X_101MS) && (value != TSL2563_G1X_13_7MS)) {
+       (value != TSL2563_G1X_101MS) && (value != TSL2563_G1X_13_7MS)) {
       PRINTF("TSL2563: invalid timming configuration values\n");
       return TSL2563_ERROR;
     }
@@ -319,16 +355,16 @@ configure(int type, int value)
       }
 
       switch(value) {
-        case TSL2563_G16X_402MS:
-        case TSL2563_G1X_402MS:
-          timming = TSL2563_TIMMING_INTEG_402MS;
-          break;
-        case TSL2563_G1X_101MS:
-          timming = TSL2563_TIMMING_INTEG_101MS;
-          break;
-        case TSL2563_G1X_13_7MS:
-          timming = TSL2563_TIMMING_INTEG_13_7MS;
-          break;
+      case TSL2563_G16X_402MS:
+      case TSL2563_G1X_402MS:
+        timming = TSL2563_TIMMING_INTEG_402MS;
+        break;
+      case TSL2563_G1X_101MS:
+        timming = TSL2563_TIMMING_INTEG_101MS;
+        break;
+      case TSL2563_G1X_13_7MS:
+        timming = TSL2563_TIMMING_INTEG_13_7MS;
+        break;
       }
 
       PRINTF("TSL2563: new timming %u gain %u\n", timming, gain);
@@ -338,8 +374,36 @@ configure(int type, int value)
     return TSL2563_ERROR;
   }
 
-  /*  Configure interrupt pins and initialize interrupts handlers */
-  tsl2563_int_callback = NULL;
+  /* From here we handle the interrupt configuration, it requires the interrupt
+   * callback handler to have been previously set using the TSL2563_REGISTER_INT
+   * macro
+   */
+
+  buf[1] = ((uint8_t *)&value)[0];
+  buf[2] = ((uint8_t *)&value)[1];
+
+  if(type == TSL2563_INT_OVER) {
+    buf[0] = (TSL2563_COMMAND + TSL2563_THRHIGHLOW);
+  } else if(type == TSL2563_INT_BELOW) {
+    buf[0] = (TSL2563_COMMAND + TSL2563_THRLOWLOW);
+  }
+
+  if(tsl2563_write_reg(buf, 3) != TSL2563_SUCCESS) {
+    PRINTF("TSL2563: failed to set interrupt level\n");
+    return TSL2563_ERROR;
+  }
+
+  /* Now configure the interruption register (level interrupt, 2 integration
+   * cycles after threshold has been reached (roughly 804ms if timming is 402ms)
+   */
+  buf[0] = (TSL2563_COMMAND + TSL2563_INTERRUPT);
+  buf[1] = (TSL2563_INTR_LEVEL << TSL2563_INTR_SHIFT);
+  buf[1] += TSL2563_INT_PERSIST_2_CYCLES;
+
+  if(tsl2563_write_reg(buf, 2) != TSL2563_SUCCESS) {
+    PRINTF("TSL2563: failed to enable interrupt\n");
+    return TSL2563_ERROR;
+  }
 
   /* Configure the interrupts pins */
   GPIO_SOFTWARE_CONTROL(TSL2563_INT_PORT_BASE, TSL2563_INT_PIN_MASK);
@@ -354,17 +418,17 @@ configure(int type, int value)
   /* Spin process until an interrupt is received */
   process_start(&tsl2563_int_process, NULL);
 
-  if(type == TSL2563_INT_OVER) {
-    /* FIXME: add code */
-  } else if(type == TSL2563_INT_BELOW) {
-    /* FIXME: add code */
-  }
-
   /* Enable interrupts */
   GPIO_ENABLE_INTERRUPT(TSL2563_INT_PORT_BASE, TSL2563_INT_PIN_MASK);
+
+  /* The RE-Mote revision A has this pin shared and with a pull-down resistor,
+   * for other platforms (like the firefly), change to enable pull-up internal
+   * resistor instead if no external pull-up is present.
+   */
   ioc_set_over(I2C_INT_PORT, I2C_INT_PIN, IOC_OVERRIDE_PUE);
   nvic_interrupt_enable(I2C_INT_VECTOR);
 
+  PRINTF("TSL2563: Interrupt configured\n");
   return TSL2563_SUCCESS;
 }
 /*---------------------------------------------------------------------------*/

--- a/platform/zoul/dev/tsl2563.c
+++ b/platform/zoul/dev/tsl2563.c
@@ -40,28 +40,69 @@
  *         Toni Lozano <tlozano@zolertia.com>
  */
 /*---------------------------------------------------------------------------*/
-#include <stdio.h>
 #include "contiki.h"
 #include "dev/i2c.h"
+#include "dev/gpio.h"
+#include "dev/zoul-sensors.h"
 #include "lib/sensors.h"
 #include "tsl2563.h"
 /*---------------------------------------------------------------------------*/
+#define DEBUG 1
+#if DEBUG
+#define PRINTF(...) printf(__VA_ARGS__)
+#else
+#define PRINTF(...)
+#endif
+/*---------------------------------------------------------------------------*/
+#define TSL2563_INT_PORT_BASE  GPIO_PORT_TO_BASE(I2C_INT_PORT)
+#define TSL2563_INT_PIN_MASK   GPIO_PIN_MASK(I2C_INT_PIN)
+/*---------------------------------------------------------------------------*/
 static uint8_t enabled;
+static uint8_t gain;
+static uint8_t timming;
+/*---------------------------------------------------------------------------*/
+void (*tsl2563_int_callback)(uint8_t value);
 /*---------------------------------------------------------------------------*/
 static uint16_t
-calculateLux(uint8_t *buf)
+calculate_lux(uint8_t *buf)
 {
   uint32_t ch0, ch1 = 0;
-  uint32_t aux = (1 << 14);
+  uint32_t chscale;
   uint32_t ratio, lratio, tmp = 0;
   uint16_t buffer[2];
 
+  /* The calculations below assume the integration time is 402ms and the gain
+   * is 16x (nominal), if not then it is required to normalize the reading
+   * before converting to lux
+   */
+
   buffer[0] = (buf[1] << 8 | (buf[0]));
   buffer[1] = (buf[3] << 8 | (buf[2]));
-  ch0 = (buffer[0] * aux) >> 10;
-  ch1 = (buffer[1] * aux) >> 10;
-  ratio = (ch1 << 10);
-  ratio = ratio / ch0;
+
+  switch(timming) {
+    case TSL2563_TIMMING_INTEG_402MS:
+      chscale = (1 << CH_SCALE);
+      break;
+    case TSL2563_TIMMING_INTEG_101MS:
+      chscale = CHSCALE_TINT1;
+      break;
+    case TSL2563_TIMMING_INTEG_13_7MS:
+      chscale = CHSCALE_TINT0;
+      break;
+  }
+
+  if(!gain) {
+    chscale = chscale << 4;
+  }
+
+  ch0 = (buffer[0] * chscale) >> CH_SCALE;
+  ch1 = (buffer[1] * chscale) >> CH_SCALE;
+
+  if(ch0 > 0) {
+    ratio = (ch1 << CH_SCALE);
+    ratio = ratio / ch0;
+  }
+
   lratio = (ratio + 1) >> 1;
 
   if((lratio >= 0) && (lratio <= K1T)) {
@@ -86,14 +127,16 @@ calculateLux(uint8_t *buf)
     tmp = 0;
   }
 
-  tmp += (1 << 13);
-  return tmp >> 14;
+  tmp += (1 << (LUX_SCALE - 1));
+  return tmp >> LUX_SCALE;
 }
 /*---------------------------------------------------------------------------*/
 static int
 tsl2563_read_reg(uint8_t reg, uint8_t *buf, uint8_t regNum)
 {
+  i2c_master_enable();
   if(i2c_single_send(TSL2563_ADDR, reg) == I2C_MASTER_ERR_NONE) {
+    while(i2c_master_busy());
     if(i2c_burst_receive(TSL2563_ADDR, buf, regNum) == I2C_MASTER_ERR_NONE) {
       return TSL2563_SUCCESS;
     }
@@ -102,49 +145,226 @@ tsl2563_read_reg(uint8_t reg, uint8_t *buf, uint8_t regNum)
 }
 /*---------------------------------------------------------------------------*/
 static int
-light_ziglet_on(void)
+tsl2563_write_reg(uint8_t *buf, uint8_t num)
 {
-  if(i2c_single_send(TSL2563_ADDR, (uint8_t)TSL2563_PWRN) == I2C_MASTER_ERR_NONE) {
+  if((buf == NULL) || (num <= 0)) {
+    PRINTF("TSL2563: invalid write values\n");
+    return TSL2563_ERROR;
+  }
+
+  i2c_master_enable();
+  if(i2c_burst_send(TSL2563_ADDR, buf, num) == I2C_MASTER_ERR_NONE) {
     return TSL2563_SUCCESS;
   }
   return TSL2563_ERROR;
 }
 /*---------------------------------------------------------------------------*/
 static int
-light_ziglet_off(void)
+tsl2563_on(void)
 {
-  if(i2c_single_send(TSL2563_ADDR, (uint8_t)TSL2563_PWROFF) == I2C_MASTER_ERR_NONE) {
-    return TSL2563_SUCCESS;
-  }
-  return TSL2563_ERROR;
-}
-/*---------------------------------------------------------------------------*/
-static int
-light_ziglet_read(uint16_t *lux)
-{
-  uint8_t buf[4];
-  if(light_ziglet_on() == TSL2563_SUCCESS) {
-    if(tsl2563_read_reg(TSL2563_READ, buf, 4) == TSL2563_SUCCESS) {
-      *lux = calculateLux(buf);
-      return light_ziglet_off();
+  uint8_t buf[2];
+  buf[0] = (TSL2563_COMMAND + TSL2563_CONTROL);
+  buf[1] = TSL2563_CONTROL_POWER_ON;
+
+  if(tsl2563_write_reg(buf, 2) == I2C_MASTER_ERR_NONE) {
+    if(i2c_single_receive(TSL2563_ADDR, &buf[0]) == I2C_MASTER_ERR_NONE) {
+      if((buf[0] & 0x0F) == TSL2563_CONTROL_POWER_ON) {
+        PRINTF("TSL2563: powered on\n");
+        return TSL2563_SUCCESS;
+      }
     }
   }
+
+  PRINTF("TSL2563: failed to power on\n");
   return TSL2563_ERROR;
+}
+/*---------------------------------------------------------------------------*/
+static int
+tsl2563_id_register(uint8_t *buf)
+{
+  if(tsl2563_read_reg((TSL2563_COMMAND + TSL2563_ID_REG),
+                       buf, 1) == TSL2563_SUCCESS) {
+    PRINTF("TSL2563: partnum/revnum 0x%02X\n", *buf);
+    return TSL2563_SUCCESS;
+  }
+
+  return TSL2563_ERROR;
+}
+/*---------------------------------------------------------------------------*/
+static int
+tsl2563_off(void)
+{
+  uint8_t buf[2];
+  buf[0] = (TSL2563_COMMAND + TSL2563_CONTROL);
+  buf[1] = TSL2563_CONTROL_POWER_OFF;
+
+  if(tsl2563_write_reg(buf, 2) == I2C_MASTER_ERR_NONE) {
+    PRINTF("TSL2563: powered off\n");
+    return TSL2563_SUCCESS;
+  }
+
+  PRINTF("TSL2563: failed to power off\n");
+  return TSL2563_ERROR;
+}
+/*---------------------------------------------------------------------------*/
+static int
+tsl2563_read_sensor(uint16_t *lux)
+{
+  uint8_t buf[4];
+
+  /* This is hardcoded to use word write/read operations */
+  if(tsl2563_read_reg((TSL2563_COMMAND + TSL2563_D0LOW),
+                      &buf[0], 2) == TSL2563_SUCCESS) {
+    if(tsl2563_read_reg((TSL2563_COMMAND + TSL2563_D1LOW),
+                        &buf[2], 2) == TSL2563_SUCCESS) {
+      *lux = calculate_lux(buf);
+      return TSL2563_SUCCESS;
+    }
+  }
+  PRINTF("TSL2563: failed to read\n");
+  return TSL2563_ERROR;
+}
+/*---------------------------------------------------------------------------*/
+PROCESS(tsl2563_int_process, "TSL2563 interrupt process handler");
+/*---------------------------------------------------------------------------*/
+PROCESS_THREAD(tsl2563_int_process, ev, data)
+{
+  PROCESS_EXITHANDLER();
+  PROCESS_BEGIN();
+  while(1) {
+    PROCESS_YIELD_UNTIL(ev == PROCESS_EVENT_POLL);
+
+    /* FIXME: Read interrupt source and clear */
+    tsl2563_int_callback(0);
+  }
+  PROCESS_END();
+}
+
+/*---------------------------------------------------------------------------*/
+static void
+tsl2563_interrupt_handler(uint8_t port, uint8_t pin)
+{
+  /* FIXME: Check if the interrupt is ours */
+  process_poll(&tsl2563_int_process);
 }
 /*---------------------------------------------------------------------------*/
 static int
 configure(int type, int value)
 {
-  if(type != SENSORS_ACTIVE) {
+  uint8_t buf[2];
+
+  if((type != TSL2563_ACTIVE) && (type != TSL2563_INT_OVER) &&
+    (type != TSL2563_INT_BELOW) && (type != TSL2563_INT_DISABLE) && 
+    (type != TSL2563_TIMMING_CFG)) {
+    PRINTF("TSL2563: invalid start value\n");
     return TSL2563_ERROR;
   }
-  enabled = value;
-  if(value) {
-    i2c_init(I2C_SDA_PORT, I2C_SDA_PIN, I2C_SCL_PORT, I2C_SCL_PIN,
-             I2C_SCL_NORMAL_BUS_SPEED);
-  } else {
-    light_ziglet_off();
+
+  /* As default the power-on values of the sensor are gain 1X, 402ms integration
+   * time (not nominal), with manual control disabled
+   */
+
+  if(type == TSL2563_ACTIVE) {   
+    if(value) {
+      i2c_init(I2C_SDA_PORT, I2C_SDA_PIN, I2C_SCL_PORT, I2C_SCL_PIN,
+               I2C_SCL_NORMAL_BUS_SPEED);
+
+      /* Power on the sensor and check for the part number */
+      if(tsl2563_on() == TSL2563_SUCCESS) {
+        if(tsl2563_id_register(&buf[0]) == TSL2563_SUCCESS) {
+          if((buf[0] & TSL2563_ID_PARTNO_MASK) == TSL2563_EXPECTED_PARTNO) {
+
+            /* Read the timming/gain configuration */
+            if(tsl2563_read_reg((TSL2563_COMMAND + TSL2563_TIMMING),
+                      &buf[0], 1) == TSL2563_SUCCESS) {
+              gain = buf[0] & TSL2563_TIMMING_GAIN;
+              timming = buf[0] & TSL2563_TIMMING_INTEG_MASK;
+              PRINTF("TSL2563: enabled, timming %u gain %u\n", timming, gain);
+              return TSL2563_SUCCESS;
+            }
+          }
+        }
+      }
+      return TSL2563_ERROR;
+
+    } else {
+      if(tsl2563_off() == TSL2563_SUCCESS) {
+        PRINTF("TSL2563: stopped\n");
+        return TSL2563_SUCCESS;
+      }
+      return TSL2563_ERROR;
+    }
   }
+
+  if(type == TSL2563_INT_DISABLE) {
+    /* FIXME: disable interrupt */
+    GPIO_DISABLE_INTERRUPT(TSL2563_INT_PORT_BASE, TSL2563_INT_PIN_MASK);
+    return TSL2563_SUCCESS;
+  }
+
+  /* Configure the timming and gain */
+  if(type == TSL2563_TIMMING_CFG) {
+    if((value != TSL2563_G16X_402MS) && (value != TSL2563_G1X_402MS) &&
+      (value != TSL2563_G1X_101MS) && (value != TSL2563_G1X_13_7MS)) {
+      PRINTF("TSL2563: invalid timming configuration values\n");
+      return TSL2563_ERROR;
+    }
+
+    buf[0] = (TSL2563_COMMAND + TSL2563_TIMMING);
+    buf[1] = value;
+
+    if(tsl2563_write_reg(buf, 2) == TSL2563_SUCCESS) {
+      if(value == TSL2563_G16X_402MS) {
+        gain = 1;
+      }
+
+      switch(value) {
+        case TSL2563_G16X_402MS:
+        case TSL2563_G1X_402MS:
+          timming = TSL2563_TIMMING_INTEG_402MS;
+          break;
+        case TSL2563_G1X_101MS:
+          timming = TSL2563_TIMMING_INTEG_101MS;
+          break;
+        case TSL2563_G1X_13_7MS:
+          timming = TSL2563_TIMMING_INTEG_13_7MS;
+          break;
+      }
+
+      PRINTF("TSL2563: new timming %u gain %u\n", timming, gain);
+      return TSL2563_SUCCESS;
+    }
+    PRINTF("TSL2563: failed to configure timming\n");
+    return TSL2563_ERROR;
+  }
+
+  /*  Configure interrupt pins and initialize interrupts handlers */
+  tsl2563_int_callback = NULL;
+
+  /* Configure the interrupts pins */
+  GPIO_SOFTWARE_CONTROL(TSL2563_INT_PORT_BASE, TSL2563_INT_PIN_MASK);
+  GPIO_SET_INPUT(TSL2563_INT_PORT_BASE, TSL2563_INT_PIN_MASK);
+
+  /* Pull-up resistor, detect falling edge */
+  GPIO_DETECT_EDGE(TSL2563_INT_PORT_BASE, TSL2563_INT_PIN_MASK);
+  GPIO_TRIGGER_SINGLE_EDGE(TSL2563_INT_PORT_BASE, TSL2563_INT_PIN_MASK);
+  GPIO_DETECT_FALLING(TSL2563_INT_PORT_BASE, TSL2563_INT_PIN_MASK);
+  gpio_register_callback(tsl2563_interrupt_handler, I2C_INT_PORT, I2C_INT_PIN);
+
+  /* Spin process until an interrupt is received */
+  process_start(&tsl2563_int_process, NULL);
+
+  if(type == TSL2563_INT_OVER) {
+    /* FIXME: add code */
+  } else if(type == TSL2563_INT_BELOW) {
+    /* FIXME: add code */
+  }
+
+  /* Enable interrupts */
+  GPIO_ENABLE_INTERRUPT(TSL2563_INT_PORT_BASE, TSL2563_INT_PIN_MASK);
+  ioc_set_over(I2C_INT_PORT, I2C_INT_PIN, IOC_OVERRIDE_PUE);
+  nvic_interrupt_enable(I2C_INT_VECTOR);
+
   return TSL2563_SUCCESS;
 }
 /*---------------------------------------------------------------------------*/
@@ -164,9 +384,10 @@ value(int type)
 {
   uint16_t lux;
   if(type == TSL2563_VAL_READ) {
-    if(light_ziglet_read(&lux) != TSL2563_ERROR) {
+    if(tsl2563_read_sensor(&lux) != TSL2563_ERROR) {
       return lux;
     }
+    PRINTF("TSL2563: fail to read\n");
   }
   return TSL2563_ERROR;
 }

--- a/platform/zoul/dev/tsl2563.h
+++ b/platform/zoul/dev/tsl2563.h
@@ -49,24 +49,93 @@
  *         Toni Lozano <tlozano@zolertia.com>
  */
 /*---------------------------------------------------------------------------*/
-#ifndef LIGHT_SENSOR_H_
-#define LIGHT_SENSOR_H_
+#ifndef TSL2563_H_
+#define TSL2563_H_
 #include <stdio.h>
 #include "lib/sensors.h"
+#include "dev/zoul-sensors.h"
 #include "i2c.h"
 /* -------------------------------------------------------------------------- */
 /**
- * \name TSL2563 digital Light sensor
+ * \name TSL2563 digital Light sensor address and registers
  * @{
  */
 /* -------------------------------------------------------------------------- */
-#define TSL2563_ADDR        0x39 /**< TSL2563 slave address */
+#define TSL2563_ADDR                  0x39
 /* -------------------------------------------------------------------------- */
-#define TSL2563_READ        0xAC   /**< TSL2563 read register */
-#define TSL2563_PWRN        0x03   /**< TSL2563 enable register */
-#define TSL2563_PWROFF      0x00   /**< TSL2563 Power OFF */
+#define TSL2563_CONTROL               0x00
+#define TSL2563_TIMMING               0x01
+#define TSL2563_THRLOWLOW             0x02
+#define TSL2563_THRLOWHIGH            0x03
+#define TSL2563_THRHIGHLOW            0x04
+#define TSL2563_THRHIGHHIGH           0x05
+#define TSL2563_INTERRUPT             0x06
+#define TSL2563_CRC                   0x08
+#define TSL2563_ID_REG                0x0A
+#define TSL2563_D0LOW                 0x0C
+#define TSL2563_D0HIGH                0x0D
+#define TSL2563_D1LOW                 0x0E
+#define TSL2563_D1HIGH                0x0F
 /* -------------------------------------------------------------------------- */
-#define K1T                 0X0040 /**< Calibration values (hardcoded) */
+/* Uses the word read/write operation protocol */
+#define TSL2563_COMMAND               0xA0
+/* -------------------------------------------------------------------------- */
+#define TSL2563_CONTROL_POWER_ON      0x03
+#define TSL2563_CONTROL_POWER_OFF     0x00
+#define TSL2563_TIMMING_GAIN          0x10
+#define TSL2563_TIMMING_MANUAL        0x08
+#define TSL2563_TIMMING_INTEG_MANUAL  0x03
+#define TSL2563_TIMMING_INTEG_402MS   0x02
+#define TSL2563_TIMMING_INTEG_101MS   0x01
+#define TSL2563_TIMMING_INTEG_13_7MS  0x00
+#define TSL2563_TIMMING_INTEG_MASK    0x03
+
+#define TSL2563_G16X_402MS (TSL2563_TIMMING_INTEG_402MS +  TSL2563_TIMMING_GAIN)        
+#define TSL2563_G1X_402MS                            TSL2563_TIMMING_INTEG_402MS
+#define TSL2563_G1X_101MS                            TSL2563_TIMMING_INTEG_101MS
+#define TSL2563_G1X_13_7MS                          TSL2563_TIMMING_INTEG_13_7MS
+
+#define TSL2563_INTR_SHIFT            0x04
+#define TSL2563_INTR_DISABLED         0x00
+#define TSL2563_INTR_LEVEL            0x01
+#define TSL2563_INTR_SMB_ALERT        0x02
+#define TSL2563_INTR_TEST             0x03
+
+#define TSL2563_INT_PERSIST_EVERY     0x00
+#define TSL2563_INT_PERSIST_ANY       0x01
+#define TSL2563_INT_PERSIST_2_CYCLES  0x02
+#define TSL2563_INT_PERSIST_3_CYCLES  0x03
+#define TSL2563_INT_PERSIST_4_CYCLES  0x04
+#define TSL2563_INT_PERSIST_5_CYCLES  0x05
+#define TSL2563_INT_PERSIST_6_CYCLES  0x06
+#define TSL2563_INT_PERSIST_7_CYCLES  0x07
+#define TSL2563_INT_PERSIST_8_CYCLES  0x08
+#define TSL2563_INT_PERSIST_9_CYCLES  0x09
+#define TSL2563_INT_PERSIST_10_CYCLES 0x0A
+#define TSL2563_INT_PERSIST_11_CYCLES 0x0B
+#define TSL2563_INT_PERSIST_12_CYCLES 0x0C
+#define TSL2563_INT_PERSIST_13_CYCLES 0x0D
+#define TSL2563_INT_PERSIST_14_CYCLES 0x0E
+#define TSL2563_INT_PERSIST_15_CYCLES 0x0F
+
+#define TSL2563_ID_PARTNO_MASK        0xF0
+#define TSL2563_ID_REV_MASK           0x0F
+#define TSL2563_EXPECTED_PARTNO       0x30
+/** @} */
+/* -------------------------------------------------------------------------- */
+/**
+ * \name TSL2563 convertion and calibration values
+ * @{
+ */
+
+#define LUX_SCALE           14     /**< scale by 2^14 */
+#define RATIO_SCALE         9      /**< scale ratio */
+#define CH_SCALE            10     /**< scale channel values by 2^10 */
+#define CHSCALE_TINT0       0x7517 /**< 322/11 * 2^CH_SCALE */
+#define CHSCALE_TINT1       0x0fe7 /**< 322/81 * 2^CH_SCALE */
+
+/* T/FN/CL package coefficients (hardcoded) */
+#define K1T                 0X0040
 #define B1T                 0x01f2
 #define M1T                 0x01b2
 #define K2T                 0x0080
@@ -92,11 +161,30 @@
 #define M8T                 0x0000
 /** @} */
 /* -------------------------------------------------------------------------- */
-#define TSL2563_SUCCESS     0x00
-#define TSL2563_LIGHT       0x01
-#define TSL2563_ERROR         -1
+/**
+ * \name Callback function to handle the TSL2563 alarm interrupt and macro
+ * @{
+ */
+#define TSL2563_REGISTER_INT(ptr) tsl2563_int_callback = ptr;
+extern void (*tsl2563_int_callback)(uint8_t value);
+/** @} */
 /* -------------------------------------------------------------------------- */
-#define TSL2563_VAL_READ    0x01
+/**
+ * \name TSL2563 return and command values
+ * @{
+ */
+#define TSL2563_SUCCESS         0x00
+#define TSL2563_LIGHT           0x01
+#define TSL2563_ERROR             -1
+
+#define TSL2563_ACTIVE          SENSORS_ACTIVE
+#define TSL2563_INT_OVER        HW_INT_OVER_THRS
+#define TSL2563_INT_BELOW       HW_INT_BELOW_THRS
+#define TSL2563_INT_DISABLE     HW_INT_DISABLE
+#define TSL2563_TIMMING_CFG     (HW_INT_DISABLE + 1)
+
+#define TSL2563_VAL_READ        0x01
+/** @} */
 /* -------------------------------------------------------------------------- */
 #define TSL2563_SENSOR "TSL2563 Light Sensor"
 /* -------------------------------------------------------------------------- */

--- a/platform/zoul/dev/tsl2563.h
+++ b/platform/zoul/dev/tsl2563.h
@@ -79,6 +79,7 @@
 /* -------------------------------------------------------------------------- */
 /* Uses the word read/write operation protocol */
 #define TSL2563_COMMAND               0xA0
+#define TSL2563_CLEAR_INTERRUPT       0x40
 /* -------------------------------------------------------------------------- */
 #define TSL2563_CONTROL_POWER_ON      0x03
 #define TSL2563_CONTROL_POWER_OFF     0x00
@@ -90,7 +91,7 @@
 #define TSL2563_TIMMING_INTEG_13_7MS  0x00
 #define TSL2563_TIMMING_INTEG_MASK    0x03
 
-#define TSL2563_G16X_402MS (TSL2563_TIMMING_INTEG_402MS +  TSL2563_TIMMING_GAIN)        
+#define TSL2563_G16X_402MS (TSL2563_TIMMING_INTEG_402MS + TSL2563_TIMMING_GAIN)
 #define TSL2563_G1X_402MS                            TSL2563_TIMMING_INTEG_402MS
 #define TSL2563_G1X_101MS                            TSL2563_TIMMING_INTEG_101MS
 #define TSL2563_G1X_13_7MS                          TSL2563_TIMMING_INTEG_13_7MS

--- a/platform/zoul/dev/zoul-sensors.h
+++ b/platform/zoul/dev/zoul-sensors.h
@@ -55,9 +55,12 @@
  * \name Zoul sensor constants
  *
  * These constants are used by various sensors on the Zoul. They can be used
- * to configure ADC decimation rate (where applicable).
+ * to configure ADC decimation rate (where applicable), enable interrupts, etc.
  * @{
  */
+#define HW_INT_OVER_THRS                              0x01
+#define HW_INT_BELOW_THRS                             0x02
+#define HW_INT_DISABLE                                0x03
 #define ZOUL_SENSORS_CONFIGURE_TYPE_DECIMATION_RATE   0x0100
 #define ZOUL_SENSORS_ERROR                            CC2538_SENSORS_ERROR
 /** @} */

--- a/platform/zoul/firefly/board.h
+++ b/platform/zoul/firefly/board.h
@@ -250,6 +250,9 @@
 #define I2C_SCL_PIN              3
 #define I2C_SDA_PORT             GPIO_C_NUM
 #define I2C_SDA_PIN              2
+#define I2C_INT_PORT             GPIO_D_NUM
+#define I2C_INT_PIN              1
+#define I2C_INT_VECTOR           NVIC_INT_GPIO_PORT_D
 /** @} */
 /*---------------------------------------------------------------------------*/
 /**

--- a/platform/zoul/remote/board.h
+++ b/platform/zoul/remote/board.h
@@ -261,12 +261,18 @@
  * These values configure which CC2538 pins to use for the I2C lines, exposed
  * over JP6 connector, also available as testpoints T2 (PC2) and T3 (PC3).
  * The I2C bus is shared with the on-board RTC.
+ * The I2C is exposed over the JP6 header, using a 5-pin connector with 2.54 mm
+ * spacing, providing also D+3.3V, GND and a generic pin that can be used as an
+ * interrupt pin
  * @{
  */
 #define I2C_SCL_PORT             GPIO_C_NUM
 #define I2C_SCL_PIN              3
 #define I2C_SDA_PORT             GPIO_C_NUM
 #define I2C_SDA_PIN              2
+#define I2C_INT_PORT             GPIO_D_NUM
+#define I2C_INT_PIN              1
+#define I2C_INT_VECTOR           NVIC_INT_GPIO_PORT_D
 /** @} */
 /*---------------------------------------------------------------------------*/
 /**
@@ -374,7 +380,6 @@
 /**
  * \name On-board RTC
  *
- * The Abracon AB0805 RTC is used by both the
  * The shutdown mode can be disabled by hardware by short-circuiting or placing
  * an 0Ohm resistor across W1 pad.  As the RTC_INT1 pin is also shared with the
  * BUTTON_USER, so either disable or not use the user button, or upon receiving


### PR DESCRIPTION
This PR fixes and enhances the current `tsl2563` driver implementation with the following:

* Interruption when a value is over/below a given threshold
* Gain and timing selectable (16X, 13.7ms up to 402ms)
* Lux calculation checked for different configurations
* Partnumber and version check

This has been tested on the `firefly` and the `RE-Mote`, for the later (revision A) as the `PD1` pin is shared with the `power-mgmt` communication pin (with a pull-down) the interruption feature is broken, a quick workaround is to use a different pin (change in `board.h`).