### PR TITLE
Added enabling up to 6 ADC channels and fixed adc-zoul driver problem. 

### DIFF
--- a/platform/zoul/contiki-main.c
+++ b/platform/zoul/contiki-main.c
@@ -218,9 +218,9 @@ main(void)
 #endif /* NETSTACK_CONF_WITH_IPV6 */
 
   process_start(&sensors_process, NULL);
-
+#if PLATFOM_HAS_BUTTON
   SENSORS_ACTIVATE(button_sensor);
-
+#endif
   energest_init();
   ENERGEST_ON(ENERGEST_TYPE_CPU);
 

--- a/platform/zoul/dev/adc-sensors.c
+++ b/platform/zoul/dev/adc-sensors.c
@@ -175,7 +175,7 @@ configure(int type, int value)
     return ADC_WRAPPER_ERROR;
   }
 
-  if((value < 0x01) || (value > 0x07) || (value == BUTTON_USER_PIN)) {
+  if((value < 0x01) || (value > 0x07) || ((value == BUTTON_USER_PIN) && (ADC_SENSORS_ADC6_PIN < 0))) {
     PRINTF("ADC sensors: invalid pin value, (PA0-PA1, PA3) are reserved\n");
     return ADC_WRAPPER_ERROR;
   }

--- a/platform/zoul/dev/adc-zoul.c
+++ b/platform/zoul/dev/adc-zoul.c
@@ -93,6 +93,9 @@ get_channel_pin(int type)
   if((ZOUL_SENSORS_ADC5) && (type == ZOUL_SENSORS_ADC5)) {
     return SOC_ADC_ADCCON_CH_AIN0 + ADC_SENSORS_ADC5_PIN;
   }
+  if((ZOUL_SENSORS_ADC6) && (type == ZOUL_SENSORS_ADC6)) {
+    return SOC_ADC_ADCCON_CH_AIN0 + ADC_SENSORS_ADC6_PIN;
+  }
   return ZOUL_SENSORS_ERROR;
 }
 /*---------------------------------------------------------------------------*/
@@ -154,9 +157,12 @@ configure(int type, int value)
     if(value & ZOUL_SENSORS_ADC5) {
       ioc_set_over(GPIO_A_NUM, ADC_SENSORS_ADC5_PIN, IOC_OVERRIDE_ANA);
     }
+    if(value & ZOUL_SENSORS_ADC6) {
+      ioc_set_over(GPIO_A_NUM, ADC_SENSORS_ADC6_PIN, IOC_OVERRIDE_ANA);
+    }
     adc_init();
     set_decimation_rate(SOC_ADC_ADCCON_DIV_512);
-    enabled_channels = value;
+    enabled_channels += value;
     break;
 
   case ZOUL_SENSORS_CONFIGURE_TYPE_DECIMATION_RATE:

--- a/platform/zoul/dev/adc-zoul.h
+++ b/platform/zoul/dev/adc-zoul.h
@@ -38,7 +38,9 @@
  *
  * Driver for the Zoul ADC interface
  *
- * This driver supports analogue sensors connected to ADC1, ADC2 and AND3 inputs
+ * This driver supports analogue sensors connected to ADC1, ADC2, ADC3,
+ * ADC4, ADC5 and ADC6 inputs. ADC6 is shared with the user button, so disable
+ * user button if ADC6 is needed.
  * This is controlled by the type argument of the value() function. Possible
  * choices are:
  *
@@ -47,6 +49,7 @@
  * - ZOUL_SENSORS_ADC3
  * - ZOUL_SENSORS_ADC4
  * - ZOUL_SENSORS_ADC5
+ * - ZOUL_SENSORS_ADC6
  *
  * To initialize the ADC sensors use the configure() function, using as first
  * argument SENSORS_HW_INIT, and choose which ADC channels to enable passing as
@@ -128,13 +131,20 @@
 #else
 #define ZOUL_SENSORS_ADC5        0
 #endif
