### PR TITLE
Update broadcast-announcement.c to prevent memory over-read

### DIFF
--- a/core/net/rime/broadcast-announcement.c
+++ b/core/net/rime/broadcast-announcement.c
@@ -134,7 +134,7 @@ adv_packet_received(struct broadcast_conn *ibc, const linkaddr_t *from)
   ptr = packetbuf_dataptr();
 
   /* Copy number of announcements */
-  if(strlen(ptr)>=sizeof(announcement_msg)){
+  if(strlen(ptr)>=sizeof(struct announcement_msg)){
   memcpy(&adata, ptr, sizeof(struct announcement_msg));
   }
   PRINTF("%d.%d: adv_packet_received from %d.%d with %d announcements\n",
@@ -151,7 +151,7 @@ adv_packet_received(struct broadcast_conn *ibc, const linkaddr_t *from)
   ptr += ANNOUNCEMENT_MSG_HEADERLEN;
   for(i = 0; i < adata.num; ++i) {
     /* Copy announcements */
-    if(strlen(ptr)>=sizeof(srtuct announcement_data)){
+    if(strlen(ptr)>=sizeof(struct announcement_data)){
     memcpy(&data, ptr, sizeof(struct announcement_data));
     }
     announcement_heard(from, data.id, data.value);

--- a/core/net/rime/broadcast-announcement.c
+++ b/core/net/rime/broadcast-announcement.c
@@ -134,7 +134,9 @@ adv_packet_received(struct broadcast_conn *ibc, const linkaddr_t *from)
   ptr = packetbuf_dataptr();
 
   /* Copy number of announcements */
+  if(strlen(ptr)>=sizeof(announcement_msg)){
   memcpy(&adata, ptr, sizeof(struct announcement_msg));
+  }
   PRINTF("%d.%d: adv_packet_received from %d.%d with %d announcements\n",
 	 linkaddr_node_addr.u8[0], linkaddr_node_addr.u8[1],
 	 from->u8[0], from->u8[1], adata.num);
@@ -149,7 +151,9 @@ adv_packet_received(struct broadcast_conn *ibc, const linkaddr_t *from)
   ptr += ANNOUNCEMENT_MSG_HEADERLEN;
   for(i = 0; i < adata.num; ++i) {
     /* Copy announcements */
+    if(strlen(ptr)>=sizeof(srtuct announcement_data)){
     memcpy(&data, ptr, sizeof(struct announcement_data));
+    }
     announcement_heard(from, data.id, data.value);
     ptr += sizeof(struct announcement_data);
   }


### PR DESCRIPTION
when the third parameter of "memcpy" is a constant, it is necessary to have a length check before the copy operation to make sure "memory over-read" won't happen.