### PR TITLE
Unified BMP180 and BMP085 drivers

### DIFF
--- a/examples/zolertia/zoul/Makefile
+++ b/examples/zolertia/zoul/Makefile
@@ -1,11 +1,11 @@
 DEFINES+=PROJECT_CONF_H=\"project-conf.h\"
 
 CONTIKI_PROJECT = zoul-demo test-tsl2563 test-sht25 test-pwm test-power-mgmt
-CONTIKI_PROJECT += test-bmp085 test-motion test-rotation-sensor
+CONTIKI_PROJECT += test-bmp085-bmp180 test-motion test-rotation-sensor
 CONTIKI_PROJECT += test-grove-light-sensor test-grove-loudness-sensor
 CONTIKI_PROJECT += test-weather-meter
 
-CONTIKI_TARGET_SOURCEFILES += tsl2563.c sht25.c bmp085.c motion-sensor.c
+CONTIKI_TARGET_SOURCEFILES += tsl2563.c sht25.c bmpx8x.c motion-sensor.c
 CONTIKI_TARGET_SOURCEFILES += adc-sensors.c weather-meter.c
 
 all: $(CONTIKI_PROJECT)

--- a/examples/zolertia/zoul/test-bmp085-bmp180.c
+++ b/examples/zolertia/zoul/test-bmp085-bmp180.c
@@ -32,13 +32,13 @@
  * \addtogroup zoul-examples
  * @{
  *
- * \defgroup zoul-bmp085-test BMP085 pressure and temperature sensor test
+ * \defgroup zoul-bmpx8x-test BMP085/BMP180 pressure and temperature sensor test
  *
- * Demonstrates the use of the BMP085 digital pressure and temperature sensor
+ * Demonstrates the use of the BMP085/BMP180 pressure and temperature sensor
  * @{
  *
  * \file
- *  Test file for the BMP085 digital pressure and temperature sensor
+ *  Test file for the BMP085/BMP180 digital pressure and temperature sensor
  *
  * \author
  *         Antonio Lignan <alinan@zolertia.com>
@@ -48,23 +48,23 @@
 #include "contiki.h"
 #include "dev/i2c.h"
 #include "dev/leds.h"
-#include "dev/bmp085.h"
+#include "dev/bmpx8x.h"
 /*---------------------------------------------------------------------------*/
 #define SENSOR_READ_INTERVAL (CLOCK_SECOND)
 /*---------------------------------------------------------------------------*/
-PROCESS(remote_bmp085_process, "BMP085 test process");
-AUTOSTART_PROCESSES(&remote_bmp085_process);
+PROCESS(remote_bmpx8x_process, "BMP085/BMP180 test process");
+AUTOSTART_PROCESSES(&remote_bmpx8x_process);
 /*---------------------------------------------------------------------------*/
 static struct etimer et;
 /*---------------------------------------------------------------------------*/
-PROCESS_THREAD(remote_bmp085_process, ev, data)
+PROCESS_THREAD(remote_bmpx8x_process, ev, data)
 {
   PROCESS_BEGIN();
   static uint16_t pressure;
   static int16_t temperature;
 
   /* Use Contiki's sensor macro to enable the sensor */
-  SENSORS_ACTIVATE(bmp085);
+  SENSORS_ACTIVATE(bmpx8x);
 
   /* And periodically poll the sensor */
 
@@ -72,14 +72,14 @@ PROCESS_THREAD(remote_bmp085_process, ev, data)
     etimer_set(&et, SENSOR_READ_INTERVAL);
     PROCESS_WAIT_EVENT_UNTIL(etimer_expired(&et));
 
-    pressure = bmp085.value(BMP085_READ_PRESSURE);
-    temperature = bmp085.value(BMP085_READ_TEMP);
+    pressure = bmpx8x.value(BMPx8x_READ_PRESSURE);
+    temperature = bmpx8x.value(BMPx8x_READ_TEMP);
 
-    if((pressure != BMP085_ERROR) && (temperature != BMP085_ERROR)) {
+    if((pressure != BMPx8x_ERROR) && (temperature != BMPx8x_ERROR)) {
       printf("Pressure = %u.%u(hPa), ", pressure / 10, pressure % 10);
       printf("Temperature = %d.%u(ºC)\n", temperature / 10, temperature % 10);
     } else {
-      printf("Error, enable the DEBUG flag in the BMP085 driver for info, ");
+      printf("Error, enable the DEBUG flag in the BMPx8x driver for info, ");
       printf("or check if the sensor is properly connected\n");
       PROCESS_EXIT();
     }

--- a/platform/zoul/dev/bmpx8x.c
+++ b/platform/zoul/dev/bmpx8x.c
@@ -29,13 +29,13 @@
  */
 /*---------------------------------------------------------------------------*/
 /**
- * \addtogroup zoul-bmp085-sensor
+ * \addtogroup zoul-bmpx8x-sensor
  * @{
  *
- * BMP085 driver implementation
+ * BMP085/BMP180 driver implementation
  *
  * \file
- *  Driver for the external BMP085 light sensor
+ *  Driver for the external BMP085/BMP180 atmospheric pressure sensor
  *
  * \author
  *         Antonio Lignan <alinan@zolertia.com>
@@ -46,7 +46,7 @@
 #include "dev/gpio.h"
 #include "dev/zoul-sensors.h"
 #include "lib/sensors.h"
-#include "bmp085.h"
+#include "bmpx8x.h"
 /*---------------------------------------------------------------------------*/
 #define DEBUG 0
 #if DEBUG
@@ -69,179 +69,179 @@ typedef struct {
   int16_t mb;
   int16_t mc;
   int16_t md;
-} bmp085_calibration_values;
+} bmpx8x_calibration_values;
 
 typedef struct {
   uint8_t oversampling_mode;
   int32_t b5;
-  bmp085_calibration_values calib;
-} bmp085_config;
+  bmpx8x_calibration_values calib;
+} bmpx8x_config;
 
-static bmp085_config bmp085_values;
+static bmpx8x_config bmpx8x_values;
 /*---------------------------------------------------------------------------*/
 static int
-bmp085_read_reg(uint8_t reg, uint8_t *buf, uint8_t num)
+bmpx8x_read_reg(uint8_t reg, uint8_t *buf, uint8_t num)
 {
   if((buf == NULL) || (num <= 0)) {
-    PRINTF("BMP085: invalid read values\n");
-    return BMP085_ERROR;
+    PRINTF("BMPx8x: invalid read values\n");
+    return BMPx8x_ERROR;
   }
 
   i2c_master_enable();
-  if(i2c_single_send(BMP085_ADDR, reg) == I2C_MASTER_ERR_NONE) {
+  if(i2c_single_send(BMPx8x_ADDR, reg) == I2C_MASTER_ERR_NONE) {
     while(i2c_master_busy());
-    if(i2c_burst_receive(BMP085_ADDR, buf, num) == I2C_MASTER_ERR_NONE) {
-      return BMP085_SUCCESS;
+    if(i2c_burst_receive(BMPx8x_ADDR, buf, num) == I2C_MASTER_ERR_NONE) {
+      return BMPx8x_SUCCESS;
     }
   }
-  return BMP085_ERROR;
+  return BMPx8x_ERROR;
 }
 /*---------------------------------------------------------------------------*/
 static int
-bmp085_write_reg(uint8_t *buf, uint8_t num)
+bmpx8x_write_reg(uint8_t *buf, uint8_t num)
 {
   if((buf == NULL) || (num <= 0)) {
-    PRINTF("BMP085: invalid write values\n");
-    return BMP085_ERROR;
+    PRINTF("BMPx8x: invalid write values\n");
+    return BMPx8x_ERROR;
   }
 
   i2c_master_enable();
-  if(i2c_burst_send(BMP085_ADDR, buf, num) == I2C_MASTER_ERR_NONE) {
-    return BMP085_SUCCESS;
+  if(i2c_burst_send(BMPx8x_ADDR, buf, num) == I2C_MASTER_ERR_NONE) {
+    return BMPx8x_SUCCESS;
   }
-  return BMP085_ERROR;
+  return BMPx8x_ERROR;
 }
 /*---------------------------------------------------------------------------*/
 static int
-bmp085_read_calib(void)
+bmpx8x_read_calib(void)
 {
-  uint8_t buf[BMP085_CALIB_TABLE_SIZE];
+  uint8_t buf[BMPx8x_CALIB_TABLE_SIZE];
 
-  if(bmp085_read_reg(BMP085_AC1_CALIB, buf,
-                     BMP085_CALIB_TABLE_SIZE) == BMP085_SUCCESS) {
+  if(bmpx8x_read_reg(BMPx8x_AC1_CALIB, buf,
+                     BMPx8x_CALIB_TABLE_SIZE) == BMPx8x_SUCCESS) {
 
     /*  MSB first */
-    bmp085_values.calib.ac1 = ((buf[0] << 8) + buf[1]);
-    bmp085_values.calib.ac2 = ((buf[2] << 8) + buf[3]);
-    bmp085_values.calib.ac3 = ((buf[4] << 8) + buf[5]);
-    bmp085_values.calib.ac4 = ((buf[6] << 8) + buf[7]);
-    bmp085_values.calib.ac5 = ((buf[8] << 8) + buf[9]);
-    bmp085_values.calib.ac6 = ((buf[10] << 8) + buf[11]);
-    bmp085_values.calib.b1 = ((buf[12] << 8) + buf[13]);
-    bmp085_values.calib.b2 = ((buf[14] << 8) + buf[15]);
-    bmp085_values.calib.mb = ((buf[16] << 8) + buf[17]);
-    bmp085_values.calib.mc = ((buf[18] << 8) + buf[19]);
-    bmp085_values.calib.md = ((buf[20] << 8) + buf[21]);
+    bmpx8x_values.calib.ac1 = ((buf[0] << 8) + buf[1]);
+    bmpx8x_values.calib.ac2 = ((buf[2] << 8) + buf[3]);
+    bmpx8x_values.calib.ac3 = ((buf[4] << 8) + buf[5]);
+    bmpx8x_values.calib.ac4 = ((buf[6] << 8) + buf[7]);
+    bmpx8x_values.calib.ac5 = ((buf[8] << 8) + buf[9]);
+    bmpx8x_values.calib.ac6 = ((buf[10] << 8) + buf[11]);
+    bmpx8x_values.calib.b1 = ((buf[12] << 8) + buf[13]);
+    bmpx8x_values.calib.b2 = ((buf[14] << 8) + buf[15]);
+    bmpx8x_values.calib.mb = ((buf[16] << 8) + buf[17]);
+    bmpx8x_values.calib.mc = ((buf[18] << 8) + buf[19]);
+    bmpx8x_values.calib.md = ((buf[20] << 8) + buf[21]);
 
-    return BMP085_SUCCESS;
+    return BMPx8x_SUCCESS;
   }
 
-  PRINTF("BMP085: failed to read calibration\n");
-  return BMP085_ERROR;
+  PRINTF("BMPx8x: failed to read calibration\n");
+  return BMPx8x_ERROR;
 }
 /*---------------------------------------------------------------------------*/
 static int
-bmp085_read_uncompensated_pressure(int32_t *pressure)
+bmpx8x_read_uncompensated_pressure(int32_t *pressure)
 {
   uint8_t buf[3];
   uint16_t delay;
   int32_t upres;
 
-  buf[0] = BMP085_CTRL_REG;
+  buf[0] = BMPx8x_CTRL_REG;
 
-  switch(bmp085_values.oversampling_mode) {
-  case BMP085_MODE_ULTRA_LOW_POWER:
-    buf[1] = BMP085_CTRL_REG_PRESS_4_5MS;
-    delay = BMP085_DELAY_4_5MS;
+  switch(bmpx8x_values.oversampling_mode) {
+  case BMPx8x_MODE_ULTRA_LOW_POWER:
+    buf[1] = BMPx8x_CTRL_REG_PRESS_4_5MS;
+    delay = BMPx8x_DELAY_4_5MS;
     break;
-  case BMP085_MODE_STANDARD:
-    buf[1] = BMP085_CTRL_REG_PRESS_7_5MS;
-    delay = BMP085_DELAY_7_5MS;
+  case BMPx8x_MODE_STANDARD:
+    buf[1] = BMPx8x_CTRL_REG_PRESS_7_5MS;
+    delay = BMPx8x_DELAY_7_5MS;
     break;
-  case BMP085_MODE_HIGH_RES:
-    buf[1] = BMP085_CTRL_REG_PRESS_13_5MS;
-    delay = BMP085_DELAY_13_5MS;
+  case BMPx8x_MODE_HIGH_RES:
+    buf[1] = BMPx8x_CTRL_REG_PRESS_13_5MS;
+    delay = BMPx8x_DELAY_13_5MS;
     break;
-  case BMP085_MODE_ULTRA_HIGH_RES:
-    buf[1] = BMP085_CTRL_REG_PRESS_25_5MS;
-    delay = BMP085_DELAY_25_5MS;
+  case BMPx8x_MODE_ULTRA_HIGH_RES:
+    buf[1] = BMPx8x_CTRL_REG_PRESS_25_5MS;
+    delay = BMPx8x_DELAY_25_5MS;
     break;
   default:
-    return BMP085_ERROR;
+    return BMPx8x_ERROR;
   }
 
-  if(bmp085_write_reg(buf, 2) == BMP085_SUCCESS) {
+  if(bmpx8x_write_reg(buf, 2) == BMPx8x_SUCCESS) {
     clock_delay_usec(delay);
-    if(bmp085_read_reg(BMP085_DATA_MSB, buf, 3) == BMP085_SUCCESS) {
+    if(bmpx8x_read_reg(BMPx8x_DATA_MSB, buf, 3) == BMPx8x_SUCCESS) {
       upres = (buf[0] << 16) + (buf[1] << 8) + buf[2];
-      *pressure = (upres >> (8 - bmp085_values.oversampling_mode));
-      return BMP085_SUCCESS;
+      *pressure = (upres >> (8 - bmpx8x_values.oversampling_mode));
+      return BMPx8x_SUCCESS;
     }
   }
-  return BMP085_ERROR;
+  return BMPx8x_ERROR;
 }
 /*---------------------------------------------------------------------------*/
 static int
-bmp085_read_uncompensated_temperature(int32_t *temp)
+bmpx8x_read_uncompensated_temperature(int32_t *temp)
 {
   uint8_t buf[2];
-  buf[0] = BMP085_CTRL_REG;
-  buf[1] = BMP085_CTRL_REG_TEMP;
+  buf[0] = BMPx8x_CTRL_REG;
+  buf[1] = BMPx8x_CTRL_REG_TEMP;
 
-  if(bmp085_write_reg(buf, 2) == BMP085_SUCCESS) {
-    clock_delay_usec(BMP085_DELAY_4_5MS);
-    if(bmp085_read_reg(BMP085_DATA_MSB, buf, 2) == BMP085_SUCCESS) {
+  if(bmpx8x_write_reg(buf, 2) == BMPx8x_SUCCESS) {
+    clock_delay_usec(BMPx8x_DELAY_4_5MS);
+    if(bmpx8x_read_reg(BMPx8x_DATA_MSB, buf, 2) == BMPx8x_SUCCESS) {
       *temp = (int32_t)((buf[0] << 8) + buf[1]);
-      return BMP085_SUCCESS;
+      return BMPx8x_SUCCESS;
     }
   }
-  return BMP085_ERROR;
+  return BMPx8x_ERROR;
 }
 /*---------------------------------------------------------------------------*/
 static int
-bmp085_read_temperature(int16_t *temp)
+bmpx8x_read_temperature(int16_t *temp)
 {
   int32_t ut = 0;
   int32_t x1, x2;
 
-  if(bmp085_read_uncompensated_temperature(&ut) == BMP085_ERROR) {
-    return BMP085_ERROR;
+  if(bmpx8x_read_uncompensated_temperature(&ut) == BMPx8x_ERROR) {
+    return BMPx8x_ERROR;
   }
 
-  x1 = ((int32_t)ut - (int32_t)bmp085_values.calib.ac6)
-    * (int32_t)bmp085_values.calib.ac5 >> 15;
-  x2 = ((int32_t)bmp085_values.calib.mc << 11) / (x1 + bmp085_values.calib.md);
-  bmp085_values.b5 = x1 + x2;
-  *temp = (int16_t)((bmp085_values.b5 + 8) >> 4);
-  return BMP085_SUCCESS;
+  x1 = ((int32_t)ut - (int32_t)bmpx8x_values.calib.ac6)
+    * (int32_t)bmpx8x_values.calib.ac5 >> 15;
+  x2 = ((int32_t)bmpx8x_values.calib.mc << 11) / (x1 + bmpx8x_values.calib.md);
+  bmpx8x_values.b5 = x1 + x2;
+  *temp = (int16_t)((bmpx8x_values.b5 + 8) >> 4);
+  return BMPx8x_SUCCESS;
 }
 /*---------------------------------------------------------------------------*/
 static int
-bmp085_read_pressure(int32_t *pressure)
+bmpx8x_read_pressure(int32_t *pressure)
 {
   int32_t ut = 0;
   int32_t up = 0;
   int32_t x1, x2, b6, x3, b3, p;
   uint32_t b4, b7;
 
-  if(bmp085_read_uncompensated_pressure(&up) == BMP085_ERROR) {
-    return BMP085_ERROR;
+  if(bmpx8x_read_uncompensated_pressure(&up) == BMPx8x_ERROR) {
+    return BMPx8x_ERROR;
   }
 
-  if(bmp085_read_uncompensated_temperature(&ut) == BMP085_ERROR) {
-    return BMP085_ERROR;
+  if(bmpx8x_read_uncompensated_temperature(&ut) == BMPx8x_ERROR) {
+    return BMPx8x_ERROR;
   }
 
-  b6 = bmp085_values.b5 - 4000;
-  x1 = (bmp085_values.calib.b2 * (b6 * b6 >> 12)) >> 11;
-  x2 = bmp085_values.calib.ac2 * b6 >> 11;
+  b6 = bmpx8x_values.b5 - 4000;
+  x1 = (bmpx8x_values.calib.b2 * (b6 * b6 >> 12)) >> 11;
+  x2 = bmpx8x_values.calib.ac2 * b6 >> 11;
   x3 = x1 + x2;
-  b3 = ((((int32_t)bmp085_values.calib.ac1) * 4 + x3) + 2) >> 2;
+  b3 = ((((int32_t)bmpx8x_values.calib.ac1) * 4 + x3) + 2) >> 2;
 
-  x1 = (bmp085_values.calib.ac3 * b6) >> 13;
-  x2 = (bmp085_values.calib.b1 * ((b6 * b6) >> 12)) >> 16;
+  x1 = (bmpx8x_values.calib.ac3 * b6) >> 13;
+  x2 = (bmpx8x_values.calib.b1 * ((b6 * b6) >> 12)) >> 16;
   x3 = ((x1 + x2) + 2) >> 2;
-  b4 = (bmp085_values.calib.ac4 * ((uint32_t)(x3 + 32768))) >> 15;
+  b4 = (bmpx8x_values.calib.ac4 * ((uint32_t)(x3 + 32768))) >> 15;
   b7 = ((uint32_t)up - b3) * 50000;
 
   if(b7 < 0x80000000) {
@@ -256,47 +256,47 @@ bmp085_read_pressure(int32_t *pressure)
   *pressure = (p + ((x1 + x2 + 3791) >> 4));
   *pressure /= 10;
 
-  return BMP085_SUCCESS;
+  return BMPx8x_SUCCESS;
 }
 /*---------------------------------------------------------------------------*/
 static int
 configure(int type, int value)
 {
-  if((type != BMP085_ACTIVE) && (type != BMP085_OVERSAMPLING)) {
-    PRINTF("BMP085: invalid start value\n");
-    return BMP085_ERROR;
+  if((type != BMPx8x_ACTIVE) && (type != BMPx8x_OVERSAMPLING)) {
+    PRINTF("BMPx8x: invalid start value\n");
+    return BMPx8x_ERROR;
   }
 
-  if(type == BMP085_ACTIVE) {
+  if(type == BMPx8x_ACTIVE) {
     if(value) {
       i2c_init(I2C_SDA_PORT, I2C_SDA_PIN, I2C_SCL_PORT, I2C_SCL_PIN,
                I2C_SCL_NORMAL_BUS_SPEED);
 
       /* Read the calibration values */
-      if(bmp085_read_calib() != BMP085_ERROR) {
-        PRINTF("BMP085: sensor started\n");
+      if(bmpx8x_read_calib() != BMPx8x_ERROR) {
+        PRINTF("BMPx8x: sensor started\n");
         enabled = 1;
-        bmp085_values.oversampling_mode = BMP085_MODE_ULTRA_LOW_POWER;
-        return BMP085_SUCCESS;
+        bmpx8x_values.oversampling_mode = BMPx8x_MODE_ULTRA_LOW_POWER;
+        return BMPx8x_SUCCESS;
       }
 
-      PRINTF("BMP085: failed to enable\n");
-      return BMP085_ERROR;
+      PRINTF("BMPx8x: failed to enable\n");
+      return BMPx8x_ERROR;
     } else {
       enabled = 0;
-      return BMP085_SUCCESS;
+      return BMPx8x_SUCCESS;
     }
-  } else if(type == BMP085_OVERSAMPLING) {
-    if((value < BMP085_MODE_ULTRA_LOW_POWER) ||
-       (value > BMP085_MODE_ULTRA_HIGH_RES)) {
-      PRINTF("BMP085: invalid oversampling value\n");
-      return BMP085_ERROR;
+  } else if(type == BMPx8x_OVERSAMPLING) {
+    if((value < BMPx8x_MODE_ULTRA_LOW_POWER) ||
+       (value > BMPx8x_MODE_ULTRA_HIGH_RES)) {
+      PRINTF("BMPx8x: invalid oversampling value\n");
+      return BMPx8x_ERROR;
     }
-    bmp085_values.oversampling_mode = value;
-    return BMP085_SUCCESS;
+    bmpx8x_values.oversampling_mode = value;
+    return BMPx8x_SUCCESS;
   }
 
-  return BMP085_ERROR;
+  return BMPx8x_ERROR;
 }
 /*---------------------------------------------------------------------------*/
 static int
@@ -311,25 +311,25 @@ status(int type)
 }
 /*---------------------------------------------------------------------------*/
 static int
-bmp085_read_sensor(int32_t *value, uint8_t type)
+bmpx8x_read_sensor(int32_t *value, uint8_t type)
 {
   int16_t temp = 0;
 
   /* The temperature is required to compensate the pressure value */
-  if(bmp085_read_temperature(&temp) != BMP085_SUCCESS) {
-    return BMP085_ERROR;
+  if(bmpx8x_read_temperature(&temp) != BMPx8x_SUCCESS) {
+    return BMPx8x_ERROR;
   }
 
   switch(type) {
-  case BMP085_READ_PRESSURE:
-    return bmp085_read_pressure(value);
+  case BMPx8x_READ_PRESSURE:
+    return bmpx8x_read_pressure(value);
 
-  case BMP085_READ_TEMP:
+  case BMPx8x_READ_TEMP:
     *value = (int16_t) temp;
-    return BMP085_SUCCESS;
+    return BMPx8x_SUCCESS;
   }
 
-  return BMP085_ERROR;
+  return BMPx8x_ERROR;
 }
 /*---------------------------------------------------------------------------*/
 static int
@@ -338,23 +338,23 @@ value(int type)
   int32_t value;
 
   if(!enabled) {
-    PRINTF("BMP085: sensor not started\n");
-    return BMP085_ERROR;
+    PRINTF("BMPx8x: sensor not started\n");
+    return BMPx8x_ERROR;
   }
 
-  if((type != BMP085_READ_PRESSURE) && (type != BMP085_READ_TEMP)) {
-    PRINTF("BMP085: invalid read value\n");
-    return BMP085_ERROR;
+  if((type != BMPx8x_READ_PRESSURE) && (type != BMPx8x_READ_TEMP)) {
+    PRINTF("BMPx8x: invalid read value\n");
+    return BMPx8x_ERROR;
   }
 
-  if(bmp085_read_sensor(&value, type) == BMP085_SUCCESS) {
+  if(bmpx8x_read_sensor(&value, type) == BMPx8x_SUCCESS) {
     return (int)value;
   }
 
-  PRINTF("BMP085: fail to read\n");
-  return BMP085_ERROR;
+  PRINTF("BMPx8x: fail to read\n");
+  return BMPx8x_ERROR;
 }
 /*---------------------------------------------------------------------------*/
-SENSORS_SENSOR(bmp085, BMP085_SENSOR, value, configure, status);
+SENSORS_SENSOR(bmpx8x, BMPx8x_SENSOR, value, configure, status);
 /*---------------------------------------------------------------------------*/
 /** @} */

--- a/platform/zoul/dev/bmpx8x.h
+++ b/platform/zoul/dev/bmpx8x.h
@@ -34,98 +34,98 @@
  * \addtogroup zoul-sensors
  * @{
  *
- * \defgroup zoul-bmp085-sensor BMP085 Sensor
+ * \defgroup zoul-bmpx8x-sensor BMP085/BMP180 Sensor
  *
- * Driver for the BMP085 sensor
+ * Driver for the BMP085/BMP180 sensor
  *
- * BMP085 digital pressure and temperature driver
+ * BMP085/BMP180 digital atmospheric pressure and temperature driver
  * @{
  *
  * \file
- * Header file for the external BMP085 Sensor Driver
+ * Header file for the external BMP085/BMP180 Sensor Driver
  *
  * \author
  *         Antonio Lignan <alinan@zolertia.com>
  */
 /*---------------------------------------------------------------------------*/
-#ifndef BMP085_H_
-#define BMP085_H_
+#ifndef BMPX8X_H_
+#define BMPX8X_H_
 #include <stdio.h>
 #include "lib/sensors.h"
 #include "dev/zoul-sensors.h"
 #include "i2c.h"
 /* -------------------------------------------------------------------------- */
 /**
- * \name BMP085 address and registers
+ * \name BMPx8x address and registers
  * @{
  */
 /* -------------------------------------------------------------------------- */
-#define BMP085_ADDR                      0x77
+#define BMPx8x_ADDR                      0x77
 /* -------------------------------------------------------------------------- */
 /* Control register */
-#define BMP085_CTRL_REG                  0xF4
+#define BMPx8x_CTRL_REG                  0xF4
 /* Read uncompensated temperature  */
-#define BMP085_CTRL_REG_TEMP             0x2E
+#define BMPx8x_CTRL_REG_TEMP             0x2E
 /* Read uncompensated pressure, no oversampling */
-#define BMP085_CTRL_REG_PRESS_4_5MS      0x34
+#define BMPx8x_CTRL_REG_PRESS_4_5MS      0x34
 /* Read uncompensated pressure, oversampling 1*/
-#define BMP085_CTRL_REG_PRESS_7_5MS      0x74
+#define BMPx8x_CTRL_REG_PRESS_7_5MS      0x74
 /* Read uncompensated pressure, oversampling 2 */
-#define BMP085_CTRL_REG_PRESS_13_5MS     0xB4
+#define BMPx8x_CTRL_REG_PRESS_13_5MS     0xB4
 /* Read uncompensated pressure, oversampling 3 */
-#define BMP085_CTRL_REG_PRESS_25_5MS     0xF4
+#define BMPx8x_CTRL_REG_PRESS_25_5MS     0xF4
 /* -------------------------------------------------------------------------- */
-#define BMP085_DATA_MSB                  0xF6
-#define BMP085_DATA_LSB                  0xF7
+#define BMPx8x_DATA_MSB                  0xF6
+#define BMPx8x_DATA_LSB                  0xF7
 /* 19-bit resolution */
-#define BMP085_DATA_XLSB                 0xF8
+#define BMPx8x_DATA_XLSB                 0xF8
 /* -------------------------------------------------------------------------- */
 /* Calibration registers, 16-bit wide */
-#define BMP085_AC1_CALIB                 0xAA
-#define BMP085_AC2_CALIB                 0xAC
-#define BMP085_AC3_CALIB                 0xAE
-#define BMP085_AC4_CALIB                 0xB0
-#define BMP085_AC5_CALIB                 0xB2
-#define BMP085_AC6_CALIB                 0xB4
-#define BMP085_B1_CALIB                  0xB6
-#define BMP085_B2_CALIB                  0xB8
-#define BMP085_MB_CALIB                  0xBA
-#define BMP085_MC_CALIB                  0xBC
-#define BMP085_MD_CALIB                  0xBE
-#define BMP085_CALIB_TABLE_SIZE          22    /**< size in bytes */
+#define BMPx8x_AC1_CALIB                 0xAA
+#define BMPx8x_AC2_CALIB                 0xAC
+#define BMPx8x_AC3_CALIB                 0xAE
+#define BMPx8x_AC4_CALIB                 0xB0
+#define BMPx8x_AC5_CALIB                 0xB2
+#define BMPx8x_AC6_CALIB                 0xB4
+#define BMPx8x_B1_CALIB                  0xB6
+#define BMPx8x_B2_CALIB                  0xB8
+#define BMPx8x_MB_CALIB                  0xBA
+#define BMPx8x_MC_CALIB                  0xBC
+#define BMPx8x_MD_CALIB                  0xBE
+#define BMPx8x_CALIB_TABLE_SIZE          22    /**< size in bytes */
 /** @} */
 /* -------------------------------------------------------------------------- */
 /**
- * \name BMP085 operation modes
+ * \name BMPx8x operation modes
  * @{
  */
-#define BMP085_MODE_ULTRA_LOW_POWER      0x00
-#define BMP085_MODE_STANDARD             0x01
-#define BMP085_MODE_HIGH_RES             0x02
-#define BMP085_MODE_ULTRA_HIGH_RES       0x03
+#define BMPx8x_MODE_ULTRA_LOW_POWER      0x00
+#define BMPx8x_MODE_STANDARD             0x01
+#define BMPx8x_MODE_HIGH_RES             0x02
+#define BMPx8x_MODE_ULTRA_HIGH_RES       0x03
 /* -------------------------------------------------------------------------- */
-#define BMP085_DELAY_4_5MS               4700
-#define BMP085_DELAY_7_5MS               7700
-#define BMP085_DELAY_13_5MS              13700
-#define BMP085_DELAY_25_5MS              25700
+#define BMPx8x_DELAY_4_5MS               4700
+#define BMPx8x_DELAY_7_5MS               7700
+#define BMPx8x_DELAY_13_5MS              13700
+#define BMPx8x_DELAY_25_5MS              25700
 /** @} */
 /* -------------------------------------------------------------------------- */
 /**
- * \name BMP085 return and command values
+ * \name BMPx8x return and command values
  * @{
  */
-#define BMP085_SUCCESS         0x00
-#define BMP085_ERROR             -1
+#define BMPx8x_SUCCESS         0x00
+#define BMPx8x_ERROR             -1
 
-#define BMP085_ACTIVE          SENSORS_ACTIVE
-#define BMP085_OVERSAMPLING    0x00
-#define BMP085_READ_PRESSURE   0x01
-#define BMP085_READ_TEMP       0x02
+#define BMPx8x_ACTIVE          SENSORS_ACTIVE
+#define BMPx8x_OVERSAMPLING    0x00
+#define BMPx8x_READ_PRESSURE   0x01
+#define BMPx8x_READ_TEMP       0x02
 /** @} */
 /* -------------------------------------------------------------------------- */
-#define BMP085_SENSOR "BMP085 pressure and temperature sensor"
+#define BMPx8x_SENSOR "BMP085/BMP180 pressure and temperature sensor"
 /* -------------------------------------------------------------------------- */
-extern const struct sensors_sensor bmp085;
+extern const struct sensors_sensor bmpx8x;
 /* -------------------------------------------------------------------------- */
 #endif
 /* -------------------------------------------------------------------------- */


### PR DESCRIPTION
This PR unifies the driver to support both BMP085 and the BMP180 atmospheric pressure sensors, as both reuse the same logic, but the BMP180 has been advertised to provide better results.