### PR TITLE
21-large-rpl: Avoid frequent timeout in Travis CI

### DIFF
--- a/regression-tests/21-large-rpl/testscript.js
+++ b/regression-tests/21-large-rpl/testscript.js
@@ -1,5 +1,5 @@
 
-TIMEOUT(2400000); /* 40 minutes */
+TIMEOUT(3000000); /* 50 minutes */
 
 var NR_FEATHERS = mote.getSimulation().getMotesCount() - 1;
 


### PR DESCRIPTION
With a timeout set to 40 min, this test often failed at about 95% of the script, causing many spurious pull request test failures. Increase the timeout to 50 min.