### PR TITLE
travis: Force AAPCS toolchain version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ before_script:
   - if [ ${BUILD_ARCH:-0} = arm-aapcs ] ; then
       sudo add-apt-repository -y ppa:team-gcc-arm-embedded/ppa &&
       sudo apt-get -qq update &&
-      sudo apt-get -qq install gcc-arm-embedded srecord &&
+      sudo apt-get -qq install gcc-arm-embedded=5-2015q4-1~precise1 srecord &&
       arm-none-eabi-gcc --version ;
     fi
 


### PR DESCRIPTION
Make Travis CI use the GNU ARM Embedded toolchain version specified by
the READMEs, instead of automatically using the latest version provided
by the PPA. In this way, the READMEs will still be correct after a PPA
upgrade, and the version used by Contiki is under control.

This is a follow-up to #1453 (@g-oikonomou @alignan).