### PR TITLE
Do not use setBaudrate

### DIFF
--- a/tools/sky/msp430-bsl-linux
+++ b/tools/sky/msp430-bsl-linux
@@ -1162,8 +1162,9 @@ class BootStrapLoader(LowLevel):
         sys.stderr.flush()
         self.bslTxRx(self.BSL_CHANGEBAUD,   #Command: change baudrate
                     a, l)                   #args are coded in adr and len
+        self.serialport.flush()
         time.sleep(0.010)                   #recomended delay
-        self.serialport.setBaudrate(baudrate)
+        self.serialport.baudrate = baudrate
 
     def actionReadBSLVersion(self):
         """informational output of BSL version number.

--- a/tools/zolertia/z1-bsl
+++ b/tools/zolertia/z1-bsl
@@ -1350,8 +1350,9 @@ class BootStrapLoader(LowLevel):
         sys.stderr.flush()
         self.bslTxRx(self.BSL_CHANGEBAUD,   #Command: change baudrate
                     a, l)                   #args are coded in adr and len
+        self.serialport.flush()
         time.sleep(0.010)                   #recomended delay
-        self.serialport.setBaudrate(baudrate)
+        self.serialport.baudrate = baudrate
 
     def actionReadBSLVersion(self):
         """informational output of BSL version number.

--- a/tools/zolertia/z1-bsl-nopic
+++ b/tools/zolertia/z1-bsl-nopic
@@ -1364,8 +1364,9 @@ class BootStrapLoader(LowLevel):
         sys.stderr.flush()
         self.bslTxRx(self.BSL_CHANGEBAUD,   #Command: change baudrate
                     a, l)                   #args are coded in adr and len
+        self.serialport.flush()
         time.sleep(0.010)                   #recomended delay
-        self.serialport.setBaudrate(baudrate)
+        self.serialport.baudrate = baudrate
 
     def actionReadBSLVersion(self):
         """informational output of BSL version number.


### PR DESCRIPTION
The the author of the library *pyserial* removed the command `setBaudrate()` starting from version 3.0. This PR solves problems caused by that in the bsl by setting the baudrate directly.
*pyserial* 3.0 is just upcoming for example in Debian stretch.