### PR TITLE
a memory overflow in shell-vars.c

### DIFF
--- a/apps/shell/shell-vars.c
+++ b/apps/shell/shell-vars.c
@@ -91,7 +91,7 @@ PROCESS_THREAD(shell_var_process, ev, data)
   int i;
   int j;
   
-  char numbuf[39];
+  char numbuf[40];
   
   PROCESS_BEGIN();
 

--- a/apps/shell/shell-vars.c
+++ b/apps/shell/shell-vars.c
@@ -90,7 +90,8 @@ PROCESS_THREAD(shell_var_process, ev, data)
 {
   int i;
   int j;
-  char numbuf[32];
+  
+  char numbuf[39];
   
   PROCESS_BEGIN();
 

--- a/apps/shell/shell-vars.c
+++ b/apps/shell/shell-vars.c
@@ -90,7 +90,6 @@ PROCESS_THREAD(shell_var_process, ev, data)
 {
   int i;
   int j;
-  
   char numbuf[40];
   
   PROCESS_BEGIN();


### PR DESCRIPTION
" sprintf(numbuf, "0x%02x 0x%02x 0x%02x 0x%02x 0x%02x 0x%02x 0x%02x 0x%02x",...)" . the formatted data wrote to "numbuf" is 39 bytes, but numbuf is 32 bytes.