### PR TITLE
galileo: Revise include flags for LLVM Clang

### DIFF
--- a/platform/galileo/Makefile.galileo
+++ b/platform/galileo/Makefile.galileo
@@ -16,7 +16,12 @@ PROJECT_SOURCEFILES += newlib-syscalls.c
 CONTIKI_CPU=$(CONTIKI)/cpu/x86
 include $(CONTIKI)/cpu/x86/Makefile.x86_quarkX1000
 
-CFLAGS += -fno-stack-protector -nostdinc -I$(LIBC)/include -isystem $(LIBGCC_PATH)/include -isystem $(LIBGCC_PATH)/include-fixed
+CFLAGS += -fno-stack-protector -I$(LIBC)/include
+ifeq (clang,$(findstring clang,$(CC)))
+        CFLAGS += -nostdlibinc
+else
+        CFLAGS += -nostdinc -isystem $(LIBGCC_PATH)/include -isystem $(LIBGCC_PATH)/include-fixed
+endif
 LDFLAGS += -nostdlib -L$(LIBC)/lib -L$(LIBGCC_PATH)/32
 
 TARGET_LIBFILES += -lm -lc -lgcc


### PR DESCRIPTION
This patch revises the compiler flags when LLVM Clang is in use to
cause Clang to automatically use its built-in header files rather than
those for GCC.  This avoids compiler errors that can otherwise
be generated by including certain built-in headers.