### PR TITLE
Removed PM10 code lines from adc-sensors driver

### DIFF
--- a/platform/zoul/dev/adc-sensors.c
+++ b/platform/zoul/dev/adc-sensors.c
@@ -118,10 +118,6 @@ convert_to_value(uint8_t index)
     /* Linear sensor from 0 to 5 V;*/
     return (uint16_t)value;
 
-  case ANALOG_PM10_SENSOR:
-    /* PM10 sensor from 0 to 3.9 V;*/
-    return (uint16_t)value;
-
   default:
     return ADC_WRAPPER_ERROR;
   }
@@ -168,8 +164,8 @@ configure(int type, int value)
   uint8_t pin_mask = GPIO_PIN_MASK(value);
 
   if((type != ANALOG_GROVE_LIGHT) && (type != ANALOG_PHIDGET_ROTATION_1109) &&
-     (type != ANALOG_GROVE_LOUDNESS) && (type != ANALOG_PM10_SENSOR) &&
-     (type != ANALOG_VAC_SENSOR) && (type != ANALOG_AAC_SENSOR) ) {
+     (type != ANALOG_GROVE_LOUDNESS) && (type != ANALOG_VAC_SENSOR) && 
+     (type != ANALOG_AAC_SENSOR) ) {
     PRINTF("ADC sensors: sensor not supported, check adc_wrapper.h header\n");
     return ADC_WRAPPER_ERROR;
   }
@@ -205,7 +201,6 @@ configure(int type, int value)
   /*V+5 sensors*/
   case ANALOG_VAC_SENSOR:
   case ANALOG_AAC_SENSOR:
-  case ANALOG_PM10_SENSOR:
     if(adc_zoul.configure(SENSORS_HW_INIT, pin_mask) == ZOUL_SENSORS_ERROR) {
       return ADC_WRAPPER_ERROR;
     }

--- a/platform/zoul/dev/adc-sensors.h
+++ b/platform/zoul/dev/adc-sensors.h
@@ -73,7 +73,6 @@
 #define ANALOG_GROVE_LOUDNESS               0x03
 #define ANALOG_VAC_SENSOR                   0x04
 #define ANALOG_AAC_SENSOR                   0x05
-#define ANALOG_PM10_SENSOR                  0x06
 /* -------------------------------------------------------------------------- */
 #define ADC_SENSORS "ADC sensors API"
 /* -------------------------------------------------------------------------- */


### PR DESCRIPTION
This pull request removes code lines related to PM10 from `adc-sensors` driver. The PM10 driver is implemented with her own files and only access to `adc-zoul` driver.