### PR TITLE
fix the bug about chameleon raw hdrsize

### DIFF
--- a/core/net/rime/chameleon-raw.c
+++ b/core/net/rime/chameleon-raw.c
@@ -205,10 +205,7 @@ hdrsize(const struct packetbuf_attrlist *a)
       continue;
     }
 #endif /* CHAMELEON_WITH_MAC_LINK_ADDRESSES */
-    len = a->len;
-    if(len < 8) {
-      len = 8;
-    }
+    len = (a->len & 0xf8) + ((a->len & 7) ? 8: 0);
     size += len;
   }
   return size / 8;


### PR DESCRIPTION
Fix the bug #1675.
If the length of some packet attribute is larger than 8, chameleon raw module's `hdrsize()` will return an incorrect header size.
This patch make the `hdrsize()` compatiblie with underlying packet attribute that the length is larger than 8.