### PR TITLE
Coffee: improve comments and code formatting

### DIFF
--- a/core/cfs/cfs-coffee.h
+++ b/core/cfs/cfs-coffee.h
@@ -46,15 +46,15 @@
  * invoke its own micro logs when file modifications occur.
  *
  * This semantical I/O setting is useful when implementing flash storage
- * algorithms on top of Coffee.
+ * algorithms such as database indices on top of Coffee.
  *
  * \sa cfs_coffee_set_io_semantics()
  */
 #define CFS_COFFEE_IO_FLASH_AWARE	0x1
 
 /**
- * Instruct Coffee not to attempt to extend the file when there is
- * an attempt to write past the reserved file size.
+ * Instruct Coffee not to attempt to extend the file upon a request
+ * to write past the reserved file size.
  *
  * A case when this is necessary is when the file has a firm size limit,
  * and a safeguard is needed to protect against writes beyond this limit.
@@ -75,8 +75,8 @@
 
 /**
  * \brief Reserve space for a file.
- * \param name The filename.
- * \param size The size of the file.
+ * \param name The file name.
+ * \param size The initial size to be reserved for the file.
  * \return 0 on success, -1 on failure.
  *
  * Coffee uses sequential page structures for files. The sequential 
@@ -88,15 +88,15 @@ int cfs_coffee_reserve(const char *name, cfs_offset_t size);
 
 /**
  * \brief Configure the on-demand log file.
- * \param file The filename.
- * \param log_size The total log size.
+ * \param file The file name.
+ * \param log_size The total log file size.
  * \param log_entry_size The log entry size.
  * \return 0 on success, -1 on failure.
  *
  * When file data is first modified, Coffee creates a micro log for the
- * file. The micro log stores a table of modifications whose 
- * parameters--the log size and the log entry size--can be modified 
- * through the cfs_coffee_configure_log function.
+ * file. The micro log stores a table of modifications whose parameters --
+ * the log size and the log entry size -- can be modified through the
+ * cfs_coffee_configure_log function.
  */
 int cfs_coffee_configure_log(const char *file, unsigned log_size,
                              unsigned log_entry_size);
@@ -109,8 +109,8 @@ int cfs_coffee_configure_log(const char *file, unsigned log_size,
  *
  * Coffee is used on a wide range of storage types, and the default 
  * I/O file semantics may not be optimal for the access pattern 
- * of a certain file. Hence, this functions allows programmers to 
- * switch the /O semantics on a file that is accessed through a 
+ * of a certain file. Hence, this function allows programmers to
+ * switch the I/O semantics on a file that is accessed through a
  * particular file descriptor.
  *
  */
@@ -123,20 +123,13 @@ int cfs_coffee_set_io_semantics(int fd, unsigned flags);
  * Coffee formats the underlying storage by setting all bits to zero.
  * Formatting must be done before using Coffee for the first time in
  * a mote.
+ *
+ * Notice that the erased bits may be set to 1 on the physical storage
+ * when using flash memory. In this case, Coffee requires that the
+ * COFFEE_READ and COFFEE_WRITE functions used to access the flash memory
+ * invert all bits.
  */
 int cfs_coffee_format(void);
-
-/**
- * \brief Points out a memory region that may not be altered during
- * checkpointing operations that use the file system.
- * \param size
- * \return A pointer to the protected memory.
- *
- * This function returns the protected memory pointer and writes its size
- * to the given parameter. Mainly used by sensornet checkpointing to protect
- * the coffee state during CFS-based checkpointing operations.
- */
-void *cfs_coffee_get_protected_mem(unsigned *size);
 
 /** @} */
 /** @} */


### PR DESCRIPTION
Improved mainly the comments, debug statements and source code formatting. Also changed type of sector indices to cfs_page_t in case <code>uint16_t</code> is too small.