### PR TITLE
Changed read-only pointers to const in enc28j60

### DIFF
--- a/dev/enc28j60/enc28j60.c
+++ b/dev/enc28j60/enc28j60.c
@@ -207,7 +207,7 @@ setregbank(uint8_t new_bank)
 }
 /*---------------------------------------------------------------------------*/
 static void
-writedata(uint8_t *data, int datalen)
+writedata(const uint8_t *data, int datalen)
 {
   int i;
   enc28j60_arch_spi_select();
@@ -477,7 +477,7 @@ reset(void)
 }
 /*---------------------------------------------------------------------------*/
 void
-enc28j60_init(uint8_t *mac_addr)
+enc28j60_init(const uint8_t *mac_addr)
 {
   if(initialized) {
     return;
@@ -496,7 +496,7 @@ enc28j60_init(uint8_t *mac_addr)
 }
 /*---------------------------------------------------------------------------*/
 int
-enc28j60_send(uint8_t *data, uint16_t datalen)
+enc28j60_send(const uint8_t *data, uint16_t datalen)
 {
   uint16_t dataend;
 

--- a/dev/enc28j60/enc28j60.h
+++ b/dev/enc28j60/enc28j60.h
@@ -32,9 +32,9 @@
 #ifndef ENC28J60_H
 #define ENC28J60_H
 
-void enc28j60_init(uint8_t *mac_addr);
+void enc28j60_init(const uint8_t *mac_addr);
 
-int enc28j60_send(uint8_t *data, uint16_t datalen);
+int enc28j60_send(const uint8_t *data, uint16_t datalen);
 
 int enc28j60_read(uint8_t *buffer, uint16_t bufsize);
 


### PR DESCRIPTION
I have changed the ptr argument passed to init/send/write to const in the enc28j60 driver.

I made the change because I was passing a const from my own code, which was causing a compiler error.

