### PR TITLE
Fix timestamps of packets recorded in pcap files

### DIFF
--- a/tools/cooja/java/org/contikios/cooja/Simulation.java
+++ b/tools/cooja/java/org/contikios/cooja/Simulation.java
@@ -71,6 +71,7 @@ public class Simulation extends Observable implements Runnable {
   private long speedLimitLastSimtime;
   private long speedLimitLastRealtime;
 
+  private long lastStartTime;
   private long currentSimulationTime = 0;
 
   private String title = null;
@@ -248,7 +249,7 @@ public class Simulation extends Observable implements Runnable {
   }
 
   public void run() {
-    long lastStartTime = System.currentTimeMillis();
+    lastStartTime = System.currentTimeMillis();
     logger.info("Simulation main loop started, system time: " + lastStartTime);
     isRunning = true;
     speedLimitLastRealtime = System.currentTimeMillis();
@@ -1072,6 +1073,16 @@ public class Simulation extends Observable implements Runnable {
    */
   public long getSimulationTimeMillis() {
     return currentSimulationTime / MILLISECOND;
+  }
+
+  /**
+   * Return the actual time value corresponding to an argument which
+   * is a simulation time value in microseconds.
+   *
+   * @return Actual time (microseconds)
+   */
+  public long convertSimTimeToActualTime(long simTime) {
+    return simTime + lastStartTime * 1000;
   }
 
   /**

--- a/tools/cooja/java/org/contikios/cooja/plugins/RadioLogger.java
+++ b/tools/cooja/java/org/contikios/cooja/plugins/RadioLogger.java
@@ -694,8 +694,8 @@ public class RadioLogger extends VisPlugin {
     StringBuilder verbose = new StringBuilder();
 
     /* default analyzer */
-    PacketAnalyzer.Packet packet = new PacketAnalyzer.Packet(data, PacketAnalyzer.MAC_LEVEL);
-
+    PacketAnalyzer.Packet packet = new PacketAnalyzer.Packet(data, PacketAnalyzer.MAC_LEVEL,
+                                                             simulation.convertSimTimeToActualTime(conn.startTime));
     if (analyzePacket(packet, brief, verbose)) {
       if (packet.hasMoreData()) {
         byte[] payload = packet.getPayload();

--- a/tools/cooja/java/org/contikios/cooja/plugins/analyzers/IEEE802154Analyzer.java
+++ b/tools/cooja/java/org/contikios/cooja/plugins/analyzers/IEEE802154Analyzer.java
@@ -69,7 +69,7 @@ public class IEEE802154Analyzer extends PacketAnalyzer {
 
     if (pcapExporter != null) {
       try {
-        pcapExporter.exportPacketData(packet.getPayload());
+        pcapExporter.exportPacketData(packet.getPayload(), packet.getTimestamp());
       } catch (IOException e) {
         logger.error("Could not export PCap data", e);
       }

--- a/tools/cooja/java/org/contikios/cooja/plugins/analyzers/PacketAnalyzer.java
+++ b/tools/cooja/java/org/contikios/cooja/plugins/analyzers/PacketAnalyzer.java
@@ -18,6 +18,7 @@ public abstract class PacketAnalyzer {
     int level;
     /* size = length - consumed bytes at tail */
     int size;
+    long ts;  /* in microseconds */
 
     /* L2 addresseses */
     byte[] llsender;
@@ -25,10 +26,11 @@ public abstract class PacketAnalyzer {
 
     byte lastDispatch = 0;
 
-    public Packet(byte[] data, int level) {
+    public Packet(byte[] data, int level, long ts) {
       this.level = level;
       this.data = data.clone();
       this.size = data.length;
+      this.ts = ts;
     }
 
     public void consumeBytesStart(int bytes) {
@@ -78,6 +80,10 @@ public abstract class PacketAnalyzer {
 
     public byte[] getLLReceiver() {
       return llreceiver;
+    }
+
+    public long getTimestamp() {
+      return ts;
     }
   };
 

--- a/tools/cooja/java/org/contikios/cooja/plugins/analyzers/PcapExporter.java
+++ b/tools/cooja/java/org/contikios/cooja/plugins/analyzers/PcapExporter.java
@@ -41,15 +41,15 @@ public class PcapExporter {
     out = null;
   }
 
-  public void exportPacketData(byte[] data) throws IOException {
+  public void exportPacketData(byte[] data, long ts) throws IOException {
     if (out == null) {
       /* pcap file never set, open default */
       openPcap(null);
     }
     try {
       /* pcap packet header */
-      out.writeInt((int) (System.currentTimeMillis() / 1000));
-      out.writeInt((int) ((System.currentTimeMillis() % 1000) * 1000));
+      out.writeInt((int) (ts / 1000000));
+      out.writeInt((int) (ts % 1000000));
       out.writeInt(data.length);
       out.writeInt(data.length);
       /* and the data */


### PR DESCRIPTION
This PR makes PcapExporter write frames with timestamps in the simulated time.

Currently, PcapExporter records timestamps when they are written into a pcap file. Because of that, by looking at the pcap file, you cannot know if packets are sent at your expected timings unless the simulation runs at 100% speed.

Here is an example which shows packets generated and recorded in the simulation of `regression-tests/11-ipv6/01-cooja-ipv6-udp.csc`:

![before](https://cloud.githubusercontent.com/assets/1230923/12823146/c0bb3aa4-cb6a-11e5-8c48-2d58cd33af17.png)

After applying the changes, you will get this:

![after](https://cloud.githubusercontent.com/assets/1230923/12823262/521df7ac-cb6b-11e5-99ee-751d8e5eb9b9.png)

In both cases above,  timestamps are represented as "Seconds Since Beginning of Capture."  If you select "Date and Time of Day", you will see a result like this:

![after-excerpt](https://cloud.githubusercontent.com/assets/1230923/12823404/15adeb64-cb6c-11e5-8a52-209da1635645.png)
