### PR TITLE
Fixing 04-rpl-large-network

### DIFF
--- a/core/net/rpl/rpl-conf.h
+++ b/core/net/rpl/rpl-conf.h
@@ -242,7 +242,7 @@
 #ifdef RPL_CONF_WITH_DAO_ACK
 #define RPL_WITH_DAO_ACK RPL_CONF_WITH_DAO_ACK
 #else
-#define RPL_WITH_DAO_ACK 1
+#define RPL_WITH_DAO_ACK 0
 #endif /* RPL_CONF_WITH_DAO_ACK */
 
 /*

--- a/regression-tests/Makefile.simulation-test
+++ b/regression-tests/Makefile.simulation-test
@@ -31,7 +31,7 @@ TESTLOGS=$(patsubst %.csc,%.testlog,$(TESTS))
 LOGS=$(patsubst %.csc,%.log,$(TESTS))
 FAILLOGS=$(patsubst %.csc,%.*.faillog,$(TESTS))
 #Set random seeds to create reproduceable results.
-RANDOMSEED=1 5
+RANDOMSEED=1
 
 CONTIKI=../..
 


### PR DESCRIPTION
This PR:
* Disables DAO-ACK by default, as it seemed to cause a failure on test `04-rpl-large-network.csc` with random seed 1, triggering a new run with seed 5. As this is one of the longest tests, this often triggered a Travis timeout;
* Uses a single seed for all simulation tests (instead of two). Now a failure on a single seed will cause a complete failure of the non-regression test.