### PR TITLE
X86 support for SafeStack

### DIFF
--- a/cpu/x86/Makefile.x86_common
+++ b/cpu/x86/Makefile.x86_common
@@ -2,7 +2,12 @@ CONTIKI_CPU_DIRS += . init/common
 
 CONTIKI_SOURCEFILES += gdt.c helpers.S idt.c cpu.c
 
-CC       = gcc
+ifeq ($(BUILT_LIBC),musl)
+	CC       = clang
+	CFLAGS   += -Wno-macro-redefined -Wno-bitfield-constant-conversion -Wno-address-of-packed-member
+else
+	CC       = gcc
+endif
 LD       = $(CC)
 # Use gcc to invoke the assembler so that the preprocessor will be run on each
 # file first, enabling us to use macros within assembly language files:

--- a/cpu/x86/Makefile.x86_quarkX1000
+++ b/cpu/x86/Makefile.x86_quarkX1000
@@ -1,3 +1,13 @@
+ifeq ($(BUILT_LIBC),musl)
+  ifdef X86_CONF_SAFE_STACK
+    ifneq ($(X86_CONF_SAFE_STACK),1)
+      $(error Incompatible X86_CONF_SAFE_STACK setting)
+    endif
+  else
+    X86_CONF_SAFE_STACK = 1
+  endif
+endif
+
 # See mm/README.md for a description of available settings:
 X86_CONF_PROT_DOMAINS ?= none
 
@@ -8,6 +18,11 @@ CONTIKI_CPU_DIRS += drivers/legacy_pc drivers/quarkX1000 init/legacy_pc net mm
 CONTIKI_SOURCEFILES += bootstrap_quarkX1000.S rtc.c pit.c pic.c irq.c nmi.c pci.c uart-16x50.c uart.c gpio.c i2c.c eth.c shared-isr.c
 CONTIKI_SOURCEFILES += imr.c msg-bus.c
 CONTIKI_SOURCEFILES += stacks.c
+
+ifeq ($(X86_CONF_SAFE_STACK),1)
+# This is only supported by LLVM Clang:
+CFLAGS += -target i586-contiki-unknown -fsanitize=safe-stack
+endif
 
 ifneq ($(X86_CONF_PROT_DOMAINS),none)
 CONTIKI_SOURCEFILES += prot-domains.c $(X86_CONF_PROT_DOMAINS)-prot-domains.c imr-conf.c

--- a/cpu/x86/bootstrap_quarkX1000.S
+++ b/cpu/x86/bootstrap_quarkX1000.S
@@ -45,6 +45,11 @@
 .global start
 start:
         cli
+#ifdef __has_feature
+#if __has_feature(safe_stack)
+        movl $(stacks_unsafe + STACKS_SIZE_UNSAFE), __safestack_unsafe_stack_ptr
+#endif
+#endif
 #if X86_CONF_PROT_DOMAINS == X86_CONF_PROT_DOMAINS__TSS
         /* TSS-based protection domains use a multi-segment model that defines
          * tight bounds around stacks.  That means that the bottom of the stack

--- a/cpu/x86/mm/README.md
+++ b/cpu/x86/mm/README.md
@@ -848,6 +848,24 @@ in an unexpected manner, since segment register load instructions are
 unprivileged.  Similar segment register updates must be performed for
 similar reasons when dispatching system calls.
 
+#### SafeStack Stack Corruption Mitigation
+
+LLVM Clang supports a stack corruption mitigation called SafeStack.
+It moves allocations that may be accessed in an unsafe manner to an
+"unsafe stack," away from the return addresses that are stored on the
+safe stack [4].
+
+This feature can be enabled by building musl libc.  It requires a
+version of LLVM Clang with support for the SafeStack feature with
+single-threaded storage for the unsafe stack pointer for Contiki.
+
+Note that it may still be possible for a malicious or erroneous memory
+write to affect the main stack, since it is accessible through the DS
+and ES segments.  Also note that unlike SafeStack with runtime support
+provided by LLVM compiler-rt, this implementation of SafeStack does
+not randomize the location of the safe stack or protect it in any
+other way.
+
 ### Software-Switched Segment-Based Protection Domains
 
 Primary implementation sources:
@@ -995,3 +1013,6 @@ References
 [3] "Intel(R) Quark(TM) SoC X1000 Secure Boot Programmer's Reference
     Manual,"
     http://www.intel.com/support/processors/quark/sb/CS-035228.htm
+
+[4] "SafeStack - Clang documentation,"
+    http://clang.llvm.org/docs/SafeStack.html

--- a/cpu/x86/mm/stacks.c
+++ b/cpu/x86/mm/stacks.c
@@ -38,3 +38,12 @@ uint8_t stacks_int[STACKS_SIZE_INT]
 uint8_t stacks_exc[STACKS_SIZE_EXC]
   __attribute__((section(".exc_stack"), aligned(4)));
 #endif
+
+#ifdef __has_feature
+#if __has_feature(safe_stack)
+/** Unsafe stack (see http://clang.llvm.org/docs/SafeStack.html). */
+uint8_t stacks_unsafe[STACKS_SIZE_UNSAFE] __attribute__((aligned(4)));
+
+uint32_t __safestack_unsafe_stack_ptr;
+#endif
+#endif

