### PR TITLE
Consolidate .upload for all CC26xx/CC13xx boards and add login make target

### DIFF
--- a/cpu/cc26xx-cc13xx/Makefile.cc26xx-cc13xx
+++ b/cpu/cc26xx-cc13xx/Makefile.cc26xx-cc13xx
@@ -81,6 +81,15 @@ CONTIKI_SOURCEFILES += $(CONTIKI_CPU_SOURCEFILES) $(DEBUG_IO_SOURCEFILES)
 TARGET_START_SOURCEFILES += fault-handlers.c $(TI_XXWARE_STARTUP_SRCS)
 TARGET_STARTFILES = $(addprefix $(OBJECTDIR)/,$(call oname, $(TARGET_START_SOURCEFILES)))
 
+PYTHON = python
+BSL_FLAGS += -e -w -v
+
+ifdef PORT
+  BSL_FLAGS += -p $(PORT)
+endif
+
+BSL = $(CONTIKI)/tools/cc2538-bsl/cc2538-bsl.py
+
 ### Don't treat the .elf as intermediate
 .PRECIOUS: %.elf %.hex %.bin
 
@@ -125,3 +134,14 @@ STACK_SIZE = 0
 	@$(SIZE) -A $< | egrep "data|bss" | awk '{s+=$$2} END {s=s+$(STACK_SIZE); f=$(RAM_SIZE)-s; printf "[RAM]   used %6d, free %6d\n",s,f;}'
 	@$(SIZE) -A $< | egrep "text|isr_vector" | awk '{s+=$$2} END {f=$(FLASH_SIZE)-s; printf "[Flash] used %6d, free %6d\n",s,f;}'
 
+ifeq ($(BOARD_SUPPORTS_BSL),1)
+%.upload: %.bin
+ifeq ($(wildcard $(BSL)), )
+	@echo "ERROR: Could not find the cc2538-bsl script. Did you run 'git submodule update --init' ?"
+else
+	$(PYTHON) $(BSL) $(BSL_FLAGS) $<
+endif
+else
+%.upload:
+	@echo "This board cannot be programmed through the ROM bootloader and therefore does not support the .upload target."
+endif

--- a/cpu/cc26xx-cc13xx/Makefile.cc26xx-cc13xx
+++ b/cpu/cc26xx-cc13xx/Makefile.cc26xx-cc13xx
@@ -145,3 +145,20 @@ else
 %.upload:
 	@echo "This board cannot be programmed through the ROM bootloader and therefore does not support the .upload target."
 endif
+
+# Check if we are running under Windows
+ifeq ($(HOST_OS),Windows)
+  SERIALDUMP ?= $(CONTIKI)/tools/sky/serialdump-windows
+else
+ifeq ($(HOST_OS),Darwin)
+  SERIALDUMP ?= $(CONTIKI)/tools/sky/serialdump-macos
+else
+  # Else assume Linux
+  SERIALDUMP ?= $(CONTIKI)/tools/sky/serialdump-linux
+endif
+endif
+
+UART_BAUDRATE = 115200
+
+login:
+	$(SERIALDUMP) -b$(UART_BAUDRATE) $(PORT)

--- a/platform/srf06-cc26xx/launchpad/Makefile.launchpad
+++ b/platform/srf06-cc26xx/launchpad/Makefile.launchpad
@@ -5,18 +5,5 @@ CONTIKI_TARGET_DIRS += launchpad common
 BOARD_SOURCEFILES += board.c launchpad-sensors.c leds-arch.c button-sensor.c
 BOARD_SOURCEFILES += ext-flash.c board-spi.c
 
-PYTHON = python
-BSL_FLAGS += -e -w -v
-
-ifdef PORT
-  BSL_FLAGS += -p $(PORT)
-endif
-
-BSL = $(CONTIKI)/tools/cc2538-bsl/cc2538-bsl.py
-
-%.upload: %.bin
-ifeq ($(wildcard $(BSL)), )
-	@echo "ERROR: Could not find the cc2538-bsl script. Did you run 'git submodule update --init' ?"
-else
-	$(PYTHON) $(BSL) $(BSL_FLAGS) $<
-endif
+### Signal that we can be programmed with cc2538-bsl
+BOARD_SUPPORTS_BSL=1

--- a/platform/srf06-cc26xx/srf06/Makefile.srf06
+++ b/platform/srf06-cc26xx/srf06/Makefile.srf06
@@ -4,18 +4,5 @@ CONTIKI_TARGET_DIRS += srf06
 
 BOARD_SOURCEFILES += leds-arch.c srf06-sensors.c button-sensor.c board.c
 
-PYTHON = python
-BSL_FLAGS += -e -w -v
-
-ifdef PORT
-  BSL_FLAGS += -p $(PORT)
-endif
-
-BSL = $(CONTIKI)/tools/cc2538-bsl/cc2538-bsl.py
-
-%.upload: %.bin
-ifeq ($(wildcard $(BSL)), )
-	@echo "ERROR: Could not find the cc2538-bsl script. Did you run 'git submodule update --init' ?"
-else
-	$(PYTHON) $(BSL) $(BSL_FLAGS) $<
-endif
+### Signal that we can be programmed with cc2538-bsl
+BOARD_SUPPORTS_BSL=1


### PR DESCRIPTION
The block that controls the `.upload` target is unnecessarily replicated in multiple sub-board Makefiles. This was originally done because the SmartRF and the Launchpad can be programmed with the c2538-bsl script, whereas the sensortag cannot.

This commit moves the `cc2538-bsl` / `.upload` target logic to the top level platform Makefile (`platform/srf06-cc26xx/Makefile.srf06-cc26xx`). Board makefiles simply set the make variable `BOARD_SUPPORTS_BSL` to 1 to signal that they can be programmed by the BSL script. If `BOARD_SUPPORTS_BSL` is not equal to 1, trying to use the `.upload` target will return an error message.

For example:

```
$ make BOARD=sensortag/cc2650 cc26xx-demo.upload
using saved target 'srf06-cc26xx'
This board cannot be programmed with the ROM bootloader and therefore does not support the .upload target.
```