+
+/* ADC phidget-like connector ADC6 */
+#if ADC_SENSORS_ADC6_PIN >= ZOUL_SENSORS_ADC_MIN
+#define ZOUL_SENSORS_ADC6        GPIO_PIN_MASK(ADC_SENSORS_ADC6_PIN)
+#else
+#define ZOUL_SENSORS_ADC6        0
+#endif
 /*
  * This is safe as the disabled sensors should have a zero value thus not
  * affecting the mask operations
  */
 #define ZOUL_SENSORS_ADC_ALL     (ZOUL_SENSORS_ADC1 + ZOUL_SENSORS_ADC2 + \
                                   ZOUL_SENSORS_ADC3 + ZOUL_SENSORS_ADC4 + \
-                                  ZOUL_SENSORS_ADC5)
+                                  ZOUL_SENSORS_ADC5 + ZOUL_SENSORS_ADC6)
 /** @} */
 /*---------------------------------------------------------------------------*/
 extern const struct sensors_sensor adc_zoul;

--- a/platform/zoul/dev/zoul-sensors.c
+++ b/platform/zoul/dev/zoul-sensors.c
@@ -47,7 +47,12 @@
 #include <string.h>
 /*---------------------------------------------------------------------------*/
 /** \brief Exports global symbols for the sensor API */
-SENSORS(&button_sensor, &vdd3_sensor, &cc2538_temp_sensor);
+SENSORS(&vdd3_sensor,
+#if PLATFORM_HAS_BUTTON
+  &button_sensor,
+#endif
+  &cc2538_temp_sensor
+);
 /*---------------------------------------------------------------------------*/
 /**
  * @}

--- a/platform/zoul/firefly/board.h
+++ b/platform/zoul/firefly/board.h
@@ -168,6 +168,92 @@
 #define UART1_RTS_PIN            (-1) /**< 0 */
 /** @} */
 /*---------------------------------------------------------------------------*/
