### PR TITLE
Fixed typo in button definition

### DIFF
--- a/platform/zoul/contiki-main.c
+++ b/platform/zoul/contiki-main.c
@@ -218,7 +218,7 @@ main(void)
 #endif /* NETSTACK_CONF_WITH_IPV6 */
 
   process_start(&sensors_process, NULL);
-#if PLATFOM_HAS_BUTTON
+#if PLATFORM_HAS_BUTTON
   SENSORS_ACTIVATE(button_sensor);
 #endif
   energest_init();


### PR DESCRIPTION
No brainer, fixes a typo in `PLATFORM_HAS_BUTTON`