### PR TITLE
Add support for digital motion/presence sensors

### DIFF
--- a/examples/zolertia/zoul/Makefile
+++ b/examples/zolertia/zoul/Makefile
@@ -1,7 +1,7 @@
 DEFINES+=PROJECT_CONF_H=\"project-conf.h\"
 CONTIKI_PROJECT = zoul-demo test-tsl2563 test-sht25 test-pwm test-power-mgmt
-CONTIKI_PROJECT += test-bmp085
-CONTIKI_TARGET_SOURCEFILES += tsl2563.c sht25.c bmp085.c
+CONTIKI_PROJECT += test-bmp085 test-motion
+CONTIKI_TARGET_SOURCEFILES += tsl2563.c sht25.c bmp085.c motion-sensor.c
 
 all: $(CONTIKI_PROJECT)
 

--- a/examples/zolertia/zoul/Makefile
+++ b/examples/zolertia/zoul/Makefile
@@ -1,6 +1,7 @@
 DEFINES+=PROJECT_CONF_H=\"project-conf.h\"
 CONTIKI_PROJECT = zoul-demo test-tsl2563 test-sht25 test-pwm test-power-mgmt
-CONTIKI_TARGET_SOURCEFILES += tsl2563.c sht25.c
+CONTIKI_PROJECT += test-bmp085
+CONTIKI_TARGET_SOURCEFILES += tsl2563.c sht25.c bmp085.c
 
 all: $(CONTIKI_PROJECT)
 

--- a/examples/zolertia/zoul/project-conf.h
+++ b/examples/zolertia/zoul/project-conf.h
@@ -41,6 +41,13 @@
 #define BROADCAST_CHANNEL     129
 #define NETSTACK_CONF_RDC     nullrdc_driver
 
+/* Pin definition for the test-motion example, for the RE-Mote it uses the
+ * ADC1 pin
+ */
+#define MOTION_SENSOR_PORT       GPIO_A_NUM
+#define MOTION_SENSOR_PIN        5
+#define MOTION_SENSOR_VECTOR     NVIC_INT_GPIO_PORT_A
+
 #endif /* PROJECT_CONF_H_ */
 
 /** @} */

--- a/examples/zolertia/zoul/test-bmp085.c
+++ b/examples/zolertia/zoul/test-bmp085.c
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2015, Zolertia - http://www.zolertia.com
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ */
+/*---------------------------------------------------------------------------*/
+/**
+ * \addtogroup zoul-examples
+ * @{
+ *
+ * \defgroup zoul-bmp085-test BMP085 pressure and temperature sensor test
+ *
+ * Demonstrates the use of the BMP085 digital pressure and temperature sensor
+ * @{
+ *
+ * \file
+ *  Driver for the external BMP085 digital pressure and temperature sensor
+ *
+ * \author
+ *         Antonio Lignan <alinan@zolertia.com>
+ */
+/*---------------------------------------------------------------------------*/
+#include <stdio.h>
+#include "contiki.h"
+#include "dev/i2c.h"
+#include "dev/leds.h"
+#include "dev/bmp085.h"
+/*---------------------------------------------------------------------------*/
+#define SENSOR_READ_INTERVAL (CLOCK_SECOND)
+/*---------------------------------------------------------------------------*/
+PROCESS(remote_bmp085_process, "BMP085 test process");
+AUTOSTART_PROCESSES(&remote_bmp085_process);
+/*---------------------------------------------------------------------------*/
+static struct etimer et;
+/*---------------------------------------------------------------------------*/
+PROCESS_THREAD(remote_bmp085_process, ev, data)
+{
+  PROCESS_BEGIN();
+  static uint16_t pressure;
+  static int16_t temperature;
+
+  /* Use Contiki's sensor macro to enable the sensor */
+  SENSORS_ACTIVATE(bmp085);
+
+  /* And periodically poll the sensor */
+
+  while(1) {
+    etimer_set(&et, SENSOR_READ_INTERVAL);
+    PROCESS_WAIT_EVENT_UNTIL(etimer_expired(&et));
+
+    pressure = bmp085.value(BMP085_READ_PRESSURE);
+    temperature = bmp085.value(BMP085_READ_TEMP);
+
+    if((pressure != BMP085_ERROR) && (temperature != BMP085_ERROR)) {
+      printf("Pressure = %u.%u(hPa), ", pressure / 10, pressure % 10);
+      printf("Temperature = %d.%u(ºC)\n", temperature / 10, temperature % 10);
+    } else {
+      printf("Error, enable the DEBUG flag in the BMP085 driver for info, ");
+      printf("or check if the sensor is properly connected\n");
+      PROCESS_EXIT();
+    }
+  }
+  PROCESS_END();
+}
+/*---------------------------------------------------------------------------*/
+/**
+ * @}
+ * @}
+ */
+

--- a/examples/zolertia/zoul/test-motion.c
+++ b/examples/zolertia/zoul/test-motion.c
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2016, Zolertia - http://www.zolertia.com
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ */
+/*---------------------------------------------------------------------------*/
+/**
+ * \addtogroup zoul-examples
+ * @{
+ *
+ * \defgroup zoul-motion-test Digital motion sensor test
+ *
+ * The example application shows how to use any digital motion sensor, basically
+ * driving a signal high when motion is detected.
+ *
+ * @{
+ *
+ * \file
+ *  Test application for the digital motion/presence sensor
+ *
+ * \author
+ *         Antonio Lignan <alinan@zolertia.com>
+ */
+/*---------------------------------------------------------------------------*/
+#include "contiki.h"
+#include "cpu.h"
+#include "sys/rtimer.h"
+#include "dev/leds.h"
+#include "dev/motion-sensor.h"
+
+#include <stdio.h>
+#include <stdint.h>
+/*---------------------------------------------------------------------------*/
+#define LEDS_OFF_HYSTERISIS      RTIMER_SECOND
+/*---------------------------------------------------------------------------*/
+static struct rtimer rt;
+/*---------------------------------------------------------------------------*/
+PROCESS(test_presence_sensor, "Test digital motion sensor");
+AUTOSTART_PROCESSES(&test_presence_sensor);
+/*---------------------------------------------------------------------------*/
+void
+rt_callback(struct rtimer *t, void *ptr)
+{
+  leds_off(LEDS_RED);
+}
+/*---------------------------------------------------------------------------*/
+static void
+presence_callback(uint8_t value)
+{
+  printf("*** Presence detected!\n");
+  leds_on(LEDS_RED);
+  rtimer_set(&rt, RTIMER_NOW() + LEDS_OFF_HYSTERISIS, 1, rt_callback, NULL);
+}
+/*---------------------------------------------------------------------------*/
+PROCESS_THREAD(test_presence_sensor, ev, data)
+{
+  PROCESS_BEGIN();
+
+  /* Register the callback handler when presence is detected */
+  MOTION_REGISTER_INT(presence_callback);
+
+  /* Enable the sensor, as default it assumes the signal pin has a pull-down
+   * resistor and a rising interrupt (signal goes high when motion is detected),
+   * this is the case of the Grove's PIR sensor v.1.0.  If the sensor has an
+   * inverse logic, change at the motion-sensor.c driver file
+   * GPIO_DETECT_FALLING instead of GPIO_DETECT_RISING if using an external
+   * pull-up resistor
+   */
+  SENSORS_ACTIVATE(motion_sensor);
+
+  PROCESS_END();
+}
+/*---------------------------------------------------------------------------*/
+/**
+ * @}
+ * @}
+ * @}
+ */