+/**
+ * \name ADC configuration
+ *
+ * These values configure which CC2538 pins and ADC channels to use for the ADC
+ * inputs. There pins are suggested as they can be changed, but note that only
+ * pins from PA can be configured as ADC.
+ *
+ * - ADC1: up to 3.3V.
+ * - ADC2: up to 3.3V.
+ * - ADC3: up to 3.3V.
+ * - ADC4: up to 3.3V.
+ * - ADC5: up to 3.3V.
+ * - ADC6: up to 3.3V, shared with user button.
+ * 
+ * Only ADC1 and ADC3 are enabled as default.
+ *
+ * The internal ADC reference is 1190mV, use either a voltage divider as input,
+ * or a different voltage reference, like AVDD5 or other externally (AIN7 or
+ * AIN6).
+ * @{
+ */
+#define ADC_SENSORS_PORT         GPIO_A_NUM /**< ADC GPIO control port */
+
+#ifndef ADC_SENSORS_CONF_ADC1_PIN
+#define ADC_SENSORS_ADC1_PIN     5             /**< ADC1 to PA5  */
+#else
+#if ((ADC_SENSORS_CONF_ADC1_PIN != -1) && (ADC_SENSORS_CONF_ADC1_PIN != 5))
+#error "ADC1 channel should be mapped to PA5 or disabled with -1"
+#else
+#define ADC_SENSORS_ADC1_PIN ADC_SENSORS_CONF_ADC1_PIN
+#endif
+#endif
+
+#ifndef ADC_SENSORS_CONF_ADC2_PIN
+#define ADC_SENSORS_ADC2_PIN     4             /**< ADC2 to PA4  */
+#else
+#if ((ADC_SENSORS_CONF_ADC2_PIN != -1) && (ADC_SENSORS_CONF_ADC2_PIN != 4))
+#error "ADC2 channel should be mapped to PA4 or disabled with -1"
+#else
+#define ADC_SENSORS_ADC2_PIN ADC_SENSORS_CONF_ADC2_PIN
+#endif
+#endif
+
+#ifndef ADC_SENSORS_CONF_ADC3_PIN
+#define ADC_SENSORS_ADC3_PIN     2             /**< ADC3 to PA2  */
+#else
+#if ((ADC_SENSORS_CONF_ADC3_PIN != -1) && (ADC_SENSORS_CONF_ADC3_PIN != 2))
+#error "ADC3 channel should be mapped to PA2 or disabled with -1"
+#else
+#define ADC_SENSORS_ADC3_PIN ADC_SENSORS_CONF_ADC3_PIN
+#endif
+#endif
+
+#ifndef ADC_SENSORS_CONF_ADC4_PIN
+#define ADC_SENSORS_ADC4_PIN     6             /**< ADC4 to PA6   */
+#else
+#if ((ADC_SENSORS_CONF_ADC4_PIN != -1) && (ADC_SENSORS_CONF_ADC4_PIN != 6))
+#error "ADC4 channel should be mapped to PA6 or disabled with -1"
+#else
+#define ADC_SENSORS_ADC4_PIN ADC_SENSORS_CONF_ADC4_PIN
+#endif
+#endif
+
+#ifndef ADC_SENSORS_CONF_ADC5_PIN
+#define ADC_SENSORS_ADC5_PIN     7             /**< ADC5 to PA7   */
+#else
+#if ((ADC_SENSORS_CONF_ADC5_PIN != -1) && (ADC_SENSORS_CONF_ADC5_PIN != 7))
+#error "ADC5 channel should be mapped to PA7 or disabled with -1"
+#else
+#define ADC_SENSORS_ADC5_PIN ADC_SENSORS_CONF_ADC5_PIN
+#endif
+#endif
+
+#ifndef ADC_SENSORS_CONF_ADC6_PIN
+#define ADC_SENSORS_ADC6_PIN     (-1)          /**< ADC6 not declared    */
+#else
+#define ADC_SENSORS_ADC6_PIN     3             /**< Hard-coded to PA3    */
+#endif
+
+#ifndef ADC_SENSORS_CONF_MAX
+#define ADC_SENSORS_MAX          5            /**< Maximum sensors       */
+#else
+#define ADC_SENSORS_MAX          ADC_SENSORS_CONF_MAX
+#endif
+/** @} */
+/*---------------------------------------------------------------------------*/
 /** \name Firefly Button configuration
  *
  * Buttons on the Firefly are connected as follows:
@@ -180,31 +266,19 @@
 #define BUTTON_USER_PIN        3
 #define BUTTON_USER_VECTOR     NVIC_INT_GPIO_PORT_A
 
-/* Notify various examples that we have Buttons */
-#define PLATFORM_HAS_BUTTON      1
-/** @} */
-/*---------------------------------------------------------------------------*/
-/**
- * \name ADC configuration
- *
- * These values configure which CC2538 pins and ADC channels to use for the ADC
- * inputs. There pins are suggested as they can be changed, but note that only
- * pins from PA can be configured as ADC.
- *
- * The Firefly, as it is, only allows 3.3VDC sensors.
- *
- * The internal ADC reference is 1190mV, use either a voltage divider as input,
- * or a different voltage reference, like AVDD5 or other externally (AIN7 or
- * AIN6).
- * @{
+/* Notify various examples that we have an user button.
+ * If ADC6 channel is used, then disable the user button
  */
