### PR TITLE
oma-lwm2m: Handle text/plain floatfix numbers without decimal point

### DIFF
--- a/apps/oma-lwm2m/lwm2m-plain-text.c
+++ b/apps/oma-lwm2m/lwm2m-plain-text.c
@@ -100,6 +100,11 @@ lwm2m_plain_text_read_float32fix(const uint8_t *inbuf, size_t len,
       break;
     }
   }
+  if(dot == 0) {
+    integerpart = counter;
+    counter = 0;
+    frac = 1;
+  }
   *value = integerpart << bits;
   if(frac > 1) {
     *value += ((counter << bits) / frac);


### PR DESCRIPTION
Fixes bug: If no decimal point is present then the entire number is treated as the decimal part instead of as the integer part