--- a/cpu/x86/mm/stacks.h
+++ b/cpu/x86/mm/stacks.h
@@ -88,6 +88,7 @@
  * the linker scripts.  See those and README.md for more details.
  */
 /* STACKS_SIZE_TOTAL is defined in platform/galileo/Makefile.galileo */
+#define STACKS_SIZE_UNSAFE STACKS_SIZE_TOTAL
 #define STACKS_SIZE_MAIN (STACKS_SIZE_TOTAL - (STACKS_SIZE_INT + STACKS_SIZE_EXC))
 
 #if !__ASSEMBLER__

--- a/cpu/x86/mm/stacks.h
+++ b/cpu/x86/mm/stacks.h
@@ -87,7 +87,8 @@
  * protection domains are in use.  The stacks are arranged contiguously by
  * the linker scripts.  See those and README.md for more details.
  */
-#define STACKS_SIZE_MAIN (8192 - (STACKS_SIZE_INT + STACKS_SIZE_EXC))
+/* STACKS_SIZE_TOTAL is defined in platform/galileo/Makefile.galileo */
+#define STACKS_SIZE_MAIN (STACKS_SIZE_TOTAL - (STACKS_SIZE_INT + STACKS_SIZE_EXC))
 
 #if !__ASSEMBLER__
 /**

--- a/cpu/x86/quarkX1000.ld
+++ b/cpu/x86/quarkX1000.ld
@@ -79,8 +79,8 @@ SECTIONS {
 
     .bss ALIGN (32) :
     {
-        *(COMMON)
         *(.main_stack)
+        *(COMMON)
         *(.bss*)
 
         *(.gdt_bss_start)

--- a/cpu/x86/quarkX1000.ld
+++ b/cpu/x86/quarkX1000.ld
@@ -93,4 +93,10 @@ SECTIONS {
     }
 
     _ebss_pre_dma_addr = ALIGN(32);
+
+    /DISCARD/ :
+    {
+        *(.eh_frame)
+        *(.eh_frame_hdr)
+    }
 }

--- a/cpu/x86/quarkX1000_multi_seg.ld
+++ b/cpu/x86/quarkX1000_multi_seg.ld
@@ -191,4 +191,10 @@ SECTIONS {
 
     /* .bss.meta may be empty, so this uses .bss.kern_priv as a base instead: */
     _ebss_pre_dma_addr = ALIGN(ALIGN(_ebss_kern_addr, 32) + SIZEOF(.bss.meta), 32);
+
+    /DISCARD/ :
+    {
+        *(.eh_frame)
+        *(.eh_frame_hdr)
+    }
 }

--- a/cpu/x86/quarkX1000_paging.ld
+++ b/cpu/x86/quarkX1000_paging.ld
@@ -207,4 +207,10 @@ SECTIONS {
     }
 
     _ebss_pre_dma_addr = ALIGN(32);
