### PR TITLE
Rename select() in various sensortag sensor drivers

### DIFF
--- a/platform/srf06-cc26xx/sensortag/bmp-280-sensor.c
+++ b/platform/srf06-cc26xx/sensortag/bmp-280-sensor.c
@@ -148,7 +148,7 @@ notify_ready(void *not_used)
 }
 /*---------------------------------------------------------------------------*/
 static void
-select(void)
+select_on_bus(void)
 {
   /* Set up I2C */
   board_i2c_select(BOARD_I2C_INTERFACE_0, BMP280_I2C_ADDRESS);
@@ -162,7 +162,7 @@ init(void)
 {
   uint8_t val;
 
-  select();
+  select_on_bus();
 
   /* Read and store calibration data */
   sensor_common_read_reg(ADDR_CALIB, calibration_data, CALIB_DATA_SIZE);
@@ -183,7 +183,7 @@ enable_sensor(bool enable)
 {
   uint8_t val;
 
-  select();
+  select_on_bus();
 
   if(enable) {
     /* Enable forced mode */
@@ -205,7 +205,7 @@ read_data(uint8_t *data)
 {
   bool success;
 
-  select();
+  select_on_bus();
 
   success = sensor_common_read_reg(ADDR_PRESS_MSB, data, MEAS_DATA_SIZE);
   if(!success) {

--- a/platform/srf06-cc26xx/sensortag/ext-flash.c
+++ b/platform/srf06-cc26xx/sensortag/ext-flash.c
@@ -86,7 +86,7 @@
  * Clear external flash CSN line
  */
 static void
-select(void)
+select_on_bus(void)
 {
   ti_lib_gpio_pin_write(BOARD_FLASH_CS, 0);
 }
@@ -110,7 +110,7 @@ wait_ready(void)
   bool ret;
   const uint8_t wbuf[1] = { BLS_CODE_READ_STATUS };
 
-  select();
+  select_on_bus();
 
   /* Throw away all garbages */
   board_spi_flush();
@@ -159,7 +159,7 @@ verify_part(void)
   uint8_t rbuf[2] = {0, 0};
   bool ret;
 
-  select();
+  select_on_bus();
 
   ret = board_spi_write(wbuf, sizeof(wbuf));
 
@@ -199,7 +199,7 @@ power_down(void)
   }
 
   cmd = BLS_CODE_PD;
-  select();
+  select_on_bus();
   board_spi_write(&cmd, sizeof(cmd));
   deselect();
 
@@ -227,7 +227,7 @@ power_standby(void)
   bool success;
 
   cmd = BLS_CODE_RPD;
-  select();
+  select_on_bus();
   success = board_spi_write(&cmd, sizeof(cmd));
 
   if(success) {
@@ -249,7 +249,7 @@ write_enable(void)
   bool ret;
   const uint8_t wbuf[] = { BLS_CODE_WRITE_ENABLE };
 
-  select();
+  select_on_bus();
   ret = board_spi_write(wbuf, sizeof(wbuf));
   deselect();
 
@@ -305,7 +305,7 @@ ext_flash_read(size_t offset, size_t length, uint8_t *buf)
   wbuf[2] = (offset >> 8) & 0xff;
   wbuf[3] = offset & 0xff;
 
-  select();
+  select_on_bus();
 
   if(board_spi_write(wbuf, sizeof(wbuf)) == false) {
     /* failure */
@@ -357,7 +357,7 @@ ext_flash_write(size_t offset, size_t length, const uint8_t *buf)
      * is not imposed here since above instructions
      * should be enough to delay
      * as much. */
-    select();
+    select_on_bus();
 
     if(board_spi_write(wbuf, sizeof(wbuf)) == false) {
       /* failure */
@@ -411,7 +411,7 @@ ext_flash_erase(size_t offset, size_t length)
     wbuf[2] = (offset >> 8) & 0xff;
     wbuf[3] = offset & 0xff;
 
-    select();
+    select_on_bus();
 
     if(board_spi_write(wbuf, sizeof(wbuf)) == false) {
       /* failure */

--- a/platform/srf06-cc26xx/sensortag/opt-3001-sensor.c
+++ b/platform/srf06-cc26xx/sensortag/opt-3001-sensor.c
@@ -132,7 +132,7 @@ static struct ctimer startup_timer;
  * \brief Select the sensor on the I2C bus
  */
 static void
-select(void)
+select_on_bus(void)
 {
   /* Select slave and set clock rate */
   board_i2c_select(BOARD_I2C_INTERFACE_0, OPT3001_I2C_ADDRESS);
@@ -148,7 +148,7 @@ notify_ready(void *not_used)
    */
   uint16_t val;
 
-  select();
+  select_on_bus();
 
   sensor_common_read_reg(REG_CONFIGURATION, (uint8_t *)&val, REGISTER_LENGTH);
 
@@ -170,7 +170,7 @@ enable_sensor(bool enable)
   uint16_t val;
   uint16_t had_data_ready = state & SENSOR_STATE_DATA_READY;
 
-  select();
+  select_on_bus();
 
   if(enable) {
     val = CONFIG_ENABLE_SINGLE_SHOT;
@@ -202,7 +202,7 @@ read_data(uint16_t *raw_data)
     return false;
   }
 
-  select();
+  select_on_bus();
 
   success = sensor_common_read_reg(REG_CONFIGURATION, (uint8_t *)&val,
                                    REGISTER_LENGTH);


### PR DESCRIPTION
This is to prevent a compile error caused by function prototype conflict between a function called `select()` (present in a number of sensortag peripheral drivers) and the one in `sys/select.h`. The error manifests itself with gcc-arm-embedded version 5.2.1 20151202 (2015-q4).

To fix the error we simply rename our function.

This is simply a compile fix. I have not tested whether the resulting binaries work correctly.

Fixes #1434