### PR TITLE
Fix warning about missing strcasecmp definition

### DIFF
--- a/core/net/ip/resolv.c
+++ b/core/net/ip/resolv.c
@@ -111,6 +111,9 @@ strcasecmp(const char *s1, const char *s2)
   /* TODO: Add case support! */
   return strcmp(s1, s2);
 }
+#else
+int strcasecmp(const char *s1, const char *s2);
+int strncasecmp(const char *s1, const char *s2, size_t n);
 #endif /* __SDCC */
 
 #define UIP_UDP_BUF ((struct uip_udpip_hdr *)&uip_buf[UIP_LLH_LEN])


### PR DESCRIPTION
On platforms which do not define the macro ```__SDCC``` the ```strcasecmp``` function may not have a definition (this happens at least on CC26xx). The prototype for this function is now defined if ```__SDCC``` is false.