### PR TITLE
Add support for the CC1310 LaunchPad (LAUNCHXL-CC1310)

### DIFF
--- a/platform/srf06-cc26xx/README.md
+++ b/platform/srf06-cc26xx/README.md
@@ -8,6 +8,7 @@ platform supports two different boards:
   (relevant files and drivers are under `srf06/`)
 * CC2650 SensorTag 2.0 (relevant drivers under `sensortag/cc2650`)
 * CC2650 LaunchPad (relevant drivers under `launchpad/cc2650`)
+* CC1310 LaunchPad (relevant drivers under `launchpad/cc1310`)
 
 The CPU code, common for both platforms, can be found under `$(CONTIKI)/cpu/cc26xx-cc13xx`.
 The port was developed and tested with CC2650s, but the intention is for it to
@@ -45,7 +46,7 @@ In terms of hardware support, the following drivers have been implemented:
   * OPT3001 sensor
   * Buzzer
   * External SPI flash
-* Launchpad
+* LaunchPads
   * LEDs
   * Buttons
   * External SPI flash
@@ -99,6 +100,7 @@ Other options for the `BOARD` make variable are:
 * Srf06+CC13xxEM: Set `BOARD=srf06/cc13xx`
 * CC2650 tag: Set `BOARD=sensortag/cc2650`
 * CC2650 Launchpad: Set `BOARD=launchpad/cc2650`
+* CC1310 Launchpad: Set `BOARD=launchpad/cc1310`
 
 If the `BOARD` variable is unspecified, an image for the Srf06 CC26XXEM will be built.
 

--- a/platform/srf06-cc26xx/common/ext-flash.c
+++ b/platform/srf06-cc26xx/common/ext-flash.c
@@ -40,6 +40,9 @@
 #include "ext-flash.h"
 #include "ti-lib.h"
 #include "board-spi.h"
+
+#include <stdint.h>
+#include <stdbool.h>
 /*---------------------------------------------------------------------------*/
 /* Instruction codes */
 
@@ -73,6 +76,7 @@
 #define BLS_DEVICE_ID_W25X20CL    0x11
 #define BLS_DEVICE_ID_W25X40CL    0x12
 #define BLS_DEVICE_ID_MX25R8035F  0x14
+#define BLS_DEVICE_ID_MX25R1635F  0x15
 
 #define BLS_WINBOND_MID           0xEF
 #define BLS_MACRONIX_MID          0xC2
@@ -179,7 +183,8 @@ verify_part(void)
 
   if((rbuf[0] != BLS_WINBOND_MID && rbuf[0] != BLS_MACRONIX_MID) ||
      (rbuf[1] != BLS_DEVICE_ID_W25X20CL && rbuf[1] != BLS_DEVICE_ID_W25X40CL
-      && rbuf[1] != BLS_DEVICE_ID_MX25R8035F)) {
+      && rbuf[1] != BLS_DEVICE_ID_MX25R8035F
+      && rbuf[1] != BLS_DEVICE_ID_MX25R1635F)) {
     return VERIFY_PART_POWERED_DOWN;
   }
   return VERIFY_PART_OK;

