### PR TITLE
Fix IPv6 HTTP URL parsing

### DIFF
--- a/core/net/http-socket/http-socket.c
+++ b/core/net/http-socket/http-socket.c
@@ -324,6 +324,7 @@ parse_url(const char *url, char *host, uint16_t *portptr, char *path)
         if(host != NULL) {
           host[i] = 0;
         }
+        urlptr++;
         break;
       }
       if(host != NULL) {


### PR DESCRIPTION
Currently, http-socket uses a `parse_url` method which only works correctly with IPv4 hosts (e.g. `http://192.168.1.1:3000`).  When using an IPv6 host (e.g. `http://[abcd::1]:3000`), the port number is not parsed due to a pointer increment error, which leads to the algorithm assuming a default port of 80 even when the user code has specified otherwise.  This fix provides full URL parsing for IPv6 hosts, and does not break IPv4 functionality.