--- a/examples/zolertia/zoul/test-sht25.c
+++ b/examples/zolertia/zoul/test-sht25.c
@@ -60,13 +60,29 @@ PROCESS_THREAD(remote_sht25_process, ev, data)
   PROCESS_BEGIN();
   SENSORS_ACTIVATE(sht25);
 
+  /* Check if the sensor voltage operation is over 2.25V */
+  if(sht25.value(SHT25_VOLTAGE_ALARM)) {
+    printf("Voltage is lower than recommended for the sensor operation\n"); 
+    PROCESS_EXIT();
+  }
+
+  /* Configure the sensor for maximum resolution (14-bit temperature, 12-bit
+   * relative humidity), this will require up to 85ms for the temperature
+   * integration, and 29ms for the relative humidity (this is the default
+   * setting at power on).  To achieve a faster integration time at the cost
+   * of a lower resolution, change the value below accordingly, see sht25.h.
+   */
+  sht25.configure(SHT25_RESOLUTION, SHT2X_RES_14T_12RH);
+
+  /* Let it spin and read sensor data */
+
   while(1) {
     etimer_set(&et, CLOCK_SECOND);
     PROCESS_WAIT_EVENT_UNTIL(etimer_expired(&et));
     temperature = sht25.value(SHT25_VAL_TEMP);
-    printf("Temperature %d.%d ºC\n", temperature / 100, temperature % 100);
+    printf("Temperature %02d.%02d ºC, ", temperature / 100, temperature % 100);
     humidity = sht25.value(SHT25_VAL_HUM);
-    printf("Humidity %d.%d RH\n", humidity / 100, humidity % 100);
+    printf("Humidity %02d.%02d RH\n", humidity / 100, humidity % 100);
   }
   PROCESS_END();
 }

--- a/examples/zolertia/zoul/test-sht25.c
+++ b/examples/zolertia/zoul/test-sht25.c
@@ -62,7 +62,7 @@ PROCESS_THREAD(remote_sht25_process, ev, data)
 
   /* Check if the sensor voltage operation is over 2.25V */
   if(sht25.value(SHT25_VOLTAGE_ALARM)) {
-    printf("Voltage is lower than recommended for the sensor operation\n"); 
+    printf("Voltage is lower than recommended for the sensor operation\n");
     PROCESS_EXIT();
   }
 

