### PR TITLE
Fix the path for wpcapslip in testscript for Instant Contiki

### DIFF
--- a/regression-tests/20-ip64/01-cooja-ip64-http-socket.csc
+++ b/regression-tests/20-ip64/01-cooja-ip64-http-socket.csc
@@ -151,7 +151,7 @@ if (travis == null) {&#xD;
     /* Instant Contiki */&#xD;
     CMD_TUNNEL = "echo '-vj' &gt; ~/.slirprc &amp;&amp; make Connect.class &amp;&amp; java Connect 'nc localhost 60001' 'script -t -f -c slirp'";&#xD;
     CMD_PING = "ping -c 5 8.8.8.8";&#xD;
-    CMD_DIR = "../../wpcapslip";&#xD;
+    CMD_DIR = "../../tools/wpcapslip";&#xD;
 } else {&#xD;
     /* Travis */&#xD;
     CMD_TUNNEL = "cd $TRAVIS_BUILD_DIR/tools/wpcapslip &amp;&amp; sudo apt-get install slirp &amp;&amp; echo '-vj' &gt; ~/.slirprc &amp;&amp; make Connect.class &amp;&amp; java Connect 'nc localhost 60001' 'script -t -f -c slirp'";&#xD;

--- a/regression-tests/21-large-rpl/testscript.js
+++ b/regression-tests/21-large-rpl/testscript.js
@@ -9,7 +9,7 @@ if (travis == null) {
     /* Instant Contiki */
     CMD_TUNNEL = "echo '-vj' > ~/.slirprc && make Connect.class && java Connect 'nc localhost 60001' 'script -t -f -c slirp'";
     CMD_PING = "ping -c 5 8.8.8.8";
-    CMD_DIR = "../../wpcapslip";
+    CMD_DIR = "../../tools/wpcapslip";
 } else {
     /* Travis */
     CMD_TUNNEL = "cd $TRAVIS_BUILD_DIR/tools/wpcapslip && sudo apt-get install slirp && echo '-vj' > ~/.slirprc && make Connect.class && java Connect 'nc localhost 60001' 'script -t -f -c slirp'";


### PR DESCRIPTION
This PR resolves errors raised on executing two of the regression tests, `20-ip64` and `21-large-rpl`, under Instant Contiki (a non Travis environment).

Here are error messages you'll see with the tests:
```shell
user@instant-contiki:~/contiki$ make -C regression-tests/20-ip64 RUNALL=yes summary
make: Entering directory `/home/user/contiki/regression-tests/20-ip64'
Running test 01-cooja-ip64-http-socket with random Seed 1: .... INFO [main] (Cooja.java:1781) - 
(snip)
FATAL [Thread-5] (LogScriptEngine.java:312) - Test script error, terminating Cooja.
FATAL [Thread-5] (LogScriptEngine.java:313) - Script error:
java.lang.reflect.UndeclaredThrowableException
	at com.sun.proxy.$Proxy5.run(Unknown Source)
	at org.contikios.cooja.plugins.LogScriptEngine$4.run(LogScriptEngine.java:300)
	at java.lang.Thread.run(Thread.java:745)
Caused by: java.security.PrivilegedActionException: javax.script.ScriptException: sun.org.mozilla.javascript.WrappedException: Wrapped java.io.IOException: Cannot run program "sh" (in directory "../../wpcapslip"): error=2, No such file or directory (<Unknown source>#34) in <Unknown source> at line number 34
	at java.security.AccessController.doPrivileged(Native Method)
	at com.sun.script.util.InterfaceImplementor$InterfaceImplementorInvocationHandler.invoke(InterfaceImplementor.java:67)
	... 3 more

...
```

```shell
user@instant-contiki:~/contiki$ make -C regression-tests/21-large-rpl RUNALL=yes summary
make: Entering directory `/home/user/contiki/regression-tests/21-large-rpl'
Running test 01-cooja-http-socket-50 with random Seed 1: ...... INFO [main] (Cooja.java:1781) -
(snip)
FATAL [Thread-5] (LogScriptEngine.java:312) - Test script error, terminating Cooja.
FATAL [Thread-5] (LogScriptEngine.java:313) - Script error:
java.lang.reflect.UndeclaredThrowableException
	at com.sun.proxy.$Proxy5.run(Unknown Source)
	at org.contikios.cooja.plugins.LogScriptEngine$4.run(LogScriptEngine.java:300)
	at java.lang.Thread.run(Thread.java:745)
Caused by: java.security.PrivilegedActionException: javax.script.ScriptException: sun.org.mozilla.javascript.WrappedException: Wrapped java.io.IOException: Cannot run program "sh" (in directory "../../wpcapslip"): error=2, No such file or directory (<Unknown source>#40) in <Unknown source> at line number 40
	at java.security.AccessController.doPrivileged(Native Method)
	at com.sun.script.util.InterfaceImplementor$InterfaceImplementorInvocationHandler.invoke(InterfaceImplementor.java:67)
	... 3 more
...
```