-#define ADC_SENSORS_PORT         GPIO_A_NUM /**< ADC GPIO control port */
-#define ADC_SENSORS_ADC1_PIN     5          /**< ADC1 to PA5, 3V3    */
-#define ADC_SENSORS_ADC2_PIN     4          /**< ADC2 to PA4, 3V3    */
-#define ADC_SENSORS_ADC3_PIN     2          /**< ADC3 to PA2, 3V3    */
-#define ADC_SENSORS_ADC4_PIN     6          /**< ADC4 to PA6, 3V3    */
-#define ADC_SENSORS_ADC5_PIN     7          /**< ADC5 to PA7, 3V3    */
-#define ADC_SENSORS_MAX          5          /**< PA2, PA4, PA5, PA6, PA7 */
+#ifdef PLATFORM_CONF_WITH_BUTTON
+#if (PLATFORM_CONF_WITH_BUTTON && (ADC_SENSORS_ADC6_PIN == 3))
+#error "The ADC6 (PA3) and user button cannot be enabled at the same time" 
+#else
+#define PLATFORM_HAS_BUTTON  (PLATFORM_CONF_WITH_BUTTON && \
+                              !(ADC_SENSORS_ADC6_PIN == 3))
+#endif /* (PLATFORM_CONF_WITH_BUTTON && (ADC_SENSORS_ADC6_PIN == 3)) */
+#else
+#define PLATFORM_HAS_BUTTON  !(ADC_SENSORS_ADC6_PIN == 3)
+#endif /* PLATFORM_CONF_WITH_BUTTON */
 /** @} */
 /*---------------------------------------------------------------------------*/
 /**

--- a/platform/zoul/remote/board.h
+++ b/platform/zoul/remote/board.h
@@ -171,23 +171,6 @@
 #define UART1_RTS_PIN            (-1)
 /** @} */
 /*---------------------------------------------------------------------------*/
-/** \name RE-Mote Button configuration
- *
- * Buttons on the RE-Mote are connected as follows:
- * - BUTTON_USER  -> PA3, S1 user button, shared with bootloader and RTC_INT1
- * - BUTTON_RESET -> RESET_N line, S2 reset both CC2538 and CoP
- * - BUTTON_PIC1W -> shared with SHUTDOWN_ENABLE, not mounted.
- * @{
- */
-/** BUTTON_USER -> PA3 */
-#define BUTTON_USER_PORT       GPIO_A_NUM
-#define BUTTON_USER_PIN        3
-#define BUTTON_USER_VECTOR     NVIC_INT_GPIO_PORT_A
-
-/* Notify various examples that we have Buttons */
-#define PLATFORM_HAS_BUTTON      1
-/** @} */
-/*---------------------------------------------------------------------------*/
 /**
  * \name ADC configuration
  *
@@ -200,6 +183,12 @@
  * - ADC1: up to 3.3V.
  * - ADC2: up to 3.3V, shared with RTC_INT
  * - ADC3: up to 5V, by means of a 2/3 voltage divider.
+ *
+ * Also there are other ADC channels shared by default with Micro SD card and
+ * user button implementations: 
+ * - ADC4: up to 3.3V.
+ * - ADC5: up to 3.3V.
+ * - ADC6: up to 3.3V.
  *
  * ADC inputs can only be on port A.
  * All ADCx are exposed in JP5 connector, but only ADC1 and ADC3 have GND and
@@ -216,12 +205,84 @@
  * @{
  */
 #define ADC_SENSORS_PORT         GPIO_A_NUM /**< ADC GPIO control port */