--- a/platform/zoul/dev/bmp085.c
+++ b/platform/zoul/dev/bmp085.c
@@ -1,0 +1,350 @@
+/*
+ * Copyright (c) 2015, Zolertia - http://www.zolertia.com
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ */
+/*---------------------------------------------------------------------------*/
+/**
+ * \addtogroup zoul-bmp085-sensor
+ * @{
+ *
+ * BMP085 driver implementation, calculations taken from Inga sensor driver
+ *
+ * \file
+ *  Driver for the external BMP085 light sensor
+ *
+ * \author
+ *         Antonio Lignan <alinan@zolertia.com>
+ */
+/*---------------------------------------------------------------------------*/
+#include "contiki.h"
+#include "dev/i2c.h"
+#include "dev/gpio.h"
+#include "dev/zoul-sensors.h"
+#include "lib/sensors.h"
+#include "bmp085.h"
+/*---------------------------------------------------------------------------*/
+#define DEBUG 1
+#if DEBUG
+#define PRINTF(...) printf(__VA_ARGS__)
+#else
+#define PRINTF(...)
+#endif
+/*---------------------------------------------------------------------------*/
+static uint8_t enabled = 0;
+/*---------------------------------------------------------------------------*/
+typedef struct {
+  int16_t ac1;
+  int16_t ac2;
+  int16_t ac3;
+  uint16_t ac4;
+  uint16_t ac5;
+  uint16_t ac6;
+  int16_t b1;
+  int16_t b2;
+  int16_t mb;
+  int16_t mc;
+  int16_t md;
+} bmp085_calibration_values;
+
+typedef struct {
+  uint8_t oversampling_mode;
+  bmp085_calibration_values calib;
+} bmp085_config;
+
+static bmp085_config bmp085_values;
+/*---------------------------------------------------------------------------*/
+static int
+bmp085_read_reg(uint8_t reg, uint8_t *buf, uint8_t num)
+{
+  if((buf == NULL) || (num <= 0)) {
+    PRINTF("BMP085: invalid read values\n");
+    return BMP085_ERROR;
+  }
+
+  i2c_master_enable();
+  if(i2c_single_send(BMP085_ADDR, reg) == I2C_MASTER_ERR_NONE) {
+    while(i2c_master_busy());
+    if(i2c_burst_receive(BMP085_ADDR, buf, num) == I2C_MASTER_ERR_NONE) {
+      return BMP085_SUCCESS;
+    }
+  }
+  return BMP085_ERROR;
+}
+/*---------------------------------------------------------------------------*/
+static int
+bmp085_write_reg(uint8_t *buf, uint8_t num)
+{
+  if((buf == NULL) || (num <= 0)) {
+    PRINTF("BMP085: invalid write values\n");
+    return BMP085_ERROR;
+  }
+
+  i2c_master_enable();
+  if(i2c_burst_send(BMP085_ADDR, buf, num) == I2C_MASTER_ERR_NONE) {
+    return BMP085_SUCCESS;
+  }
+  return BMP085_ERROR;
+}
+/*---------------------------------------------------------------------------*/
+static int
+bmp085_read_calib(void)
+{
+  uint8_t buf[BMP085_CALIB_TABLE_SIZE];
+
+  if(bmp085_read_reg(BMP085_AC1_CALIB, buf,
+                     BMP085_CALIB_TABLE_SIZE) == BMP085_SUCCESS) {
+
+    /*  MSB first */
+    bmp085_values.calib.ac1 = ((buf[0] << 8) + buf[1]);
+    bmp085_values.calib.ac2 = ((buf[2] << 8) + buf[3]);
+    bmp085_values.calib.ac3 = ((buf[4] << 8) + buf[5]);
+    bmp085_values.calib.ac4 = ((buf[6] << 8) + buf[7]);
+    bmp085_values.calib.ac5 = ((buf[8] << 8) + buf[9]);
+    bmp085_values.calib.ac6 = ((buf[10] << 8) + buf[11]);
+    bmp085_values.calib.b1 = ((buf[12] << 8) + buf[13]);
+    bmp085_values.calib.b2 = ((buf[14] << 8) + buf[15]);
+    bmp085_values.calib.mb = ((buf[16] << 8) + buf[17]);
+    bmp085_values.calib.mc = ((buf[18] << 8) + buf[19]);
+    bmp085_values.calib.md = ((buf[20] << 8) + buf[21]);
+
+    return BMP085_SUCCESS;
+  }
+
+  PRINTF("BMP085: failed to read calibration\n");
+  return BMP085_ERROR;
+}
+/*---------------------------------------------------------------------------*/
+static int
+bmp085_read_uncompensated_pressure(int32_t *pressure)
+{
+  uint8_t buf[3];
+  uint16_t delay;
+  int32_t upres;
+
+  buf[0] = BMP085_CTRL_REG;
+
+  switch(bmp085_values.oversampling_mode) {
+  case BMP085_MODE_ULTRA_LOW_POWER:
+    buf[1] = BMP085_CTRL_REG_PRESS_4_5MS;
+    delay = BMP085_DELAY_4_5MS;
+    break;
+  case BMP085_MODE_STANDARD:
+    buf[1] = BMP085_CTRL_REG_PRESS_7_5MS;
+    delay = BMP085_DELAY_7_5MS;
+    break;
+  case BMP085_MODE_HIGH_RES:
+    buf[1] = BMP085_CTRL_REG_PRESS_13_5MS;
+    delay = BMP085_DELAY_13_5MS;
+    break;
+  case BMP085_MODE_ULTRA_HIGH_RES:
+    buf[1] = BMP085_CTRL_REG_PRESS_25_5MS;
+    delay = BMP085_DELAY_25_5MS;
+    break;
+  default:
+    return BMP085_ERROR;
+  }
+
+  if(bmp085_write_reg(buf, 2) == BMP085_SUCCESS) {
+    clock_delay_usec(delay);
+    if(bmp085_read_reg(BMP085_DATA_MSB, buf, 3) == BMP085_SUCCESS) {
+      upres = (buf[0] << 16) + (buf[1] << 8) + buf[2];
+      *pressure = (upres >> (8 - bmp085_values.oversampling_mode));
+      return BMP085_SUCCESS;
+    }
+  }
+  return BMP085_ERROR;
+}
+/*---------------------------------------------------------------------------*/
+static int
+bmp085_read_uncompensated_temperature(int32_t *temp)
+{
+  uint8_t buf[2];
+  buf[0] = BMP085_CTRL_REG;
+  buf[1] = BMP085_CTRL_REG_TEMP;
+
+  if(bmp085_write_reg(buf, 2) == BMP085_SUCCESS) {
+    clock_delay_usec(BMP085_DELAY_4_5MS);
+    if(bmp085_read_reg(BMP085_DATA_MSB, buf, 2) == BMP085_SUCCESS) {
+      *temp = (int32_t)((buf[0] << 8) + buf[1]);
+      return BMP085_SUCCESS;
+    }
+  }
+  return BMP085_ERROR;
+}
+/*---------------------------------------------------------------------------*/
+static int
+bmp085_read_temperature(int16_t *temp)
+{
+  int32_t ut = 0;
+  int32_t x1, x2, b5;
+
+  if(bmp085_read_uncompensated_temperature(&ut) == BMP085_ERROR) {
+    return BMP085_ERROR;
+  }
+
+  x1 = ((int32_t)ut - (int32_t)bmp085_values.calib.ac6)
+    * (int32_t)bmp085_values.calib.ac5 >> 15;
+  x2 = ((int32_t)bmp085_values.calib.mc << 11) / (x1 + bmp085_values.calib.md);
+  b5 = x1 + x2;
+  *temp = (int16_t)((b5 + 8) >> 4);
+  return BMP085_SUCCESS;
+}
+/*---------------------------------------------------------------------------*/
+static int
+bmp085_read_pressure(int32_t *pressure)
+{
+  int32_t ut = 0;
+  int32_t up = 0;
+  int32_t x1, x2, b5, b6, x3, b3, p;
+  uint32_t b4, b7;
+
+  if(bmp085_read_uncompensated_pressure(&up) == BMP085_ERROR) {
+    return BMP085_ERROR;
+  }
+
+  if(bmp085_read_uncompensated_temperature(&ut) == BMP085_ERROR) {
+    return BMP085_ERROR;
+  }
+
+  b6 = b5 - 4000;
+  x1 = (bmp085_values.calib.b2 * (b6 * b6 >> 12)) >> 11;
+  x2 = bmp085_values.calib.ac2 * b6 >> 11;
+  x3 = x1 + x2;
+  b3 = ((((int32_t)bmp085_values.calib.ac1) * 4 + x3) + 2) >> 2;
+
+  x1 = (bmp085_values.calib.ac3 * b6) >> 13;
+  x2 = (bmp085_values.calib.b1 * ((b6 * b6) >> 12)) >> 16;
+  x3 = ((x1 + x2) + 2) >> 2;
+  b4 = (bmp085_values.calib.ac4 * ((uint32_t)(x3 + 32768))) >> 15;
+  b7 = ((uint32_t)up - b3) * 50000;
+
+  if(b7 < 0x80000000) {
+    p = (b7 << 1) / b4;
+  } else {
+    p = (b7 / b4) << 1;
+  }
+
+  x1 = (p >> 8) * (p >> 8);
+  x1 = (x1 * 3038) >> 16;
+  x2 = (-7357 * p) >> 16;
+  *pressure = (p + ((x1 + x2 + 3791) >> 4));
+  *pressure /= 10;
+
+  return BMP085_SUCCESS;
+}
+/*---------------------------------------------------------------------------*/
+static int
+configure(int type, int value)
+{
+  if((type != BMP085_ACTIVE) && (type != BMP085_OVERSAMPLING)) {
+    PRINTF("BMP085: invalid start value\n");
+    return BMP085_ERROR;
+  }
+
+  if(type == BMP085_ACTIVE) {
+    if(value) {
+      i2c_init(I2C_SDA_PORT, I2C_SDA_PIN, I2C_SCL_PORT, I2C_SCL_PIN,
+               I2C_SCL_NORMAL_BUS_SPEED);
+
+      /* Read the calibration values */
+      if(bmp085_read_calib() != BMP085_ERROR) {
+        PRINTF("BMP085: sensor started\n");
+        enabled = 1;
+        bmp085_values.oversampling_mode = BMP085_MODE_ULTRA_LOW_POWER;
+        return BMP085_SUCCESS;
+      }
+
+      PRINTF("BMP085: failed to enable\n");
+      return BMP085_ERROR;
+    } else {
+      enabled = 0;
+      return BMP085_SUCCESS;
+    }
+  } else if(type == BMP085_OVERSAMPLING) {
+    if((value < BMP085_MODE_ULTRA_LOW_POWER) ||
+       (value > BMP085_MODE_ULTRA_HIGH_RES)) {
+      PRINTF("BMP085: invalid oversampling value\n");
+      return BMP085_ERROR;
+    }
+    bmp085_values.oversampling_mode = value;
+    return BMP085_SUCCESS;
+  }
+
+  return BMP085_ERROR;
+}
+/*---------------------------------------------------------------------------*/
+static int
+status(int type)
+{
+  switch(type) {
+  case SENSORS_ACTIVE:
+  case SENSORS_READY:
+    return enabled;
+  }
+  return 0;
+}
+/*---------------------------------------------------------------------------*/
+static int
+bmp085_read_sensor(int32_t *value, uint8_t type)
+{
+  switch(type) {
+  case BMP085_READ_PRESSURE:
+    return bmp085_read_pressure(value);
+  case BMP085_READ_TEMP:
+    return bmp085_read_temperature((int16_t *)value);
+  }
+
+  return BMP085_ERROR;
+}
+/*---------------------------------------------------------------------------*/
+static int
+value(int type)
+{
+  int32_t value;
+
+  if(!enabled) {
+    PRINTF("BMP085: sensor not started\n");
+    return BMP085_ERROR;
+  }
+
+  if((type != BMP085_READ_PRESSURE) && (type != BMP085_READ_TEMP)) {
+    PRINTF("BMP085: invalid read value\n");
+    return BMP085_ERROR;
+  }
+
+  if(bmp085_read_sensor(&value, type) == BMP085_SUCCESS) {
+    return (int)value;
+  }
+
+  PRINTF("BMP085: fail to read\n");
+  return BMP085_ERROR;
+}
+/*---------------------------------------------------------------------------*/
+SENSORS_SENSOR(bmp085, BMP085_SENSOR, value, configure, status);
+/*---------------------------------------------------------------------------*/
+/** @} */

