### PR TITLE
added output function in NETSTACK network to enable IP packet filters, etc.

### DIFF
--- a/core/net/ip/tcpip.c
+++ b/core/net/ip/tcpip.c
@@ -109,25 +109,18 @@ enum {
 /* Called on IP packet output. */
 #if NETSTACK_CONF_WITH_IPV6
 
-static uint8_t (* outputfunc)(const uip_lladdr_t *a);
-
 uint8_t
 tcpip_output(const uip_lladdr_t *a)
 {
   int ret;
-  if(outputfunc != NULL) {
-    ret = outputfunc(a);
+  if(NETSTACK_NETWORK.output != NULL) {
+    ret = NETSTACK_NETWORK.output((const linkaddr_t *) a);
     return ret;
   }
-  UIP_LOG("tcpip_output: Use tcpip_set_outputfunc() to set an output function");
+  UIP_LOG("tcpip_output: add NETSTACK_NETWORK.output to set an output function");
   return 0;
 }
 
-void
-tcpip_set_outputfunc(uint8_t (*f)(const uip_lladdr_t *))
-{
-  outputfunc = f;
-}
 #else
 
 static uint8_t (* outputfunc)(void);

--- a/core/net/netstack.h
+++ b/core/net/netstack.h
@@ -110,6 +110,7 @@
 #include "net/mac/rdc.h"
 #include "net/mac/framer.h"
 #include "dev/radio.h"
+#include "net/linkaddr.h"
 
 /**
  * The structure of a network driver in Contiki.
@@ -122,6 +123,10 @@ struct network_driver {
 
   /** Callback for getting notified of incoming packet. */
   void (* input)(void);
+
+  /** Callback for sending outgoing packets. */
+  uint8_t (* output)(const linkaddr_t *localdest);
+
 };
 
 extern const struct network_driver NETSTACK_NETWORK;

--- a/cpu/native/net/tapdev-drv.c
+++ b/cpu/native/net/tapdev-drv.c
@@ -57,6 +57,7 @@ tapdev_output(void)
    return 0;
 }
 #endif
+
 /*---------------------------------------------------------------------------*/
 static void
 pollhandler(void)
@@ -81,11 +82,23 @@ pollhandler(void)
        if(uip_len > 0) {
 	  tapdev_send();
        }
-#endif              
+#endif
     } else {
       uip_clear_buf();
     }
   }
+}
+/*---------------------------------------------------------------------------*/
+static uint8_t
+output(const linkaddr_t *dest)
+{
+  return tapdev_send((const uip_lladdr_t *)dest);
+}
+/*---------------------------------------------------------------------------*/
+static void
+input(void)
+{
+  /* This should not happen as this should be the "lowest" in the stack.*/
 }
 /*---------------------------------------------------------------------------*/
 PROCESS_THREAD(tapdev_process, ev, data)
@@ -94,11 +107,8 @@ PROCESS_THREAD(tapdev_process, ev, data)
 
   PROCESS_BEGIN();
 
-  tapdev_init();
 #if !NETSTACK_CONF_WITH_IPV6
   tcpip_set_outputfunc(tapdev_output);
-#else
-  tcpip_set_outputfunc(tapdev_send);
 #endif
   process_poll(&tapdev_process);
 
@@ -108,4 +118,11 @@ PROCESS_THREAD(tapdev_process, ev, data)
 
   PROCESS_END();
 }
+/*---------------------------------------------------------------------------*/
+const struct network_driver eth_driver = {
+  "tapdev",
+  tapdev_init,
+  input,
+  output
+};
 /*---------------------------------------------------------------------------*/

--- a/cpu/native/net/wpcap-drv.c
+++ b/cpu/native/net/wpcap-drv.c
@@ -153,13 +153,23 @@ bail:
 
 }
 /*---------------------------------------------------------------------------*/
+static uint8_t
+output(const linkaddr_t *dest)
+{
+  wpcap_send((const uip_lladdr_t *)dest);
+}
+/*---------------------------------------------------------------------------*/
+static void
+input(void)
+{
+  /* This should not happen as this should be the "lowest" in the stack.*/
+}
+/*---------------------------------------------------------------------------*/
 PROCESS_THREAD(wpcap_process, ev, data)
 {
   PROCESS_POLLHANDLER(pollhandler());
 
   PROCESS_BEGIN();
-
-  wpcap_init();
 
 #if !NETSTACK_CONF_WITH_IPV6
   tcpip_set_outputfunc(wpcap_output);
@@ -177,4 +187,11 @@ PROCESS_THREAD(wpcap_process, ev, data)
 
   PROCESS_END();
 }
+/*---------------------------------------------------------------------------*/
+const struct network_driver eth_driver = {
+  "wpcapdev",
+  wpcap_init,
+  input,
+  output,
+};
 /*---------------------------------------------------------------------------*/

--- a/platform/minimal-net/contiki-conf.h
+++ b/platform/minimal-net/contiki-conf.h
@@ -64,6 +64,9 @@ typedef  int32_t s32_t;
 
 typedef unsigned short uip_stats_t;
 
+#ifndef NETSTACK_CONF_NETWORK
+#define NETSTACK_CONF_NETWORK     eth_driver
+#endif /* NETSTACK_CONF_MAC */
 
 #if NETSTACK_CONF_WITH_IPV6
 /* The Windows build uses wpcap to connect to a host interface. It finds the interface by scanning for

--- a/platform/minimal-net/contiki-main.c
+++ b/platform/minimal-net/contiki-main.c
@@ -245,6 +245,8 @@ main(int argc, char **argv)
   process_start(&etimer_process, NULL);
   ctimer_init();
 
+  NETSTACK_NETWORK.init();
+
 #if RPL_BORDER_ROUTER
   process_start(&border_router_process, NULL);
   printf("Border Router Process started\n");


### PR DESCRIPTION
Adding an output function to NETSTACK network adapted for IPv6 networking. It enables a full replacement of the network layer so that packet logging, packet filtering, firewalls, dual-radio trick can be easily implemented.

This is a yet failing pull request (some issues with Z1 builds) and will need some fixes in native platform (for the hooks into the linux / windows stack). I will take a look at fixing these things - but puts the PR in to get some comments on the idea of adding the output function.
