### PR TITLE
Platform nrf52dk: use RTIMER_CLOCK_DIFF instead of RTIMER_CLOCK_LT

### DIFF
--- a/platform/nrf52dk/platform-conf.h
+++ b/platform/nrf52dk/platform-conf.h
@@ -131,9 +131,9 @@ typedef uint32_t uip_stats_t;
 #define RTIMER_ARCH_SECOND 62500
 /*
  * rtimer.h typedefs rtimer_clock_t as unsigned short. We need to define
- * RTIMER_CLOCK_LT to override this
+ * RTIMER_CLOCK_DIFF to override this
 typedef uint32_t rtimer_clock_t;
-#define RTIMER_CLOCK_LT(a, b)     ((int32_t)((a) - (b)) < 0)
+#define RTIMER_CLOCK_DIFF(a,b)     ((int32_t)((a)-(b)))
 */
 
 /** @} */


### PR DESCRIPTION
addresses https://github.com/contiki-os/contiki/pull/1701/files/7dd2f1144bfd56a2374839482646231cb926c95e#r65634049