### PR TITLE
Added net-debug.[ch] to provide debug functions even in the non-IP case

### DIFF
--- a/core/net/ip/uip-debug.c
+++ b/core/net/ip/uip-debug.c
@@ -30,7 +30,7 @@
 
 /**
  * \file
- *         A set of debugging tools
+ *         A set of debugging tools for the IP stack
  * \author
  *         Nicolas Tsiftes <nvt@sics.se>
  *         Niclas Finne <nfi@sics.se>
@@ -90,21 +90,5 @@ uip_debug_ipaddr_print(const uip_ipaddr_t *addr)
 #else /* NETSTACK_CONF_WITH_IPV6 */
   PRINTA("%u.%u.%u.%u", addr->u8[0], addr->u8[1], addr->u8[2], addr->u8[3]);
 #endif /* NETSTACK_CONF_WITH_IPV6 */
-}
-/*---------------------------------------------------------------------------*/
-void
-uip_debug_lladdr_print(const uip_lladdr_t *addr)
-{
-  unsigned int i;
-  if(addr == NULL) {
-    PRINTA("(NULL LL addr)");
-    return;
-  }
-  for(i = 0; i < sizeof(uip_lladdr_t); i++) {
-    if(i > 0) {
-      PRINTA(":");
-    }
-    PRINTA("%02x", addr->addr[i]);
-  }
 }
 /*---------------------------------------------------------------------------*/

--- a/core/net/ip/uip-debug.h
+++ b/core/net/ip/uip-debug.h
@@ -31,57 +31,27 @@
  */
 /**
  * \file
- *         A set of debugging macros.
+ *         A set of debugging macros for the IP stack
  *
  * \author Nicolas Tsiftes <nvt@sics.se>
  *         Niclas Finne <nfi@sics.se>
  *         Joakim Eriksson <joakime@sics.se>
+ *         Simon Duquennoy <simon.duquennoy@inria.fr>
  */
 
 #ifndef UIP_DEBUG_H
 #define UIP_DEBUG_H
 
+#include "net/net-debug.h"
 #include "net/ip/uip.h"
 #include <stdio.h>
 
 void uip_debug_ipaddr_print(const uip_ipaddr_t *addr);
-void uip_debug_lladdr_print(const uip_lladdr_t *addr);
-
-#define DEBUG_NONE      0
-#define DEBUG_PRINT     1
-#define DEBUG_ANNOTATE  2
-#define DEBUG_FULL      DEBUG_ANNOTATE | DEBUG_PRINT
-
-/* PRINTA will always print if the debug routines are called directly */
-#ifdef __AVR__
-#include <avr/pgmspace.h>
-#define PRINTA(FORMAT,args...) printf_P(PSTR(FORMAT),##args)
-#else
-#define PRINTA(...) printf(__VA_ARGS__)
-#endif
-
-#if (DEBUG) & DEBUG_ANNOTATE
-#ifdef __AVR__
-#define ANNOTATE(FORMAT,args...) printf_P(PSTR(FORMAT),##args)
-#else
-#define ANNOTATE(...) printf(__VA_ARGS__)
-#endif
-#else
-#define ANNOTATE(...)
-#endif /* (DEBUG) & DEBUG_ANNOTATE */
 
 #if (DEBUG) & DEBUG_PRINT
-#ifdef __AVR__
-#define PRINTF(FORMAT,args...) printf_P(PSTR(FORMAT),##args)
-#else
-#define PRINTF(...) printf(__VA_ARGS__)
-#endif
 #define PRINT6ADDR(addr) uip_debug_ipaddr_print(addr)
-#define PRINTLLADDR(lladdr) uip_debug_lladdr_print(lladdr)
 #else
-#define PRINTF(...)
 #define PRINT6ADDR(addr)
-#define PRINTLLADDR(lladdr)
 #endif /* (DEBUG) & DEBUG_PRINT */
 
-#endif
+#endif /* UIP_DEBUG_H */

