### PR TITLE
Prevent uIP buffer over-read with big UDP packets

### DIFF
--- a/core/net/ip/uip-udp-packet.c
+++ b/core/net/ip/uip-udp-packet.c
@@ -51,12 +51,10 @@ void
 uip_udp_packet_send(struct uip_udp_conn *c, const void *data, int len)
 {
 #if UIP_UDP
-  if(data != NULL) {
+  if(data != NULL && len <= (UIP_BUFSIZE - (UIP_LLH_LEN + UIP_IPUDPH_LEN))) {
     uip_udp_conn = c;
     uip_slen = len;
-    memmove(&uip_buf[UIP_LLH_LEN + UIP_IPUDPH_LEN], data,
-            len > UIP_BUFSIZE - UIP_LLH_LEN - UIP_IPUDPH_LEN?
-            UIP_BUFSIZE - UIP_LLH_LEN - UIP_IPUDPH_LEN: len);
+    memmove(&uip_buf[UIP_LLH_LEN + UIP_IPUDPH_LEN], data, len);
     uip_process(UIP_UDP_SEND_CONN);
 
 #if UIP_CONF_IPV6_MULTICAST


### PR DESCRIPTION
When an UDP packet too big to fit in the uIP packet buffer is to be sent, the part fitting in the uIP buffer is copied to it (so no buffer overflow occurs) but uIP actually sends a packet of the original size therefore a buffer over-read occurs.

This modification makes uIP sends only the data copied to the packet buffer. An alternative would be not to send anything and return an error.