### PR TITLE
Renamed and moved the update neighbor table function in RPL. 

### DIFF
--- a/core/net/ipv6/uip-ds6-nbr.c
+++ b/core/net/ipv6/uip-ds6-nbr.c
@@ -78,6 +78,21 @@ uip_ds6_neighbors_init(void)
 }
 /*---------------------------------------------------------------------------*/
 uip_ds6_nbr_t *
+uip_ds6_nbr_refresh(const uip_ipaddr_t *ipaddr)
+{
+  uip_ds6_nbr_t *nbr;
+
+  if((nbr = uip_ds6_nbr_lookup(ipaddr)) != NULL) {
+#if UIP_ND6_SEND_NA
+    stimer_set(&nbr->reachable, UIP_ND6_REACHABLE_TIME / 1000);
+    nbr->state = NBR_REACHABLE;
+#endif /* UIP_ND6_SEND_NA */
+    return nbr;
+  }
+  return NULL;
+}
+/*---------------------------------------------------------------------------*/
+uip_ds6_nbr_t *
 uip_ds6_nbr_add(const uip_ipaddr_t *ipaddr, const uip_lladdr_t *lladdr,
                 uint8_t isrouter, uint8_t state, nbr_table_reason_t reason,
                 void *data)

--- a/core/net/ipv6/uip-ds6-nbr.h
+++ b/core/net/ipv6/uip-ds6-nbr.h
@@ -100,6 +100,9 @@ const uip_lladdr_t *uip_ds6_nbr_lladdr_from_ipaddr(const uip_ipaddr_t *ipaddr);
 void uip_ds6_link_neighbor_callback(int status, int numtx);
 void uip_ds6_neighbor_periodic(void);
 int uip_ds6_nbr_num(void);
+/* uip_ds6_nbr_refresh() - used for refreshing a nbr entry from an applicaion */
+uip_ds6_nbr_t *uip_ds6_nbr_refresh(const uip_ipaddr_t *ipaddr);
+
 
 /**
  * \brief

--- a/core/net/rpl/rpl-icmp6.c
+++ b/core/net/rpl/rpl-icmp6.c
@@ -183,34 +183,6 @@ set16(uint8_t *buffer, int pos, uint16_t value)
   buffer[pos++] = value & 0xff;
 }
 /*---------------------------------------------------------------------------*/
-uip_ds6_nbr_t *
-rpl_icmp6_update_nbr_table(uip_ipaddr_t *from, nbr_table_reason_t reason, void *data)
-{
-  uip_ds6_nbr_t *nbr;
-
-  if((nbr = uip_ds6_nbr_lookup(from)) == NULL) {
-    if((nbr = uip_ds6_nbr_add(from, (uip_lladdr_t *)
-                              packetbuf_addr(PACKETBUF_ADDR_SENDER),
-                              0, NBR_REACHABLE, reason, data)) != NULL) {
-      PRINTF("RPL: Neighbor added to neighbor cache ");
-      PRINT6ADDR(from);
-      PRINTF(", ");
-      PRINTLLADDR((uip_lladdr_t *)packetbuf_addr(PACKETBUF_ADDR_SENDER));
-      PRINTF("\n");
-    }
-  }
-
-  if(nbr != NULL) {
-#if UIP_ND6_SEND_NA
-    /* set reachable timer if we added or found the nbr entry - and update
-       neighbor entry to reachable to avoid sending NS/NA, etc.  */
-    stimer_set(&nbr->reachable, UIP_ND6_REACHABLE_TIME / 1000);
-    nbr->state = NBR_REACHABLE;
-#endif /* UIP_ND6_SEND_NA */
-  }
-  return nbr;
- }
-/*---------------------------------------------------------------------------*/
 static void
 dis_input(void)
 {
@@ -235,18 +207,21 @@ dis_input(void)
       } else {
 #endif /* !RPL_LEAF_ONLY */
 	/* Check if this neighbor should be added according to the policy. */
-        if(rpl_icmp6_update_nbr_table(&UIP_IP_BUF->srcipaddr,
-                                      NBR_TABLE_REASON_RPL_DIS, NULL) == NULL) {
-          PRINTF("RPL: Out of Memory, not sending unicast DIO, DIS from ");
-          PRINT6ADDR(&UIP_IP_BUF->srcipaddr);
-          PRINTF(", ");
-          PRINTLLADDR((uip_lladdr_t *)packetbuf_addr(PACKETBUF_ADDR_SENDER));
-          PRINTF("\n");
-        } else {
-          PRINTF("RPL: Unicast DIS, reply to sender\n");
-          dio_output(instance, &UIP_IP_BUF->srcipaddr);
-        }
-	/* } */
+        if(uip_ds6_nbr_refresh(&UIP_IP_BUF->srcipaddr) == NULL) {
+          if(uip_ds6_nbr_add(&UIP_IP_BUF->srcipaddr, (uip_lladdr_t *)
+                             packetbuf_addr(PACKETBUF_ADDR_SENDER),
+                             0, NBR_REACHABLE, NBR_TABLE_REASON_RPL_DIS,
+                             NULL) == NULL) {
+            PRINTF("RPL: Out of Memory, not sending unicast DIO, DIS from ");
+            PRINT6ADDR(&UIP_IP_BUF->srcipaddr);
+            PRINTF(", ");
+            PRINTLLADDR((uip_lladdr_t *)packetbuf_addr(PACKETBUF_ADDR_SENDER));
+            PRINTF("\n");
+          } else {
+            PRINTF("RPL: Unicast DIS, reply to sender\n");
+            dio_output(instance, &UIP_IP_BUF->srcipaddr);
+          }
+	}
       }
     }
   }
@@ -652,7 +627,6 @@ dao_input(void)
   int i;
   int learned_from;
   rpl_parent_t *parent;
