### PR TITLE
fix SerialSocketServer when run without GUI

### DIFF
--- a/tools/cooja/apps/serial_socket/java/org/contikios/cooja/serialsocket/SerialSocketServer.java
+++ b/tools/cooja/apps/serial_socket/java/org/contikios/cooja/serialsocket/SerialSocketServer.java
@@ -644,6 +644,7 @@ public class SerialSocketServer extends VisPlugin implements MotePlugin {
   private Timer updateTimer = new Timer(UPDATE_INTERVAL, new ActionListener() {
     @Override
 	  public void actionPerformed(ActionEvent e) {
+	  	if (Cooja.isVisualized()) {
 		  if (closed) {
 			  updateTimer.stop();
 			  return;
@@ -651,6 +652,7 @@ public class SerialSocketServer extends VisPlugin implements MotePlugin {
 		  
 		  socketToMoteLabel.setText(inBytes + " bytes");
 		  moteToSocketLabel.setText(outBytes + " bytes");
+	  }
 	  }
   });
 }


### PR DESCRIPTION
I add a problem running Cooja serial socket server without a graphical interface. It created NullPointerException at the initial stage.

```
Exception in thread "AWT-EventQueue-0" java.lang.NullPointerException
	at org.contikios.cooja.serialsocket.SerialSocketServer$6.actionPerformed(SerialSocketServer.java:652)
	at javax.swing.Timer.fireActionPerformed(Timer.java:312)
	at javax.swing.Timer$DoPostEvent.run(Timer.java:244)
	at java.awt.event.InvocationEvent.dispatch(InvocationEvent.java:312)
	at java.awt.EventQueue.dispatchEventImpl(EventQueue.java:745)
	at java.awt.EventQueue.access$300(EventQueue.java:103)
	at java.awt.EventQueue$3.run(EventQueue.java:706)
	at java.awt.EventQueue$3.run(EventQueue.java:704)
	at java.security.AccessController.doPrivileged(Native Method)
	at java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:77)
	at java.awt.EventQueue.dispatchEvent(EventQueue.java:715)
	at java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:242)
	at java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:161)
	at java.awt.EventDispatchThread.pumpEventsForHierarchy(EventDispatchThread.java:150)
	at java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:146)
	at java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:138)
	at java.awt.EventDispatchThread.run(EventDispatchThread.java:91)

```