### PR TITLE
rpl-ext-header: Use 8-octet unit for HBHO length

### DIFF
--- a/core/net/rpl/rpl-ext-header.c
+++ b/core/net/rpl/rpl-ext-header.c
@@ -78,7 +78,7 @@ rpl_verify_hbh_header(int uip_ext_opt_offset)
   uip_ds6_route_t *route;
   rpl_parent_t *sender = NULL;
 
-  if(UIP_HBHO_BUF->len != RPL_HOP_BY_HOP_LEN - 8) {
+  if(UIP_HBHO_BUF->len != ((RPL_HOP_BY_HOP_LEN - 8) / 8)) {
     PRINTF("RPL: Hop-by-hop extension header has wrong size\n");
     return 1;
   }
@@ -492,7 +492,7 @@ update_hbh_header(void)
 
   switch(UIP_IP_BUF->proto) {
   case UIP_PROTO_HBHO:
-    if(UIP_HBHO_BUF->len != RPL_HOP_BY_HOP_LEN - 8) {
+    if(UIP_HBHO_BUF->len != ((RPL_HOP_BY_HOP_LEN - 8) / 8)) {
       PRINTF("RPL: Hop-by-hop extension header has wrong size\n");
       uip_ext_len = last_uip_ext_len;
       return 1;
@@ -604,7 +604,7 @@ insert_hbh_header(void)
   UIP_EXT_HDR_OPT_RPL_BUF->senderrank = 0;
   uip_len += RPL_HOP_BY_HOP_LEN;
   temp_len = UIP_IP_BUF->len[1];
-  UIP_IP_BUF->len[1] += UIP_HBHO_BUF->len + 8;
+  UIP_IP_BUF->len[1] += RPL_HOP_BY_HOP_LEN;
   if(UIP_IP_BUF->len[1] < temp_len) {
     UIP_IP_BUF->len[0]++;
   }
@@ -625,7 +625,7 @@ rpl_finalize_header(uip_ipaddr_t *addr)
   uip_ext_opt_offset = 2;
 
   if(UIP_IP_BUF->proto == UIP_PROTO_HBHO) {
-    if(UIP_HBHO_BUF->len != RPL_HOP_BY_HOP_LEN - 8) {
+    if(UIP_HBHO_BUF->len != ((RPL_HOP_BY_HOP_LEN - 8) / 8)) {
       PRINTF("RPL: Non RPL Hop-by-hop options support not implemented\n");
       uip_ext_len = last_uip_ext_len;
       return 1;


### PR DESCRIPTION
According to [RFC 2460](https://tools.ietf.org/html/rfc2460#section-4.3) the length field of the Hop-by-Hop options header uses a 8-octet unit (multiple of 8 byte). This is also correctly handled in [`uip6.c`](https://github.com/contiki-os/contiki/blob/master/core/net/ipv6/uip6.c#L1168), but not when setting up the header.

In a normal configuration the `RPL_HOP_BY_HOP_LEN` define is 8, so the current implementation works, but it is a bit misleading.

This fix is needed, when `RPL_HOP_BY_HOP_LEN` is more than 8. For example when adding extra elements to the `uip_ext_hdr_opt_rpl` for a custom header extension (eq. tracing packets).
