### PR TITLE
Fix a number of leftover mentions of aaaa as a prefix (now fd00)

### DIFF
--- a/examples/ipso-objects/README.md
+++ b/examples/ipso-objects/README.md
@@ -26,10 +26,10 @@ First program a device with the examples/ipso-objects/example-ipso-objects.c
 >...
 ```
 
-After that start up a native-border router or other border router on aaaa::1/64
+After that start up a native-border router or other border router on fd00::1/64
 or another prefix - NOTE: if you use another prefix you will need to change LWM2M_SERVER_ADDRESS for which the device will register - in project-conf.h:
 ```
-#define LWM2M_SERVER_ADDRESS "aaaa::1"
+#define LWM2M_SERVER_ADDRESS "fd00::1"
 ```
 
 Then when everything is setup you can download a Leshan and use that to

--- a/examples/ipso-objects/example-ipso-objects.c
+++ b/examples/ipso-objects/example-ipso-objects.c
@@ -52,7 +52,7 @@
 #endif
 
 #ifndef LWM2M_SERVER_ADDRESS
-#define LWM2M_SERVER_ADDRESS "aaaa::1"
+#define LWM2M_SERVER_ADDRESS "fd00::1"
 #endif
 
 PROCESS(example_ipso_objects, "IPSO object example");

--- a/examples/ipso-objects/example-server.c
+++ b/examples/ipso-objects/example-server.c
@@ -229,19 +229,19 @@ setup_network(void)
  * Obviously the choice made here must also be selected in udp-client.c.
  *
  * For correct Wireshark decoding using a sniffer, add the /64 prefix to the 6LowPAN protocol preferences,
- * e.g. set Context 0 to aaaa::.  At present Wireshark copies Context/128 and then overwrites it.
- * (Setting Context 0 to aaaa::1111:2222:3333:4444 will report a 16 bit compressed address of aaaa::1111:22ff:fe33:xxxx)
+ * e.g. set Context 0 to fd00::.  At present Wireshark copies Context/128 and then overwrites it.
+ * (Setting Context 0 to fd00::1111:2222:3333:4444 will report a 16 bit compressed address of fd00::1111:22ff:fe33:xxxx)
  * Note Wireshark's IPCMV6 checksum verification depends on the correct uncompressed addresses.
  */
 #if 0
 /* Mode 1 - 64 bits inline */
-   uip_ip6addr(&ipaddr, 0xaaaa, 0, 0, 0, 0, 0, 0, 1);
+   uip_ip6addr(&ipaddr, UIP_DS6_DEFAULT_PREFIX, 0, 0, 0, 0, 0, 0, 1);
 #elif 1
 /* Mode 2 - 16 bits inline */
-  uip_ip6addr(&ipaddr, 0xaaaa, 0, 0, 0, 0, 0x00ff, 0xfe00, 1);
+  uip_ip6addr(&ipaddr, UIP_DS6_DEFAULT_PREFIX, 0, 0, 0, 0, 0x00ff, 0xfe00, 1);
 #else
 /* Mode 3 - derived from link local (MAC) address */
-  uip_ip6addr(&ipaddr, 0xaaaa, 0, 0, 0, 0, 0, 0, 0);
+  uip_ip6addr(&ipaddr, UIP_DS6_DEFAULT_PREFIX, 0, 0, 0, 0, 0, 0, 0);
   uip_ds6_set_addr_iid(&ipaddr, &uip_lladdr);
 #endif
 
@@ -249,7 +249,7 @@ setup_network(void)
   root_if = uip_ds6_addr_lookup(&ipaddr);
   if(root_if != NULL) {
     dag = rpl_set_root(RPL_DEFAULT_INSTANCE, &ipaddr);
-    uip_ip6addr(&ipaddr, 0xaaaa, 0, 0, 0, 0, 0, 0, 0);
+    uip_ip6addr(&ipaddr, UIP_DS6_DEFAULT_PREFIX, 0, 0, 0, 0, 0, 0, 0);
     rpl_set_prefix(dag, &ipaddr, 64);
     PRINTF("created a new RPL dag\n");
   } else {

--- a/examples/ipv6/rpl-tsch/node.c
+++ b/examples/ipv6/rpl-tsch/node.c
@@ -187,7 +187,7 @@ PROCESS_THREAD(node_process, ev, data)
 
   if(is_coordinator) {
     uip_ipaddr_t prefix;
-    uip_ip6addr(&prefix, 0xaaaa, 0, 0, 0, 0, 0, 0, 0);
+    uip_ip6addr(&prefix, UIP_DS6_DEFAULT_PREFIX, 0, 0, 0, 0, 0, 0, 0);
     net_init(&prefix);
   } else {
     net_init(NULL);

--- a/examples/jn516x/tsch/tx-power-verification/node/node.c
+++ b/examples/jn516x/tsch/tx-power-verification/node/node.c
@@ -105,7 +105,7 @@ PROCESS_THREAD(start_app, ev, data)
   /* Start network stack */
   if(is_coordinator) {
     uip_ipaddr_t prefix;
-    uip_ip6addr(&prefix, 0xaaaa, 0, 0, 0, 0, 0, 0, 0);
+    uip_ip6addr(&prefix, UIP_DS6_DEFAULT_PREFIX, 0, 0, 0, 0, 0, 0, 0);
     rpl_tools_init(&prefix);
   } else {
     rpl_tools_init(NULL);

--- a/examples/jn516x/tsch/tx-power-verification/node/node.c
+++ b/examples/jn516x/tsch/tx-power-verification/node/node.c
@@ -32,6 +32,7 @@
 *
 */
 #include "contiki.h"
+#include "net/ipv6/uip-ds6.h"
 #include "net/netstack.h"
 #include "net/ip/uip.h"
 #include "net/linkaddr.h"

--- a/examples/jn516x/tsch/uart1-test-node/uart1-test-node.c
+++ b/examples/jn516x/tsch/uart1-test-node/uart1-test-node.c
@@ -145,7 +145,7 @@ PROCESS_THREAD(start_app, ev, data)
   /* Start network stack */
   if(is_coordinator) {
     uip_ipaddr_t prefix;
-    uip_ip6addr(&prefix, 0xaaaa, 0, 0, 0, 0, 0, 0, 0);
+    uip_ip6addr(&prefix, UIP_DS6_DEFAULT_PREFIX, 0, 0, 0, 0, 0, 0, 0);
     rpl_tools_init(&prefix);
   } else {
     rpl_tools_init(NULL);

--- a/examples/jn516x/tsch/uart1-test-node/uart1-test-node.c
+++ b/examples/jn516x/tsch/uart1-test-node/uart1-test-node.c
@@ -31,6 +31,8 @@
 * Author: Theo van Daele <theo.van.daele@nxp.com>
 *
 */
+#include "contiki.h"
+#include "net/ipv6/uip-ds6.h"
 #include "net/ip/uip.h"
 #include "net/linkaddr.h"
 #include "rpl-tools.h"


### PR DESCRIPTION
A number of new "aaaa" slipped in between the original PR and its merge. This replaces them with the new local prefix "fd00"