### PR TITLE
TSCH with Rime

### DIFF
--- a/core/net/mac/tsch/tsch-packet.c
+++ b/core/net/mac/tsch/tsch-packet.c
@@ -85,12 +85,12 @@ tsch_packet_create_eack(uint8_t *buf, int buf_size,
   p.seq = seqno;
 #if TSCH_PACKET_EACK_WITH_DEST_ADDR
   if(dest_addr != NULL) {
-    p.fcf.dest_addr_mode = FRAME802154_LONGADDRMODE;
+    p.fcf.dest_addr_mode = LINKADDR_SIZE > 2 ? FRAME802154_LONGADDRMODE : FRAME802154_SHORTADDRMODE;;
     linkaddr_copy((linkaddr_t *)&p.dest_addr, dest_addr);
   }
 #endif
 #if TSCH_PACKET_EACK_WITH_SRC_ADDR
-  p.fcf.src_addr_mode = FRAME802154_LONGADDRMODE;
+  p.fcf.src_addr_mode = LINKADDR_SIZE > 2 ? FRAME802154_LONGADDRMODE : FRAME802154_SHORTADDRMODE;;
   p.src_pid = IEEE802154_PANID;
   linkaddr_copy((linkaddr_t *)&p.src_addr, &linkaddr_node_addr);
 #endif
@@ -208,7 +208,7 @@ tsch_packet_create_eb(uint8_t *buf, int buf_size, uint8_t seqno,
   p.fcf.frame_type = FRAME802154_BEACONFRAME;
   p.fcf.ie_list_present = 1;
   p.fcf.frame_version = FRAME802154_IEEE802154E_2012;
-  p.fcf.src_addr_mode = FRAME802154_LONGADDRMODE;
+  p.fcf.src_addr_mode = LINKADDR_SIZE > 2 ? FRAME802154_LONGADDRMODE : FRAME802154_SHORTADDRMODE;
   p.fcf.dest_addr_mode = FRAME802154_SHORTADDRMODE;
   p.seq = seqno;
   p.fcf.sequence_number_suppression = FRAME802154_SUPPR_SEQNO;

--- a/core/net/mac/tsch/tsch.c
+++ b/core/net/mac/tsch/tsch.c
@@ -69,8 +69,10 @@
 /* Use to collect link statistics even on Keep-Alive, even though they were
  * not sent from an upper layer and don't have a valid packet_sent callback */
 #ifndef TSCH_LINK_NEIGHBOR_CALLBACK
+#if NETSTACK_CONF_WITH_IPV6
 void uip_ds6_link_neighbor_callback(int status, int numtx);
 #define TSCH_LINK_NEIGHBOR_CALLBACK(dest, status, num) uip_ds6_link_neighbor_callback(status, num)
+#endif /* NETSTACK_CONF_WITH_IPV6 */
 #endif /* TSCH_LINK_NEIGHBOR_CALLBACK */
 
 /* 802.15.4 duplicate frame detection */

--- a/core/net/mac/tsch/tsch.c
+++ b/core/net/mac/tsch/tsch.c
@@ -45,6 +45,7 @@
 #include "net/netstack.h"
 #include "net/packetbuf.h"
 #include "net/queuebuf.h"
+#include "net/nbr-table.h"
 #include "net/mac/framer-802154.h"
 #include "net/mac/tsch/tsch.h"
 #include "net/mac/tsch/tsch-slot-operation.h"
@@ -282,13 +283,13 @@ eb_input(struct input_packet *current_input)
 #if TSCH_AUTOSELECT_TIME_SOURCE
     if(!tsch_is_coordinator) {
       /* Maintain EB received counter for every neighbor */
-      struct eb_stat *stat = (struct eb_stat *)nbr_table_get_from_lladdr(eb_stats, &frame.src_addr);
+      struct eb_stat *stat = (struct eb_stat *)nbr_table_get_from_lladdr(eb_stats, (linkaddr_t *)&frame.src_addr);
       if(stat == NULL) {
-        stat = (struct eb_stat *)nbr_table_add_lladdr(eb_stats, &frame.src_addr);
+        stat = (struct eb_stat *)nbr_table_add_lladdr(eb_stats, (linkaddr_t *)&frame.src_addr, NBR_TABLE_REASON_MAC, NULL);
       }
       if(stat != NULL) {
         stat->rx_count++;
-        stat->jp = eb_ies.join_priority;
+        stat->jp = eb_ies.ie_join_priority;
         best_neighbor_eb_count = MAX(best_neighbor_eb_count, stat->rx_count);
       }
       /* Select best time source */

--- a/examples/rime-tsch/Makefile
+++ b/examples/rime-tsch/Makefile
@@ -1,0 +1,10 @@
+CONTIKI=../..
+CONTIKI_PROJECT = node
+CFLAGS += -DPROJECT_CONF_H=\"project-conf.h\"
+
+CONTIKI_WITH_RIME = 1
+MODULES += core/net/mac/tsch
+
+all: $(CONTIKI_PROJECT)
+
+include $(CONTIKI)/Makefile.include

--- a/examples/rime-tsch/node.c
+++ b/examples/rime-tsch/node.c
@@ -45,7 +45,6 @@
 #include "net/mac/tsch/tsch.h"
 
 const linkaddr_t coordinator_addr =    { { 1, 0 } };
-const linkaddr_t sender_addr =         { { 2, 0 } };
 const linkaddr_t destination_addr =    { { 1, 0 } };
 
 /*---------------------------------------------------------------------------*/
@@ -89,7 +88,7 @@ PROCESS_THREAD(unicast_test_process, ev, data)
 
     packetbuf_copyfrom("Hello", 5);
 
-    if(linkaddr_cmp(&sender_addr, &linkaddr_node_addr)) {
+    if(!linkaddr_cmp(&destination_addr, &linkaddr_node_addr)) {
       printf("App: sending unicast message to %u.%u\n", destination_addr.u8[0], destination_addr.u8[1]);
       unicast_send(&uc, &destination_addr);
     }

--- a/examples/rime-tsch/node.c
+++ b/examples/rime-tsch/node.c
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2016, Inria.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * This file is part of the Contiki operating system.
+ *
+ */
+
+/**
+ * \file
+ *         An example of Rime/TSCH
+ * \author
+ *         Simon Duquennoy <simon.duquennoy@inria.fr>
+ *
+ */
+
+#include <stdio.h>
+#include "contiki-conf.h"
+#include "net/netstack.h"
+#include "net/rime/rime.h"
+#include "net/mac/tsch/tsch.h"
+
+const linkaddr_t coordinator_addr =    { { 1, 0 } };
+const linkaddr_t sender_addr =         { { 2, 0 } };
+const linkaddr_t destination_addr =    { { 1, 0 } };
+
+/*---------------------------------------------------------------------------*/
+PROCESS(unicast_test_process, "Rime Node");
+AUTOSTART_PROCESSES(&unicast_test_process);
+
+/*---------------------------------------------------------------------------*/
+static void
+recv_uc(struct unicast_conn *c, const linkaddr_t *from)
+{
+  printf("App: unicast message received from %u.%u\n",
+   from->u8[0], from->u8[1]);
+}
+/*---------------------------------------------------------------------------*/
+static void
+sent_uc(struct unicast_conn *ptr, int status, int num_tx)
+{
+  printf("App: unicast message sent, status %u, num_tx %u\n",
+   status, num_tx);
+}
+
+static const struct unicast_callbacks unicast_callbacks = { recv_uc, sent_uc };
+static struct unicast_conn uc;
+
+/*---------------------------------------------------------------------------*/
+PROCESS_THREAD(unicast_test_process, ev, data)
+{
+  PROCESS_BEGIN();
+
+  tsch_set_coordinator(linkaddr_cmp(&coordinator_addr, &linkaddr_node_addr));
+  NETSTACK_MAC.on();
+
+  unicast_open(&uc, 146, &unicast_callbacks);
+
+  while(1) {
+    static struct etimer et;
+
+    etimer_set(&et, CLOCK_SECOND);
+
+    PROCESS_WAIT_EVENT_UNTIL(etimer_expired(&et));
+
+    packetbuf_copyfrom("Hello", 5);
+
+    if(linkaddr_cmp(&sender_addr, &linkaddr_node_addr)) {
+      printf("App: sending unicast message to %u.%u\n", destination_addr.u8[0], destination_addr.u8[1]);
+      unicast_send(&uc, &destination_addr);
+    }
+  }
+
+  PROCESS_END();
+}
+/*---------------------------------------------------------------------------*/

--- a/examples/rime-tsch/project-conf.h
+++ b/examples/rime-tsch/project-conf.h
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2016, Inria.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * This file is part of the Contiki operating system.
+ *
+ */
+
+/**
+ * \file
+ *         Project config file
+ * \author
+ *         Simon Duquennoy <simon.duquennoy@inria.fr>
+ *
+ */
+
+#ifndef __PROJECT_CONF_H__
+#define __PROJECT_CONF_H__
+
+/* Netstack layers */
+#undef NETSTACK_CONF_MAC
+#define NETSTACK_CONF_MAC     tschmac_driver
+#undef NETSTACK_CONF_RDC
+#define NETSTACK_CONF_RDC     nordc_driver
+#undef NETSTACK_CONF_FRAMER
+#define NETSTACK_CONF_FRAMER  framer_802154
+
+/* IEEE802.15.4 frame version */
+#undef FRAME802154_CONF_VERSION
+#define FRAME802154_CONF_VERSION FRAME802154_IEEE802154E_2012
+
+#undef TSCH_CONF_AUTOSELECT_TIME_SOURCE
+#define TSCH_CONF_AUTOSELECT_TIME_SOURCE 1
+
+/* Needed for cc2420 platforms only */
+/* Disable DCO calibration (uses timerB) */
+#undef DCOSYNCH_CONF_ENABLED
+#define DCOSYNCH_CONF_ENABLED            0
+/* Enable SFD timestamps (uses timerB) */
+#undef CC2420_CONF_SFD_TIMESTAMPS
+#define CC2420_CONF_SFD_TIMESTAMPS       1
+
+/* TSCH logging. 0: disabled. 1: basic log. 2: with delayed
+ * log messages from interrupt */
+#undef TSCH_LOG_CONF_LEVEL
+#define TSCH_LOG_CONF_LEVEL 2
+
+/* IEEE802.15.4 PANID */
+#undef IEEE802154_CONF_PANID
+#define IEEE802154_CONF_PANID 0xabcd
+
+/* Do not start TSCH at init, wait for NETSTACK_MAC.on() */
+#undef TSCH_CONF_AUTOSTART
+#define TSCH_CONF_AUTOSTART 0
+
+/* 6TiSCH minimal schedule length.
+ * Larger values result in less frequent active slots: reduces capacity and saves energy. */
+#undef TSCH_SCHEDULE_CONF_DEFAULT_LENGTH
+#define TSCH_SCHEDULE_CONF_DEFAULT_LENGTH 3
+
+#undef TSCH_LOG_CONF_ID_FROM_LINKADDR
+#define TSCH_LOG_CONF_ID_FROM_LINKADDR(addr) ((addr) ? (addr)->u8[LINKADDR_SIZE - 2] : 0)
+
+#endif /* __PROJECT_CONF_H__ */


### PR DESCRIPTION
This PR makes TSCH work with short addresses and Rime. Added new example for Rime/TSCH. Useful for testing TSCH without a full IPv6 stack.

Note that this PR includes https://github.com/contiki-os/contiki/pull/1609