### PR TITLE
Add typecast to native border router switch statement

### DIFF
--- a/examples/ipv6/native-border-router/slip-config.c
+++ b/examples/ipv6/native-border-router/slip-config.c
@@ -67,7 +67,7 @@ int
 slip_config_handle_arguments(int argc, char **argv)
 {
   const char *prog;
-  char c;
+  int c;
   int baudrate = 115200;
 
   slip_config_verbose = 0;


### PR DESCRIPTION
When running the native border router on my raspbian installation it would always fail because for some reason the while loop would not consider the statement to be true.
My best guess would be that the -1 value for a char is `0xFF` while the same for an int would be `0xFFFFFFFF`.