--- a/platform/srf06-cc26xx/contiki-main.c
+++ b/platform/srf06-cc26xx/contiki-main.c
@@ -32,13 +32,14 @@
  * \addtogroup cc26xx-platforms
  * @{
  *
- * \defgroup cc26xx-srf-tag SmartRF+CC13xx/CC26xx EM, CC2650 SensorTag and LaunchPad
+ * \defgroup cc26xx-srf-tag SmartRF+CC13xx/CC26xx EM, CC2650 SensorTag and LaunchPads
  *
  * This platform supports a number of different boards:
  * - A standard TI SmartRF06EB with a CC26xx EM mounted on it
  * - A standard TI SmartRF06EB with a CC1310 EM mounted on it
  * - The new TI SensorTag2.0
  * - The TI CC2650 LaunchPad
+ * - The TI CC1310 LaunchPad
  * @{
  */
 #include "ti-lib.h"

--- a/platform/srf06-cc26xx/launchpad/cc1310/Makefile.cc1310
+++ b/platform/srf06-cc26xx/launchpad/cc1310/Makefile.cc1310
@@ -1,0 +1,8 @@
+### Will allow the inclusion of the correct CPU makefile
+CPU_FAMILY = cc13xx
+
+### Add to the source dirs
+CONTIKI_TARGET_DIRS += launchpad/cc1310
+
+### Include the common launchpad makefile
+include $(PLATFORM_ROOT_DIR)/launchpad/Makefile.launchpad

--- a/platform/srf06-cc26xx/launchpad/cc1310/board.h
+++ b/platform/srf06-cc26xx/launchpad/cc1310/board.h
@@ -1,0 +1,189 @@
+/*
+ * Copyright (c) 2016, Texas Instruments Incorporated - http://www.ti.com/
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+/*---------------------------------------------------------------------------*/
+/** \addtogroup launchpad-peripherals
+ * @{
+ *
+ * \defgroup launchpad-cc1310-specific CC1310 LaunchPad Peripherals
+ *
+ * Defines related to the CC1310 LaunchPad
+ *
+ * This file provides connectivity information on LEDs, Buttons, UART and
+ * other peripherals
+ *
+ * This file is not meant to be modified by the user.
+ * @{
+ *
+ * \file
+ * Header file with definitions related to the I/O connections on the TI
+ * CC1310 LaunchPad
+ *
+ * \note   Do not include this file directly. It gets included by contiki-conf
+ *         after all relevant directives have been set.
+ */
+/*---------------------------------------------------------------------------*/
+#ifndef BOARD_H_
+#define BOARD_H_
+/*---------------------------------------------------------------------------*/
+#include "ioc.h"
+/*---------------------------------------------------------------------------*/
+/**
+ * \name LED configurations
+ *
+ * Those values are not meant to be modified by the user
+ * @{
+ */
+/* Some files include leds.h before us, so we need to get rid of defaults in
+ * leds.h before we provide correct definitions */
+#undef LEDS_GREEN
+#undef LEDS_YELLOW
+#undef LEDS_RED
+#undef LEDS_CONF_ALL
+
+#define LEDS_RED       1
+#define LEDS_GREEN     2
+#define LEDS_YELLOW    LEDS_GREEN
+#define LEDS_ORANGE    LEDS_RED
+
+#define LEDS_CONF_ALL  3
+
+/* Notify various examples that we have LEDs */
+#define PLATFORM_HAS_LEDS        1
+/** @} */
+/*---------------------------------------------------------------------------*/
+/**
+ * \name LED IOID mappings
+ *
+ * Those values are not meant to be modified by the user
+ * @{
+ */
+#define BOARD_IOID_LED_1          IOID_6
+#define BOARD_IOID_LED_2          IOID_7
+#define BOARD_LED_1               (1 << BOARD_IOID_LED_1)
+#define BOARD_LED_2               (1 << BOARD_IOID_LED_2)
+#define BOARD_LED_ALL             (BOARD_LED_1 | BOARD_LED_2)
+/** @} */
+/*---------------------------------------------------------------------------*/
+/**
+ * \name UART IOID mapping
+ *
+ * Those values are not meant to be modified by the user
+ * @{
+ */
+#define BOARD_IOID_UART_RX        IOID_2
+#define BOARD_IOID_UART_TX        IOID_3
+#define BOARD_IOID_UART_RTS       IOID_18
+#define BOARD_IOID_UART_CTS       IOID_19
+#define BOARD_UART_RX             (1 << BOARD_IOID_UART_RX)
+#define BOARD_UART_TX             (1 << BOARD_IOID_UART_TX)
+#define BOARD_UART_RTS            (1 << BOARD_IOID_UART_RTS)
+#define BOARD_UART_CTS            (1 << BOARD_IOID_UART_CTS)
+/** @} */
+/*---------------------------------------------------------------------------*/
+/**
+ * \name Button IOID mapping
+ *
+ * Those values are not meant to be modified by the user
+ * @{
+ */
+#define BOARD_IOID_KEY_LEFT       IOID_13
+#define BOARD_IOID_KEY_RIGHT      IOID_14
+#define BOARD_KEY_LEFT            (1 << BOARD_IOID_KEY_LEFT)
+#define BOARD_KEY_RIGHT           (1 << BOARD_IOID_KEY_RIGHT)
+/** @} */
+/*---------------------------------------------------------------------------*/
+/**
+ * \brief SPI IOID mappings
+ *
+ * Those values are not meant to be modified by the user
+ * @{
+ */
+#define BOARD_IOID_SPI_MOSI       IOID_9
+#define BOARD_IOID_SPI_MISO       IOID_8
+/** @} */
+/*---------------------------------------------------------------------------*/
+/**
+ * \name External flash IOID mapping
+ *
+ * Those values are not meant to be modified by the user
+ * @{
+ */
+#define BOARD_IOID_FLASH_CS       IOID_20
+#define BOARD_FLASH_CS            (1 << BOARD_IOID_FLASH_CS)
+#define BOARD_IOID_SPI_CLK_FLASH  IOID_10
+/** @} */
+/*---------------------------------------------------------------------------*/
+/**
+ * \brief I2C IOID mappings
+ *
+ * Those values are not meant to be modified by the user
+ * @{
+ */
+#define BOARD_IOID_SCL            IOID_4
+#define BOARD_IOID_SDA            IOID_5
+/** @} */
+/*---------------------------------------------------------------------------*/
+/**
+ * \brief Remaining pins
+ *
+ * Those values are not meant to be modified by the user
+ * @{
+ */
+#define BOARD_IOID_CS             IOID_11
+#define BOARD_IOID_TDO            IOID_16
+#define BOARD_IOID_TDI            IOID_17
+#define BOARD_IOID_DIO12          IOID_12
+#define BOARD_IOID_DIO15          IOID_15
+#define BOARD_IOID_DIO21          IOID_21
+#define BOARD_IOID_DIO22          IOID_22
+#define BOARD_IOID_DIO23          IOID_23
+#define BOARD_IOID_DIO24          IOID_24
+#define BOARD_IOID_DIO25          IOID_25
+#define BOARD_IOID_DIO26          IOID_26
+#define BOARD_IOID_DIO27          IOID_27
+#define BOARD_IOID_DIO28          IOID_28
+#define BOARD_IOID_DIO29          IOID_29
+#define BOARD_IOID_DIO30          IOID_30
+/** @} */
+/*---------------------------------------------------------------------------*/
+/**
+ * \name Device string used on startup
+ * @{
+ */
+#define BOARD_STRING "TI CC1310 LaunchPad"
+
+/** @} */
+/*---------------------------------------------------------------------------*/
+#endif /* BOARD_H_ */
+/*---------------------------------------------------------------------------*/
+/**
+ * @}
+ * @}
+ */

--- a/regression-tests/18-compile-arm-ports/Makefile
+++ b/regression-tests/18-compile-arm-ports/Makefile
@@ -12,6 +12,7 @@ cc26xx/very-sleepy-demo/srf06-cc26xx:BOARD=sensortag/cc2650 \
 cc26xx/cc26xx-web-demo/srf06-cc26xx:BOARD=sensortag/cc2650 \
 cc26xx/cc26xx-web-demo/srf06-cc26xx:BOARD=srf06/cc13xx \
 cc26xx/cc26xx-web-demo/srf06-cc26xx:BOARD=launchpad/cc2650 \
+cc26xx/cc26xx-web-demo/srf06-cc26xx:BOARD=launchpad/cc1310 \
 cc26xx/very-sleepy-demo/srf06-cc26xx \
 hello-world/cc2538dk \
 ipv6/rpl-border-router/cc2538dk \


### PR DESCRIPTION
This pull request adds support for TI's CC1310 Launchpad.

We support LEDs and Buttons and also the LP's external flash. Examples under `examples/cc26xx` should work off-the-shelf.

According to the CC1310LP design files, the flash on it is the same as the flash on the CC2650 LP (MX25R8035F 8Mbit). However, the flash on some CC1310 LPs reportedly identifies itself as the 16Mbit one (MX25R1635F) instead. Instruction sets are identical, we simply need to tell the driver to recognize this part's Device ID. Thus, this pull also extends the driver to support this part, in case any user happens to have one of those launchpads.

Build with `BOARD=launchpad/cc1310`.

This pull also adds a travis test for the CC1310 LP build.