### PR TITLE
Fix bug in TSCH for platforms with 16-bit rtimer

### DIFF
--- a/core/net/mac/tsch/tsch-slot-operation.c
+++ b/core/net/mac/tsch/tsch-slot-operation.c
@@ -737,7 +737,7 @@ PT_THREAD(tsch_rx_slot(struct pt *pt, struct rtimer *t))
           if(linkaddr_cmp(&destination_address, &linkaddr_node_addr)
              || linkaddr_cmp(&destination_address, &linkaddr_null)) {
             int do_nack = 0;
-            estimated_drift = ((int32_t)expected_rx_time - (int32_t)rx_start_time);
+            estimated_drift = RTIMER_CLOCK_DIFF(expected_rx_time, rx_start_time);
 
 #if TSCH_TIMESYNC_REMOVE_JITTER
             /* remove jitter due to measurement errors */

--- a/core/sys/rtimer.h
+++ b/core/sys/rtimer.h
@@ -55,10 +55,12 @@
 
 #include "contiki-conf.h"
 
-#ifndef RTIMER_CLOCK_LT
+#ifndef RTIMER_CLOCK_DIFF
 typedef unsigned short rtimer_clock_t;
-#define RTIMER_CLOCK_LT(a,b)     ((signed short)((a)-(b)) < 0)
-#endif /* RTIMER_CLOCK_LT */
+#define RTIMER_CLOCK_DIFF(a,b)     ((signed short)((a)-(b)))
+#endif /* RTIMER_CLOCK_DIFF */
+
+#define RTIMER_CLOCK_LT(a, b)      (RTIMER_CLOCK_DIFF((a),(b)) < 0)
 
 #include "rtimer-arch.h"
 

--- a/cpu/arm/aducrf101/aducrf101-contiki.h
+++ b/cpu/arm/aducrf101/aducrf101-contiki.h
@@ -46,7 +46,7 @@ typedef uint32_t clock_time_t;
 typedef uint16_t uip_stats_t;
 
 typedef uint32_t rtimer_clock_t;
-#define RTIMER_CLOCK_LT(a, b)  ((int32_t)((a) - (b)) < 0)
+#define RTIMER_CLOCK_DIFF(a, b)  ((int32_t)((a) - (b)))
 rtimer_clock_t rtimer_arch_now(void);
 
 #endif

--- a/cpu/mc1322x/contiki-mc1322x-conf.h
+++ b/cpu/mc1322x/contiki-mc1322x-conf.h
@@ -55,8 +55,8 @@ typedef unsigned short uip_stats_t;
 
 typedef uint32_t clock_time_t;
 
-/* Core rtimer.h defaults to 16 bit timer unless RTIMER_CLOCK_LT is defined */
+/* Core rtimer.h defaults to 16 bit timer unless RTIMER_CLOCK_DIFF is defined */
 typedef unsigned long rtimer_clock_t;
-#define RTIMER_CLOCK_LT(a,b)     ((signed long)((a)-(b)) < 0)
+#define RTIMER_CLOCK_DIFF(a,b)     ((signed long)((a)-(b)))
 
 #endif

--- a/platform/cc2538dk/contiki-conf.h
+++ b/platform/cc2538dk/contiki-conf.h
@@ -34,10 +34,10 @@ typedef uint32_t uip_stats_t;
 
 /*
  * rtimer.h typedefs rtimer_clock_t as unsigned short. We need to define
- * RTIMER_CLOCK_LT to override this
+ * RTIMER_CLOCK_DIFF to override this
  */
 typedef uint32_t rtimer_clock_t;
-#define RTIMER_CLOCK_LT(a,b)     ((int32_t)((a)-(b)) < 0)
+#define RTIMER_CLOCK_DIFF(a,b)     ((int32_t)((a)-(b)))
 /** @} */
 /*---------------------------------------------------------------------------*/
 /**

--- a/platform/cooja/contiki-conf.h
+++ b/platform/cooja/contiki-conf.h
@@ -201,7 +201,7 @@ typedef unsigned short uip_stats_t;
 #define CLOCK_CONF_SECOND 1000L
 typedef unsigned long clock_time_t;
 typedef unsigned long rtimer_clock_t;
-#define RTIMER_CLOCK_LT(a,b)     ((signed long)((a)-(b)) < 0)
+#define RTIMER_CLOCK_DIFF(a,b)     ((signed long)((a)-(b)))
 
 #define AODV_COMPLIANCE
 #define AODV_NUM_RT_ENTRIES 32

--- a/platform/galileo/contiki-conf.h
+++ b/platform/galileo/contiki-conf.h
@@ -46,7 +46,7 @@ typedef unsigned long clock_time_t;
 
 typedef uint64_t rtimer_clock_t;
 #define RTIMER_ARCH_SECOND 1024
-#define RTIMER_CLOCK_LT(a, b)     ((int64_t)((a) - (b)) < 0)
+#define RTIMER_CLOCK_DIFF(a, b)     ((int64_t)((a) - (b)))
 
 /* We define the following macros and types otherwise Contiki does not
  * compile.

--- a/platform/jn516x/platform-conf.h
+++ b/platform/jn516x/platform-conf.h
@@ -80,9 +80,9 @@
 #define JN516X_EXTERNAL_CRYSTAL_OSCILLATOR (RTIMER_USE_32KHZ || JN516X_SLEEP_ENABLED)
 #endif /* JN516X_EXTERNAL_CRYSTAL_OSCILLATOR */
 
-/* Core rtimer.h defaults to 16 bit timer unless RTIMER_CLOCK_LT is defined */
+/* Core rtimer.h defaults to 16 bit timer unless RTIMER_CLOCK_DIFF is defined */
 typedef uint32_t rtimer_clock_t;
-#define RTIMER_CLOCK_LT(a, b)     ((int32_t)((a) - (b)) < 0)
+#define RTIMER_CLOCK_DIFF(a, b)     ((int32_t)((a) - (b)))
 
 /* 8ms timer tick */
 #define CLOCK_CONF_SECOND 125

--- a/platform/mbxxx/platform-conf.h
+++ b/platform/mbxxx/platform-conf.h
@@ -87,7 +87,7 @@ typedef unsigned long clock_time_t;
 
 typedef unsigned long rtimer_clock_t;
 
-#define RTIMER_CLOCK_LT(a,b)     ((signed long)((a)-(b)) < 0)
+#define RTIMER_CLOCK_DIFF(a,b)     ((signed long)((a)-(b)))
 
 #define LEDS_CONF_RED_PIN     boardDescription->io->leds[1].gpioPin
 #define LEDS_CONF_GREEN_PIN   boardDescription->io->leds[0].gpioPin

--- a/platform/openmote-cc2538/contiki-conf.h
+++ b/platform/openmote-cc2538/contiki-conf.h
@@ -73,10 +73,10 @@ typedef uint32_t uip_stats_t;
 
 /*
  * rtimer.h typedefs rtimer_clock_t as unsigned short. We need to define
- * RTIMER_CLOCK_LT to override this
+ * RTIMER_CLOCK_DIFF to override this
  */
 typedef uint32_t rtimer_clock_t;
-#define RTIMER_CLOCK_LT(a, b)     ((int32_t)((a) - (b)) < 0)
+#define RTIMER_CLOCK_DIFF(a, b)     ((int32_t)((a) - (b)))
 /** @} */
 /*---------------------------------------------------------------------------*/
 /**

--- a/platform/seedeye/contiki-conf.h
+++ b/platform/seedeye/contiki-conf.h
@@ -60,7 +60,7 @@ typedef uint16_t uip_stats_t;
 typedef uint32_t clock_time_t;
 
 typedef uint32_t rtimer_clock_t;
-#define RTIMER_CLOCK_LT(a,b) ((int32_t)((a)-(b)) < 0)
+#define RTIMER_CLOCK_DIFF(a,b) ((int32_t)((a)-(b)))
 
 #define RF_CHANNEL                              13
 

--- a/platform/srf06-cc26xx/contiki-conf.h
+++ b/platform/srf06-cc26xx/contiki-conf.h
@@ -325,10 +325,10 @@ typedef uint32_t uip_stats_t;
 
 /*
  * rtimer.h typedefs rtimer_clock_t as unsigned short. We need to define
- * RTIMER_CLOCK_LT to override this
+ * RTIMER_CLOCK_DIFF to override this
  */
 typedef uint32_t rtimer_clock_t;
-#define RTIMER_CLOCK_LT(a, b)     ((int32_t)((a) - (b)) < 0)
+#define RTIMER_CLOCK_DIFF(a, b)     ((int32_t)((a) - (b)))
 /** @} */
 /*---------------------------------------------------------------------------*/
 /* board.h assumes that basic configuration is done */

--- a/platform/stm32nucleo-spirit1/platform-conf.h
+++ b/platform/stm32nucleo-spirit1/platform-conf.h
@@ -78,7 +78,7 @@
 #define CLOCK_CONF_SECOND             128
 /* One tick: 62.5 ms */
 
-#define RTIMER_CLOCK_LT(a, b)     ((signed short)((a) - (b)) < 0)
+#define RTIMER_CLOCK_DIFF(a, b)     ((signed short)((a) - (b)))
 /*---------------------------------------------------------------------------*/
 typedef unsigned long clock_time_t;
 typedef unsigned long long rtimer_clock_t;

--- a/platform/zoul/contiki-conf.h
+++ b/platform/zoul/contiki-conf.h
@@ -71,10 +71,10 @@ typedef uint32_t uip_stats_t;
 
 /*
  * rtimer.h typedefs rtimer_clock_t as unsigned short. We need to define
- * RTIMER_CLOCK_LT to override this
+ * RTIMER_CLOCK_DIFF to override this
  */
 typedef uint32_t rtimer_clock_t;
-#define RTIMER_CLOCK_LT(a, b)     ((int32_t)((a) - (b)) < 0)
+#define RTIMER_CLOCK_DIFF(a, b)     ((int32_t)((a) - (b)))
 /** @} */
 /*---------------------------------------------------------------------------*/
 /**


### PR DESCRIPTION
On platforms with 16-bit rtimer, the current `estimated_drift` is wrong when either (but not both) `expected_rx_time` or `rx_start_time` has wrapped. This sends the node straight off sync.

The fix introduces a new macro `RTIMER_CLOCK_DIFF`, defined exactly where `RTIMER_CLOCK_LT` was already set.