--- a/platform/zoul/dev/bmp085.h
+++ b/platform/zoul/dev/bmp085.h
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2015, Zolertia - http://www.zolertia.com
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * This file is part of the Contiki operating system.
+ *
+ */
+/*---------------------------------------------------------------------------*/
+/**
+ * \addtogroup zoul-sensors
+ * @{
+ *
+ * \defgroup zoul-bmp085-sensor BMP085 Sensor
+ *
+ * Driver for the BMP085 sensor
+ *
+ * BMP085 digital pressure and temperature driver
+ * @{
+ *
+ * \file
+ * Header file for the external BMP085 Sensor Driver
+ *
+ * \author
+ *         Antonio Lignan <alinan@zolertia.com>
+ */
+/*---------------------------------------------------------------------------*/
+#ifndef BMP085_H_
+#define BMP085_H_
+#include <stdio.h>
+#include "lib/sensors.h"
+#include "dev/zoul-sensors.h"
+#include "i2c.h"
+/* -------------------------------------------------------------------------- */
+/**
+ * \name BMP085 address and registers
+ * @{
+ */
+/* -------------------------------------------------------------------------- */
+#define BMP085_ADDR                      0x77
+/* -------------------------------------------------------------------------- */
+/* Control register */
+#define BMP085_CTRL_REG                  0xF4
+/* Read uncompensated temperature  */
+#define BMP085_CTRL_REG_TEMP             0x2E
+/* Read uncompensated pressure, no oversampling */
+#define BMP085_CTRL_REG_PRESS_4_5MS      0x34
+/* Read uncompensated pressure, oversampling 1*/
+#define BMP085_CTRL_REG_PRESS_7_5MS      0x74
+/* Read uncompensated pressure, oversampling 2 */
+#define BMP085_CTRL_REG_PRESS_13_5MS     0xB4
+/* Read uncompensated pressure, oversampling 3 */
+#define BMP085_CTRL_REG_PRESS_25_5MS     0xF4
+/* -------------------------------------------------------------------------- */
+#define BMP085_DATA_MSB                  0xF6
+#define BMP085_DATA_LSB                  0xF7
+/* 19-bit resolution */
+#define BMP085_DATA_XLSB                 0xF8
+/* -------------------------------------------------------------------------- */
+/* Calibration registers, 16-bit wide */
+#define BMP085_AC1_CALIB                 0xAA
+#define BMP085_AC2_CALIB                 0xAC
+#define BMP085_AC3_CALIB                 0xAE
+#define BMP085_AC4_CALIB                 0xB0
+#define BMP085_AC5_CALIB                 0xB2
+#define BMP085_AC6_CALIB                 0xB4
+#define BMP085_B1_CALIB                  0xB6
+#define BMP085_B2_CALIB                  0xB8
+#define BMP085_MB_CALIB                  0xBA
+#define BMP085_MC_CALIB                  0xBC
+#define BMP085_MD_CALIB                  0xBE
+#define BMP085_CALIB_TABLE_SIZE          22    /**< size in bytes */
+/** @} */
+/* -------------------------------------------------------------------------- */
+/**
+ * \name BMP085 operation modes
+ * @{
+ */
+#define BMP085_MODE_ULTRA_LOW_POWER      0x00
+#define BMP085_MODE_STANDARD             0x01
+#define BMP085_MODE_HIGH_RES             0x02
+#define BMP085_MODE_ULTRA_HIGH_RES       0x03
+/* -------------------------------------------------------------------------- */
+#define BMP085_DELAY_4_5MS               4700
+#define BMP085_DELAY_7_5MS               7700
+#define BMP085_DELAY_13_5MS              13700
+#define BMP085_DELAY_25_5MS              25700
+/** @} */
+/* -------------------------------------------------------------------------- */
+/**
+ * \name BMP085 return and command values
+ * @{
+ */
+#define BMP085_SUCCESS         0x00
+#define BMP085_ERROR             -1
+
+#define BMP085_ACTIVE          SENSORS_ACTIVE
+#define BMP085_OVERSAMPLING    0x00
+#define BMP085_READ_PRESSURE   0x01
+#define BMP085_READ_TEMP       0x02
+/** @} */
+/* -------------------------------------------------------------------------- */
+#define BMP085_SENSOR "BMP085 pressure and temperature sensor"
+/* -------------------------------------------------------------------------- */
+extern const struct sensors_sensor bmp085;
+/* -------------------------------------------------------------------------- */
+#endif
+/* -------------------------------------------------------------------------- */
+/**
+ * @}
+ * @}
+ */
+

