### PR TITLE
Fix putchar include when using IPv4

### DIFF
--- a/cpu/msp430/dev/uart0-putchar.c
+++ b/cpu/msp430/dev/uart0-putchar.c
@@ -1,9 +1,12 @@
-#include "dev/uart0.h"
 #include <stdio.h>
+#include "dev/uart0.h"
 
+#ifndef NETSTACK_CONF_WITH_IPV4
+/* In case of IPv4: putchar() is defined by the SLIP driver */
 int
 putchar(int c)
 {
   uart0_writeb((char)c);
   return c;
 }
+#endif /* NETSTACK_CONF_WITH_IPV4 */

--- a/cpu/msp430/dev/uart0-putchar.c
+++ b/cpu/msp430/dev/uart0-putchar.c
@@ -1,7 +1,7 @@
 #include <stdio.h>
 #include "dev/uart0.h"
 
-#ifndef NETSTACK_CONF_WITH_IPV4
+#if !NETSTACK_CONF_WITH_IPV4
 /* In case of IPv4: putchar() is defined by the SLIP driver */
 int
 putchar(int c)
@@ -9,4 +9,4 @@ putchar(int c)
   uart0_writeb((char)c);
   return c;
 }
-#endif /* NETSTACK_CONF_WITH_IPV4 */
+#endif /* ! NETSTACK_CONF_WITH_IPV4 */

--- a/cpu/msp430/dev/uart0-putchar.c
+++ b/cpu/msp430/dev/uart0-putchar.c
@@ -1,4 +1,3 @@
-#include <stdio.h>
 #include "dev/uart0.h"
 
 #if !NETSTACK_CONF_WITH_IPV4

--- a/cpu/msp430/dev/uart1-putchar.c
+++ b/cpu/msp430/dev/uart1-putchar.c
@@ -1,7 +1,7 @@
 #include <stdio.h>
 #include "dev/uart1.h"
 
-#ifndef NETSTACK_CONF_WITH_IPV4
+#if !NETSTACK_CONF_WITH_IPV4
 /* In case of IPv4: putchar() is defined by the SLIP driver */
 int
 putchar(int c)
@@ -9,4 +9,4 @@ putchar(int c)
   uart1_writeb((char)c);
   return c;
 }
-#endif /* NETSTACK_CONF_WITH_IPV4 */
+#endif /* ! NETSTACK_CONF_WITH_IPV4 */

--- a/cpu/msp430/dev/uart1-putchar.c
+++ b/cpu/msp430/dev/uart1-putchar.c
@@ -1,4 +1,3 @@
-#include <stdio.h>
 #include "dev/uart1.h"
 
 #if !NETSTACK_CONF_WITH_IPV4

--- a/cpu/msp430/dev/uart1-putchar.c
+++ b/cpu/msp430/dev/uart1-putchar.c
@@ -1,9 +1,12 @@
 #include <stdio.h>
 #include "dev/uart1.h"
 
+#ifndef NETSTACK_CONF_WITH_IPV4
+/* In case of IPv4: putchar() is defined by the SLIP driver */
 int
 putchar(int c)
 {
   uart1_writeb((char)c);
   return c;
 }
+#endif /* NETSTACK_CONF_WITH_IPV4 */


### PR DESCRIPTION
In case of using IPv4, `putchar()` is provided by the SLIP device. The missing `#ifndef` result into an error: `multiple definition of 'putchar'`