### PR TITLE
Trailing zeros in file leading to unexpected file length get set in destination buffer

### DIFF
--- a/core/cfs/cfs-coffee.c
+++ b/core/cfs/cfs-coffee.c
@@ -1100,7 +1100,7 @@ cfs_read(int fd, void *buf, unsigned size)
   file = fdp->file;
   
 #if COFFEE_IO_SEMANTICS
-  if(fdp->io_flags & CFS_COFFEE_IO_FIRM_SIZE) {
+  if(fdp->io_flags & CFS_COFFEE_IO_ENSURE_READ_LENGTH) {
     while(fdp->offset + size > file->end) {
       ((char*)buf)[--size] = 0;
     }

--- a/core/cfs/cfs-coffee.c
+++ b/core/cfs/cfs-coffee.c
@@ -1098,8 +1098,8 @@ cfs_read(int fd, void *buf, unsigned size)
 
   fdp = &coffee_fd_set[fd];
   file = fdp->file;
-  if(fdp->offset + size > file->end) {
-    size = file->end - fdp->offset;
+  while(fdp->offset + size > file->end) {
+    ((char*)buf)[--size] = 0;
   }
 
   /* If the file is not modified, read directly from the file extent. */

--- a/core/cfs/cfs-coffee.c
+++ b/core/cfs/cfs-coffee.c
@@ -1098,9 +1098,20 @@ cfs_read(int fd, void *buf, unsigned size)
 
   fdp = &coffee_fd_set[fd];
   file = fdp->file;
-  while(fdp->offset + size > file->end) {
-    ((char*)buf)[--size] = 0;
+  
+#if COFFEE_IO_SEMANTICS
+  if(fdp->io_flags & CFS_COFFEE_IO_FIRM_SIZE) {
+    while(fdp->offset + size > file->end) {
+      ((char*)buf)[--size] = 0;
+    }
+  } else {
+#endif
+    if(fdp->offset + size > file->end) {
+      size = file->end - fdp->offset;
+    }
+#if COFFEE_IO_SEMANTICS
   }
+#endif
 
   /* If the file is not modified, read directly from the file extent. */
   if(!FILE_MODIFIED(file)) {

--- a/core/cfs/cfs-coffee.h
+++ b/core/cfs/cfs-coffee.h
@@ -64,6 +64,15 @@
 #define CFS_COFFEE_IO_FIRM_SIZE		0x2
 
 /**
+ * Instruct Coffee to set unused bytes in the destination buffer to zero.
+ * Trailing zeros may cause a wrong file size, this option ensures that
+ * the corresponding bytes get set, so Coffee does not read unexpected data.
+ *
+ * \sa cfs_coffee_set_io_semantics()
+ */
+#define CFS_COFFEE_IO_ENSURE_READ_LENGTH		0x4
+
+/**
  * \file
  *	Header for the Coffee file system.
  * \author


### PR DESCRIPTION
We encountered the problem with trailing zeros in files leading to wrong file size. This fix ensures that all bytes will get set to zero and works fine for us as it ensures that there are no zeros in the buffer on adresses we expected to get set to the content of the file. Also as long as there are enough bytes to read in the file the execution time should't increase at all. In cases that the given size only represents the size of the buffer and there are way less bytes to be read in the file the execution time will slightly increase.