### PR TITLE
Fix for IPv6 compilation and linkage errors

### DIFF
--- a/examples/ravenusbstick/Makefile.ravenusbstick
+++ b/examples/ravenusbstick/Makefile.ravenusbstick
@@ -8,7 +8,7 @@ CONTIKI_WITH_IPV6=0
 
 CONTIKI = ../..
 
-MODULES+=core/net/mac/sicslowmac core/net/mac core/net/llsec
+MODULES+=core/net/mac/sicslowmac core/net core/net/mac core/net/llsec
 
 PROJECT_SOURCEFILES += fakeuip.c
 

--- a/platform/avr-ravenusb/cdc_task.c
+++ b/platform/avr-ravenusb/cdc_task.c
@@ -611,7 +611,7 @@ extern uip_ds6_netif_t uip_ds6_if;
 				uip_ds6_route_t *route;
 		    for(route = uip_ds6_route_head();
 		        route != NULL;
-		        route = uip_ds6_route_next(r)) {
+		        route = uip_ds6_route_next(route)) {
 					ipaddr_add(&route->ipaddr);
 					PRINTF_P(PSTR("/%u (via "), route->length);
 					ipaddr_add(uip_ds6_route_nexthop(route));


### PR DESCRIPTION
Two errors have been spotted, when IPv6 is enabled in the **ravenusb**
Project-Makefile:
`#CONTIKI_NO_NET=1`
`CONTIKI_WITH_IPV6=1`

The compile error results from a variable name mismatch in `cdc_task.c`
The variable `r` is undeclared and should be renamed to `route`

The linker also fails with _undefined references_
This has been mediated by adding `core/net` to Modules in the
Project-Makefile.