### PR TITLE
Handle the case when log->link is NULL in tsch_log_process_pending

### DIFF
--- a/core/net/mac/tsch/tsch-log.c
+++ b/core/net/mac/tsch/tsch-log.c
@@ -84,11 +84,15 @@ tsch_log_process_pending(void)
   }
   while((log_index = ringbufindex_peek_get(&log_ringbuf)) != -1) {
     struct tsch_log_t *log = &log_array[log_index];
-    struct tsch_slotframe *sf = tsch_schedule_get_slotframe_by_handle(log->link->slotframe_handle);
-    printf("TSCH: {asn-%x.%lx link-%u-%u-%u-%u ch-%u} ",
-        log->asn.ms1b, log->asn.ls4b,
-        log->link->slotframe_handle, sf ? sf->size.val : 0, log->link->timeslot, log->link->channel_offset,
-        tsch_calculate_channel(&log->asn, log->link->channel_offset));
+    if(log->link == NULL) {
+      printf("TSCH: {asn-%x.%lx link-NULL} ", log->asn.ms1b, log->asn.ls4b);
+    } else {
+      struct tsch_slotframe *sf = tsch_schedule_get_slotframe_by_handle(log->link->slotframe_handle);
+      printf("TSCH: {asn-%x.%lx link-%u-%u-%u-%u ch-%u} ",
+             log->asn.ms1b, log->asn.ls4b,
+             log->link->slotframe_handle, sf ? sf->size.val : 0, log->link->timeslot, log->link->channel_offset,
+             tsch_calculate_channel(&log->asn, log->link->channel_offset));
+    }
     switch(log->type) {
       case tsch_log_tx:
         printf("%s-%u-%u %u tx %d, st %d-%d",


### PR DESCRIPTION
This PR prevents possible NULL pointer access for `log->link` in `tsch_log_process_pending()`.

`log->link` would have NULL if `current_link` is NULL when `tsch_log_prepare_add()` is called. This could happen in `tsch_slot_operation` Protothread. Here is the relevant code block, where the TSCH_LOG_ADD macro expands with `tsch_log_prepare_add()` when TSCH_LOG_LEVEL is greater than or equal to 2.

```C
if(current_link == NULL || tsch_lock_requested) { /* Skip slot operation if there is no link
                                                      or if there is a pending request for getting the lock */
  /* Issue a log whenever skipping a slot */
  TSCH_LOG_ADD(tsch_log_message,
                  snprintf(log->message, sizeof(log->message),
                      "!skipped slot %u %u %u",
                        tsch_locked,
                        tsch_lock_requested,
                        current_link == NULL);
  );
```