-#define ADC_SENSORS_ADC1_PIN     5          /**< ADC1 to PA5, 3V3    */
-#define ADC_SENSORS_ADC2_PIN     (-1)       /**< ADC2 to PA4, 3V3    */
-#define ADC_SENSORS_ADC3_PIN     2          /**< ADC3 to PA2, 5V0    */
-#define ADC_SENSORS_ADC4_PIN     (-1)       /**< Not present    */
-#define ADC_SENSORS_ADC5_PIN     (-1)       /**< Not present    */
-#define ADC_SENSORS_MAX          2          /**< PA2, PA5 */
+
+#ifndef ADC_SENSORS_CONF_ADC1_PIN
+#define ADC_SENSORS_ADC1_PIN     5             /**< ADC1 to PA5, 3V3    */
+#else
+#if ((ADC_SENSORS_CONF_ADC1_PIN != -1) && (ADC_SENSORS_CONF_ADC1_PIN != 5))
+#error "ADC1 channel should be mapped to PA5 or disabled with -1"
+#else
+#define ADC_SENSORS_ADC1_PIN ADC_SENSORS_CONF_ADC1_PIN
+#endif
+#endif
+
+#ifndef ADC_SENSORS_CONF_ADC3_PIN
+#define ADC_SENSORS_ADC3_PIN     2             /**< ADC3 to PA2, 5V     */
+#else
+#if ((ADC_SENSORS_CONF_ADC3_PIN != -1) && (ADC_SENSORS_CONF_ADC3_PIN != 2))
+#error "ADC3 channel should be mapped to PA2 or disabled with -1"
+#else
+#define ADC_SENSORS_ADC3_PIN ADC_SENSORS_CONF_ADC3_PIN
+#endif
+#endif
+
+#ifndef ADC_SENSORS_CONF_ADC2_PIN
+#define ADC_SENSORS_ADC2_PIN     (-1)          /**< ADC2 no declared    */
+#else
+#define ADC_SENSORS_ADC2_PIN     4             /**< Hard-coded to PA4    */
+#endif
+
+#ifndef ADC_SENSORS_CONF_ADC4_PIN
+#define ADC_SENSORS_ADC4_PIN     (-1)          /**< ADC4 not declared    */
+#else
+#define ADC_SENSORS_ADC4_PIN     6             /**< Hard-coded to PA6    */
+#endif
+
+#ifndef ADC_SENSORS_CONF_ADC5_PIN
+#define ADC_SENSORS_ADC5_PIN     (-1)          /**< ADC5 not declared    */
+#else
+#define ADC_SENSORS_ADC5_PIN     7             /**< Hard-coded to PA7    */
+#endif
+
+#ifndef ADC_SENSORS_CONF_ADC6_PIN
+#define ADC_SENSORS_ADC6_PIN     (-1)             /**< ADC6 not declared    */
+#else
+#define ADC_SENSORS_ADC6_PIN     3             /**< Hard-coded to PA3    */
+#endif
+
+#ifndef ADC_SENSORS_CONF_MAX
+#define ADC_SENSORS_MAX          2             /**< Maximum sensors    */
+#else
+#define ADC_SENSORS_MAX          ADC_SENSORS_CONF_MAX
+#endif
+/** @} */
+/*---------------------------------------------------------------------------*/
+/** \name RE-Mote Button configuration
+ *
+ * Buttons on the RE-Mote are connected as follows:
+ * - BUTTON_USER  -> PA3, S1 user button, shared with bootloader and RTC_INT1
+ * - BUTTON_RESET -> RESET_N line, S2 reset both CC2538 and CoP
+ * - BUTTON_PIC1W -> shared with SHUTDOWN_ENABLE, not mounted.
+ * @{
+ */
+/** BUTTON_USER -> PA3 */
+#define BUTTON_USER_PORT       GPIO_A_NUM
+#define BUTTON_USER_PIN        3
+#define BUTTON_USER_VECTOR     NVIC_INT_GPIO_PORT_A
+
+/* Notify various examples that we have an user button.
+ * If ADC6 channel is used, then disable the user button
+ */
+#ifdef PLATFORM_CONF_WITH_BUTTON
+#if (PLATFORM_CONF_WITH_BUTTON && (ADC_SENSORS_ADC6_PIN == 3))
+#error "The ADC6 (PA3) and user button cannot be enabled at the same time" 
+#else
+#define PLATFORM_HAS_BUTTON  (PLATFORM_CONF_WITH_BUTTON && \
+                              !(ADC_SENSORS_ADC6_PIN == 3))
+#endif /* (PLATFORM_CONF_WITH_BUTTON && (ADC_SENSORS_ADC6_PIN == 3)) */
+#else
+#define PLATFORM_HAS_BUTTON  !(ADC_SENSORS_ADC6_PIN == 3)
+#endif /* PLATFORM_CONF_WITH_BUTTON */
 /** @} */
 /*---------------------------------------------------------------------------*/
 /**


### PR DESCRIPTION
Added enabling up to 6 ADC channels for RE-Mote and Firefly platforms.
Solved problem with `enabled_channels` variable in adc-zoul driver.