--- a/core/net/mac/frame802154e-ie.c
+++ b/core/net/mac/frame802154e-ie.c
@@ -41,7 +41,7 @@
 #include "net/mac/frame802154e-ie.h"
 
 #define DEBUG DEBUG_NONE
-#include "net/ip/uip-debug.h"
+#include "net/net-debug.h"
 
 /* c.f. IEEE 802.15.4e Table 4b */
 enum ieee802154e_header_ie_id {

--- a/core/net/mac/tsch/tsch-log.c
+++ b/core/net/mac/tsch/tsch-log.c
@@ -56,7 +56,7 @@
 #else /* TSCH_LOG_LEVEL */
 #define DEBUG DEBUG_NONE
 #endif /* TSCH_LOG_LEVEL */
-#include "net/ip/uip-debug.h"
+#include "net/net-debug.h"
 
 #if TSCH_LOG_LEVEL >= 2 /* Skip this file for log levels 0 or 1 */
 

--- a/core/net/mac/tsch/tsch-packet.c
+++ b/core/net/mac/tsch/tsch-packet.c
@@ -60,7 +60,7 @@
 #else /* TSCH_LOG_LEVEL */
 #define DEBUG DEBUG_NONE
 #endif /* TSCH_LOG_LEVEL */
-#include "net/ip/uip-debug.h"
+#include "net/net-debug.h"
 
 /*---------------------------------------------------------------------------*/
 /* Construct enhanced ACK packet and return ACK length */

--- a/core/net/mac/tsch/tsch-queue.c
+++ b/core/net/mac/tsch/tsch-queue.c
@@ -61,7 +61,7 @@
 #else /* TSCH_LOG_LEVEL */
 #define DEBUG DEBUG_NONE
 #endif /* TSCH_LOG_LEVEL */
-#include "net/ip/uip-debug.h"
+#include "net/net-debug.h"
 
 /* Check if TSCH_QUEUE_NUM_PER_NEIGHBOR is power of two */
 #if (TSCH_QUEUE_NUM_PER_NEIGHBOR & (TSCH_QUEUE_NUM_PER_NEIGHBOR - 1)) != 0

--- a/core/net/mac/tsch/tsch-rpl.c
+++ b/core/net/mac/tsch/tsch-rpl.c
@@ -51,7 +51,7 @@
 #else /* TSCH_LOG_LEVEL */
 #define DEBUG DEBUG_NONE
 #endif /* TSCH_LOG_LEVEL */
-#include "net/ip/uip-debug.h"
+#include "net/net-debug.h"
 
 /*---------------------------------------------------------------------------*/
 /* To use, set #define TSCH_CALLBACK_JOINING_NETWORK tsch_rpl_callback_joining_network */

--- a/core/net/mac/tsch/tsch-schedule.c
+++ b/core/net/mac/tsch/tsch-schedule.c
@@ -60,7 +60,7 @@
 #else /* TSCH_LOG_LEVEL */
 #define DEBUG DEBUG_NONE
 #endif /* TSCH_LOG_LEVEL */
-#include "net/ip/uip-debug.h"
+#include "net/net-debug.h"
 
 /* Pre-allocated space for links */
 MEMB(link_memb, struct tsch_link, TSCH_SCHEDULE_MAX_LINKS);

--- a/core/net/mac/tsch/tsch-security.c
+++ b/core/net/mac/tsch/tsch-security.c
@@ -58,7 +58,7 @@
 #else /* TSCH_LOG_LEVEL */
 #define DEBUG DEBUG_NONE
 #endif /* TSCH_LOG_LEVEL */
-#include "net/ip/uip-debug.h"
+#include "net/net-debug.h"
 
 /* The two keys K1 and K2 from 6TiSCH minimal configuration
  * K1: well-known, used for EBs

--- a/core/net/mac/tsch/tsch-slot-operation.c
+++ b/core/net/mac/tsch/tsch-slot-operation.c
@@ -59,7 +59,7 @@
 #else /* TSCH_LOG_LEVEL */
 #define DEBUG DEBUG_NONE
 #endif /* TSCH_LOG_LEVEL */
-#include "net/ip/uip-debug.h"
+#include "net/net-debug.h"
 
 /* TSCH debug macros, i.e. to set LEDs or GPIOs on various TSCH
  * timeslot events */

--- a/core/net/mac/tsch/tsch.c
+++ b/core/net/mac/tsch/tsch.c
@@ -64,7 +64,7 @@
 #else /* TSCH_LOG_LEVEL */
 #define DEBUG DEBUG_NONE
 #endif /* TSCH_LOG_LEVEL */
-#include "net/ip/uip-debug.h"
+#include "net/net-debug.h"
 
 /* Use to collect link statistics even on Keep-Alive, even though they were
  * not sent from an upper layer and don't have a valid packet_sent callback */

--- a/core/net/net-debug.c
+++ b/core/net/net-debug.c
@@ -30,41 +30,36 @@
 
 /**
  * \file
- *         A set of debugging tools
+ *         A set of debugging tools for the IP stack
  * \author
  *         Nicolas Tsiftes <nvt@sics.se>
  *         Niclas Finne <nfi@sics.se>
  *         Joakim Eriksson <joakime@sics.se>
+ *         Simon Duquennoy <simon.duquennoy@inria.fr>
  */
 
-#include "net/ip/uip-debug.h"
-#include "debug.h"
+#include "net/net-debug.h"
+
 /*---------------------------------------------------------------------------*/
 void
-uip_debug_ipaddr_print(const uip_ipaddr_t *addr)
+net_debug_lladdr_print(const uip_lladdr_t *addr)
 {
-#if NETSTACK_CONF_WITH_IPV6
-  uint16_t a;
-  unsigned int i;
-  int f;
-  for(i = 0, f = 0; i < sizeof(uip_ipaddr_t); i += 2) {
-    a = (addr->u8[i] << 8) + addr->u8[i + 1];
-    if(a == 0 && f >= 0) {
-      if(f++ == 0) {
-        putstring("::");
+  if(addr == NULL) {
+    PRINTA("(NULL LL addr)");
+    return;
+  } else {
+#if NETSTACK_CONF_WITH_RIME
+    /* Rime uses traditionally a %u.%u format */
+    PRINTA("%u.%u", addr->addr[0], addr->addr[1]);
+#else /* NETSTACK_CONF_WITH_RIME */
+    unsigned int i;
+    for(i = 0; i < LINKADDR_SIZE; i++) {
+      if(i > 0) {
+        PRINTA(":");
       }
-    } else {
-      if(f > 0) {
-        f = -1;
-      } else if(i > 0) {
-        putstring(":");
-      }
-      puthex(a >> 8);
-      puthex(a & 0xFF);
+      PRINTA("%02x", addr->addr[i]);
     }
+#endif /* NETSTACK_CONF_WITH_RIME */
   }
-#else /* NETSTACK_CONF_WITH_IPV6 */
-  PRINTA("%u.%u.%u.%u", addr->u8[0], addr->u8[1], addr->u8[2], addr->u8[3]);
-#endif /* NETSTACK_CONF_WITH_IPV6 */
 }
 /*---------------------------------------------------------------------------*/

--- a/core/net/net-debug.h
+++ b/core/net/net-debug.h
@@ -26,45 +26,61 @@
  * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
  * SUCH DAMAGE.
  *
+ * This file is part of the Contiki operating system.
+ *
  */
-
 /**
  * \file
- *         A set of debugging tools
- * \author
- *         Nicolas Tsiftes <nvt@sics.se>
+ *         A set of debugging macros for the netstack
+ *
+ * \author Nicolas Tsiftes <nvt@sics.se>
  *         Niclas Finne <nfi@sics.se>
  *         Joakim Eriksson <joakime@sics.se>
+ *         Simon Duquennoy <simon.duquennoy@inria.fr>
  */
 
-#include "net/ip/uip-debug.h"
-#include "debug.h"
-/*---------------------------------------------------------------------------*/
-void
-uip_debug_ipaddr_print(const uip_ipaddr_t *addr)
-{
-#if NETSTACK_CONF_WITH_IPV6
-  uint16_t a;
-  unsigned int i;
-  int f;
-  for(i = 0, f = 0; i < sizeof(uip_ipaddr_t); i += 2) {
-    a = (addr->u8[i] << 8) + addr->u8[i + 1];
-    if(a == 0 && f >= 0) {
-      if(f++ == 0) {
-        putstring("::");
-      }
-    } else {
-      if(f > 0) {
-        f = -1;
-      } else if(i > 0) {
-        putstring(":");
-      }
-      puthex(a >> 8);
-      puthex(a & 0xFF);
-    }
-  }
-#else /* NETSTACK_CONF_WITH_IPV6 */
-  PRINTA("%u.%u.%u.%u", addr->u8[0], addr->u8[1], addr->u8[2], addr->u8[3]);
-#endif /* NETSTACK_CONF_WITH_IPV6 */
-}
-/*---------------------------------------------------------------------------*/
+#ifndef NET_DEBUG_H
+#define NET_DEBUG_H
+
+#include "net/ip/uip.h"
+#include "net/linkaddr.h"
+#include <stdio.h>
+
+void net_debug_lladdr_print(const uip_lladdr_t *addr);
+
+#define DEBUG_NONE      0
+#define DEBUG_PRINT     1
+#define DEBUG_ANNOTATE  2
+#define DEBUG_FULL      DEBUG_ANNOTATE | DEBUG_PRINT
+
+/* PRINTA will always print if the debug routines are called directly */
+#ifdef __AVR__
+#include <avr/pgmspace.h>
+#define PRINTA(FORMAT,args...) printf_P(PSTR(FORMAT),##args)
+#else
+#define PRINTA(...) printf(__VA_ARGS__)
+#endif
+
+#if (DEBUG) & DEBUG_ANNOTATE
+#ifdef __AVR__
+#define ANNOTATE(FORMAT,args...) printf_P(PSTR(FORMAT),##args)
+#else
+#define ANNOTATE(...) printf(__VA_ARGS__)
+#endif
+#else
+#define ANNOTATE(...)
+#endif /* (DEBUG) & DEBUG_ANNOTATE */
+
+#if (DEBUG) & DEBUG_PRINT
+#ifdef __AVR__
+#define PRINTF(FORMAT,args...) printf_P(PSTR(FORMAT),##args)
+#else
+#define PRINTF(...) printf(__VA_ARGS__)
+#endif
+#define PRINTLLADDR(lladdr) net_debug_lladdr_print(lladdr)
+#else
+#define PRINTF(...)
+#define PRINTLLADDR(lladdr)
+#endif /* (DEBUG) & DEBUG_PRINT */
+
+#endif /* NET_DEBUG_H */

--- a/platform/mbxxx/contiki-main.c
+++ b/platform/mbxxx/contiki-main.c
@@ -179,7 +179,7 @@ main(void)
                                   NETSTACK_RDC.channel_check_interval()));
   printf("802.15.4 PAN ID 0x%x, EUI-%d:",
       IEEE802154_CONF_PANID, UIP_CONF_LL_802154?64:16);
-  uip_debug_lladdr_print((const uip_lladdr_t *)&linkaddr_node_addr);
+  net_debug_lladdr_print((const uip_lladdr_t *)&linkaddr_node_addr);
   printf(", radio channel %u\n", RF_CHANNEL);
 
   procinit_init();


### PR DESCRIPTION
This PR moves non IP related debug functions from `ip-debug.[ch]` to `net-debug.[ch]`, enabling the use macros such as `PRINTF` and `PRINTLLADDR` in code that may run without IP.