### PR TITLE
Added sensniff support for the CC1200

### DIFF
--- a/examples/zolertia/zoul/cc1200-sniffer/Makefile
+++ b/examples/zolertia/zoul/cc1200-sniffer/Makefile
@@ -1,0 +1,10 @@
+DEFINES+=PROJECT_CONF_H=\"project-conf.h\"
+PROJECT_SOURCEFILES += stub-rdc.c
+
+CONTIKI_PROJECT = sniffer
+
+all: $(CONTIKI_PROJECT)
+
+CONTIKI = ../../../..
+CONTIKI_WITH_RIME = 1
+include $(CONTIKI)/Makefile.include

--- a/examples/zolertia/zoul/cc1200-sniffer/Makefile.target
+++ b/examples/zolertia/zoul/cc1200-sniffer/Makefile.target
@@ -1,0 +1,1 @@
+TARGET = zoul

--- a/examples/zolertia/zoul/cc1200-sniffer/README.md
+++ b/examples/zolertia/zoul/cc1200-sniffer/README.md
@@ -1,0 +1,35 @@
+CC1200 README
+========================
+
+The CC1200 sniffer is heavily based on the CC2538 sniffer, used with the
+IEEE 802.15.4 Sensniff application by George Oikonomou.
+
+Sensniff requires [Wireshark](http://www.wireshark.org/).
+
+Get Wireshark
+-----------------
+The best way is to go to the Wireshark site and follow the instructions for your
+specific OS, in a bundle this will install for Ubuntu/LInux systems:
+
+`sudo apt-get install wireshark`
+
+To allow non-super users to capture packets:
+
+`sudo dpkg-reconfigure wireshark`
+
+Flash the sniffer application to the Zoul
+-----------------
+make sniffer.upload
+
+Run Sensniff
+-----------------
+```
+git clone https://github.com/g-oikonomou/sensniff
+cd sensniff/host
+python sensniff.py --non-interactive -d /dev/ttyUSB0 -b 460800
+```
+
+On another terminal run:
+
+`sudo wireshark -i /tmp/sensnifff`
+

--- a/examples/zolertia/zoul/cc1200-sniffer/netstack.c
+++ b/examples/zolertia/zoul/cc1200-sniffer/netstack.c
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2010, Loughborough University - Computer Science
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+/**
+ * \file
+ *         Stub file overriding core/net/netstack.c. What we want to achieve
+ *         here is call netstack_init from main without initialising the RDC,
+ *         MAC and Network layers. It will just turn on the radio instead.
+ *
+ * \author
+ *         George Oikonomou - <oikonomou@users.sourceforge.net>
+ */
+#include "netstack.h"
+/*---------------------------------------------------------------------------*/
+void
+netstack_init(void)
+{
+  NETSTACK_RADIO.init();
+  NETSTACK_RADIO.on();
+}
+/*---------------------------------------------------------------------------*/

--- a/examples/zolertia/zoul/cc1200-sniffer/project-conf.h
+++ b/examples/zolertia/zoul/cc1200-sniffer/project-conf.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2012, Texas Instruments Incorporated - http://www.ti.com/
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+/**
+ * \addtogroup zoul-cc1200-sniffer
+ * @{
+ *
+ * \file
+ *         Project specific configuration defines for the CC1200 sniffer
+ */
+#ifndef PROJECT_CONF_H_
+#define PROJECT_CONF_H_
+
+#define CC1200_CONF_SNIFFER         1
+#define CC1200_RF_CONF_SNIFFER_UART 0
+#define CC1200_CONF_RF_CFG          cc1200_802154g_863_870_fsk_50kbps
+
+#undef  NETSTACK_CONF_RADIO
+#define NETSTACK_CONF_RADIO         cc1200_driver
+
+#define CC1200_CONF_USE_GPIO2       0
+#define CC1200_CONF_USE_RX_WATCHDOG 0
+#define ANTENNA_SW_SELECT_DEF_CONF  ANTENNA_SW_SELECT_SUBGHZ
+
+#undef NETSTACK_CONF_RDC
+#define NETSTACK_CONF_RDC           stub_rdc_driver
+
+#define UART0_CONF_BAUD_RATE        460800
+
+#endif /* PROJECT_CONF_H_ */
+
+/** @} */

--- a/examples/zolertia/zoul/cc1200-sniffer/sniffer.c
+++ b/examples/zolertia/zoul/cc1200-sniffer/sniffer.c
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2012, Texas Instruments Incorporated - http://www.ti.com/
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+/**
+ * \addtogroup zoul-examples
+ * @{
+ *
+ * \defgroup zoul-cc1200-sniffer CC1200 Sniffer
+ *
+ * Sniffer for the Zolertia's Zoul CC1200 on-board radio
+ *
+ * This example is to be used combined with the sensniff host-side tool,
+ * which can be downloaded from: https://github.com/g-oikonomou/sensniff
+ *
+ * @{
+ *
+ * \file
+ * Implementation of a Sniffer Process Thread
+ */
+#include "contiki.h"
+
+#define DEBUG DEBUG_NONE
+#include "net/ip/uip-debug.h"
+/*---------------------------------------------------------------------------*/
+PROCESS(sniffer_process, "Sniffer process");
+AUTOSTART_PROCESSES(&sniffer_process);
+/*---------------------------------------------------------------------------*/
+PROCESS_THREAD(sniffer_process, ev, data)
+{
+  PROCESS_BEGIN();
+  PRINTF("Sniffer started\n");
+  PROCESS_EXIT();
+  PROCESS_END();
+}
+/*---------------------------------------------------------------------------*/
+
+/**
+ * @}
+ * @}
+ */

--- a/examples/zolertia/zoul/cc1200-sniffer/stub-rdc.c
+++ b/examples/zolertia/zoul/cc1200-sniffer/stub-rdc.c
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2010, Loughborough University - Computer Science
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+/**
+ * \file
+ *         Definition of a fake RDC driver to be used with passive
+ *         examples. The sniffer will never send packets and it will never
+ *         push incoming packets up the stack. We do this by defining this
+ *         driver as our RDC. We then drop everything
+ *
+ * \author
+ *         George Oikonomou - <oikonomou@users.sourceforge.net>
+ */
+#include "net/mac/mac.h"
+#include "net/mac/rdc.h"
+/*---------------------------------------------------------------------------*/
+static void
+send(mac_callback_t sent, void *ptr)
+{
+  if(sent) {
+    sent(ptr, MAC_TX_OK, 1);
+  }
+}
+/*---------------------------------------------------------------------------*/
+static void
+send_list(mac_callback_t sent, void *ptr, struct rdc_buf_list *list)
+{
+  if(sent) {
+    sent(ptr, MAC_TX_OK, 1);
+  }
+}
+/*---------------------------------------------------------------------------*/
+static void
+input(void)
+{
+}
+/*---------------------------------------------------------------------------*/
+static int
+on(void)
+{
+  return 1;
+}
+/*---------------------------------------------------------------------------*/
+static int
+off(int keep_radio_on)
+{
+  return keep_radio_on;
+}
+/*---------------------------------------------------------------------------*/
+static unsigned short
+cca(void)
+{
+  return 0;
+}
+/*---------------------------------------------------------------------------*/
+static void
+init(void)
+{
+}
+/*---------------------------------------------------------------------------*/
+const struct rdc_driver stub_rdc_driver = {
+  "stub-rdc",
+  init,
+  send,
+  send_list,
+  input,
+  on,
+  off,
+  cca,
+};
+/*---------------------------------------------------------------------------*/


### PR DESCRIPTION
This PR allows the CC1200 to run the [Sensniff](https://github.com/g-oikonomou/sensniff) Sniffer application.  This has been tested with the `RE-Mote` platform extensively.

As it is heavily based on the `cc2538dk` sniffer application (well, copy/pasted) I'm open for suggestions to have a single sniffer application, instead of instances per platform (there's was also a previous PR with support for the Z1 mote).