### PR TITLE
uip6, icmp6 and ext header handling fixes: traceroute now working!

### DIFF
--- a/core/net/ipv6/uip-icmp6.c
+++ b/core/net/ipv6/uip-icmp6.c
@@ -206,15 +206,14 @@ echo_request_input(void)
 /*---------------------------------------------------------------------------*/
 void
 uip_icmp6_error_output(uint8_t type, uint8_t code, uint32_t param) {
-
- /* check if originating packet is not an ICMP error*/
-  if (uip_ext_len) {
-    if(UIP_EXT_BUF->next == UIP_PROTO_ICMP6 && UIP_ICMP_BUF->type < 128){
+  /* check if originating packet is not an ICMP error */
+  if(uip_ext_len) {
+    if(UIP_EXT_BUF->next == UIP_PROTO_ICMP6 && UIP_ICMP_BUF->type < 128) {
       uip_clear_buf();
       return;
     }
   } else {
-    if(UIP_IP_BUF->proto == UIP_PROTO_ICMP6 && UIP_ICMP_BUF->type < 128){
+    if(UIP_IP_BUF->proto == UIP_PROTO_ICMP6 && UIP_ICMP_BUF->type < 128) {
       uip_clear_buf();
       return;
     }
@@ -231,8 +230,9 @@ uip_icmp6_error_output(uint8_t type, uint8_t code, uint32_t param) {
 
   uip_len += UIP_IPICMPH_LEN + UIP_ICMP6_ERROR_LEN;
 
-  if(uip_len > UIP_LINK_MTU)
+  if(uip_len > UIP_LINK_MTU) {
     uip_len = UIP_LINK_MTU;
+  }
 
   memmove((uint8_t *)UIP_ICMP6_ERROR_BUF + uip_ext_len + UIP_ICMP6_ERROR_LEN,
           (void *)UIP_IP_BUF, uip_len - UIP_IPICMPH_LEN - uip_ext_len - UIP_ICMP6_ERROR_LEN);

--- a/core/net/ipv6/uip-icmp6.c
+++ b/core/net/ipv6/uip-icmp6.c
@@ -220,8 +220,8 @@ uip_icmp6_error_output(uint8_t type, uint8_t code, uint32_t param) {
   }
 
 #if UIP_CONF_IPV6_RPL
-  uip_ext_len = rpl_invert_header();
-#else /* UIP_CONF_IPV6_RPL */
+  rpl_remove_header();
+#else
   uip_ext_len = 0;
 #endif /* UIP_CONF_IPV6_RPL */
 
@@ -279,6 +279,10 @@ uip_icmp6_error_output(uint8_t type, uint8_t code, uint32_t param) {
   UIP_IP_BUF->len[1] = ((uip_len - UIP_IPH_LEN) & 0xff);
   UIP_ICMP_BUF->icmpchksum = 0;
   UIP_ICMP_BUF->icmpchksum = ~uip_icmp6chksum();
+
+#if UIP_CONF_IPV6_RPL
+  rpl_insert_header();
+#endif /* UIP_CONF_IPV6_RPL */
 
   UIP_STAT(++uip_stat.icmp.sent);
 

--- a/core/net/ipv6/uip6.c
+++ b/core/net/ipv6/uip6.c
@@ -1482,8 +1482,6 @@ uip_process(uint8_t flag)
      work. If the application sets uip_slen, it has a packet to
      send. */
 #if UIP_UDP_CHECKSUMS
-  uip_len = uip_len - UIP_IPUDPH_LEN;
-  uip_appdata = &uip_buf[UIP_IPUDPH_LEN + UIP_LLH_LEN];
   /* XXX hack: UDP/IPv6 receivers should drop packets with UDP
      checksum 0. Here, we explicitly receive UDP packets with checksum
      0. This is to be able to debug code that for one reason or
@@ -1496,8 +1494,6 @@ uip_process(uint8_t flag)
            uip_udpchksum());
     goto drop;
   }
-#else /* UIP_UDP_CHECKSUMS */
-  uip_len = uip_len - UIP_IPUDPH_LEN;
 #endif /* UIP_UDP_CHECKSUMS */
 
   /* Make sure that the UDP destination port number is not zero. */
@@ -1536,6 +1532,8 @@ uip_process(uint8_t flag)
   PRINTF("In udp_found\n");
   UIP_STAT(++uip_stat.udp.recv);
 
+  uip_len = uip_len - UIP_IPUDPH_LEN;
+  uip_appdata = &uip_buf[UIP_IPUDPH_LEN + UIP_LLH_LEN];
   uip_conn = NULL;
   uip_flags = UIP_NEWDATA;
   uip_sappdata = uip_appdata = &uip_buf[UIP_IPUDPH_LEN + UIP_LLH_LEN];

--- a/core/net/ipv6/uip6.c
+++ b/core/net/ipv6/uip6.c
@@ -1529,12 +1529,8 @@ uip_process(uint8_t flag)
   PRINTF("udp: no matching connection found\n");
   UIP_STAT(++uip_stat.udp.drop);
 
-#if UIP_UDP_SEND_UNREACH_NOPORT
   uip_icmp6_error_output(ICMP6_DST_UNREACH, ICMP6_DST_UNREACH_NOPORT, 0);
   goto send;
-#else
-  goto drop;
-#endif
 
  udp_found:
   PRINTF("In udp_found\n");

--- a/core/net/ipv6/uip6.c
+++ b/core/net/ipv6/uip6.c
@@ -1473,6 +1473,7 @@ uip_process(uint8_t flag)
  udp_input:
 
   remove_ext_hdr();
+  UIP_IP_BUF->proto = UIP_PROTO_UDP;
 
   PRINTF("Receiving UDP packet\n");
 
@@ -1593,6 +1594,7 @@ uip_process(uint8_t flag)
  tcp_input:
 
   remove_ext_hdr();
+  UIP_IP_BUF->proto = UIP_PROTO_TCP;
 
   UIP_STAT(++uip_stat.tcp.recv);
   PRINTF("Receiving TCP packet\n");


### PR DESCRIPTION
This is a collection of fixes required to get traceroute to work.
There were several connected problems:
* icmp error messages should return the original incoming packet, but they returned an altered version due to extension header handling and buffer length bugs
* the last hop never returned a "port unreachable" message