--- a/platform/zoul/dev/motion-sensor.c
+++ b/platform/zoul/dev/motion-sensor.c
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2015, Zolertia <http://www.zolertia.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * This file is part of the Contiki operating system.
+ *
+ */
+/*---------------------------------------------------------------------------*/
+/**
+ * \addtogroup zoul-motion-sensor
+ * @{
+ *
+ * \file
+ *         Digital motion sensor driver
+ * \author
+ *         Antonio Lignan <alinan@zolertia.com>
+ */
+/*---------------------------------------------------------------------------*/
+#include <stdio.h>
+#include "contiki.h"
+#include "dev/i2c.h"
+#include "dev/motion-sensor.h"
+#include "lib/sensors.h"
+#include "dev/sys-ctrl.h"
+#include "dev/gpio.h"
+#include "dev/ioc.h"
+/*---------------------------------------------------------------------------*/
+#define DEBUG 1
+#if DEBUG
+#define PRINTF(...) printf(__VA_ARGS__)
+#else
+#define PRINTF(...)
+#endif
+/*---------------------------------------------------------------------------*/
+#define MOTION_SENSOR_PORT_BASE  GPIO_PORT_TO_BASE(MOTION_SENSOR_PORT)
+#define MOTION_SENSOR_PIN_MASK   GPIO_PIN_MASK(MOTION_SENSOR_PIN)
+/*---------------------------------------------------------------------------*/
+void (*presence_int_callback)(uint8_t value);
+/*---------------------------------------------------------------------------*/
+PROCESS(motion_int_process, "Motion interrupt process handler");
+/*---------------------------------------------------------------------------*/
+PROCESS_THREAD(motion_int_process, ev, data)
+{
+  PROCESS_EXITHANDLER();
+  PROCESS_BEGIN();
+
+  while(1) {
+    PROCESS_YIELD_UNTIL(ev == PROCESS_EVENT_POLL);
+    presence_int_callback(0);
+  }
+  PROCESS_END();
+}
+/*---------------------------------------------------------------------------*/
+static void
+motion_interrupt_handler(uint8_t port, uint8_t pin)
+{
+  process_poll(&motion_int_process);
+}
+/*---------------------------------------------------------------------------*/
+static int
+status(int type)
+{
+  return MOTION_SUCCESS;
+}
+/*---------------------------------------------------------------------------*/
+static int
+value(int type)
+{
+  return GPIO_READ_PIN(MOTION_SENSOR_PORT_BASE, MOTION_SENSOR_PIN_MASK);
+}
+/*---------------------------------------------------------------------------*/
+static int
+configure(int type, int value)
+{
+  if(type != MOTION_ACTIVE) {
+    PRINTF("Motion: invalid configuration option\n");
+    return MOTION_ERROR;
+  }
+
+  if(!value) {
+    presence_int_callback = NULL;
+    GPIO_DISABLE_INTERRUPT(MOTION_SENSOR_PORT_BASE, MOTION_SENSOR_PIN_MASK);
+    return MOTION_SUCCESS;
+  }
+
+  /* Configure interruption */
+  GPIO_SOFTWARE_CONTROL(MOTION_SENSOR_PORT_BASE, MOTION_SENSOR_PIN_MASK);
+  GPIO_SET_INPUT(MOTION_SENSOR_PORT_BASE, MOTION_SENSOR_PIN_MASK);
+  GPIO_DETECT_RISING(MOTION_SENSOR_PORT_BASE, MOTION_SENSOR_PIN_MASK);
+  GPIO_TRIGGER_SINGLE_EDGE(MOTION_SENSOR_PORT_BASE, MOTION_SENSOR_PIN_MASK);
+  ioc_set_over(MOTION_SENSOR_PORT, MOTION_SENSOR_PIN, IOC_OVERRIDE_DIS);
+  gpio_register_callback(motion_interrupt_handler, MOTION_SENSOR_PORT,
+                         MOTION_SENSOR_PIN);
+
+  process_start(&motion_int_process, NULL);
+
+  GPIO_ENABLE_INTERRUPT(MOTION_SENSOR_PORT_BASE, MOTION_SENSOR_PIN_MASK);
+  nvic_interrupt_enable(MOTION_SENSOR_VECTOR);
+  return MOTION_SUCCESS;
+}
+/*---------------------------------------------------------------------------*/
+SENSORS_SENSOR(motion_sensor, MOTION_SENSOR, value, configure, status);
+/*---------------------------------------------------------------------------*/
+/** @} */

