### PR TITLE
galileo: build_newlib.sh: Exit on configuration error

### DIFF
--- a/platform/galileo/bsp/libc/build_newlib.sh
+++ b/platform/galileo/bsp/libc/build_newlib.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 JOBS=5
 TARGET=i586-elf
 VERSION=2.2.0-1
@@ -99,7 +101,9 @@ cleanup() {
 
 
 # By default we always call prepare, build and setup.
-prepare && build && setup
+prepare
+build
+setup
 
 # But we only cleanup if -c is used.
 case $1 in


### PR DESCRIPTION
This patch adds a check for the result of the newlib configure command
and immediately exits the build_newlib.sh script if configure fails.