### PR TITLE
Change travis arm tests to use gcc-arm-embedded v5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,9 +44,9 @@ before_script:
   ## in Ubuntu >= 14.04, but this external PPA is needed for 12.04.
   ## Install srecord
   - if [ ${BUILD_ARCH:-0} = arm-aapcs ] ; then
-      sudo add-apt-repository -y ppa:terry.guo/gcc-arm-embedded &&
+      sudo add-apt-repository -y ppa:team-gcc-arm-embedded/ppa &&
       sudo apt-get -qq update &&
-      sudo apt-get -qq install gcc-arm-none-eabi srecord &&
+      sudo apt-get -qq install gcc-arm-embedded srecord &&
       arm-none-eabi-gcc --version ;
     fi
 

--- a/platform/cc2538dk/README.md
+++ b/platform/cc2538dk/README.md
@@ -66,21 +66,15 @@ The platform has been developed and tested under Windows XP, Mac OS X 10.9.1 and
 
 Install a Toolchain
 -------------------
-The toolchain used to build contiki is arm-gcc, also used by other arm-based Contiki ports. If you are using Instant Contiki, you will have a version pre-installed in your system. To find out if this is the case, try this:
+The toolchain used to build contiki is arm-gcc, also used by other arm-based Contiki ports. If you are using Instant Contiki, you may have a version pre-installed in your system.
 
-    $ arm-none-eabi-gcc -v
-    Using built-in specs.
-    Target: arm-none-eabi
-    Configured with: /scratch/julian/lite-respin/eabi/src/gcc-4.3/configure
-    ...
-    (skip)
-    ...
-    Thread model: single
-    gcc version 4.3.2 (Sourcery G++ Lite 2008q3-66)
+The platform is currently being used/tested with "GNU Tools for ARM Embedded Processors" (<https://launchpad.net/gcc-arm-embedded>). The current recommended version and the one being used by Contiki's regression tests on Travis is shown below.
 
-The platform is currently being used/tested with "GNU Tools for ARM Embedded Processors". This is the recommended version and the one being used by Contiki's regression tests on Travis. <https://launchpad.net/gcc-arm-embedded>
-
-The older version (Sourcery G++ Lite 2008q3-66) shown above should still work, but the port is no longer being tested with it. <http://sourcery.mentor.com/public/gnu_toolchain/arm-none-eabi>
+    $ arm-none-eabi-gcc --version
+    arm-none-eabi-gcc (GNU Tools for ARM Embedded Processors) 5.2.1 20151202 (release) [ARM/embedded-5-branch revision 231848]
+    Copyright (C) 2015 Free Software Foundation, Inc.
+    This is free software; see the source for copying conditions.  There is NO
+    warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 
 Drivers
 -------

--- a/platform/srf06-cc26xx/README.md
+++ b/platform/srf06-cc26xx/README.md
@@ -58,12 +58,15 @@ To use the port you need:
   Note that uploading over serial doesn't work for the Sensortag, you can use
   TI's SmartRF Flash Programmer in this case.
 * A toolchain to build firmware: The port has been developed and tested with
-  GNU Tools for ARM Embedded Processors <https://launchpad.net/gcc-arm-embedded>.
-  The port was developed and tested using this version:
+  GNU Tools for ARM Embedded Processors (<https://launchpad.net/gcc-arm-embedded>).
+  The current recommended version and the one being used by Contiki's regression
+  tests on Travis is shown below.
 
-        $ arm-none-eabi-gcc -v
-        [...]
-        gcc version 4.9.3 20141119 (release) [ARM/embedded-4_9-branch revision 218278] (GNU Tools for ARM Embedded Processors)
+        $ arm-none-eabi-gcc --version
+        arm-none-eabi-gcc (GNU Tools for ARM Embedded Processors) 5.2.1 20151202 (release) [ARM/embedded-5-branch revision 231848]
+        Copyright (C) 2015 Free Software Foundation, Inc.
+        This is free software; see the source for copying conditions.  There is NO
+        warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 
 * srecord (http://srecord.sourceforge.net/)
 * You may also need other drivers so that the SmartRF can communicate with your

--- a/platform/zoul/README.md
+++ b/platform/zoul/README.md
@@ -74,22 +74,15 @@ To start using Contiki, the following is required:
 
 Install a Toolchain
 -------------------
-The toolchain used to build contiki is arm-gcc, also used by other arm-based Contiki ports. If you are using Instant Contiki, you will have a version pre-installed in your system. To find out if this is the case, try this:
+The toolchain used to build contiki is arm-gcc, also used by other arm-based Contiki ports. If you are using Instant Contiki, you may have a version pre-installed in your system.
 
-    $ arm-none-eabi-gcc -v
-    Using built-in specs.
-    Target: arm-none-eabi
-    Configured with: /scratch/julian/lite-respin/eabi/src/gcc-4.3/configure
-    ...
-    (skip)
-    ...
-    Thread model: single
-    gcc version 4.3.2 (Sourcery G++ Lite 2008q3-66)
+The platform is currently being used/tested with "GNU Tools for ARM Embedded Processors" (<https://launchpad.net/gcc-arm-embedded>). The current recommended version and the one being used by Contiki's regression tests on Travis is shown below.
 
-The platform is currently being used/tested with the following toolchains:
-
-* GNU Tools for ARM Embedded Processors. This is the recommended version. Works nicely on OS X. <https://launchpad.net/gcc-arm-embedded>
-* Alternatively, you can use this older version for Linux. At the time of writing, this is the version used by Contiki's regression tests. <https://sourcery.mentor.com/public/gnu_toolchain/arm-none-eabi/arm-2008q3-66-arm-none-eabi-i686-pc-linux-gnu.tar.bz2>
+    $ arm-none-eabi-gcc --version
+    arm-none-eabi-gcc (GNU Tools for ARM Embedded Processors) 5.2.1 20151202 (release) [ARM/embedded-5-branch revision 231848]
+    Copyright (C) 2015 Free Software Foundation, Inc.
+    This is free software; see the source for copying conditions.  There is NO
+    warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 
 Drivers
 -------


### PR DESCRIPTION
Do we want to switch travis to arm-gcc v5.2.1?

We'll first need to make sure that resulting binaries work well for the affected platforms.

If #1452 gets merged, then merging this one here will cause travis errors unless #1451 also gets merged.