### PR TITLE
CoAP: fix possible concurrency of multiple responses

### DIFF
--- a/apps/er-coap/er-coap-engine.h
+++ b/apps/er-coap/er-coap-engine.h
@@ -62,9 +62,9 @@ struct request_state_t {
   coap_transaction_t *transaction;
   coap_packet_t *response;
   uint32_t block_num;
+  uint8_t more;
+  uint8_t block_error_count;
 };
-
-typedef void (*blocking_response_handler)(void *response);
 
 PT_THREAD(coap_blocking_request
             (struct request_state_t *state, process_event_t ev,

--- a/apps/er-coap/er-coap-transactions.h
+++ b/apps/er-coap/er-coap-transactions.h
@@ -48,6 +48,8 @@
 #define COAP_RESPONSE_TIMEOUT_TICKS         (CLOCK_SECOND * COAP_RESPONSE_TIMEOUT)
 #define COAP_RESPONSE_TIMEOUT_BACKOFF_MASK  (long)((CLOCK_SECOND * COAP_RESPONSE_TIMEOUT * ((float)COAP_RESPONSE_RANDOM_FACTOR - 1.0)) + 0.5) + 1
 
+typedef void (*blocking_response_handler)(void *response);
+
 /* container for transactions with message buffer and retransmission info */
 typedef struct coap_transaction {
   struct coap_transaction *next;        /* for LIST */
@@ -60,6 +62,7 @@ typedef struct coap_transaction {
   uint16_t port;
 
   restful_response_handler callback;
+  blocking_response_handler blocking_callback;
   void *callback_data;
 
   uint16_t packet_len;


### PR DESCRIPTION
This PR fixes a concurrecyy problem, when two CoAP responses are arriving at the same time.
In the current version of the code, the yielded thread for a blocking request is polled through a callback.

The error scenario is as below:
1. CoAP request (1)
2. CoAP request (2)
3. CoAP response (1)
4. coap_blocking_request_callback (1)
5. CoAP response (2) -> overrides uip buf, where CoAP payload is stored
6. invoke yielded thread
7. call CoAP response (1) handler with wrong payload 

(in case of block 2 transfers, the block numbers are also affected and were moved to the state structure)
