### PR TITLE
jn516x: flush only uart Tx FIFO in main loop, leaving Rx FIFO intact

### DIFF
--- a/platform/jn516x/contiki-jn516x-main.c
+++ b/platform/jn516x/contiki-jn516x-main.c
@@ -463,7 +463,7 @@ main_loop(void)
 #endif /* DCOSYNCH_CONF_ENABLED */
 
     /* flush standard output before sleeping */
-    uart_driver_flush(E_AHI_UART_0);
+    uart_driver_flush(E_AHI_UART_0, TRUE, FALSE);
 
     /* calculate the time to the next etimer and rtimer */
     time_to_etimer = clock_arch_time_to_etimer();

--- a/platform/jn516x/dev/uart-driver.c
+++ b/platform/jn516x/dev/uart-driver.c
@@ -589,19 +589,21 @@ uart_driver_tx_in_progress(uint8_t uart_dev)
  *
  * PARAMETERS:      Name            RW  Usage
  *                  uart_dev        R   UART to disable, eg, E_AHI_UART_0
+ *                  reset_tx        R   to reset the transmit FIFO
+ *                  reset_rx        R   to reset the receive FIFO
  *
  * RETURNS:
  * void
  *
  ****************************************************************************/
 void
-uart_driver_flush(uint8_t uart_dev)
+uart_driver_flush(uint8_t uart_dev, bool_t reset_tx, bool_t reset_rx)
 {
   /* Disable TX Fifo empty and Rx data interrupts */
   uart_driver_disable_interrupts(uart_dev);
 
   /* flush hardware buffer */
-  vAHI_UartReset(uart_dev, TRUE, TRUE);
+  vAHI_UartReset(uart_dev, reset_tx, reset_rx);
   vAHI_UartReset(uart_dev, FALSE, FALSE);
 
   /* Re-enable TX Fifo empty and Rx data interrupts */

--- a/platform/jn516x/dev/uart-driver.h
+++ b/platform/jn516x/dev/uart-driver.h
@@ -58,7 +58,7 @@ void uart_driver_restore_interrupts(uint8_t uart_dev);
 uint8_t uart_driver_tx_in_progress(uint8_t uart_dev);
 
 #ifdef UART_EXTRAS
-void uart_driver_flush(uint8_t uart_dev);
+void uart_driver_flush(uint8_t uart_dev, bool_t reset_tx, bool_t reset_rx);
 #endif
 
 #endif /* UARTDRIVER_H */


### PR DESCRIPTION
Fixes a bug that caused loss of some incoming uart data