--- a/platform/zoul/dev/motion-sensor.h
+++ b/platform/zoul/dev/motion-sensor.h
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2015, Zolertia <http://www.zolertia.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * This file is part of the Contiki operating system.
+ *
+ */
+/*---------------------------------------------------------------------------*/
+/**
+ * \addtogroup zoul-sensors
+ * @{
+ *
+ * \defgroup zoul-motion-sensor Digital motion sensor
+ * @{
+ *
+ * \file
+ *         Digital motion sensor header file
+ * \author
+ *         Antonio Lignan <alinan@zolertia.com>
+ */
+/*---------------------------------------------------------------------------*/
+#include "lib/sensors.h"
+/* -------------------------------------------------------------------------- */
+#ifndef SHT25_H_
+#define SHT25_H_
+/* -------------------------------------------------------------------------- */
+/**
+ * \name Motion sensor return and operation values
+ * @{
+ */
+#define MOTION_ACTIVE     SENSORS_ACTIVE
+#define MOTION_SUCCESS    0
+#define MOTION_ERROR      (-1)
+/** @} */
+/* -------------------------------------------------------------------------- */
+/**
+ * \name Motion sensor interrupt callback macro
+ * @{
+ */
+#define MOTION_REGISTER_INT(ptr) presence_int_callback = ptr;
+extern void (*presence_int_callback)(uint8_t value);
+/** @} */
+/* -------------------------------------------------------------------------- */
+#define MOTION_SENSOR "Digital motion sensor"
+/* -------------------------------------------------------------------------- */
+extern const struct sensors_sensor motion_sensor;
+/* -------------------------------------------------------------------------- */
+#endif /* ifndef MOTION_SENSOR_H_ */
+/**
+ * @}
+ * @}
+ */

