### PR TITLE
Fixed using target AVR ATmega128RFA1

### DIFF
--- a/platform/avr-atmega128rfa1/Makefile.avr-atmega128rfa1
+++ b/platform/avr-atmega128rfa1/Makefile.avr-atmega128rfa1
@@ -9,7 +9,7 @@ CONTIKI_TARGET_SOURCEFILES += button-sensor.c sensors.c slip_uart0.c slip.c
 CONTIKIAVR=$(CONTIKI)/cpu/avr
 CONTIKIBOARD=.
 
-CONTIKI_PLAT_DEFS = -DF_CPU=8000000UL -DAUTO_CRC_PADDING=2
+CONTIKI_PLAT_DEFS = -DF_CPU=16000000UL -DAUTO_CRC_PADDING=2
 
 MCU=atmega128rfa1
 
@@ -31,4 +31,4 @@ AVRDUDE_MCU=m128rfa1
 
 include $(CONTIKIAVR)/Makefile.avr
 include $(CONTIKIAVR)/radio/Makefile.radio
-MODULES += core/net/mac core/net core/net/mac/sicslowmac core/net/mac/contikimac
+MODULES += core/net/mac core/net core/net/mac/sicslowmac core/net/mac/contikimac core/net/llsec

--- a/platform/avr-atmega128rfa1/contiki-conf.h
+++ b/platform/avr-atmega128rfa1/contiki-conf.h
@@ -45,7 +45,7 @@
 #define PLATFORM_NAME  "RFA1"
 #define PLATFORM_TYPE  ATMEGA128RFA1
 #ifndef F_CPU
-#define F_CPU          8000000UL
+#define F_CPU          16000000UL
 #endif
 
 #include <stdint.h>


### PR DESCRIPTION
Set operating speed to 16MHz and added missing dependency to llsec.
This fix was tested with sparkfun ATmega128RFA1 Dev Board.