### PR TITLE
fix warning: function declaration isn't a prototype

### DIFF
--- a/apps/er-coap/er-coap-separate.h
+++ b/apps/er-coap/er-coap-separate.h
@@ -61,7 +61,7 @@ typedef struct coap_separate {
 
 int coap_separate_handler(resource_t *resource, void *request,
                           void *response);
-void coap_separate_reject();
+void coap_separate_reject(void);
 void coap_separate_accept(void *request, coap_separate_t *separate_store);
 void coap_separate_resume(void *response, coap_separate_t *separate_store,
                           uint8_t code);

--- a/apps/er-coap/er-coap-transactions.h
+++ b/apps/er-coap/er-coap-transactions.h
@@ -67,7 +67,7 @@ typedef struct coap_transaction {
                                                  * Use snprintf(buf, len+1, "", ...) to completely fill payload */
 } coap_transaction_t;
 
-void coap_register_as_transaction_handler();
+void coap_register_as_transaction_handler(void);
 
 coap_transaction_t *coap_new_transaction(uint16_t mid, uip_ipaddr_t *addr,
                                          uint16_t port);
@@ -75,6 +75,6 @@ void coap_send_transaction(coap_transaction_t *t);
 void coap_clear_transaction(coap_transaction_t *t);
 coap_transaction_t *coap_get_transaction_by_mid(uint16_t mid);
 
-void coap_check_transactions();
+void coap_check_transactions(void);
 
 #endif /* COAP_TRANSACTIONS_H_ */

--- a/core/lib/gcr.c
+++ b/core/lib/gcr.c
@@ -64,13 +64,13 @@ static unsigned char gcr_bits = 0;
 static unsigned short gcr_val = 0;
 
 /* Call before starting encoding or decoding */
-void gcr_init() {
+void gcr_init(void) {
   gcr_val = 0;
   gcr_bits = 0;
 }
 
 /* Use this to check if encoding / decoding is complete for now */
-unsigned char gcr_finished() {
+unsigned char gcr_finished(void) {
   return gcr_bits == 0;
 }
 
@@ -100,7 +100,7 @@ void gcr_decode(unsigned char gcr_data) {
 }
 
 /* check if the current decoded stream is correct */
-unsigned char gcr_valid() {
+unsigned char gcr_valid(void) {
   if (gcr_bits >= 10) {
     unsigned short val = gcr_val & 0x3ff;
     if ((GCR_decode[val >> 5u] << 4u) == 0xff ||

--- a/core/lib/settings.h
+++ b/core/lib/settings.h
@@ -186,7 +186,7 @@ extern settings_status_t settings_delete(settings_key_t key, uint8_t index);
 typedef eeprom_addr_t settings_iter_t;
 
 /** Will return \ref SETTINGS_INVALID_ITER if the settings store is empty. */
-extern settings_iter_t settings_iter_begin();
+extern settings_iter_t settings_iter_begin(void);
 
 /** Will return \ref SETTINGS_INVALID_ITER if at the end of settings list. */
 extern settings_iter_t settings_iter_next(settings_iter_t iter);

--- a/core/lib/trickle-timer.c
+++ b/core/lib/trickle-timer.c
@@ -79,7 +79,7 @@ static void double_interval(void *ptr);
 #if TRICKLE_TIMER_WIDE_RAND
 /* Returns a 4-byte wide, unsigned random number */
 static uint32_t
-wide_rand()
+wide_rand(void)
 {
   return ((uint32_t)random_rand() << 16 | random_rand());
 }

--- a/core/net/ipv6/sicslowpan.c
+++ b/core/net/ipv6/sicslowpan.c
@@ -452,7 +452,7 @@ rime_sniffer_remove(struct rime_sniffer *s)
 }
 
 static void
-set_packet_attrs()
+set_packet_attrs(void)
 {
   int c = 0;
   /* set protocol in NETWORK_ID */

--- a/core/net/rpl/rpl-dag.c
+++ b/core/net/rpl/rpl-dag.c
@@ -88,7 +88,7 @@ rpl_instance_t *default_instance;
 
 /*---------------------------------------------------------------------------*/
 void
-rpl_print_neighbor_list()
+rpl_print_neighbor_list(void)
 {
   if(default_instance != NULL && default_instance->current_dag != NULL &&
       default_instance->of != NULL && default_instance->of->calculate_rank != NULL) {
@@ -160,7 +160,7 @@ rpl_get_parent_link_metric(const uip_lladdr_t *addr)
 {
   uip_ds6_nbr_t *nbr;
   nbr = nbr_table_get_from_lladdr(ds6_neighbors, (const linkaddr_t *)addr);
-  
+
   if(nbr != NULL) {
     return nbr->link_metric;
   } else {
@@ -645,7 +645,7 @@ rpl_add_parent(rpl_dag_t *dag, rpl_dio_t *dio, uip_ipaddr_t *addr)
       p->dag = dag;
       p->rank = dio->rank;
       p->dtsn = dio->dtsn;
-      
+
       /* Check whether we have a neighbor that has not gotten a link metric yet */
       if(nbr != NULL && nbr->link_metric == 0) {
 	nbr->link_metric = RPL_INIT_LINK_METRIC * RPL_DAG_MC_ETX_DIVISOR;

--- a/core/net/rpl/rpl.h
+++ b/core/net/rpl/rpl.h
@@ -179,7 +179,7 @@ typedef struct rpl_instance rpl_instance_t;
  * update_metric_container(dag)
  *
  *  Updates the metric container for outgoing DIOs in a certain DAG.
- *  If the objective function of the DAG does not use metric containers, 
+ *  If the objective function of the DAG does not use metric containers,
  *  the function should set the object type to RPL_DAG_MC_NONE.
  */
 struct rpl_of {
@@ -257,7 +257,7 @@ rpl_rank_t rpl_get_parent_rank(uip_lladdr_t *addr);
 uint16_t rpl_get_parent_link_metric(const uip_lladdr_t *addr);
 void rpl_dag_init(void);
 uip_ds6_nbr_t *rpl_get_nbr(rpl_parent_t *parent);
-void rpl_print_neighbor_list();
+void rpl_print_neighbor_list(void);
 
 /* Per-parent RPL information */
 NBR_TABLE_DECLARE(rpl_parents);

--- a/examples/er-rest-example/resources/res-event.c
+++ b/examples/er-rest-example/resources/res-event.c
@@ -53,7 +53,7 @@
 #endif
 
 static void res_get_handler(void *request, void *response, uint8_t *buffer, uint16_t preferred_size, int32_t *offset);
-static void res_event_handler();
+static void res_event_handler(void);
 
 /*
  * Example for an event resource.
@@ -86,7 +86,7 @@ res_get_handler(void *request, void *response, uint8_t *buffer, uint16_t preferr
  * It is called through <res_name>.trigger(), usually from the server process.
  */
 static void
-res_event_handler()
+res_event_handler(void)
 {
   /* Do the update triggered by the event here, e.g., sampling a sensor. */
   ++event_counter;


### PR DESCRIPTION
I was getting warnings when building with `-Wstrict-prototypes`:
```
In file included from ./resources/res-b1-sep-b2.c:42:0:
../../apps/er-coap/er-coap-separate.h:64:1: warning: function declaration isn’t a prototype [-Wstrict-prototypes]
 void coap_separate_reject();
 ^
In file included from ./resources/res-b1-sep-b2.c:43:0:
../../apps/er-coap/er-coap-transactions.h:70:1: warning: function declaration isn’t a prototype [-Wstrict-prototypes]
 void coap_register_as_transaction_handler();
 ^
../../apps/er-coap/er-coap-transactions.h:78:1: warning: function declaration isn’t a prototype [-Wstrict-prototypes]
 void coap_check_transactions();
 ^
./resources/res-event.c:56:1: warning: function declaration isn’t a prototype [-Wstrict-prototypes]
 static void res_event_handler();
 ^
./resources/res-event.c:89:1: warning: function declaration isn’t a prototype [-Wstrict-prototypes]
 res_event_handler()
 ^
```

Further reading: http://stackoverflow.com/questions/51032/is-there-a-difference-between-foovoid-and-foo-in-c-or-c