### PR TITLE
Fix ip64 warnings and error

### DIFF
--- a/core/net/ip64/ip64-eth-interface.c
+++ b/core/net/ip64/ip64-eth-interface.c
@@ -89,7 +89,6 @@ output(void)
 {
   int len, ret;
 
-
   printf("ip64-interface: output source ");
   PRINT6ADDR(&UIP_IP_BUF->srcipaddr);
   PRINTF(" destination ");
@@ -117,6 +116,8 @@ output(void)
       return IP64_ETH_DRIVER.output(ip64_packet_buffer, len);
     }
   }
+
+  return 0;
 }
 /*---------------------------------------------------------------------------*/
 const struct uip_fallback_interface ip64_eth_interface = {

--- a/core/net/ip64/ip64.c
+++ b/core/net/ip64/ip64.c
@@ -897,11 +897,13 @@ interface_init(void)
   IP64_UIP_FALLBACK_INTERFACE.init();
 }
 /*---------------------------------------------------------------------------*/
-static void
+static int
 interface_output(void)
 {
   PRINTF("ip64: interface_output len %d\n", uip_len);
   IP64_UIP_FALLBACK_INTERFACE.output();
+
+  return 0;
 }
 /*---------------------------------------------------------------------------*/
 const struct uip_fallback_interface ip64_uip_fallback_interface = {

--- a/dev/enc28j60/enc28j60-ip64-driver.c
+++ b/dev/enc28j60/enc28j60-ip64-driver.c
@@ -35,6 +35,7 @@
 
 #include "ip64.h"
 #include "ip64-eth.h"
+#include "rime.h"
 
 #include <string.h>
 #include <stdio.h>


### PR DESCRIPTION
This PR fixes warning upon compiling for `ip64` and fixes broken `enc28j60-ip64-driver.c` related to `linkaddr_node_addr` being undeclared