### PR TITLE
Add support for the CC2650 LaunchPad (LAUNCHXL-CC2650)

### DIFF
--- a/examples/cc26xx/cc26xx-demo.c
+++ b/examples/cc26xx/cc26xx-demo.c
@@ -44,6 +44,7 @@
  *   This example will work for the following boards:
  *   - srf06-cc26xx: SmartRF06EB + CC26XX EM
  *   - sensortag-cc26xx: CC26XX sensortag
+ *   - The CC2650 LaunchPad
  *
  *   By default, the example will build for the srf06-cc26xx board. To switch
  *   between platforms:
@@ -114,6 +115,10 @@
 #define CC26XX_DEMO_SENSOR_3     CC26XX_DEMO_SENSOR_NONE
 #define CC26XX_DEMO_SENSOR_4     CC26XX_DEMO_SENSOR_NONE
 #define CC26XX_DEMO_SENSOR_5     &reed_relay_sensor
+#elif BOARD_LAUNCHPAD
+#define CC26XX_DEMO_SENSOR_3     CC26XX_DEMO_SENSOR_NONE
+#define CC26XX_DEMO_SENSOR_4     CC26XX_DEMO_SENSOR_NONE
+#define CC26XX_DEMO_SENSOR_5     CC26XX_DEMO_SENSOR_NONE
 #else
 #define CC26XX_DEMO_SENSOR_3     &button_up_sensor
 #define CC26XX_DEMO_SENSOR_4     &button_down_sensor
