### PR TITLE
Removed harsh restriction on mask values and disabled debug flags

### DIFF
--- a/platform/zoul/dev/adc-sensors.c
+++ b/platform/zoul/dev/adc-sensors.c
@@ -49,7 +49,7 @@
 #include <stdio.h>
 #include <stdint.h>
 /*---------------------------------------------------------------------------*/
-#define DEBUG 1
+#define DEBUG 0
 #if DEBUG
 #define PRINTF(...) printf(__VA_ARGS__)
 #else

--- a/platform/zoul/dev/adc-zoul.c
+++ b/platform/zoul/dev/adc-zoul.c
@@ -48,7 +48,7 @@
 #include <stdio.h>
 #include <stdint.h>
 /*---------------------------------------------------------------------------*/
-#define DEBUG 1
+#define DEBUG 0
 #if DEBUG
 #define PRINTF(...) printf(__VA_ARGS__)
 #else
@@ -133,13 +133,6 @@ configure(int type, int value)
     /* This should filter out disabled sensors as its value should be zero */
     if((value < ZOUL_SENSORS_ADC_MIN) || (value > ZOUL_SENSORS_ADC_ALL)) {
       PRINTF("ADC: invalid adc pin mask (0x%02X)\n", value);
-      return ZOUL_SENSORS_ERROR;
-    }
-
-    if((value != ZOUL_SENSORS_ADC1) && (value != ZOUL_SENSORS_ADC2) &&
-       (value != ZOUL_SENSORS_ADC3) && (value != ZOUL_SENSORS_ADC4) &&
-       (value != ZOUL_SENSORS_ADC5)) {
-      PRINTF("ADC: invalid adc pin mask\n");
       return ZOUL_SENSORS_ERROR;
     }
 


### PR DESCRIPTION
Fixes mask OR'ed values being treated as invalid due to restrictive check, leftover from a previous commit