### PR TITLE
cc26xx-cc13xx oscillator control issue

### DIFF
--- a/cpu/cc26xx-cc13xx/rf-core/ieee-mode.c
+++ b/cpu/cc26xx-cc13xx/rf-core/ieee-mode.c
@@ -1049,12 +1049,6 @@ static int
 on(void)
 {
   /*
-   * Request the HF XOSC as the source for the HF clock. Needed before we can
-   * use the FS. This will only request, it will _not_ perform the switch.
-   */
-  oscillators_request_hf_xosc();
-
-  /*
    * If we are in the middle of a BLE operation, we got called by ContikiMAC
    * from within an interrupt context. Abort, but pretend everything is OK.
    */
@@ -1062,6 +1056,12 @@ on(void)
     PRINTF("on: Interrupt context but BLE in progress\n");
     return RF_CORE_CMD_OK;
   }
+
+  /*
+   * Request the HF XOSC as the source for the HF clock. Needed before we can
+   * use the FS. This will only request, it will _not_ perform the switch.
+   */
+  oscillators_request_hf_xosc();
 
   if(rf_is_on()) {
     PRINTF("on: We were on. PD=%u, RX=0x%04x \n", rf_core_is_accessible(),

--- a/cpu/cc26xx-cc13xx/rf-core/prop-mode.c
+++ b/cpu/cc26xx-cc13xx/rf-core/prop-mode.c
@@ -894,18 +894,18 @@ static int
 on(void)
 {
   /*
-   * Request the HF XOSC as the source for the HF clock. Needed before we can
-   * use the FS. This will only request, it will _not_ perform the switch.
-   */
-  oscillators_request_hf_xosc();
-
-  /*
    * If we are in the middle of a BLE operation, we got called by ContikiMAC
    * from within an interrupt context. Abort, but pretend everything is OK.
    */
   if(rf_ble_is_active() == RF_BLE_ACTIVE) {
     return RF_CORE_CMD_OK;
   }
+
+  /*
+   * Request the HF XOSC as the source for the HF clock. Needed before we can
+   * use the FS. This will only request, it will _not_ perform the switch.
+   */
+  oscillators_request_hf_xosc();
 
   if(rf_is_on()) {
     PRINTF("on: We were on. PD=%u, RX=0x%04x \n", rf_core_is_accessible(),


### PR DESCRIPTION
This pull request fixes an issue in the cc26xx-cc13xx oscillator control which causes occasional faults and device lockup.

When running both ContikiMAC and the BLE beacon process, the ContikiMAC interrupt will occasionally preempt the beacon process while it is modifying the oscillators. This causes occasional bus faults and infinite loops if it happens at just the right time.

This pull request prevents the conflicts by checking that the BLE beacon is not active prior to modifying the oscillators.