### PR TITLE
galileo: build_newlib.sh: Only apply patch files with the extension ".patch"

### DIFF
--- a/platform/galileo/bsp/libc/build_newlib.sh
+++ b/platform/galileo/bsp/libc/build_newlib.sh
@@ -38,7 +38,7 @@ prepare() {
     tar xf ${TARBALL}
     cd ${SRC_DIR}
 
-    for i in  `ls ${PATCH_DIR}`; do patch -p0 < ${PATCH_DIR}/${i}; done
+    for i in  `ls ${PATCH_DIR}/*.patch`; do patch -p0 < ${i}; done
 }
 
 


### PR DESCRIPTION
This avoids treating as patches other files that may happen to be
present in the newlib patch directory in a working tree.