### PR TITLE
RIME: Extend unicast example to include a sent callback.

### DIFF
--- a/examples/rime/example-unicast.c
+++ b/examples/rime/example-unicast.c
@@ -39,11 +39,6 @@
 
 #include "contiki.h"
 #include "net/rime/rime.h"
-
-#include "dev/button-sensor.h"
-
-#include "dev/leds.h"
-
 #include <stdio.h>
 
 /*---------------------------------------------------------------------------*/
@@ -56,7 +51,19 @@ recv_uc(struct unicast_conn *c, const linkaddr_t *from)
   printf("unicast message received from %d.%d\n",
 	 from->u8[0], from->u8[1]);
 }
-static const struct unicast_callbacks unicast_callbacks = {recv_uc};
+/*---------------------------------------------------------------------------*/
+static void
+sent_uc(struct unicast_conn *c, int status, int num_tx)
+{
+  const linkaddr_t *dest = packetbuf_addr(PACKETBUF_ADDR_RECEIVER);
+  if(linkaddr_cmp(dest, &linkaddr_null)) {
+    return;
+  }
+  printf("unicast message sent to %d.%d: status %d num_tx %d\n",
+    dest->u8[0], dest->u8[1], status, num_tx);
+}
+/*---------------------------------------------------------------------------*/
+static const struct unicast_callbacks unicast_callbacks = {recv_uc, sent_uc};
 static struct unicast_conn uc;
 /*---------------------------------------------------------------------------*/
 PROCESS_THREAD(example_unicast_process, ev, data)


### PR DESCRIPTION
This PR simply adds a packet sent callback to the unicast connection used in the example to better illustrate the possibilities of the unicast primitive. Every time a packet is sent the callback is called and prints the linkaddr_t destination, the MAC status of the message sent, and the link layer number of transmissions of the packet. The PR also removes some unneeded headers for the example.