--- a/platform/zoul/dev/sht25.c
+++ b/platform/zoul/dev/sht25.c
@@ -163,14 +163,14 @@ value(int type)
   }
 
   if((type != SHT25_VAL_TEMP) && (type != SHT25_VAL_HUM) &&
-    (type != SHT25_VOLTAGE_ALARM)) {
+     (type != SHT25_VOLTAGE_ALARM)) {
     PRINTF("SHT25: invalid value requested\n");
     return SHT25_ERROR;
   }
 
   if(type == SHT25_VOLTAGE_ALARM) {
     if(sht25_read_user_register() == SHT25_SUCCESS) {
-      return ((user_reg & SHT2x_LOW_VOLTAGE_MASK) >> SHT2x_LOW_VOLTAGE_SHIFT);
+      return (user_reg & SHT2x_LOW_VOLTAGE_MASK) >> SHT2x_LOW_VOLTAGE_SHIFT;
     }
   } else {
     if(sht25_read(type, &val) == SHT25_SUCCESS) {
@@ -186,52 +186,52 @@ configure(int type, int value)
   uint8_t buf[2];
 
   if((type != SHT25_ACTIVE) && (type != SHT25_SOFT_RESET) &&
-    (type != SHT25_RESOLUTION)) {
+     (type != SHT25_RESOLUTION)) {
     PRINTF("SHT25: option not supported\n");
     return SHT25_ERROR;
   }
 
   switch(type) {
-    case SHT25_ACTIVE:
-      if(value) {
-        i2c_init(I2C_SDA_PORT, I2C_SDA_PIN, I2C_SCL_PORT, I2C_SCL_PIN,
-                 I2C_SCL_NORMAL_BUS_SPEED);
+  case SHT25_ACTIVE:
+    if(value) {
+      i2c_init(I2C_SDA_PORT, I2C_SDA_PIN, I2C_SCL_PORT, I2C_SCL_PIN,
+               I2C_SCL_NORMAL_BUS_SPEED);
 
-        /* Read the user config register */
-        if(sht25_read_user_register() == SHT25_SUCCESS) {
-          enabled = value;
-          return SHT25_SUCCESS;
-        }
-      }
-
-    case SHT25_SOFT_RESET:
-      buf[0] = SHT2X_SOFT_RESET;
-      if(sht25_write_reg(&buf[0], 1) != SHT25_SUCCESS) {
-        PRINTF("SHT25: failed to reset the sensor\n");
-        return SHT25_ERROR;
-      }
-      clock_delay_usec(SHT25_RESET_DELAY);
-      return SHT25_SUCCESS;
-
-    case SHT25_RESOLUTION:
-      if((value != SHT2X_RES_14T_12RH) && (value != SHT2X_RES_12T_08RH) &&
-        (value != SHT2X_RES_13T_10RH) && (value != SHT2X_RES_11T_11RH)) {
-        PRINTF("SHT25: invalid resolution value\n");
-        return SHT25_ERROR;
-      }
-
-      user_reg &= ~SHT2X_RES_11T_11RH;
-      user_reg |= value;
-      buf[0] = SHT2X_UREG_WRITE;
-      buf[1] = user_reg;
-
-      if(sht25_write_reg(buf, 2) == SHT25_SUCCESS) {
-        PRINTF("SHT25: new user register value 0x%02X\n", user_reg);
+      /* Read the user config register */
+      if(sht25_read_user_register() == SHT25_SUCCESS) {
+        enabled = value;
         return SHT25_SUCCESS;
       }
+    }
 
-    default:
+  case SHT25_SOFT_RESET:
+    buf[0] = SHT2X_SOFT_RESET;
+    if(sht25_write_reg(&buf[0], 1) != SHT25_SUCCESS) {
+      PRINTF("SHT25: failed to reset the sensor\n");
       return SHT25_ERROR;
+    }
+    clock_delay_usec(SHT25_RESET_DELAY);
+    return SHT25_SUCCESS;
+
+  case SHT25_RESOLUTION:
+    if((value != SHT2X_RES_14T_12RH) && (value != SHT2X_RES_12T_08RH) &&
+       (value != SHT2X_RES_13T_10RH) && (value != SHT2X_RES_11T_11RH)) {
+      PRINTF("SHT25: invalid resolution value\n");
+      return SHT25_ERROR;
+    }
+
+    user_reg &= ~SHT2X_RES_11T_11RH;
+    user_reg |= value;
+    buf[0] = SHT2X_UREG_WRITE;
+    buf[1] = user_reg;
+
+    if(sht25_write_reg(buf, 2) == SHT25_SUCCESS) {
+      PRINTF("SHT25: new user register value 0x%02X\n", user_reg);
+      return SHT25_SUCCESS;
+    }
+
+  default:
+    return SHT25_ERROR;
   }
 
   return SHT25_ERROR;

--- a/platform/zoul/dev/sht25.c
+++ b/platform/zoul/dev/sht25.c
@@ -46,7 +46,7 @@
 #include "dev/sht25.h"
 #include "lib/sensors.h"
 /*---------------------------------------------------------------------------*/
-#define DEBUG 0
+#define DEBUG 1
 #if DEBUG
 #define PRINTF(...) printf(__VA_ARGS__)
 #else
@@ -54,23 +54,7 @@
 #endif
 /*---------------------------------------------------------------------------*/
 static uint8_t enabled;
-/*---------------------------------------------------------------------------*/
-static int
-configure(int type, int value)
-{
-  if(type != SENSORS_ACTIVE) {
-    PRINTF("SHT25: option not supported\n");
-    return SHT25_ERROR;
-  }
-
-  if(value) {
-    i2c_init(I2C_SDA_PORT, I2C_SDA_PIN, I2C_SCL_PORT, I2C_SCL_PIN,
-             I2C_SCL_NORMAL_BUS_SPEED);
-  }
-
-  enabled = value;
-  return SHT25_SUCCESS;
-}
+static uint8_t user_reg;
 /*---------------------------------------------------------------------------*/
 static int
 status(int type)
@@ -84,11 +68,15 @@ status(int type)
 }
 /*---------------------------------------------------------------------------*/
 static uint16_t
-sht25_read_reg(uint8_t reg, uint8_t *buf, uint8_t regNum)
+sht25_read_reg(uint8_t reg, uint8_t *buf, uint8_t num)
 {
+  if((buf == NULL) || (num <= 0)) {
+    return SHT25_ERROR;
+  }
+
   i2c_master_enable();
   if(i2c_single_send(SHT25_ADDR, reg) == I2C_MASTER_ERR_NONE) {
-    if(i2c_burst_receive(SHT25_ADDR, buf, regNum) == I2C_MASTER_ERR_NONE) {
+    if(i2c_burst_receive(SHT25_ADDR, buf, num) == I2C_MASTER_ERR_NONE) {
       return SHT25_SUCCESS;
     }
   }
@@ -100,7 +88,10 @@ sht25_convert(uint8_t variable, uint16_t value)
 {
   int16_t rd;
   uint32_t buff;
-  buff = (uint32_t)value;
+
+  /* Clear the status bits */
+  buff = (uint32_t)(value & ~SHT25_STATUS_BITS_MASK);
+
   if(variable == SHT25_VAL_TEMP) {
     buff *= 17572;
     buff = buff >> 16;
@@ -114,7 +105,7 @@ sht25_convert(uint8_t variable, uint16_t value)
   return rd;
 }
 /*---------------------------------------------------------------------------*/
-static int16_t
+static int
 sht25_read(uint8_t variable, uint16_t *rd)
 {
   uint8_t buf[2];
@@ -136,6 +127,32 @@ sht25_read(uint8_t variable, uint16_t *rd)
 }
 /*---------------------------------------------------------------------------*/
 static int
+sht25_write_reg(uint8_t *buf, uint8_t num)
+{
+  if((buf == NULL) || (num <= 0)) {
+    PRINTF("SHT25: invalid write values\n");
+    return SHT25_ERROR;
+  }
+
+  i2c_master_enable();
+  if(i2c_burst_send(SHT25_ADDR, buf, num) == I2C_MASTER_ERR_NONE) {
+    return SHT25_SUCCESS;
+  }
+  return SHT25_ERROR;
+}
+/*---------------------------------------------------------------------------*/
+static int
+sht25_read_user_register(void)
+{
+  if(sht25_read_reg(SHT2X_UREG_READ, &user_reg, 1) == SHT25_SUCCESS) {
+    PRINTF("SHT25: user register 0x%02X\n", user_reg);
+    return SHT25_SUCCESS;
+  }
+  PRINTF("SHT25: failed to read user register\n");
+  return SHT25_ERROR;
+}
+/*---------------------------------------------------------------------------*/
+static int
 value(int type)
 {
   uint16_t val;
@@ -145,9 +162,78 @@ value(int type)
     return SHT25_ERROR;
   }
 
-  if(sht25_read(type, &val) == SHT25_SUCCESS) {
-    return val;
+  if((type != SHT25_VAL_TEMP) && (type != SHT25_VAL_HUM) &&
+    (type != SHT25_VOLTAGE_ALARM)) {
+    PRINTF("SHT25: invalid value requested\n");
+    return SHT25_ERROR;
   }
+
+  if(type == SHT25_VOLTAGE_ALARM) {
+    if(sht25_read_user_register() == SHT25_SUCCESS) {
+      return ((user_reg & SHT2x_LOW_VOLTAGE_MASK) >> SHT2x_LOW_VOLTAGE_SHIFT);
+    }
+  } else {
+    if(sht25_read(type, &val) == SHT25_SUCCESS) {
+      return val;
+    }
+  }
+  return SHT25_ERROR;
+}
+/*---------------------------------------------------------------------------*/
+static int
+configure(int type, int value)
+{
+  uint8_t buf[2];
+
+  if((type != SHT25_ACTIVE) && (type != SHT25_SOFT_RESET) &&
+    (type != SHT25_RESOLUTION)) {
+    PRINTF("SHT25: option not supported\n");
+    return SHT25_ERROR;
+  }
+
+  switch(type) {
+    case SHT25_ACTIVE:
+      if(value) {
+        i2c_init(I2C_SDA_PORT, I2C_SDA_PIN, I2C_SCL_PORT, I2C_SCL_PIN,
+                 I2C_SCL_NORMAL_BUS_SPEED);
+
+        /* Read the user config register */
+        if(sht25_read_user_register() == SHT25_SUCCESS) {
+          enabled = value;
+          return SHT25_SUCCESS;
+        }
+      }
+
+    case SHT25_SOFT_RESET:
+      buf[0] = SHT2X_SOFT_RESET;
+      if(sht25_write_reg(&buf[0], 1) != SHT25_SUCCESS) {
+        PRINTF("SHT25: failed to reset the sensor\n");
+        return SHT25_ERROR;
+      }
+      clock_delay_usec(SHT25_RESET_DELAY);
+      return SHT25_SUCCESS;
+
+    case SHT25_RESOLUTION:
+      if((value != SHT2X_RES_14T_12RH) && (value != SHT2X_RES_12T_08RH) &&
+        (value != SHT2X_RES_13T_10RH) && (value != SHT2X_RES_11T_11RH)) {
+        PRINTF("SHT25: invalid resolution value\n");
+        return SHT25_ERROR;
+      }
+
+      user_reg &= ~SHT2X_RES_11T_11RH;
+      user_reg |= value;
+      buf[0] = SHT2X_UREG_WRITE;
+      buf[1] = user_reg;
+
+      if(sht25_write_reg(buf, 2) == SHT25_SUCCESS) {
+        PRINTF("SHT25: new user register value 0x%02X\n", user_reg);
+        return SHT25_SUCCESS;
+      }
+
+    default:
+      return SHT25_ERROR;
+  }
+
   return SHT25_ERROR;
 }
 /*---------------------------------------------------------------------------*/

--- a/platform/zoul/dev/sht25.h
+++ b/platform/zoul/dev/sht25.h
@@ -44,34 +44,43 @@
  */
 /*---------------------------------------------------------------------------*/
 #include "lib/sensors.h"
-
+/* -------------------------------------------------------------------------- */
 #ifndef SHT25_H_
 #define SHT25_H_
+/* -------------------------------------------------------------------------- */
+#define SHT25_ADDR              0x40
+#define SHT25_TEMP_HOLD         0xE3
+#define SHT25_HUM_HOLD          0xE5
+#define SHT25_TEMP_NO_HOLD      0xF3
+#define SHT25_HUM_NO_HOLD       0xF5
+#define SHT2X_UREG_WRITE        0xE6
+#define SHT2X_UREG_READ         0xE7
+#define SHT2X_SOFT_RESET        0XFE
+#define SHT2X_NULL              0x00
+/* -------------------------------------------------------------------------- */
+#define SHT2X_RES_14T_12RH      0x00
+#define SHT2X_RES_12T_08RH      0x01
+#define SHT2X_RES_13T_10RH      0x80
+#define SHT2X_RES_11T_11RH      0x81
+#define SHT2X_HEATER_ON         0x04
+#define SHT2X_HEATER_OFF        0x00
+#define SHT2X_OTP_RELOAD_EN     0x00
+#define SHT2X_OTP_RELOAD_DIS    0x02
+#define SHT2x_LOW_VOLTAGE_MASK  0x40
+#define SHT2x_LOW_VOLTAGE_SHIFT 0x06
+/* -------------------------------------------------------------------------- */
+#define SHT25_ACTIVE            SENSORS_ACTIVE
+#define SHT25_SOFT_RESET        0x01
+#define SHT25_RESOLUTION        0x02
 
-/* -------------------------------------------------------------------------- */
-#define SHT25_ADDR            0x40
-#define SHT25_TEMP_HOLD       0xE3
-#define SHT25_HUM_HOLD        0xE5
-#define SHT25_TEMP_NO_HOLD    0xF3
-#define SHT25_HUM_NO_HOLD     0xF5
-#define SHT2X_UREG_WRITE      0xE6
-#define SHT2X_UREG_READ       0xE7
-#define SHT2X_SOFT_RESET      0XFE
-#define SHT2X_NULL            0x00
-/* -------------------------------------------------------------------------- */
-#define SHT2X_RES_14T_12RH    0x00
-#define SHT2X_RES_12T_08RH    0x01
-#define SHT2X_RES_13T_10RH    0x80
-#define SHT2X_RES_11T_11RH    0x81
-#define SHT2X_HEATER_ON       0x04
-#define SHT2X_HEATER_OFF      0x00
-#define SHT2X_OTP_RELOAD_EN   0x00
-#define SHT2X_OTP_RELOAD_DIS  0x02
-/* -------------------------------------------------------------------------- */
-#define SHT25_VAL_TEMP        SHT25_TEMP_HOLD
-#define SHT25_VAL_HUM         SHT25_HUM_HOLD
-#define SHT25_ERROR           -1
-#define SHT25_SUCCESS         0x00
+#define SHT25_VAL_TEMP          SHT25_TEMP_HOLD
+#define SHT25_VAL_HUM           SHT25_HUM_HOLD
+#define SHT25_VOLTAGE_ALARM     0x01
+
+#define SHT25_ERROR             (-1)
+#define SHT25_SUCCESS           0x00
+#define SHT25_RESET_DELAY       15000
+#define SHT25_STATUS_BITS_MASK  0x0003
 /* -------------------------------------------------------------------------- */
 #define SHT25_SENSOR "SHT25 Sensor"
 /* -------------------------------------------------------------------------- */


### PR DESCRIPTION
This PR enables support for PIR-based digital motion sensors, based on driving a signal low/high when motion is detected.  This driver has been tested with the [Seeedstudio's PIR motion sensor](http://www.seeedstudio.com/depot/PIR-Motion-Sensor-Large-Lens-version-p-1976.html) and [IRTEC 550LP sensor](http://www.irtec.com/en/pirtybvi.asp?PagNO=1&PcID=60&fxfID=49&Mde=V)

This PR depends on #1454 