### PR TITLE
Fix doxygen warning

### DIFF
--- a/doc/uip6-doc.txt
+++ b/doc/uip6-doc.txt
@@ -161,7 +161,7 @@ Determine the link-layer address of a %neighbor given its IPv6 address.\n
 \li Neighbor unreachability detection\n
 Verify that a neighbor is still reachable via a cached link-layer
 address.\n
--> send a NS (done in #uip_ds6_neighbor_periodic).
+-> send a NS (done in uip_ds6_neighbor_periodic).
 \li Next-hop determination\n
 Map an IPv6 destination address into the IPv6 address of the %neighbor
 to which traffic for the destination should be sent.\n


### PR DESCRIPTION
that one warning slipped in after merging https://github.com/contiki-os/contiki/pull/1387, which was last run in Travis in November. Not sure if this is the cleanest of fixes, simply suppresses the ref to `uip_ds6_neighbor_periodic` as the function is now compiled out by default.