+
+    /DISCARD/ :
+    {
+        *(.eh_frame)
+        *(.eh_frame_hdr)
+    }
 }

--- a/cpu/x86/uefi/bootstrap_uefi.c
+++ b/cpu/x86/uefi/bootstrap_uefi.c
@@ -41,6 +41,11 @@ void start(void);
  * To avoid that, we avoid including prot-domains.h from this file.
  */
 EFI_STATUS EFIAPI __attribute__((section(".boot_text")))
+#ifdef __has_feature
+#if __has_feature(safe_stack)
+__attribute__((no_sanitize("safe-stack")))
+#endif
+#endif
 uefi_start(IN EFI_HANDLE ImageHandle, IN EFI_SYSTEM_TABLE *SystemTable)
 {
   EFI_MEMORY_DESCRIPTOR mem_map[MAX_MEM_DESC];

--- a/platform/galileo/Makefile.galileo
+++ b/platform/galileo/Makefile.galileo
@@ -21,7 +21,23 @@ ifeq ($(CONTIKI_WITH_IPV6),1)
 	CONTIKI_SOURCEFILES += nbr-table.c packetbuf.c linkaddr.c link-stats.c
 endif
 
-PROJECT_SOURCEFILES += newlib-syscalls.c
+-include $(LIBC_PATH)/Makefile.libc
+
+ifndef BUILT_LIBC
+  $(error Build the C library by executing $(LIBC_PATH)/build_newlib.sh or $(LIBC_PATH)/build_musl.sh)
+endif
+
+ifeq ($(BUILT_LIBC),musl)
+  PROJECT_SOURCEFILES += musl-syscalls.c musl-syscalls-asm.S
+  CFLAGS += -DSTACKS_SIZE_TOTAL=16384
+else
+  ifeq ($(BUILT_LIBC),newlib)
+    PROJECT_SOURCEFILES += newlib-syscalls.c
+    CFLAGS += -DSTACKS_SIZE_TOTAL=8192
+  else
+    $(error Unrecognized value for BUILT_LIBC: $(BUILT_LIBC))
+  endif
+endif
 
 CONTIKI_CPU=$(CONTIKI)/cpu/x86
 include $(CONTIKI)/cpu/x86/Makefile.x86_quarkX1000
@@ -35,9 +51,3 @@ endif
 LDFLAGS += -nostdlib -L$(LIBC)/lib -L$(LIBGCC_PATH)/32
 
 TARGET_LIBFILES += -lm -lc -lgcc
-
--include $(LIBC_PATH)/Makefile.libc
-
-ifndef BUILT_LIBC
-  $(error Build the C library by executing $(LIBC_PATH)/build_newlib.sh)
-endif

--- a/platform/galileo/Makefile.galileo
+++ b/platform/galileo/Makefile.galileo
@@ -30,6 +30,7 @@ endif
 ifeq ($(BUILT_LIBC),musl)
   PROJECT_SOURCEFILES += musl-syscalls.c musl-syscalls-asm.S
   CFLAGS += -DSTACKS_SIZE_TOTAL=16384
+  X86_CONF_SAFE_STACK = 1
 else
   ifeq ($(BUILT_LIBC),newlib)
     PROJECT_SOURCEFILES += newlib-syscalls.c

--- a/platform/galileo/Makefile.galileo
+++ b/platform/galileo/Makefile.galileo
@@ -43,11 +43,14 @@ CONTIKI_CPU=$(CONTIKI)/cpu/x86
 include $(CONTIKI)/cpu/x86/Makefile.x86_quarkX1000
 
 CFLAGS += -fno-stack-protector -I$(LIBC)/include
+TARGET_LIBFILES += -lm -lc
 ifeq (clang,$(findstring clang,$(CC)))
         CFLAGS += -nostdlibinc
+        TARGET_LIBFILES += $(shell find `llvm-config --libdir` -name libclang_rt.builtins-i386.a)
 else
         CFLAGS += -nostdinc -isystem $(LIBGCC_PATH)/include -isystem $(LIBGCC_PATH)/include-fixed
+        LDFLAGS += -L$(LIBGCC_PATH)/32
+        TARGET_LIBFILES += -lgcc
 endif
-LDFLAGS += -nostdlib -L$(LIBC)/lib -L$(LIBGCC_PATH)/32
+LDFLAGS += -nostdlib -L$(LIBC)/lib
 
-TARGET_LIBFILES += -lm -lc -lgcc

--- a/platform/galileo/README.md
+++ b/platform/galileo/README.md
@@ -114,9 +114,10 @@ $ ./platform/galileo/bsp/libc/build_musl.sh
 
 Once a C library is built, you are ready to build applications.  By
 default, the following steps will use gcc as the C compiler and to
-invoke the linker.  To use LLVM Clang instead, change the values for
-both the CC and LD variables in cpu/x86/Makefile.x86_common to
-'clang'.
+invoke the linker if newlib was built.  To use LLVM Clang instead,
+change the values for both the CC and LD variables in
+cpu/x86/Makefile.x86_common to 'clang'.  LLVM Clang will be used by
+default if musl libc was built.
 
 To build applications for the Galileo platform you should set the TARGET
 variable to 'galileo'.  For instance, building the hello-world application

--- a/platform/galileo/README.md
+++ b/platform/galileo/README.md
@@ -107,10 +107,16 @@ command:
 $ ./platform/galileo/bsp/libc/build_newlib.sh
 ```
 
-Once newlib is built, you are ready to build applications.  By default, the
-following steps will use gcc as the C compiler and to invoke the linker.  To
-use LLVM clang instead, change the values for both the CC and LD variables in
-cpu/x86/Makefile.x86_common to 'clang'.
+Alternatively, you can run the following command to build musl libc:
+```
+$ ./platform/galileo/bsp/libc/build_musl.sh
+```
+
+Once a C library is built, you are ready to build applications.  By
+default, the following steps will use gcc as the C compiler and to
+invoke the linker.  To use LLVM Clang instead, change the values for
+both the CC and LD variables in cpu/x86/Makefile.x86_common to
+'clang'.
 
 To build applications for the Galileo platform you should set the TARGET
 variable to 'galileo'.  For instance, building the hello-world application

--- a/platform/galileo/README.md
+++ b/platform/galileo/README.md
@@ -107,7 +107,9 @@ command:
 $ ./platform/galileo/bsp/libc/build_newlib.sh
 ```
 
-Alternatively, you can run the following command to build musl libc:
+Alternatively, you can run the following command to build musl libc if
+you have a version of LLVM Clang that supports the SafeStack feature
+with single-threaded storage for the unsafe stack pointer for Contiki:
 ```
 $ ./platform/galileo/bsp/libc/build_musl.sh
 ```
@@ -117,7 +119,10 @@ default, the following steps will use gcc as the C compiler and to
 invoke the linker if newlib was built.  To use LLVM Clang instead,
 change the values for both the CC and LD variables in
 cpu/x86/Makefile.x86_common to 'clang'.  LLVM Clang will be used by
-default if musl libc was built.
+default if musl libc was built.  Furthermore, musl libc is built with
+the SafeStack mitigation against stack corruption, and building musl
+libc causes the rest of the image to be built by default with
+SafeStack.  See cpu/x86/mm/README.md for more details.
 
 To build applications for the Galileo platform you should set the TARGET
 variable to 'galileo'.  For instance, building the hello-world application

--- a/platform/galileo/bsp/libc/build_musl.sh
+++ b/platform/galileo/bsp/libc/build_musl.sh
@@ -34,7 +34,7 @@ prepare() {
 
 build() {
     export CC=clang
-    export CFLAGS="-m32 -march=i586 -mtune=i586 -fno-omit-frame-pointer -Qunused-arguments"
+    export CFLAGS="-target i586-contiki-unknown -march=i586 -mtune=i586 -fno-omit-frame-pointer -Qunused-arguments -fsanitize=safe-stack"
 
     mkdir -p install
     ./configure --target=${TARGET} \

--- a/platform/galileo/bsp/libc/build_musl.sh
+++ b/platform/galileo/bsp/libc/build_musl.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+
+set -e
+
+JOBS=5
+TARGET=i586-elf
+PKG_NAME=musl
+SRC_DIR=${PKG_NAME}
+DIST_SITE=git://git.musl-libc.org
+COMMIT_HASH=e738b8cbe64b6dd3ed9f47b6d4cd7eb2c422b38d
+
+SCRIPT_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+
+# This script will always run on its own basepath, no matter where you call it from.
+pushd ${SCRIPT_DIR}
+
+prepare() {
+    # If the source directory doesn't exist, download it.
+    if [[ ! -d ./${SRC_DIR} ]]; then
+        git clone ${DIST_SITE}/${PKG_NAME}
+        pushd ${SRC_DIR}
+        git checkout ${COMMIT_HASH}
+        popd
+    fi
+
+    # Clean up the previous install dir, if any.
+    if [[ -d ./${TARGET} ]]; then
+        rm -rf ./${TARGET}
+    fi
+
+    cd ${SRC_DIR}
+}
+
+
+build() {
+    export CFLAGS="-m32 -march=i586 -mtune=i586 -fno-omit-frame-pointer"
+
+    mkdir -p install
+    ./configure --target=${TARGET} \
+        --build=${TARGET} \
+        --prefix=`pwd`/install \
+        --disable-wrapper \
+        --disable-shared
+
+    make clean
+    make -j${JOBS} install
+    cd ..
+
+    echo "BUILT_LIBC = musl" > Makefile.libc
+}
+
+setup() {
+    mkdir ${TARGET}
+    cp -r ./${SRC_DIR}/install/lib ./${SRC_DIR}/install/include ${TARGET}
+}
+
+cleanup() {
+    rm -rf ./${SRC_DIR}*
+}
+
+
+# By default we always call prepare, build and setup.
+prepare
+build
+setup
+
+# But we only cleanup if -c is used.
+case $1 in
+    -c | --cleanup)
+        cleanup
+        shift
+        ;;
+    *)
+        # unknown option
+        ;;
+esac
+
+popd

--- a/platform/galileo/bsp/libc/build_musl.sh
+++ b/platform/galileo/bsp/libc/build_musl.sh
@@ -33,7 +33,8 @@ prepare() {
 
 
 build() {
-    export CFLAGS="-m32 -march=i586 -mtune=i586 -fno-omit-frame-pointer"
+    export CC=clang
+    export CFLAGS="-m32 -march=i586 -mtune=i586 -fno-omit-frame-pointer -Qunused-arguments"
 
     mkdir -p install
     ./configure --target=${TARGET} \

--- a/platform/galileo/contiki-main.c
+++ b/platform/galileo/contiki-main.c
@@ -76,11 +76,14 @@ app_main(void)
   halt();
 }
 /*---------------------------------------------------------------------------*/
+void libc_init(void);
 /* Kernel entrypoint */
 int
 main(void)
 {
   uintptr_t *func_ptr;
+
+  libc_init();
 
 #ifdef X86_CONF_RESTRICT_DMA
   quarkX1000_imr_conf();

--- a/platform/galileo/musl-syscalls-asm.S
+++ b/platform/galileo/musl-syscalls-asm.S
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2015-2016, Intel Corporation. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+	.section .text
+
+	.extern galileo_vsyscall
+	.global galileo_vsyscall_asm
+
+galileo_vsyscall_asm:
+	/* Save and restore the registers that are defined to be caller-saved by the
+	 * cdecl convention, just in case the caller has not done this already.
+	 * This may not actually be necessary here.
+	 */
+	push %ecx
+	push %edx
+
+	push %ebp
+	push %edi
+	push %esi
+	push %edx
+	push %ecx
+	push %ebx
+	push %eax
+
+	call galileo_vsyscall
+
+	add $28, %esp
+
+	pop %edx
+	pop %ecx
+
+	ret

--- a/platform/galileo/musl-syscalls.c
+++ b/platform/galileo/musl-syscalls.c
@@ -1,0 +1,110 @@
+/*
+ * Copyright (C) 2015-2016, Intel Corporation. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <assert.h>
+#include <stdio.h>
+#include <sys/ioctl.h>
+#include <sys/syscall.h>
+#include <sys/uio.h>
+#include <unistd.h>
+#include "helpers.h"
+#include "uart.h"
+
+#define CONSOLE_OUTPUT_DEV QUARK_X1000_UART_1
+
+/*---------------------------------------------------------------------------*/
+long
+galileo_writev(int fd, struct iovec *iovs, int iovcnt)
+{
+  int i;
+  long res = 0;
+
+  assert((fd == STDOUT_FILENO) || (fd == STDERR_FILENO));
+
+  for(i = 0; i < iovcnt; i++) {
+    int j;
+    for(j = 0; j < iovs[i].iov_len; j++) {
+      char c = ((char *)iovs[i].iov_base)[j];
+      if(c == '\n') {
+        quarkX1000_uart_tx(CONSOLE_OUTPUT_DEV, '\r');
+      }
+      quarkX1000_uart_tx(CONSOLE_OUTPUT_DEV, c);
+      res++;
+    }
+  }
+
+  return res;
+}
+/*---------------------------------------------------------------------------*/
+long
+galileo_vsyscall(long syscall_id,
+                 long arg0, long arg1, long arg2,
+                 long arg3, long arg4, long arg5)
+{
+  long res = 0;
+
+  switch(syscall_id) {
+  case SYS_ioctl:
+    if(arg1 == TIOCGWINSZ) {
+      assert((arg0 == STDOUT_FILENO) || (arg0 != STDERR_FILENO));
+
+      struct winsize *w_sz = (struct winsize *)arg2;
+      w_sz->ws_row = 25;
+      w_sz->ws_col = 80;
+      res = 0;
+    } else {
+      fprintf(stderr, "Unimplemented IOCTL: %ld.\n", arg1);
+      halt();
+    }
+    break;
+
+  case SYS_writev:
+    res = galileo_writev((int)arg0, (struct iovec *)arg1, (int)arg2);
+    break;
+
+  default:
+    fprintf(stderr, "Unimplemented syscall: %ld.\n", syscall_id);
+    halt();
+  }
+
+  return res;
+}
+/*---------------------------------------------------------------------------*/
+void
+libc_init(void)
+{
+  typedef long (vsyscall_t)(void);
+
+  extern vsyscall_t galileo_vsyscall_asm;
+
+  extern vsyscall_t *__sysinfo;
+
+  __sysinfo = galileo_vsyscall_asm;
+}

--- a/platform/galileo/newlib-syscalls.c
+++ b/platform/galileo/newlib-syscalls.c
@@ -172,3 +172,7 @@ _sbrk_r(struct _reent *ptr, int incr)
 
   return prev_prog_break;
 }
+/*---------------------------------------------------------------------------*/
+void libc_init(void)
+{
+}


### PR DESCRIPTION
Depends on #1433.

Adds support for the LLVM SafeStack pass.  The purpose of the SafeStack pass is to define an unsafe stack that is separate from the main stack so that just variables that are accessed safely are placed on the main stack with return addresses.  This helps to block corruption of return addresses, e.g. as occurs during Return-Oriented Programming (ROP) exploits.  Support for using this in single-threaded mode with Contiki is in a set of LLVM patches that are under review.

However, it is still possible for a stray write to affect the main stack, since it is accessible through the DS and ES segments.  I have another PR ready to submit that adds support for separating the stack and data segments from each other.  It depends on a second set of LLVM patches that are still under review.  I plan to submit that PR if and when the necessary LLVM patches are accepted.

More information on the SafeStack pass is available here: http://clang.llvm.org/docs/SafeStack.html

This PR also adds support for musl libc, since it can be built with LLVM Clang.
