### PR TITLE
Add upload script to Makefile.launchpad

### DIFF
--- a/platform/srf06-cc26xx/launchpad/Makefile.launchpad
+++ b/platform/srf06-cc26xx/launchpad/Makefile.launchpad
@@ -4,3 +4,19 @@ CONTIKI_TARGET_DIRS += launchpad common
 
 BOARD_SOURCEFILES += board.c launchpad-sensors.c leds-arch.c button-sensor.c
 BOARD_SOURCEFILES += ext-flash.c board-spi.c
+
+PYTHON = python
+BSL_FLAGS += -e -w -v
+
+ifdef PORT
+  BSL_FLAGS += -p $(PORT)
+endif
+
+BSL = $(CONTIKI)/tools/cc2538-bsl/cc2538-bsl.py
+
+%.upload: %.bin
+ifeq ($(wildcard $(BSL)), )
+	@echo "ERROR: Could not find the cc2538-bsl script. Did you run 'git submodule update --init' ?"
+else
+	$(PYTHON) $(BSL) $(BSL_FLAGS) $<
+endif


### PR DESCRIPTION
This PR simply adds the upload command to the Makefile of the CC2650 Launchpad addressing the comment of @joakimeriksson on the already merged [#1485](https://github.com/contiki-os/contiki/pull/1485) pull request. I also confirm that the BSL script worked for me on Mac OS X without any problem after addressing the changes described by @g-oikonomou and also setting the `SET_CCFG_BL_CONFIG_BL_LEVEL` to `0x0` in the `ccfg.c` file.

I have set `115200` as predefined baud rate for the script.