### PR TITLE
cc26xx-cc13xx BLE beacon event issue

### DIFF
--- a/cpu/cc26xx-cc13xx/rf-core/rf-ble.c
+++ b/cpu/cc26xx-cc13xx/rf-core/rf-ble.c
@@ -256,7 +256,7 @@ PROCESS_THREAD(rf_ble_beacon_process, ev, data)
   while(1) {
     etimer_set(&ble_adv_et, beacond_config.interval);
 
-    PROCESS_WAIT_EVENT();
+    PROCESS_WAIT_EVENT_UNTIL(etimer_expired(&ble_adv_et) || ev == PROCESS_EVENT_EXIT);
 
     if(ev == PROCESS_EVENT_EXIT) {
       PROCESS_EXIT();
@@ -374,7 +374,7 @@ PROCESS_THREAD(rf_ble_beacon_process, ev, data)
 
       /* Wait unless this is the last burst */
       if(i < BLE_ADV_MESSAGES - 1) {
-        PROCESS_WAIT_EVENT();
+        PROCESS_WAIT_EVENT_UNTIL(etimer_expired(&ble_adv_et));
       }
     }
 


### PR DESCRIPTION
This pull request fixes an issue in the cc26xx-cc13xx BLE beacon process.

The rf_ble_beacon_process yields the thread using PROCESS_WAIT_EVENT() which allows the process to continue when _any_ event is posted rather than checking that the event timer has expired, which is what we really want. This pull request adds a check for ble_adv_et event timer expiration, which prevents broadcasts from sensor updates, etc. from triggering the BLE beacon.