### PR TITLE
Fixed loading SerialSocketServer plugin in Cooja using FQDN

### DIFF
--- a/examples/er-rest-example/server-client-native.csc
+++ b/examples/er-rest-example/server-client-native.csc
@@ -219,7 +219,7 @@
     <location_y>182</location_y>
   </plugin>
   <plugin>
-    SerialSocketServer
+    org.contikios.cooja.serialsocket.SerialSocketServer
     <mote_arg>0</mote_arg>
     <width>422</width>
     <z>1</z>

--- a/examples/er-rest-example/server-client.csc
+++ b/examples/er-rest-example/server-client.csc
@@ -188,7 +188,7 @@
     <minimized>true</minimized>
   </plugin>
   <plugin>
-    SerialSocketServer
+    org.contikios.cooja.serialsocket.SerialSocketServer
     <mote_arg>0</mote_arg>
     <width>422</width>
     <z>4</z>

--- a/examples/er-rest-example/server-only.csc
+++ b/examples/er-rest-example/server-only.csc
@@ -151,7 +151,7 @@
     <minimized>true</minimized>
   </plugin>
   <plugin>
-    SerialSocketServer
+    org.contikios.cooja.serialsocket.SerialSocketServer
     <mote_arg>0</mote_arg>
     <width>422</width>
     <z>4</z>

--- a/examples/ipv6/sky-websense/example-sky-websense.csc
+++ b/examples/ipv6/sky-websense/example-sky-websense.csc
@@ -196,7 +196,7 @@
     <location_y>-1</location_y>
   </plugin>
   <plugin>
-    SerialSocketServer
+    org.contikios.cooja.serialsocket.SerialSocketServer
     <mote_arg>0</mote_arg>
     <width>422</width>
     <z>1</z>

--- a/examples/zolertia/z1/ipv6/z1-websense/example-sky-websense.csc
+++ b/examples/zolertia/z1/ipv6/z1-websense/example-sky-websense.csc
@@ -196,7 +196,7 @@
     <location_y>-1</location_y>
   </plugin>
   <plugin>
-    SerialSocketServer
+    org.contikios.cooja.serialsocket.SerialSocketServer
     <mote_arg>0</mote_arg>
     <width>422</width>
     <z>1</z>

--- a/regression-tests/13-ipv6-apps/x02-sky-coap.csc
+++ b/regression-tests/13-ipv6-apps/x02-sky-coap.csc
@@ -141,7 +141,7 @@
     <minimized>true</minimized>
   </plugin>
   <plugin>
-    SerialSocketServer
+    org.contikios.cooja.serialsocket.SerialSocketServer
     <mote_arg>0</mote_arg>
     <width>428</width>
     <z>4</z>


### PR DESCRIPTION
Loading examples using the SerialSocketServer plugin in Cooja failed. This was because of using SerialSocketServer instead of the full name org.contikios.cooja.serialsocket.SerialSocketServer. This patch fixed the problem on my side.

To reproduce the failure:
1.) Launch cooja (ant run)
2.) Load e.g. examples/ipv6/sky-websense/example-sky-websense.csc
3.) On the command prompt you should see an error on loading SerialSocketServer
4.) Setup tunslip (e.g. make connect-router-cooja) will fail without this patch