@@ -423,7 +428,7 @@ PROCESS_THREAD(cc26xx_demo_process, ev, data)
         get_tmp_reading();
       } else if(ev == sensors_event && data == &mpu_9250_sensor) {
         get_mpu_reading();
-#else
+#elif BOARD_SMARTRF06EB
         printf("Sel: Pin %d, press duration %d clock ticks\n",
                button_select_sensor.value(BUTTON_SENSOR_VALUE_STATE),
                button_select_sensor.value(BUTTON_SENSOR_VALUE_DURATION));

--- a/examples/cc26xx/cc26xx-web-demo/cc26xx-web-demo.c
+++ b/examples/cc26xx/cc26xx-web-demo/cc26xx-web-demo.c
@@ -175,7 +175,7 @@ static void
 save_config()
 {
   /* Dump current running config to flash */
-#if BOARD_SENSORTAG
+#if BOARD_SENSORTAG || BOARD_LAUNCHPAD
   int rv;
   cc26xx_web_demo_sensor_reading_t *reading = NULL;
 
@@ -218,7 +218,7 @@ save_config()
 static void
 load_config()
 {
-#if BOARD_SENSORTAG
+#if BOARD_SENSORTAG || BOARD_LAUNCHPAD
   /* Read from flash into a temp buffer */
   cc26xx_web_demo_config_t tmp_cfg;
   cc26xx_web_demo_sensor_reading_t *reading = NULL;

--- a/examples/cc26xx/cc26xx-web-demo/cc26xx-web-demo.h
+++ b/examples/cc26xx/cc26xx-web-demo/cc26xx-web-demo.h
@@ -100,6 +100,8 @@
 #if BOARD_SENSORTAG
 /* Force an MQTT publish on sensor event */
 #define CC26XX_WEB_DEMO_MQTT_PUBLISH_TRIGGER &reed_relay_sensor
+#elif BOARD_LAUNCHPAD
+#define CC26XX_WEB_DEMO_MQTT_PUBLISH_TRIGGER &button_left_sensor
 #else
 #define CC26XX_WEB_DEMO_MQTT_PUBLISH_TRIGGER &button_down_sensor
 #endif

--- a/examples/cc26xx/cc26xx-web-demo/coap-server.c
+++ b/examples/cc26xx/cc26xx-web-demo/coap-server.c
@@ -63,6 +63,9 @@ extern resource_t res_parent_ip;
 extern resource_t res_ble_advd;
 #endif
 
+extern resource_t res_toggle_red;
+extern resource_t res_toggle_green;
+
 /* Board-specific resources */
 #if BOARD_SENSORTAG
 extern resource_t res_bmp280_temp;
@@ -78,11 +81,7 @@ extern resource_t res_mpu_acc_z;
 extern resource_t res_mpu_gyro_x;
 extern resource_t res_mpu_gyro_y;
 extern resource_t res_mpu_gyro_z;
-extern resource_t res_toggle_red;
-extern resource_t res_toggle_green;
 #else
-extern resource_t res_toggle_red;
-extern resource_t res_toggle_green;
 extern resource_t res_toggle_orange;
 extern resource_t res_toggle_yellow;
 #endif
@@ -96,6 +95,11 @@ const char *coap_server_supported_msg = "Supported:"
 static void
 start_board_resources(void)
 {
+
+  rest_activate_resource(&res_toggle_green, "lt/g");
+  rest_activate_resource(&res_toggle_red, "lt/r");
+  rest_activate_resource(&res_leds, "lt");
+
 #if BOARD_SENSORTAG
   rest_activate_resource(&res_bmp280_temp, "sen/bar/temp");
   rest_activate_resource(&res_bmp280_press, "sen/bar/pres");
@@ -110,14 +114,8 @@ start_board_resources(void)
   rest_activate_resource(&res_mpu_gyro_x, "sen/mpu/gyro/x");
   rest_activate_resource(&res_mpu_gyro_y, "sen/mpu/gyro/y");
   rest_activate_resource(&res_mpu_gyro_z, "sen/mpu/gyro/z");
-  rest_activate_resource(&res_leds, "lt");
-  rest_activate_resource(&res_toggle_green, "lt/g");
-  rest_activate_resource(&res_toggle_red, "lt/r");
 #elif BOARD_SMARTRF06EB
-  rest_activate_resource(&res_leds, "lt");
-  rest_activate_resource(&res_toggle_red, "lt/r");
   rest_activate_resource(&res_toggle_yellow, "lt/y");
-  rest_activate_resource(&res_toggle_green, "lt/g");
   rest_activate_resource(&res_toggle_orange, "lt/o");
 #endif
 }

--- a/examples/cc26xx/cc26xx-web-demo/resources/res-leds.c
+++ b/examples/cc26xx/cc26xx-web-demo/resources/res-leds.c
@@ -94,7 +94,7 @@ res_post_put_handler(void *request, void *response, uint8_t *buffer,
  * A simple actuator example, depending on the color query parameter and post
  * variable mode, corresponding led is activated or deactivated
  */
-#if BOARD_SENSORTAG
+#if BOARD_SENSORTAG || BOARD_LAUNCHPAD
 #define RESOURCE_PARAMS "r|g"
 #elif BOARD_SMARTRF06EB
 #define RESOURCE_PARAMS "r|g|y|o"

--- a/platform/srf06-cc26xx/README.md
+++ b/platform/srf06-cc26xx/README.md
@@ -107,6 +107,8 @@ errors.
 
 If you want to upload the compiled firmware to a node via the serial boot loader you need to manually enable the boot loader and then use `make cc26xx-demo.upload`. On the SmartRF06 board you enable the boot loader by resetting the board (EM RESET button) while holding the `select` button. (The boot loader backdoor needs to be enabled on the chip, and the chip needs to be configured correctly, for this to work. See README in the `tools/cc2538-bsl` directory for more info). The serial uploader script will automatically pick the first available serial port. If this is not the port where your node is connected, you can force the script to use a specific port by defining the `PORT` argument eg. `make cc26xx-demo.upload PORT=/dev/tty.usbserial`
 
+The serial bootloader can also be used with the LaunchPad and the changes required to achieve this are the same as those required for the SmartRF. The only difference is that you will need to map `BL_PIN_NUMBER` to either the left or right user button (values to be used for `BL_PIN_NUMBER` in `ccfg.c` are `0x0D` and `0x0E` respectively).
+
 Note that uploading over serial doesn't work for the Sensortag, you can use TI's SmartRF Flash Programmer in this case.
 
 For the `cc26xx-demo`, the included readme describes in detail what the example does.

--- a/platform/srf06-cc26xx/README.md
+++ b/platform/srf06-cc26xx/README.md
@@ -7,6 +7,7 @@ platform supports two different boards:
 * SmartRF 06 Evaluation Board with a CC26xx or CC13xx Evaluation Module
   (relevant files and drivers are under `srf06/`)
 * CC2650 SensorTag 2.0 (relevant drivers under `sensortag/cc2650`)
+* CC2650 LaunchPad (relevant drivers under `launchpad/cc2650`)
 
 The CPU code, common for both platforms, can be found under `$(CONTIKI)/cpu/cc26xx-cc13xx`.
 The port was developed and tested with CC2650s, but the intention is for it to
@@ -43,6 +44,10 @@ In terms of hardware support, the following drivers have been implemented:
   * HDC1000 sensor
   * OPT3001 sensor
   * Buzzer
+  * External SPI flash
+* Launchpad
+  * LEDs
+  * Buttons
   * External SPI flash
 
 Requirements
@@ -93,6 +98,7 @@ Other options for the `BOARD` make variable are:
 * Srf06+CC26xxEM: Set `BOARD=srf06/cc26xx`
 * Srf06+CC13xxEM: Set `BOARD=srf06/cc13xx`
 * CC2650 tag: Set `BOARD=sensortag/cc2650`
+* CC2650 Launchpad: Set `BOARD=launchpad/cc2650`
 
 If the `BOARD` variable is unspecified, an image for the Srf06 CC26XXEM will be built.
 

--- a/platform/srf06-cc26xx/common/board-spi.c
+++ b/platform/srf06-cc26xx/common/board-spi.c
@@ -33,7 +33,7 @@
  * @{
  *
  * \file
- * Board-specific SPI driver for the Sensortag-CC26xx
+ * Board-specific SPI driver common to the Sensortag and LaunchPad
  */
 /*---------------------------------------------------------------------------*/
 #include "contiki.h"
@@ -120,7 +120,7 @@ board_spi_open(uint32_t bit_rate, uint32_t clk_pin)
   /* First, make sure the SERIAL PD is on */
   ti_lib_prcm_power_domain_on(PRCM_DOMAIN_SERIAL);
   while((ti_lib_prcm_power_domain_status(PRCM_DOMAIN_SERIAL)
-        != PRCM_DOMAIN_POWER_ON));
+         != PRCM_DOMAIN_POWER_ON));
 
   /* Enable clock in active mode */
   ti_lib_rom_prcm_peripheral_run_enable(PRCM_PERIPH_SSI0);

--- a/platform/srf06-cc26xx/common/board-spi.h
+++ b/platform/srf06-cc26xx/common/board-spi.h
@@ -29,14 +29,22 @@
  */
 /*---------------------------------------------------------------------------*/
 /**
- * \addtogroup sensortag-cc26xx-peripherals
+ * \addtogroup cc26xx-srf-tag
  * @{
  *
- * \defgroup sensortag-cc26xx-spi SensorTag 2.0 SPI functions
+ * \defgroup common-cc26xx-peripherals CC13xx/CC26xx peripheral driver pool
+ *
+ * Drivers for peripherals present on more than one CC13xx/CC26xx board. For
+ * example, the same external flash driver is used for both the part found on
+ * the Sensortag as well as the part on the LaunchPad.
+ *
+ * @{
+ *
+ * \defgroup sensortag-cc26xx-spi SensorTag/LaunchPad SPI functions
  * @{
  *
  * \file
- * Header file for the Sensortag-CC26xx SPI Driver
+ * Header file for the Sensortag/LaunchPad SPI Driver
  */
 /*---------------------------------------------------------------------------*/
 #ifndef BOARD_SPI_H_
@@ -100,6 +108,7 @@ bool board_spi_write(const uint8_t *buf, size_t length);
 #endif /* BOARD_SPI_H_ */
 /*---------------------------------------------------------------------------*/
 /**
+ * @}
  * @}
  * @}
  */

--- a/platform/srf06-cc26xx/common/ext-flash.c
+++ b/platform/srf06-cc26xx/common/ext-flash.c
@@ -33,7 +33,7 @@
  * @{
  *
  * \file
- *  Driver for the Sensortag-CC26xx WinBond W25X20CL Flash
+ *  Driver for the LaunchPad Flash and the Sensortag WinBond W25X20CL/W25X40CL
  */
 /*---------------------------------------------------------------------------*/
 #include "contiki.h"
@@ -158,7 +158,7 @@ static uint8_t
 verify_part(void)
 {
   const uint8_t wbuf[] = { BLS_CODE_MDID, 0xFF, 0xFF, 0x00 };
-  uint8_t rbuf[2] = {0, 0};
+  uint8_t rbuf[2] = { 0, 0 };
   bool ret;
 
   select_on_bus();

--- a/platform/srf06-cc26xx/common/ext-flash.h
+++ b/platform/srf06-cc26xx/common/ext-flash.h
@@ -29,14 +29,14 @@
  */
 /*---------------------------------------------------------------------------*/
 /**
- * \addtogroup sensortag-cc26xx-peripherals
+ * \addtogroup common-cc26xx-peripherals
  * @{
  *
- * \defgroup sensortag-cc26xx-ext-flash SensorTag 2.0 External Flash
+ * \defgroup sensortag-cc26xx-ext-flash SensorTag/LaunchPad External Flash
  * @{
  *
  * \file
- * Header file for the Sensortag-CC26xx External Flash Driver
+ * Header file for the Sensortag/LaunchPad External Flash Driver
  */
 /*---------------------------------------------------------------------------*/
 #ifndef EXT_FLASH_H_

--- a/platform/srf06-cc26xx/contiki-main.c
+++ b/platform/srf06-cc26xx/contiki-main.c
@@ -32,12 +32,13 @@
  * \addtogroup cc26xx-platforms
  * @{
  *
- * \defgroup cc26xx-srf-tag SmartRF+CC13xx/CC26xx EM and the CC2650 SensorTag
+ * \defgroup cc26xx-srf-tag SmartRF+CC13xx/CC26xx EM, CC2650 SensorTag and LaunchPad
  *
  * This platform supports a number of different boards:
  * - A standard TI SmartRF06EB with a CC26xx EM mounted on it
  * - A standard TI SmartRF06EB with a CC1310 EM mounted on it
  * - The new TI SensorTag2.0
+ * - The TI CC2650 LaunchPad
  * @{
  */
 #include "ti-lib.h"

--- a/platform/srf06-cc26xx/launchpad/Makefile.launchpad
+++ b/platform/srf06-cc26xx/launchpad/Makefile.launchpad
@@ -1,0 +1,6 @@
+CFLAGS += -DBOARD_LAUNCHPAD=1
+
+CONTIKI_TARGET_DIRS += launchpad common
+
+BOARD_SOURCEFILES += board.c launchpad-sensors.c leds-arch.c button-sensor.c
+BOARD_SOURCEFILES += ext-flash.c board-spi.c

--- a/platform/srf06-cc26xx/launchpad/board-peripherals.h
+++ b/platform/srf06-cc26xx/launchpad/board-peripherals.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2015, Texas Instruments Incorporated - http://www.ti.com/
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+/*---------------------------------------------------------------------------*/
+/** \addtogroup cc26xx-srf-tag
+ * @{
+ *
+ * \defgroup launchpad-peripherals LaunchPad peripherals
+ *
+ * Defines related to LaunchPad peripherals.
+ *
+ * @{
+ *
+ * \file
+ * Header file with definitions related to LaunchPad peripherals
+ *
+ * \note   Do not include this file directly.
+ */
+/*---------------------------------------------------------------------------*/
+#ifndef BOARD_PERIPHERALS_H_
+#define BOARD_PERIPHERALS_H_
+/*---------------------------------------------------------------------------*/
+#include "ext-flash.h"
+/*---------------------------------------------------------------------------*/
+#endif /* BOARD_PERIPHERALS_H_ */
+/*---------------------------------------------------------------------------*/
+/**
+ * @}
+ * @}
+ */

--- a/platform/srf06-cc26xx/launchpad/board.c
+++ b/platform/srf06-cc26xx/launchpad/board.c
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2015, Texas Instruments Incorporated - http://www.ti.com/
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+/*---------------------------------------------------------------------------*/
+/**
+ * \addtogroup launchpad-peripherals
+ * @{
+ *
+ * \file
+ *  LaunchPad-specific board initialisation driver
+ */
+/*---------------------------------------------------------------------------*/
+#include "contiki-conf.h"
+#include "lib/sensors.h"
+#include "lpm.h"
+#include "ti-lib.h"
+#include "board-peripherals.h"
+
+#include <stdint.h>
+#include <string.h>
+#include <stdbool.h>
+/*---------------------------------------------------------------------------*/
+static void
+wakeup_handler(void)
+{
+  /* Turn on the PERIPH PD */
+  ti_lib_prcm_power_domain_on(PRCM_DOMAIN_PERIPH);
+  while((ti_lib_prcm_power_domain_status(PRCM_DOMAIN_PERIPH)
+         != PRCM_DOMAIN_POWER_ON));
+}
+/*---------------------------------------------------------------------------*/
+/*
+ * Declare a data structure to register with LPM.
+ * We don't care about what power mode we'll drop to, we don't care about
+ * getting notified before deep sleep. All we need is to be notified when we
+ * wake up so we can turn power domains back on
+ */
+LPM_MODULE(launchpad_module, NULL, NULL, wakeup_handler, LPM_DOMAIN_NONE);
+/*---------------------------------------------------------------------------*/
+static void
+configure_unused_pins(void)
+{
+  uint32_t pins[] = {
+    BOARD_IOID_CS, BOARD_IOID_TDO, BOARD_IOID_TDI, BOARD_IOID_DIO12,
+    BOARD_IOID_DIO15, BOARD_IOID_DIO21, BOARD_IOID_DIO22, BOARD_IOID_DIO23,
+    BOARD_IOID_DIO24, BOARD_IOID_DIO25, BOARD_IOID_DIO26, BOARD_IOID_DIO27,
+    BOARD_IOID_DIO28, BOARD_IOID_DIO29, BOARD_IOID_DIO30,
+    IOID_UNUSED
+  };
+
+  uint32_t *pin;
+
+  for(pin = pins; *pin != IOID_UNUSED; pin++) {
+    ti_lib_ioc_pin_type_gpio_input(*pin);
+    ti_lib_ioc_io_port_pull_set(*pin, IOC_IOPULL_DOWN);
+  }
+}
+/*---------------------------------------------------------------------------*/
+void
+board_init()
+{
+  /* Disable global interrupts */
+  bool int_disabled = ti_lib_int_master_disable();
+
+  /* Turn on relevant PDs */
+  wakeup_handler();
+
+  /* Enable GPIO peripheral */
+  ti_lib_prcm_peripheral_run_enable(PRCM_PERIPH_GPIO);
+
+  /* Apply settings and wait for them to take effect */
+  ti_lib_prcm_load_set();
+  while(!ti_lib_prcm_load_get());
+
+  /* Make sure the external flash is in the lower power mode */
+  ext_flash_init();
+
+  lpm_register_module(&launchpad_module);
+
+  /* For unsupported peripherals, select a default pin configuration */
+  configure_unused_pins();
+
+  /* Re-enable interrupt if initially enabled. */
+  if(!int_disabled) {
+    ti_lib_int_master_enable();
+  }
+}
+/*---------------------------------------------------------------------------*/
+/** @} */

--- a/platform/srf06-cc26xx/launchpad/button-sensor.c
+++ b/platform/srf06-cc26xx/launchpad/button-sensor.c
@@ -1,0 +1,218 @@
+/*
+ * Copyright (c) 2015, Texas Instruments Incorporated - http://www.ti.com/
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+/*---------------------------------------------------------------------------*/
+/**
+ * \addtogroup launchpad-button-sensor
+ * @{
+ *
+ * \file
+ * Driver for LaunchPad buttons
+ */
+/*---------------------------------------------------------------------------*/
+#include "contiki.h"
+#include "lib/sensors.h"
+#include "launchpad/button-sensor.h"
+#include "gpio-interrupt.h"
+#include "sys/timer.h"
+#include "lpm.h"
+
+#include "ti-lib.h"
+
+#include <stdint.h>
+/*---------------------------------------------------------------------------*/
+#ifdef BUTTON_SENSOR_CONF_ENABLE_SHUTDOWN
+#define BUTTON_SENSOR_ENABLE_SHUTDOWN BUTTON_SENSOR_CONF_ENABLE_SHUTDOWN
+#else
+#define BUTTON_SENSOR_ENABLE_SHUTDOWN 1
+#endif
+/*---------------------------------------------------------------------------*/
+#define BUTTON_GPIO_CFG         (IOC_CURRENT_2MA  | IOC_STRENGTH_AUTO | \
+                                 IOC_IOPULL_UP    | IOC_SLEW_DISABLE  | \
+                                 IOC_HYST_DISABLE | IOC_BOTH_EDGES    | \
+                                 IOC_INT_ENABLE   | IOC_IOMODE_NORMAL | \
+                                 IOC_NO_WAKE_UP   | IOC_INPUT_ENABLE)
+/*---------------------------------------------------------------------------*/
+#define DEBOUNCE_DURATION (CLOCK_SECOND >> 5)
+
+struct btn_timer {
+  struct timer debounce;
+  clock_time_t start;
+  clock_time_t duration;
+};
+
+static struct btn_timer left_timer, right_timer;
+/*---------------------------------------------------------------------------*/
+static void
+button_press_handler(uint8_t ioid)
+{
+  if(ioid == BOARD_IOID_KEY_LEFT) {
+    if(!timer_expired(&left_timer.debounce)) {
+      return;
+    }
+
+    timer_set(&left_timer.debounce, DEBOUNCE_DURATION);
+
+    /*
+     * Start press duration counter on press (falling), notify on release
+     * (rising)
+     */
+    if(ti_lib_gpio_pin_read(BOARD_KEY_LEFT) == 0) {
+      left_timer.start = clock_time();
+      left_timer.duration = 0;
+    } else {
+      left_timer.duration = clock_time() - left_timer.start;
+      sensors_changed(&button_left_sensor);
+    }
+  }
+
+  if(ioid == BOARD_IOID_KEY_RIGHT) {
+    if(BUTTON_SENSOR_ENABLE_SHUTDOWN == 0) {
+      if(!timer_expired(&right_timer.debounce)) {
+        return;
+      }
+
+      timer_set(&right_timer.debounce, DEBOUNCE_DURATION);
+
+      /*
+       * Start press duration counter on press (falling), notify on release
+       * (rising)
+       */
+      if(ti_lib_gpio_pin_read(BOARD_KEY_RIGHT) == 0) {
+        right_timer.start = clock_time();
+        right_timer.duration = 0;
+      } else {
+        right_timer.duration = clock_time() - right_timer.start;
+        sensors_changed(&button_right_sensor);
+      }
+    } else {
+      lpm_shutdown(BOARD_IOID_KEY_RIGHT, IOC_IOPULL_UP, IOC_WAKE_ON_LOW);
+    }
+  }
+}
+/*---------------------------------------------------------------------------*/
+static void
+config_buttons(int type, int c, uint32_t key)
+{
+  switch(type) {
+  case SENSORS_HW_INIT:
+    ti_lib_gpio_event_clear(1 << key);
+    ti_lib_ioc_port_configure_set(key, IOC_PORT_GPIO, BUTTON_GPIO_CFG);
+    ti_lib_gpio_dir_mode_set((1 << key), GPIO_DIR_MODE_IN);
+    gpio_interrupt_register_handler(key, button_press_handler);
+    break;
+  case SENSORS_ACTIVE:
+    if(c) {
+      ti_lib_gpio_event_clear(1 << key);
+      ti_lib_ioc_port_configure_set(key, IOC_PORT_GPIO, BUTTON_GPIO_CFG);
+      ti_lib_gpio_dir_mode_set((1 << key), GPIO_DIR_MODE_IN);
+      ti_lib_ioc_int_enable(key);
+    } else {
+      ti_lib_ioc_int_disable(key);
+    }
+    break;
+  default:
+    break;
+  }
+}
+/*---------------------------------------------------------------------------*/
+static int
+config_left(int type, int value)
+{
+  config_buttons(type, value, BOARD_IOID_KEY_LEFT);
+
+  return 1;
+}
+/*---------------------------------------------------------------------------*/
+static int
+config_right(int type, int value)
+{
+  config_buttons(type, value, BOARD_IOID_KEY_RIGHT);
+
+  return 1;
+}
+/*---------------------------------------------------------------------------*/
+static int
+status(int type, uint32_t key_io_id)
+{
+  switch(type) {
+  case SENSORS_ACTIVE:
+  case SENSORS_READY:
+    if(ti_lib_ioc_port_configure_get(key_io_id) & IOC_INT_ENABLE) {
+      return 1;
+    }
+    break;
+  default:
+    break;
+  }
+  return 0;
+}
+/*---------------------------------------------------------------------------*/
+static int
+value_left(int type)
+{
+  if(type == BUTTON_SENSOR_VALUE_STATE) {
+    return ti_lib_gpio_pin_read(BOARD_KEY_LEFT) == 0 ?
+           BUTTON_SENSOR_VALUE_PRESSED : BUTTON_SENSOR_VALUE_RELEASED;
+  } else if(type == BUTTON_SENSOR_VALUE_DURATION) {
+    return (int)left_timer.duration;
+  }
+  return 0;
+}
+/*---------------------------------------------------------------------------*/
+static int
+value_right(int type)
+{
+  if(type == BUTTON_SENSOR_VALUE_STATE) {
+    return ti_lib_gpio_pin_read(BOARD_KEY_RIGHT) == 0 ?
+           BUTTON_SENSOR_VALUE_PRESSED : BUTTON_SENSOR_VALUE_RELEASED;
+  } else if(type == BUTTON_SENSOR_VALUE_DURATION) {
+    return (int)right_timer.duration;
+  }
+  return 0;
+}
+/*---------------------------------------------------------------------------*/
+static int
+status_left(int type)
+{
+  return status(type, BOARD_IOID_KEY_LEFT);
+}
+/*---------------------------------------------------------------------------*/
+static int
+status_right(int type)
+{
+  return status(type, BOARD_IOID_KEY_RIGHT);
+}
+/*---------------------------------------------------------------------------*/
+SENSORS_SENSOR(button_left_sensor, BUTTON_SENSOR, value_left, config_left,
+               status_left);
+SENSORS_SENSOR(button_right_sensor, BUTTON_SENSOR, value_right, config_right,
+               status_right);
+/*---------------------------------------------------------------------------*/
+/** @} */

--- a/platform/srf06-cc26xx/launchpad/button-sensor.h
+++ b/platform/srf06-cc26xx/launchpad/button-sensor.h
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2015, Texas Instruments Incorporated - http://www.ti.com/
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+/*---------------------------------------------------------------------------*/
+/**
+ * \addtogroup launchpad-peripherals
+ * @{
+ *
+ * \defgroup launchpad-button-sensor LaunchPad Button Driver
+ *
+ * One of the buttons can be configured as general purpose or as an on/off key
+ * @{
+ *
+ * \file
+ * Header file for the LaunchPad Button Driver
+ */
+/*---------------------------------------------------------------------------*/
+#ifndef BUTTON_SENSOR_H_
+#define BUTTON_SENSOR_H_
+/*---------------------------------------------------------------------------*/
+#include "lib/sensors.h"
+/*---------------------------------------------------------------------------*/
+#define BUTTON_SENSOR "Button"
+/*---------------------------------------------------------------------------*/
+#define BUTTON_SENSOR_VALUE_STATE    0
+#define BUTTON_SENSOR_VALUE_DURATION 1
+
+#define BUTTON_SENSOR_VALUE_RELEASED 0
+#define BUTTON_SENSOR_VALUE_PRESSED  1
+/*---------------------------------------------------------------------------*/
+extern const struct sensors_sensor button_left_sensor;
+extern const struct sensors_sensor button_right_sensor;
+/*---------------------------------------------------------------------------*/
+#endif /* BUTTON_SENSOR_H_ */
+/*---------------------------------------------------------------------------*/
+/**
+ * @}
+ * @}
+ */

--- a/platform/srf06-cc26xx/launchpad/cc2650/Makefile.cc2650
+++ b/platform/srf06-cc26xx/launchpad/cc2650/Makefile.cc2650
@@ -1,0 +1,8 @@
+### Will allow the inclusion of the correct CPU makefile
+CPU_FAMILY = cc26xx
+
+### Add to the source dirs
+CONTIKI_TARGET_DIRS += launchpad/cc2650
+
+### Include the common launchpad makefile
+include $(PLATFORM_ROOT_DIR)/launchpad/Makefile.launchpad

--- a/platform/srf06-cc26xx/launchpad/cc2650/board.h
+++ b/platform/srf06-cc26xx/launchpad/cc2650/board.h
@@ -1,0 +1,189 @@
+/*
+ * Copyright (c) 2015, Texas Instruments Incorporated - http://www.ti.com/
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+/*---------------------------------------------------------------------------*/
+/** \addtogroup launchpad-peripherals
+ * @{
+ *
+ * \defgroup launchpad-cc26xx-specific CC2650 LaunchPad Peripherals
+ *
+ * Defines related to the CC2650 LaunchPad
+ *
+ * This file provides connectivity information on LEDs, Buttons, UART and
+ * other peripherals
+ *
+ * This file is not meant to be modified by the user.
+ * @{
+ *
+ * \file
+ * Header file with definitions related to the I/O connections on the TI
+ * CC2650 LaunchPad
+ *
+ * \note   Do not include this file directly. It gets included by contiki-conf
+ *         after all relevant directives have been set.
+ */
+/*---------------------------------------------------------------------------*/
+#ifndef BOARD_H_
+#define BOARD_H_
+/*---------------------------------------------------------------------------*/
+#include "ioc.h"
+/*---------------------------------------------------------------------------*/
+/**
+ * \name LED configurations
+ *
+ * Those values are not meant to be modified by the user
+ * @{
+ */
+/* Some files include leds.h before us, so we need to get rid of defaults in
+ * leds.h before we provide correct definitions */
+#undef LEDS_GREEN
+#undef LEDS_YELLOW
+#undef LEDS_RED
+#undef LEDS_CONF_ALL
+
+#define LEDS_RED       1
+#define LEDS_GREEN     2
+#define LEDS_YELLOW    LEDS_GREEN
+#define LEDS_ORANGE    LEDS_RED
+
+#define LEDS_CONF_ALL  3
+
+/* Notify various examples that we have LEDs */
+#define PLATFORM_HAS_LEDS        1
+/** @} */
+/*---------------------------------------------------------------------------*/
+/**
+ * \name LED IOID mappings
+ *
+ * Those values are not meant to be modified by the user
+ * @{
+ */
+#define BOARD_IOID_LED_1          IOID_6
+#define BOARD_IOID_LED_2          IOID_7
+#define BOARD_LED_1               (1 << BOARD_IOID_LED_1)
+#define BOARD_LED_2               (1 << BOARD_IOID_LED_2)
+#define BOARD_LED_ALL             (BOARD_LED_1 | BOARD_LED_2)
+/** @} */
+/*---------------------------------------------------------------------------*/
+/**
+ * \name UART IOID mapping
+ *
+ * Those values are not meant to be modified by the user
+ * @{
+ */
+#define BOARD_IOID_UART_RX        IOID_2
+#define BOARD_IOID_UART_TX        IOID_3
+#define BOARD_IOID_UART_RTS       IOID_18
+#define BOARD_IOID_UART_CTS       IOID_19
+#define BOARD_UART_RX             (1 << BOARD_IOID_UART_RX)
+#define BOARD_UART_TX             (1 << BOARD_IOID_UART_TX)
+#define BOARD_UART_RTS            (1 << BOARD_IOID_UART_RTS)
+#define BOARD_UART_CTS            (1 << BOARD_IOID_UART_CTS)
+/** @} */
+/*---------------------------------------------------------------------------*/
+/**
+ * \name Button IOID mapping
+ *
+ * Those values are not meant to be modified by the user
+ * @{
+ */
+#define BOARD_IOID_KEY_LEFT       IOID_13
+#define BOARD_IOID_KEY_RIGHT      IOID_14
+#define BOARD_KEY_LEFT            (1 << BOARD_IOID_KEY_LEFT)
+#define BOARD_KEY_RIGHT           (1 << BOARD_IOID_KEY_RIGHT)
+/** @} */
+/*---------------------------------------------------------------------------*/
+/**
+ * \brief SPI IOID mappings
+ *
+ * Those values are not meant to be modified by the user
+ * @{
+ */
+#define BOARD_IOID_SPI_MOSI       IOID_9
+#define BOARD_IOID_SPI_MISO       IOID_8
+/** @} */
+/*---------------------------------------------------------------------------*/
+/**
+ * \name External flash IOID mapping
+ *
+ * Those values are not meant to be modified by the user
+ * @{
+ */
+#define BOARD_IOID_FLASH_CS       IOID_20
+#define BOARD_FLASH_CS            (1 << BOARD_IOID_FLASH_CS)
+#define BOARD_IOID_SPI_CLK_FLASH  IOID_10
+/** @} */
+/*---------------------------------------------------------------------------*/
+/**
+ * \brief I2C IOID mappings
+ *
+ * Those values are not meant to be modified by the user
+ * @{
+ */
+#define BOARD_IOID_SCL            IOID_4
+#define BOARD_IOID_SDA            IOID_5
+/** @} */
+/*---------------------------------------------------------------------------*/
+/**
+ * \brief Remaining pins
+ *
+ * Those values are not meant to be modified by the user
+ * @{
+ */
+#define BOARD_IOID_CS             IOID_11
+#define BOARD_IOID_TDO            IOID_16
+#define BOARD_IOID_TDI            IOID_17
+#define BOARD_IOID_DIO12          IOID_12
+#define BOARD_IOID_DIO15          IOID_15
+#define BOARD_IOID_DIO21          IOID_21
+#define BOARD_IOID_DIO22          IOID_22
+#define BOARD_IOID_DIO23          IOID_23
+#define BOARD_IOID_DIO24          IOID_24
+#define BOARD_IOID_DIO25          IOID_25
+#define BOARD_IOID_DIO26          IOID_26
+#define BOARD_IOID_DIO27          IOID_27
+#define BOARD_IOID_DIO28          IOID_28
+#define BOARD_IOID_DIO29          IOID_29
+#define BOARD_IOID_DIO30          IOID_30
+/** @} */
+/*---------------------------------------------------------------------------*/
+/**
+ * \name Device string used on startup
+ * @{
+ */
+#define BOARD_STRING "TI CC2650 LaunchPad"
+
+/** @} */
+/*---------------------------------------------------------------------------*/
+#endif /* BOARD_H_ */
+/*---------------------------------------------------------------------------*/
+/**
+ * @}
+ * @}
+ */

--- a/platform/srf06-cc26xx/launchpad/launchpad-sensors.c
+++ b/platform/srf06-cc26xx/launchpad/launchpad-sensors.c
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2015, Texas Instruments Incorporated - http://www.ti.com/
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+/*---------------------------------------------------------------------------*/
+/**
+ * \addtogroup launchpad-peripherals
+ * @{
+ *
+ * \file
+ * Generic module controlling LaunchPad sensors
+ */
+/*---------------------------------------------------------------------------*/
+#include "contiki.h"
+#include "launchpad/button-sensor.h"
+
+#include <string.h>
+/*---------------------------------------------------------------------------*/
+/** \brief Exports a global symbol to be used by the sensor API */
+SENSORS(&button_left_sensor, &button_right_sensor);
+/*---------------------------------------------------------------------------*/
+/** @} */

--- a/platform/srf06-cc26xx/launchpad/leds-arch.c
+++ b/platform/srf06-cc26xx/launchpad/leds-arch.c
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2015, Texas Instruments Incorporated - http://www.ti.com/
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+/*---------------------------------------------------------------------------*/
+/**
+ * \addtogroup launchpad-peripherals
+ * @{
+ *
+ * \file
+ *  Driver for LaunchPad LEDs
+ */
+/*---------------------------------------------------------------------------*/
+#include "contiki.h"
+#include "dev/leds.h"
+
+#include "ti-lib.h"
+/*---------------------------------------------------------------------------*/
+static unsigned char c;
+static int inited = 0;
+/*---------------------------------------------------------------------------*/
+void
+leds_arch_init(void)
+{
+  if(inited) {
+    return;
+  }
+  inited = 1;
+
+  ti_lib_rom_ioc_pin_type_gpio_output(BOARD_IOID_LED_1);
+  ti_lib_rom_ioc_pin_type_gpio_output(BOARD_IOID_LED_2);
+
+  ti_lib_gpio_pin_write(BOARD_LED_ALL, 0);
+}
+/*---------------------------------------------------------------------------*/
+unsigned char
+leds_arch_get(void)
+{
+  return c;
+}
+/*---------------------------------------------------------------------------*/
+void
+leds_arch_set(unsigned char leds)
+{
+  c = leds;
+  ti_lib_gpio_pin_write(BOARD_LED_ALL, 0);
+
+  if((leds & LEDS_RED) == LEDS_RED) {
+    ti_lib_gpio_pin_write(BOARD_LED_1, 1);
+  }
+  if((leds & LEDS_YELLOW) == LEDS_YELLOW) {
+    ti_lib_gpio_pin_write(BOARD_LED_2, 1);
+  }
+}
+/*---------------------------------------------------------------------------*/
+/** @} */

--- a/platform/srf06-cc26xx/sensortag/Makefile.sensortag
+++ b/platform/srf06-cc26xx/sensortag/Makefile.sensortag
@@ -1,7 +1,7 @@
 CFLAGS += -DBOARD_SENSORTAG=1
 CFLAGS += -DBACKDOOR_IOID=0x00000000
 
-CONTIKI_TARGET_DIRS += sensortag
+CONTIKI_TARGET_DIRS += sensortag common
 
 BOARD_SOURCEFILES += sensortag-sensors.c  sensor-common.c
 BOARD_SOURCEFILES += bmp-280-sensor.c tmp-007-sensor.c opt-3001-sensor.c

--- a/platform/srf06-cc26xx/sensortag/ext-flash.c
+++ b/platform/srf06-cc26xx/sensortag/ext-flash.c
@@ -72,8 +72,10 @@
 /* Part specific constants */
 #define BLS_DEVICE_ID_W25X20CL    0x11
 #define BLS_DEVICE_ID_W25X40CL    0x12
+#define BLS_DEVICE_ID_MX25R8035F  0x14
 
-#define BLS_MANUFACTURER_ID       0xEF
+#define BLS_WINBOND_MID           0xEF
+#define BLS_MACRONIX_MID          0xC2
 
 #define BLS_PROGRAM_PAGE_SIZE      256
 #define BLS_ERASE_SECTOR_SIZE     4096
@@ -175,8 +177,9 @@ verify_part(void)
     return VERIFY_PART_ERROR;
   }
 
-  if(rbuf[0] != BLS_MANUFACTURER_ID ||
-     (rbuf[1] != BLS_DEVICE_ID_W25X20CL && rbuf[1] != BLS_DEVICE_ID_W25X40CL)) {
+  if((rbuf[0] != BLS_WINBOND_MID && rbuf[0] != BLS_MACRONIX_MID) ||
+     (rbuf[1] != BLS_DEVICE_ID_W25X20CL && rbuf[1] != BLS_DEVICE_ID_W25X40CL
+      && rbuf[1] != BLS_DEVICE_ID_MX25R8035F)) {
     return VERIFY_PART_POWERED_DOWN;
   }
   return VERIFY_PART_OK;

--- a/regression-tests/18-compile-arm-ports/Makefile
+++ b/regression-tests/18-compile-arm-ports/Makefile
@@ -11,6 +11,7 @@ cc26xx/cc26xx-web-demo/srf06-cc26xx \
 cc26xx/very-sleepy-demo/srf06-cc26xx:BOARD=sensortag/cc2650 \
 cc26xx/cc26xx-web-demo/srf06-cc26xx:BOARD=sensortag/cc2650 \
 cc26xx/cc26xx-web-demo/srf06-cc26xx:BOARD=srf06/cc13xx \
+cc26xx/cc26xx-web-demo/srf06-cc26xx:BOARD=launchpad/cc2650 \
 cc26xx/very-sleepy-demo/srf06-cc26xx \
 hello-world/cc2538dk \
 ipv6/rpl-border-router/cc2538dk \


### PR DESCRIPTION
This adds support for one more CC26xx board: the new LaunchPad

We support LEDs and Buttons and also the LP's external flash.

The flash is a Macronix part with an instruction set that is basically a superset of the one of the Winbond part present on Sensortags. Thus, we extend the sensortag flash driver to support this additional part and we use the same driver for both boards. We create a `common` dir under `srf06-cc26xx` and we put the flash and SPI drivers therein. These are shared across the two boards for now, but it's really meant as a pool of drivers for devices present on more than one board.

This pull also extends cc26xx examples to support the LP and adds compile tests for LP builds