### PR TITLE
Compile-test the CC2650 Sensortag and Srf06+CC1310EM code

### DIFF
--- a/regression-tests/18-compile-arm-ports/Makefile
+++ b/regression-tests/18-compile-arm-ports/Makefile
@@ -8,6 +8,9 @@ webserver-ipv6/ev-aducrf101mkxz \
 ipv6/multicast/ev-aducrf101mkxz \
 cc2538dk/sniffer/ev-aducrf101mkxz \
 cc26xx/cc26xx-web-demo/srf06-cc26xx \
+cc26xx/very-sleepy-demo/srf06-cc26xx:BOARD=sensortag/cc2650 \
+cc26xx/cc26xx-web-demo/srf06-cc26xx:BOARD=sensortag/cc2650 \
+cc26xx/cc26xx-web-demo/srf06-cc26xx:BOARD=srf06/cc13xx \
 cc26xx/very-sleepy-demo/srf06-cc26xx \
 hello-world/cc2538dk \
 ipv6/rpl-border-router/cc2538dk \


### PR DESCRIPTION
This adds three travis compile jobs in order to test:

* Drivers for the CC2650 Sensortag
* Drivers for CC1310 RF prop mode
* The cc2650 web demo and the very sleepy demo for the CC2650 Sensortag

This is what it looks like:
```
[...]
Building example 07: cc26xx/very-sleepy-demo/ BOARD=sensortag/cc2650 for target srf06-cc26xx
cc26xx/very-sleepy-demo/ srf06-cc26xx: OK
Building example 08: cc26xx/cc26xx-web-demo/ BOARD=sensortag/cc2650 for target srf06-cc26xx
cc26xx/cc26xx-web-demo/ srf06-cc26xx: OK
Building example 09: cc26xx/cc26xx-web-demo/ BOARD=srf06/cc13xx for target srf06-cc26xx
cc26xx/cc26xx-web-demo/ srf06-cc26xx: OK
[...]
```