### PR TITLE
Minor TSCH fixes

### DIFF
--- a/core/net/mac/tsch/tsch-packet.h
+++ b/core/net/mac/tsch/tsch-packet.h
@@ -36,6 +36,7 @@
 /********** Includes **********/
 
 #include "contiki.h"
+#include "net/packetbuf.h"
 #include "net/mac/tsch/tsch-private.h"
 #include "net/mac/frame802154.h"
 #include "net/mac/frame802154e-ie.h"
@@ -81,7 +82,7 @@ by default, useful in case of duplicate seqno */
 /********** Constants *********/
 
 /* Max TSCH packet lenght */
-#define TSCH_PACKET_MAX_LEN 127
+#define TSCH_PACKET_MAX_LEN MIN(127,PACKETBUF_SIZE)
 
 /********** Functions *********/
 

--- a/core/net/mac/tsch/tsch-queue.c
+++ b/core/net/mac/tsch/tsch-queue.c
@@ -302,14 +302,17 @@ tsch_queue_free_packet(struct tsch_packet *p)
 /*---------------------------------------------------------------------------*/
 /* Flush all neighbor queues */
 void
-tsch_queue_flush_all(void)
+tsch_queue_reset(void)
 {
   /* Deallocate unneeded neighbors */
   if(!tsch_is_locked()) {
     struct tsch_neighbor *n = list_head(neighbor_list);
     while(n != NULL) {
       struct tsch_neighbor *next_n = list_item_next(n);
+      /* Flush queue */
       tsch_queue_flush_nbr_queue(n);
+      /* Reset backoff exponent */
+      tsch_queue_backoff_reset(n);
       n = next_n;
     }
   }
@@ -379,6 +382,7 @@ tsch_queue_get_packet_for_dest_addr(const linkaddr_t *addr, struct tsch_link *li
   }
   return NULL;
 }
+/*---------------------------------------------------------------------------*/
 /* Returns the head packet of any neighbor queue with zero backoff counter.
  * Writes pointer to the neighbor in *n */
 struct tsch_packet *

--- a/core/net/mac/tsch/tsch-queue.h
+++ b/core/net/mac/tsch/tsch-queue.h
@@ -166,8 +166,8 @@ int tsch_queue_packet_count(const linkaddr_t *addr);
 struct tsch_packet *tsch_queue_remove_packet_from_queue(struct tsch_neighbor *n);
 /* Free a packet */
 void tsch_queue_free_packet(struct tsch_packet *p);
-/* Flush all neighbor queues */
-void tsch_queue_flush_all(void);
+/* Reset neighbor queues */
+void tsch_queue_reset(void);
 /* Deallocate neighbors with empty queue */
 void tsch_queue_free_unused_neighbors(void);
 /* Is the neighbor queue empty? */

--- a/core/net/mac/tsch/tsch-slot-operation.c
+++ b/core/net/mac/tsch/tsch-slot-operation.c
@@ -506,7 +506,7 @@ PT_THREAD(tsch_tx_slot(struct pt *pt, struct rtimer *t))
                   tx_start_time, tx_duration + tsch_timing[tsch_ts_rx_ack_delay] + tsch_timing[tsch_ts_ack_wait]);
               TSCH_DEBUG_TX_EVENT();
 
-              ack_start_time = RTIMER_NOW();
+              ack_start_time = RTIMER_NOW() - RADIO_DELAY_BEFORE_DETECT;
 
               /* Wait for ACK to finish */
               BUSYWAIT_UNTIL_ABS(!NETSTACK_RADIO.receiving_packet(),

--- a/core/net/mac/tsch/tsch-slot-operation.c
+++ b/core/net/mac/tsch/tsch-slot-operation.c
@@ -776,6 +776,7 @@ PT_THREAD(tsch_rx_slot(struct pt *pt, struct rtimer *t))
                   packet_duration + tsch_timing[tsch_ts_tx_ack_delay] - RADIO_DELAY_BEFORE_TX, "RxBeforeAck");
               TSCH_DEBUG_RX_EVENT();
               NETSTACK_RADIO.transmit(ack_len);
+              NETSTACK_RADIO.off();
             }
 
             /* If the sender is a time source, proceed to clock drift compensation */

--- a/core/net/mac/tsch/tsch.c
+++ b/core/net/mac/tsch/tsch.c
@@ -199,8 +199,8 @@ tsch_reset(void)
   frame802154_set_pan_id(0xffff);
   /* First make sure pending packet callbacks are sent etc */
   process_post_synch(&tsch_pending_events_process, PROCESS_EVENT_POLL, NULL);
-  /* Empty all neighbor queues */
-  /* tsch_queue_flush_all(); */
+  /* Reset neighbor queues */
+  tsch_queue_reset();
   /* Remove unused neighbors */
   tsch_queue_free_unused_neighbors();
   tsch_queue_update_time_source(NULL);


### PR DESCRIPTION
Do not merge yet, this is not tested on all platforms.

Explicitly turn off the radio after ACK Tx, may be needed on some platforms (most platform would turn it off anyway as it was off before Tx). Also fixes `TSCH_PACKET_MAX_LEN` for platforms with smaller `PACKETBUF_SIZE`.

Added another fix: we now flush all queues and reset backoff exponents whenever re-associating.