### PR TITLE
JN516x clock module sign error fix

### DIFF
--- a/platform/jn516x/dev/clock.c
+++ b/platform/jn516x/dev/clock.c
@@ -258,7 +258,7 @@ clock_arch_time_to_etimer(void)
   clock_time_t time_to_etimer;
   if(etimer_pending()) {
     time_to_etimer = etimer_next_expiration_time() - clock_time();
-    if(time_to_etimer < 0) {
+    if((int32_t)time_to_etimer < 0) {
       time_to_etimer = 0;
     }
   } else {


### PR DESCRIPTION
This small fix has a huge impact on the etimer events. The current check is wrong for sure since `clock_time_t` is unsigned. For further details check my comment on #1265.