-  uip_ds6_nbr_t *nbr;
   int is_root;
 
   prefixlen = 0;
@@ -693,11 +667,11 @@ dao_input(void)
   }
 
   learned_from = uip_is_addr_mcast(&dao_sender_addr) ?
-                 RPL_ROUTE_FROM_MULTICAST_DAO : RPL_ROUTE_FROM_UNICAST_DAO;
+    RPL_ROUTE_FROM_MULTICAST_DAO : RPL_ROUTE_FROM_UNICAST_DAO;
 
   /* Destination Advertisement Object */
   PRINTF("RPL: Received a (%s) DAO with sequence number %u from ",
-      learned_from == RPL_ROUTE_FROM_UNICAST_DAO? "unicast": "multicast", sequence);
+         learned_from == RPL_ROUTE_FROM_UNICAST_DAO? "unicast": "multicast", sequence);
   PRINT6ADDR(&dao_sender_addr);
   PRINTF("\n");
 
@@ -709,7 +683,7 @@ dao_input(void)
     if(parent != NULL &&
        DAG_RANK(parent->rank, instance) < DAG_RANK(dag->rank, instance)) {
       PRINTF("RPL: Loop detected when receiving a unicast DAO from a node with a lower rank! (%u < %u)\n",
-          DAG_RANK(parent->rank, instance), DAG_RANK(dag->rank, instance));
+             DAG_RANK(parent->rank, instance), DAG_RANK(dag->rank, instance));
       parent->rank = INFINITE_RANK;
       parent->flags |= RPL_PARENT_FLAG_UPDATED;
       goto discard;
@@ -752,7 +726,7 @@ dao_input(void)
   }
 
   PRINTF("RPL: DAO lifetime: %u, prefix length: %u prefix: ",
-          (unsigned)lifetime, (unsigned)prefixlen);
+         (unsigned)lifetime, (unsigned)prefixlen);
   PRINT6ADDR(&prefix);
   PRINTF("\n");
 
@@ -812,20 +786,25 @@ dao_input(void)
 
   PRINTF("RPL: Adding DAO route\n");
 
-  /* Update and add neighbor - if no room - fail. */
-  if((nbr = rpl_icmp6_update_nbr_table(&dao_sender_addr, NBR_TABLE_REASON_RPL_DAO, instance)) == NULL) {
-    PRINTF("RPL: Out of Memory, dropping DAO from ");
-    PRINT6ADDR(&dao_sender_addr);
-    PRINTF(", ");
-    PRINTLLADDR((uip_lladdr_t *)packetbuf_addr(PACKETBUF_ADDR_SENDER));
-    PRINTF("\n");
-    if(flags & RPL_DAO_K_FLAG) {
-      /* signal the failure to add the node */
-      dao_ack_output(instance, &dao_sender_addr, sequence,
-		     is_root ? RPL_DAO_ACK_UNABLE_TO_ADD_ROUTE_AT_ROOT :
-		     RPL_DAO_ACK_UNABLE_TO_ACCEPT);
+  /* Update and if not there add neighbor - if no room - fail. */
+  if(uip_ds6_nbr_refresh(&dao_sender_addr) == NULL) {
+    if(uip_ds6_nbr_add(&dao_sender_addr, (uip_lladdr_t *)
+                       packetbuf_addr(PACKETBUF_ADDR_SENDER),
+                       0, NBR_REACHABLE, NBR_TABLE_REASON_RPL_DAO,
+                       instance) == NULL) {
+      PRINTF("RPL: Out of Memory, dropping DAO from ");
+      PRINT6ADDR(&dao_sender_addr);
+      PRINTF(", ");
+      PRINTLLADDR((uip_lladdr_t *)packetbuf_addr(PACKETBUF_ADDR_SENDER));
+      PRINTF("\n");
+      if(flags & RPL_DAO_K_FLAG) {
+        /* signal the failure to add the node - will not work? No NBR entry? */
+        dao_ack_output(instance, &dao_sender_addr, sequence,
+                       is_root ? RPL_DAO_ACK_UNABLE_TO_ADD_ROUTE_AT_ROOT :
+                       RPL_DAO_ACK_UNABLE_TO_ACCEPT);
+      }
+      goto discard;
     }
-    goto discard;
   }
 
   rep = rpl_add_route(dag, &prefix, prefixlen, &dao_sender_addr);

--- a/core/net/rpl/rpl-private.h
+++ b/core/net/rpl/rpl-private.h
@@ -292,8 +292,6 @@ void dao_output(rpl_parent_t *, uint8_t lifetime);
 void dao_output_target(rpl_parent_t *, uip_ipaddr_t *, uint8_t lifetime);
 void dao_ack_output(rpl_instance_t *, uip_ipaddr_t *, uint8_t, uint8_t);
 void rpl_icmp6_register_handlers(void);
-uip_ds6_nbr_t *rpl_icmp6_update_nbr_table(uip_ipaddr_t *from,
-                                          nbr_table_reason_t r, void *data);
 
 /* RPL logic functions. */
 void rpl_join_dag(uip_ipaddr_t *from, rpl_dio_t *dio);


### PR DESCRIPTION
This PR moves the function rpl_icmp6_update_nbr_table from RPL into uip-ds6-nbr so that it is in a more logical module. It is also changed to refresh a neighbor entry only - rather than both refreshing and adding if not already there. This makes the function more easy to understand and also more useful for applications or other modules that know that a neighbor is showing forward progress on the IP layer. This is useful for avoiding neighbor entry to go in to non-reachable state and cause NS to be sent (and packets to be lost).

The new function is uip_ds6_nbr_t *uip_ds6_nbr_refresh(const uip_ipaddr_t *ipaddr) which just refresh a IPv6 neighbor entry.
