### PR TITLE
Make use of new cl65 option --print-target-path.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,7 +70,6 @@ before_script:
       git clone https://github.com/cc65/cc65 /tmp/cc65 &&
       make -C /tmp/cc65 bin apple2enh atarixl c64 c128 &&
       sudo make -C /tmp/cc65 avail &&
-      export CC65_HOME=/tmp/cc65/ &&
       cc65 --version ;
     fi
 

--- a/cpu/6502/Makefile.6502
+++ b/cpu/6502/Makefile.6502
@@ -31,10 +31,6 @@
 # Author: Oliver Schmidt <ol.sc@web.de>
 #
 
-ifndef CC65_HOME
-  ${error CC65_HOME not defined! You must specify where cc65 resides}
-endif
-
 .SUFFIXES:
 
 CONTIKI_TARGET_DIRS = . lib sys
@@ -70,3 +66,5 @@ ASFLAGS = -t $(TARGET)
 CFLAGS += -t $(TARGET) -Or -W -unused-param
 LDFLAGS = -t $(TARGET) -m contiki-$(TARGET).map -D __STACKSIZE__=0x200
 AROPTS  = a
+
+CC65_TARGET_DIR := $(shell $(CC) --print-target-path)/$(TARGET)

--- a/platform/apple2enh/Makefile.apple2enh
+++ b/platform/apple2enh/Makefile.apple2enh
@@ -55,14 +55,14 @@ endif
 
 disk: all
 	cp $(CONTIKI)/tools/$(TARGET)/prodos.dsk contiki.dsk
-	java -jar $(AC) -p    contiki.dsk contiki.system sys   < $(CC65_HOME)/targetutil/loader.system
+	java -jar $(AC) -p    contiki.dsk contiki.system sys   < $(CC65_TARGET_DIR)/util/loader.system
 	java -jar $(AC) -cc65 contiki.dsk contiki        bin   < $(CONTIKI_PROJECT).$(TARGET)
 	java -jar $(AC) -p    contiki.dsk contiki.cfg    bin 0 < $(CONTIKI)/tools/$(TARGET)/sample.cfg
 	java -jar $(AC) -p    contiki.dsk cs8900a.eth    rel 0 < cs8900a.eth
 	java -jar $(AC) -p    contiki.dsk lan91c96.eth   rel 0 < lan91c96.eth
 	java -jar $(AC) -p    contiki.dsk w5100.eth      rel 0 < w5100.eth
 ifeq ($(findstring WITH_MOUSE,$(DEFINES)),WITH_MOUSE)
-	java -jar $(AC) -p    contiki.dsk contiki.mou    rel 0 < $(CC65_HOME)/mou/a2e.stdmou.mou
+	java -jar $(AC) -p    contiki.dsk contiki.mou    rel 0 < $(CC65_TARGET_DIR)/drv/mou/a2e.stdmou.mou
 endif
 ifeq ($(HTTPD-CFS),1)
 	java -jar $(AC) -p    contiki.dsk index.htm      bin 0 < httpd-cfs/index.htm

--- a/platform/atarixl/Makefile.atarixl
+++ b/platform/atarixl/Makefile.atarixl
@@ -55,7 +55,7 @@ disk: all
 	cp $(CONTIKI)/tools/$(TARGET)/sample.cfg    atr/contiki.cfg
 	cp cs8900a.eth                              atr/cs8900a.eth
 ifeq ($(findstring WITH_MOUSE,$(DEFINES)),WITH_MOUSE)
-	cp $(CC65_HOME)/mou/atrxst.mou              atr/contiki.mou
+	cp $(CC65_TARGET_DIR)/drv/mou/atrxst.mou    atr/contiki.mou
 endif
 ifeq ($(HTTPD-CFS),1)
 	cp httpd-cfs/index.htm                      atr/index.htm

--- a/platform/c128/Makefile.c128
+++ b/platform/c128/Makefile.c128
@@ -46,16 +46,16 @@ endif
 
 disk: all
 	$(C1541) -format contiki,00 d71 contiki.d71
-	$(C1541) -attach contiki.d71 -write $(CONTIKI_PROJECT).$(TARGET)          contiki,p
-	$(C1541) -attach contiki.d71 -write $(CONTIKI)/tools/$(TARGET)/sample.cfg contiki.cfg,s
-	$(C1541) -attach contiki.d71 -write cs8900a.eth                           cs8900a.eth,s
-	$(C1541) -attach contiki.d71 -write lan91c96.eth                          lan91c96.eth,s
+	$(C1541) -attach contiki.d71 -write $(CONTIKI_PROJECT).$(TARGET)             contiki,p
+	$(C1541) -attach contiki.d71 -write $(CONTIKI)/tools/$(TARGET)/sample.cfg    contiki.cfg,s
+	$(C1541) -attach contiki.d71 -write cs8900a.eth                              cs8900a.eth,s
+	$(C1541) -attach contiki.d71 -write lan91c96.eth                             lan91c96.eth,s
 ifeq ($(findstring WITH_MOUSE,$(DEFINES)),WITH_MOUSE)
-	$(C1541) -attach contiki.d71 -write $(CC65_HOME)/mou/c128-1351.mou        contiki.mou,s
+	$(C1541) -attach contiki.d71 -write $(CC65_TARGET_DIR)/drv/mou/c128-1351.mou contiki.mou,s
 endif
 ifeq ($(HTTPD-CFS),1)
-	$(C1541) -attach contiki.d71 -write httpd-cfs/index.htm                   index.htm,s
-	$(C1541) -attach contiki.d71 -write httpd-cfs/backgrnd.gif                backgrnd.gif,s
-	$(C1541) -attach contiki.d71 -write httpd-cfs/contiki.gif                 contiki.gif,s
-	$(C1541) -attach contiki.d71 -write httpd-cfs/notfound.htm                notfound.htm,s
+	$(C1541) -attach contiki.d71 -write httpd-cfs/index.htm                      index.htm,s
+	$(C1541) -attach contiki.d71 -write httpd-cfs/backgrnd.gif                   backgrnd.gif,s
+	$(C1541) -attach contiki.d71 -write httpd-cfs/contiki.gif                    contiki.gif,s
+	$(C1541) -attach contiki.d71 -write httpd-cfs/notfound.htm                   notfound.htm,s
 endif

--- a/platform/c64/Makefile.c64
+++ b/platform/c64/Makefile.c64
@@ -50,16 +50,16 @@ endif
 
 disk: all
 	$(C1541) -format contiki,00 d64 contiki.d64
-	$(C1541) -attach contiki.d64 -write $(CONTIKI_PROJECT).$(TARGET)          contiki,p
-	$(C1541) -attach contiki.d64 -write $(CONTIKI)/tools/$(TARGET)/sample.cfg contiki.cfg,s
-	$(C1541) -attach contiki.d64 -write cs8900a.eth                           cs8900a.eth,s
-	$(C1541) -attach contiki.d64 -write lan91c96.eth                          lan91c96.eth,s
+	$(C1541) -attach contiki.d64 -write $(CONTIKI_PROJECT).$(TARGET)            contiki,p
+	$(C1541) -attach contiki.d64 -write $(CONTIKI)/tools/$(TARGET)/sample.cfg   contiki.cfg,s
+	$(C1541) -attach contiki.d64 -write cs8900a.eth                             cs8900a.eth,s
+	$(C1541) -attach contiki.d64 -write lan91c96.eth                            lan91c96.eth,s
 ifeq ($(findstring WITH_MOUSE,$(DEFINES)),WITH_MOUSE)
-	$(C1541) -attach contiki.d64 -write $(CC65_HOME)/mou/c64-1351.mou         contiki.mou,s
+	$(C1541) -attach contiki.d64 -write $(CC65_TARGET_DIR)/drv/mou/c64-1351.mou contiki.mou,s
 endif
 ifeq ($(HTTPD-CFS),1)
-	$(C1541) -attach contiki.d64 -write httpd-cfs/index.htm                   index.htm,s
-	$(C1541) -attach contiki.d64 -write httpd-cfs/backgrnd.gif                backgrnd.gif,s
-	$(C1541) -attach contiki.d64 -write httpd-cfs/contiki.gif                 contiki.gif,s
-	$(C1541) -attach contiki.d64 -write httpd-cfs/notfound.htm                notfound.htm,s
+	$(C1541) -attach contiki.d64 -write httpd-cfs/index.htm                     index.htm,s
+	$(C1541) -attach contiki.d64 -write httpd-cfs/backgrnd.gif                  backgrnd.gif,s
+	$(C1541) -attach contiki.d64 -write httpd-cfs/contiki.gif                   contiki.gif,s
+	$(C1541) -attach contiki.d64 -write httpd-cfs/notfound.htm                  notfound.htm,s
 endif

--- a/tools/6502/Makefile
+++ b/tools/6502/Makefile
@@ -35,10 +35,6 @@ ifndef CONTIKI
   ${error CONTIKI not defined! You must specify where Contiki resides}
 endif
 
-ifndef CC65_HOME
-  ${error CC65_HOME not defined! You must specify where cc65 resides}
-endif
-
 ifndef AC
   ${error AC not defined! You must specify where the AppleCommander jar resides}
 endif
@@ -66,6 +62,8 @@ else
   ZIPCOMMENT := N/A
 endif
 
+CC65 := $(shell cl65 --print-target-path)
+
 define makes
 $1-makes:
 	$(MAKE) -C ../../cpu/6502/ethconfig        TARGET=$1
@@ -92,51 +90,51 @@ contiki-apple2.zip: contiki-apple2-1.dsk contiki-apple2-2.dsk contiki-apple2-3.d
 contiki-apple2-1.dsk: apple2enh-makes
 	cp ../apple2enh/prodos.dsk $@
 	java -jar $(AC) -p    $@ menu.system     sys   < ../apple2enh/menu.system
-	java -jar $(AC) -p    $@ ethconfi.system sys   < $(CC65_HOME)/targetutil/loader.system
+	java -jar $(AC) -p    $@ ethconfi.system sys   < $(CC65)/apple2enh/util/loader.system
 	java -jar $(AC) -cc65 $@ ethconfi        bin   < ../../cpu/6502/ethconfig/ethconfig.apple2enh
-	java -jar $(AC) -p    $@ ipconfig.system sys   < $(CC65_HOME)/targetutil/loader.system
+	java -jar $(AC) -p    $@ ipconfig.system sys   < $(CC65)/apple2enh/util/loader.system
 	java -jar $(AC) -cc65 $@ ipconfig        bin   < ../../cpu/6502/ipconfig/ipconfig.apple2enh
-	java -jar $(AC) -p    $@ webbrows.system sys   < $(CC65_HOME)/targetutil/loader.system
+	java -jar $(AC) -p    $@ webbrows.system sys   < $(CC65)/apple2enh/util/loader.system
 	java -jar $(AC) -cc65 $@ webbrows        bin   < ../../examples/webbrowser-80col/webbrowser.apple2enh
-	java -jar $(AC) -p    $@ wget.system     sys   < $(CC65_HOME)/targetutil/loader.system
+	java -jar $(AC) -p    $@ wget.system     sys   < $(CC65)/apple2enh/util/loader.system
 	java -jar $(AC) -cc65 $@ wget            bin   < ../../examples/wget/wget.apple2enh
 	java -jar $(AC) -p    $@ contiki.cfg     bin 0 < ../apple2enh/default.cfg
 	java -jar $(AC) -p    $@ cs8900a.eth     rel 0 < ../../cpu/6502/ethconfig/cs8900a.eth
 	java -jar $(AC) -p    $@ lan91c96.eth    rel 0 < ../../cpu/6502/ethconfig/lan91c96.eth
 	java -jar $(AC) -p    $@ w5100.eth       rel 0 < ../../cpu/6502/ethconfig/w5100.eth
-	java -jar $(AC) -p    $@ contiki.mou     rel 0 < $(CC65_HOME)/mou/a2e.stdmou.mou
+	java -jar $(AC) -p    $@ contiki.mou     rel 0 < $(CC65)/apple2enh/drv/mou/a2e.stdmou.mou
 
 contiki-apple2-2.dsk: apple2enh-makes
 	cp ../apple2enh/prodos.dsk $@
 	java -jar $(AC) -p    $@ menu.system     sys   < ../apple2enh/menu.system
-	java -jar $(AC) -p    $@ ethconfi.system sys   < $(CC65_HOME)/targetutil/loader.system
+	java -jar $(AC) -p    $@ ethconfi.system sys   < $(CC65)/apple2enh/util/loader.system
 	java -jar $(AC) -cc65 $@ ethconfi        bin   < ../../cpu/6502/ethconfig/ethconfig.apple2enh
-	java -jar $(AC) -p    $@ ipconfig.system sys   < $(CC65_HOME)/targetutil/loader.system
+	java -jar $(AC) -p    $@ ipconfig.system sys   < $(CC65)/apple2enh/util/loader.system
 	java -jar $(AC) -cc65 $@ ipconfig        bin   < ../../cpu/6502/ipconfig/ipconfig.apple2enh
-	java -jar $(AC) -p    $@ irc.system      sys   < $(CC65_HOME)/targetutil/loader.system
+	java -jar $(AC) -p    $@ irc.system      sys   < $(CC65)/apple2enh/util/loader.system
 	java -jar $(AC) -cc65 $@ irc             bin   < ../../examples/irc-80col/irc-client.apple2enh
 	java -jar $(AC) -p    $@ contiki.cfg     bin 0 < ../apple2enh/default.cfg
 	java -jar $(AC) -p    $@ cs8900a.eth     rel 0 < ../../cpu/6502/ethconfig/cs8900a.eth
 	java -jar $(AC) -p    $@ lan91c96.eth    rel 0 < ../../cpu/6502/ethconfig/lan91c96.eth
 	java -jar $(AC) -p    $@ w5100.eth       rel 0 < ../../cpu/6502/ethconfig/w5100.eth
-	java -jar $(AC) -p    $@ contiki.mou     rel 0 < $(CC65_HOME)/mou/a2e.stdmou.mou
+	java -jar $(AC) -p    $@ contiki.mou     rel 0 < $(CC65)/apple2enh/drv/mou/a2e.stdmou.mou
 
 contiki-apple2-3.dsk: apple2enh-makes
 	cp ../apple2enh/prodos.dsk $@
 	java -jar $(AC) -p    $@ menu.system     sys   < ../apple2enh/menu.system
-	java -jar $(AC) -p    $@ ethconfi.system sys   < $(CC65_HOME)/targetutil/loader.system
+	java -jar $(AC) -p    $@ ethconfi.system sys   < $(CC65)/apple2enh/util/loader.system
 	java -jar $(AC) -cc65 $@ ethconfi        bin   < ../../cpu/6502/ethconfig/ethconfig.apple2enh
-	java -jar $(AC) -p    $@ ipconfig.system sys   < $(CC65_HOME)/targetutil/loader.system
+	java -jar $(AC) -p    $@ ipconfig.system sys   < $(CC65)/apple2enh/util/loader.system
 	java -jar $(AC) -cc65 $@ ipconfig        bin   < ../../cpu/6502/ipconfig/ipconfig.apple2enh
-	java -jar $(AC) -p    $@ webserv.system  sys   < $(CC65_HOME)/targetutil/loader.system
+	java -jar $(AC) -p    $@ webserv.system  sys   < $(CC65)/apple2enh/util/loader.system
 	java -jar $(AC) -cc65 $@ webserv         bin   < ../../examples/webserver/webserver-example.apple2enh
-	java -jar $(AC) -p    $@ telnetd.system  sys   < $(CC65_HOME)/targetutil/loader.system
+	java -jar $(AC) -p    $@ telnetd.system  sys   < $(CC65)/apple2enh/util/loader.system
 	java -jar $(AC) -cc65 $@ telnetd         bin   < ../../examples/telnet-server/telnet-server.apple2enh
 	java -jar $(AC) -p    $@ contiki.cfg     bin 0 < ../apple2enh/default.cfg
 	java -jar $(AC) -p    $@ cs8900a.eth     rel 0 < ../../cpu/6502/ethconfig/cs8900a.eth
 	java -jar $(AC) -p    $@ lan91c96.eth    rel 0 < ../../cpu/6502/ethconfig/lan91c96.eth
 	java -jar $(AC) -p    $@ w5100.eth       rel 0 < ../../cpu/6502/ethconfig/w5100.eth
-	java -jar $(AC) -p    $@ contiki.mou     rel 0 < $(CC65_HOME)/mou/a2e.stdmou.mou
+	java -jar $(AC) -p    $@ contiki.mou     rel 0 < $(CC65)/apple2enh/drv/mou/a2e.stdmou.mou
 	java -jar $(AC) -p    $@ index.htm       bin 0 < ../../examples/webserver/httpd-cfs/index.htm
 	java -jar $(AC) -p    $@ backgrnd.gif    bin 0 < ../../examples/webserver/httpd-cfs/backgrnd.gif
 	java -jar $(AC) -p    $@ contiki.gif     bin 0 < ../../examples/webserver/httpd-cfs/contiki.gif
@@ -145,25 +143,25 @@ contiki-apple2-3.dsk: apple2enh-makes
 contiki-apple2.po: apple2enh-makes
 	cp ../apple2enh/prodos.po $@
 	java -jar $(AC) -p    $@ menu.system     sys   < ../apple2enh/menu.system
-	java -jar $(AC) -p    $@ ethconfi.system sys   < $(CC65_HOME)/targetutil/loader.system
+	java -jar $(AC) -p    $@ ethconfi.system sys   < $(CC65)/apple2enh/util/loader.system
 	java -jar $(AC) -cc65 $@ ethconfi        bin   < ../../cpu/6502/ethconfig/ethconfig.apple2enh
-	java -jar $(AC) -p    $@ ipconfig.system sys   < $(CC65_HOME)/targetutil/loader.system
+	java -jar $(AC) -p    $@ ipconfig.system sys   < $(CC65)/apple2enh/util/loader.system
 	java -jar $(AC) -cc65 $@ ipconfig        bin   < ../../cpu/6502/ipconfig/ipconfig.apple2enh
-	java -jar $(AC) -p    $@ webbrows.system sys   < $(CC65_HOME)/targetutil/loader.system
+	java -jar $(AC) -p    $@ webbrows.system sys   < $(CC65)/apple2enh/util/loader.system
 	java -jar $(AC) -cc65 $@ webbrows        bin   < ../../examples/webbrowser-80col/webbrowser.apple2enh
-	java -jar $(AC) -p    $@ wget.system     sys   < $(CC65_HOME)/targetutil/loader.system
+	java -jar $(AC) -p    $@ wget.system     sys   < $(CC65)/apple2enh/util/loader.system
 	java -jar $(AC) -cc65 $@ wget            bin   < ../../examples/wget/wget.apple2enh
-	java -jar $(AC) -p    $@ irc.system      sys   < $(CC65_HOME)/targetutil/loader.system
+	java -jar $(AC) -p    $@ irc.system      sys   < $(CC65)/apple2enh/util/loader.system
 	java -jar $(AC) -cc65 $@ irc             bin   < ../../examples/irc-80col/irc-client.apple2enh
-	java -jar $(AC) -p    $@ webserv.system  sys   < $(CC65_HOME)/targetutil/loader.system
+	java -jar $(AC) -p    $@ webserv.system  sys   < $(CC65)/apple2enh/util/loader.system
 	java -jar $(AC) -cc65 $@ webserv         bin   < ../../examples/webserver/webserver-example.apple2enh
-	java -jar $(AC) -p    $@ telnetd.system  sys   < $(CC65_HOME)/targetutil/loader.system
+	java -jar $(AC) -p    $@ telnetd.system  sys   < $(CC65)/apple2enh/util/loader.system
 	java -jar $(AC) -cc65 $@ telnetd         bin   < ../../examples/telnet-server/telnet-server.apple2enh
 	java -jar $(AC) -p    $@ contiki.cfg     bin 0 < ../apple2enh/default.cfg
 	java -jar $(AC) -p    $@ cs8900a.eth     rel 0 < ../../cpu/6502/ethconfig/cs8900a.eth
 	java -jar $(AC) -p    $@ lan91c96.eth    rel 0 < ../../cpu/6502/ethconfig/lan91c96.eth
 	java -jar $(AC) -p    $@ w5100.eth       rel 0 < ../../cpu/6502/ethconfig/w5100.eth
-	java -jar $(AC) -p    $@ contiki.mou     rel 0 < $(CC65_HOME)/mou/a2e.stdmou.mou
+	java -jar $(AC) -p    $@ contiki.mou     rel 0 < $(CC65)/apple2enh/drv/mou/a2e.stdmou.mou
 	java -jar $(AC) -p    $@ index.htm       bin 0 < ../../examples/webserver/httpd-cfs/index.htm
 	java -jar $(AC) -p    $@ backgrnd.gif    bin 0 < ../../examples/webserver/httpd-cfs/backgrnd.gif
 	java -jar $(AC) -p    $@ contiki.gif     bin 0 < ../../examples/webserver/httpd-cfs/contiki.gif
@@ -184,11 +182,11 @@ contiki-atari-1.atr: atarixl-makes
 	cp ../../examples/wget/wget.atarixl             atr/wget.com
 	cp ../atarixl/default.cfg                       atr/contiki.cfg
 	cp ../../cpu/6502/ethconfig/cs8900a.eth         atr/cs8900a.eth
-	cp $(CC65_HOME)/mou/atrxst.mou                  atr/contiki.mou
-	cp $(CC65_HOME)/mou/atrxami.mou                 atr/ami.mou
-	cp $(CC65_HOME)/mou/atrxjoy.mou                 atr/joy.mou
-	cp $(CC65_HOME)/mou/atrxtrk.mou                 atr/trk.mou
-	cp $(CC65_HOME)/mou/atrxtt.mou                  atr/tt.mou
+	cp $(CC65)/atarixl/drv/mou/atrxst.mou           atr/contiki.mou
+	cp $(CC65)/atarixl/drv/mou/atrxami.mou          atr/ami.mou
+	cp $(CC65)/atarixl/drv/mou/atrxjoy.mou          atr/joy.mou
+	cp $(CC65)/atarixl/drv/mou/atrxtrk.mou          atr/trk.mou
+	cp $(CC65)/atarixl/drv/mou/atrxtt.mou           atr/tt.mou
 	$(DIR2ATR) -b Dos25 1040 $@ atr
 	rm -r atr
 
@@ -200,11 +198,11 @@ contiki-atari-2.atr: atarixl-makes
 	cp ../../examples/irc/irc-client.atarixl    atr/irc.com
 	cp ../atarixl/default.cfg                   atr/contiki.cfg
 	cp ../../cpu/6502/ethconfig/cs8900a.eth     atr/cs8900a.eth
-	cp $(CC65_HOME)/mou/atrxst.mou              atr/contiki.mou
-	cp $(CC65_HOME)/mou/atrxami.mou             atr/ami.mou
-	cp $(CC65_HOME)/mou/atrxjoy.mou             atr/joy.mou
-	cp $(CC65_HOME)/mou/atrxtrk.mou             atr/trk.mou
-	cp $(CC65_HOME)/mou/atrxtt.mou              atr/tt.mou
+	cp $(CC65)/atarixl/drv/mou/atrxst.mou       atr/contiki.mou
+	cp $(CC65)/atarixl/drv/mou/atrxami.mou      atr/ami.mou
+	cp $(CC65)/atarixl/drv/mou/atrxjoy.mou      atr/joy.mou
+	cp $(CC65)/atarixl/drv/mou/atrxtrk.mou      atr/trk.mou
+	cp $(CC65)/atarixl/drv/mou/atrxtt.mou       atr/tt.mou
 	$(DIR2ATR) -b Dos25 1040 $@ atr
 	rm -r atr
 
@@ -217,11 +215,11 @@ contiki-atari-3.atr: atarixl-makes
 	cp ../../examples/telnet-server/telnet-server.atarixl atr/telnetd.com
 	cp ../atarixl/default.cfg                             atr/contiki.cfg
 	cp ../../cpu/6502/ethconfig/cs8900a.eth               atr/cs8900a.eth
-	cp $(CC65_HOME)/mou/atrxst.mou                        atr/contiki.mou
-	cp $(CC65_HOME)/mou/atrxami.mou                       atr/ami.mou
-	cp $(CC65_HOME)/mou/atrxjoy.mou                       atr/joy.mou
-	cp $(CC65_HOME)/mou/atrxtrk.mou                       atr/trk.mou
-	cp $(CC65_HOME)/mou/atrxtt.mou                        atr/tt.mou
+	cp $(CC65)/atarixl/drv/mou/atrxst.mou                 atr/contiki.mou
+	cp $(CC65)/atarixl/drv/mou/atrxami.mou                atr/ami.mou
+	cp $(CC65)/atarixl/drv/mou/atrxjoy.mou                atr/joy.mou
+	cp $(CC65)/atarixl/drv/mou/atrxtrk.mou                atr/trk.mou
+	cp $(CC65)/atarixl/drv/mou/atrxtt.mou                 atr/tt.mou
 	cp ../../examples/webserver/httpd-cfs/index.htm       atr/index.htm
 	cp ../../examples/webserver/httpd-cfs/backgrnd.gif    atr/backgrnd.gif
 	cp ../../examples/webserver/httpd-cfs/contiki.gif     atr/contiki.gif
@@ -241,11 +239,11 @@ contiki-atari.atr: atarixl-makes
 	cp ../../examples/telnet-server/telnet-server.atarixl atr/telnetd.com
 	cp ../atarixl/default.cfg                             atr/contiki.cfg
 	cp ../../cpu/6502/ethconfig/cs8900a.eth               atr/cs8900a.eth
-	cp $(CC65_HOME)/mou/atrxst.mou                        atr/contiki.mou
-	cp $(CC65_HOME)/mou/atrxami.mou                       atr/ami.mou
-	cp $(CC65_HOME)/mou/atrxjoy.mou                       atr/joy.mou
-	cp $(CC65_HOME)/mou/atrxtrk.mou                       atr/trk.mou
-	cp $(CC65_HOME)/mou/atrxtt.mou                        atr/tt.mou
+	cp $(CC65)/atarixl/drv/mou/atrxst.mou                 atr/contiki.mou
+	cp $(CC65)/atarixl/drv/mou/atrxami.mou                atr/ami.mou
+	cp $(CC65)/atarixl/drv/mou/atrxjoy.mou                atr/joy.mou
+	cp $(CC65)/atarixl/drv/mou/atrxtrk.mou                atr/trk.mou
+	cp $(CC65)/atarixl/drv/mou/atrxtt.mou                 atr/tt.mou
 	cp ../../examples/webserver/httpd-cfs/index.htm       atr/index.htm
 	cp ../../examples/webserver/httpd-cfs/backgrnd.gif    atr/backgrnd.gif
 	cp ../../examples/webserver/httpd-cfs/contiki.gif     atr/contiki.gif
@@ -261,96 +259,96 @@ contiki-c64.zip: contiki-c64-1.d64 contiki-c64-2.d64 contiki-c64-3.d64 contiki-c
 
 contiki-c64-1.d64: c64-makes
 	$(C1541) -format contiki-1,00 d64 $@
-	$(C1541) -attach $@ -write ../../cpu/6502/ethconfig/ethconfig.c64         ethconfig,p
-	$(C1541) -attach $@ -write ../../cpu/6502/ipconfig/ipconfig.c64           ipconfig,p
-	$(C1541) -attach $@ -write ../../examples/webbrowser/webbrowser.c64       webbrowser,p
-	$(C1541) -attach $@ -write ../../examples/webbrowser-80col/webbrowser.c64 webbrowser80,p
-	$(C1541) -attach $@ -write ../../examples/wget/wget.c64                   wget,p
-	$(C1541) -attach $@ -write ../c64/default.cfg                             contiki.cfg,s
-	$(C1541) -attach $@ -write ../../cpu/6502/ethconfig/cs8900a.eth           cs8900a.eth,s
-	$(C1541) -attach $@ -write ../../cpu/6502/ethconfig/lan91c96.eth          lan91c96.eth,s
-	$(C1541) -attach $@ -write $(CC65_HOME)/mou/c64-1351.mou                  contiki.mou,s
-	$(C1541) -attach $@ -write $(CC65_HOME)/mou/c64-inkwell.mou               inkwell.mou,s
-	$(C1541) -attach $@ -write $(CC65_HOME)/mou/c64-joy.mou                   joy.mou,s
-	$(C1541) -attach $@ -write $(CC65_HOME)/mou/c64-pot.mou                   pot.mou,s
+	$(C1541) -attach $@ -write ../../cpu/6502/ethconfig/ethconfig.c64         ethconfig,p    >$(NULLDEV)
+	$(C1541) -attach $@ -write ../../cpu/6502/ipconfig/ipconfig.c64           ipconfig,p     >$(NULLDEV)
+	$(C1541) -attach $@ -write ../../examples/webbrowser/webbrowser.c64       webbrowser,p   >$(NULLDEV)
+	$(C1541) -attach $@ -write ../../examples/webbrowser-80col/webbrowser.c64 webbrowser80,p >$(NULLDEV)
+	$(C1541) -attach $@ -write ../../examples/wget/wget.c64                   wget,p         >$(NULLDEV)
+	$(C1541) -attach $@ -write ../c64/default.cfg                             contiki.cfg,s  >$(NULLDEV)
+	$(C1541) -attach $@ -write ../../cpu/6502/ethconfig/cs8900a.eth           cs8900a.eth,s  >$(NULLDEV)
+	$(C1541) -attach $@ -write ../../cpu/6502/ethconfig/lan91c96.eth          lan91c96.eth,s >$(NULLDEV)
+	$(C1541) -attach $@ -write $(CC65)/c64/drv/mou/c64-1351.mou               contiki.mou,s  >$(NULLDEV)
+	$(C1541) -attach $@ -write $(CC65)/c64/drv/mou/c64-inkwell.mou            inkwell.mou,s  >$(NULLDEV)
+	$(C1541) -attach $@ -write $(CC65)/c64/drv/mou/c64-joy.mou                joy.mou,s      >$(NULLDEV)
+	$(C1541) -attach $@ -write $(CC65)/c64/drv/mou/c64-pot.mou                pot.mou,s      >$(NULLDEV)
 
 contiki-c64-2.d64: c64-makes
 	$(C1541) -format contiki-2,00 d64 $@
-	$(C1541) -attach $@ -write ../../cpu/6502/ethconfig/ethconfig.c64  ethconfig,p
-	$(C1541) -attach $@ -write ../../cpu/6502/ipconfig/ipconfig.c64    ipconfig,p
-	$(C1541) -attach $@ -write ../../examples/irc/irc-client.c64       irc,p
-	$(C1541) -attach $@ -write ../../examples/irc-80col/irc-client.c64 irc80,p
-	$(C1541) -attach $@ -write ../c64/default.cfg                      contiki.cfg,s
-	$(C1541) -attach $@ -write ../../cpu/6502/ethconfig/cs8900a.eth    cs8900a.eth,s
-	$(C1541) -attach $@ -write ../../cpu/6502/ethconfig/lan91c96.eth   lan91c96.eth,s
-	$(C1541) -attach $@ -write $(CC65_HOME)/mou/c64-1351.mou           contiki.mou,s
-	$(C1541) -attach $@ -write $(CC65_HOME)/mou/c64-inkwell.mou        inkwell.mou,s
-	$(C1541) -attach $@ -write $(CC65_HOME)/mou/c64-joy.mou            joy.mou,s
-	$(C1541) -attach $@ -write $(CC65_HOME)/mou/c64-pot.mou            pot.mou,s
+	$(C1541) -attach $@ -write ../../cpu/6502/ethconfig/ethconfig.c64  ethconfig,p    >$(NULLDEV)
+	$(C1541) -attach $@ -write ../../cpu/6502/ipconfig/ipconfig.c64    ipconfig,p     >$(NULLDEV)
+	$(C1541) -attach $@ -write ../../examples/irc/irc-client.c64       irc,p          >$(NULLDEV)
+	$(C1541) -attach $@ -write ../../examples/irc-80col/irc-client.c64 irc80,p        >$(NULLDEV)
+	$(C1541) -attach $@ -write ../c64/default.cfg                      contiki.cfg,s  >$(NULLDEV)
+	$(C1541) -attach $@ -write ../../cpu/6502/ethconfig/cs8900a.eth    cs8900a.eth,s  >$(NULLDEV)
+	$(C1541) -attach $@ -write ../../cpu/6502/ethconfig/lan91c96.eth   lan91c96.eth,s >$(NULLDEV)
+	$(C1541) -attach $@ -write $(CC65)/c64/drv/mou/c64-1351.mou        contiki.mou,s  >$(NULLDEV)
+	$(C1541) -attach $@ -write $(CC65)/c64/drv/mou/c64-inkwell.mou     inkwell.mou,s  >$(NULLDEV)
+	$(C1541) -attach $@ -write $(CC65)/c64/drv/mou/c64-joy.mou         joy.mou,s      >$(NULLDEV)
+	$(C1541) -attach $@ -write $(CC65)/c64/drv/mou/c64-pot.mou         pot.mou,s      >$(NULLDEV)
 
 contiki-c64-3.d64: c64-makes
 	$(C1541) -format contiki-3,00 d64 $@
-	$(C1541) -attach $@ -write ../../cpu/6502/ethconfig/ethconfig.c64          ethconfig,p
-	$(C1541) -attach $@ -write ../../cpu/6502/ipconfig/ipconfig.c64            ipconfig,p
-	$(C1541) -attach $@ -write ../../examples/webserver/webserver-example.c64  webserver,p
-	$(C1541) -attach $@ -write ../../examples/telnet-server/telnet-server.c64  telnetd,p
-	$(C1541) -attach $@ -write ../c64/default.cfg                              contiki.cfg,s
-	$(C1541) -attach $@ -write ../../cpu/6502/ethconfig/cs8900a.eth            cs8900a.eth,s
-	$(C1541) -attach $@ -write ../../cpu/6502/ethconfig/lan91c96.eth           lan91c96.eth,s
-	$(C1541) -attach $@ -write $(CC65_HOME)/mou/c64-1351.mou                   contiki.mou,s
-	$(C1541) -attach $@ -write $(CC65_HOME)/mou/c64-inkwell.mou                inkwell.mou,s
-	$(C1541) -attach $@ -write $(CC65_HOME)/mou/c64-joy.mou                    joy.mou,s
-	$(C1541) -attach $@ -write $(CC65_HOME)/mou/c64-pot.mou                    pot.mou,s
-	$(C1541) -attach $@ -write ../../examples/webserver/httpd-cfs/index.htm    index.htm,s
-	$(C1541) -attach $@ -write ../../examples/webserver/httpd-cfs/backgrnd.gif backgrnd.gif,s
-	$(C1541) -attach $@ -write ../../examples/webserver/httpd-cfs/contiki.gif  contiki.gif,s
-	$(C1541) -attach $@ -write ../../examples/webserver/httpd-cfs/notfound.htm notfound.htm,s
+	$(C1541) -attach $@ -write ../../cpu/6502/ethconfig/ethconfig.c64          ethconfig,p    >$(NULLDEV)
+	$(C1541) -attach $@ -write ../../cpu/6502/ipconfig/ipconfig.c64            ipconfig,p     >$(NULLDEV)
+	$(C1541) -attach $@ -write ../../examples/webserver/webserver-example.c64  webserver,p    >$(NULLDEV)
+	$(C1541) -attach $@ -write ../../examples/telnet-server/telnet-server.c64  telnetd,p      >$(NULLDEV)
+	$(C1541) -attach $@ -write ../c64/default.cfg                              contiki.cfg,s  >$(NULLDEV)
+	$(C1541) -attach $@ -write ../../cpu/6502/ethconfig/cs8900a.eth            cs8900a.eth,s  >$(NULLDEV)
+	$(C1541) -attach $@ -write ../../cpu/6502/ethconfig/lan91c96.eth           lan91c96.eth,s >$(NULLDEV)
+	$(C1541) -attach $@ -write $(CC65)/c64/drv/mou/c64-1351.mou                contiki.mou,s  >$(NULLDEV)
+	$(C1541) -attach $@ -write $(CC65)/c64/drv/mou/c64-inkwell.mou             inkwell.mou,s  >$(NULLDEV)
+	$(C1541) -attach $@ -write $(CC65)/c64/drv/mou/c64-joy.mou                 joy.mou,s      >$(NULLDEV)
+	$(C1541) -attach $@ -write $(CC65)/c64/drv/mou/c64-pot.mou                 pot.mou,s      >$(NULLDEV)
+	$(C1541) -attach $@ -write ../../examples/webserver/httpd-cfs/index.htm    index.htm,s    >$(NULLDEV)
+	$(C1541) -attach $@ -write ../../examples/webserver/httpd-cfs/backgrnd.gif backgrnd.gif,s >$(NULLDEV)
+	$(C1541) -attach $@ -write ../../examples/webserver/httpd-cfs/contiki.gif  contiki.gif,s  >$(NULLDEV)
+	$(C1541) -attach $@ -write ../../examples/webserver/httpd-cfs/notfound.htm notfound.htm,s >$(NULLDEV)
 
 contiki-c64.d71: c64-makes
 	$(C1541) -format contiki,00 d71 $@
-	$(C1541) -attach $@ -write ../../cpu/6502/ethconfig/ethconfig.c64          ethconfig,p
-	$(C1541) -attach $@ -write ../../cpu/6502/ipconfig/ipconfig.c64            ipconfig,p
-	$(C1541) -attach $@ -write ../../examples/webbrowser/webbrowser.c64        webbrowser,p
-	$(C1541) -attach $@ -write ../../examples/webbrowser-80col/webbrowser.c64  webbrowser80,p
-	$(C1541) -attach $@ -write ../../examples/wget/wget.c64                    wget,p
-	$(C1541) -attach $@ -write ../../examples/irc/irc-client.c64               irc,p
-	$(C1541) -attach $@ -write ../../examples/irc-80col/irc-client.c64         irc80,p
-	$(C1541) -attach $@ -write ../../examples/webserver/webserver-example.c64  webserver,p
-	$(C1541) -attach $@ -write ../../examples/telnet-server/telnet-server.c64  telnetd,p
-	$(C1541) -attach $@ -write ../c64/default.cfg                              contiki.cfg,s
-	$(C1541) -attach $@ -write ../../cpu/6502/ethconfig/cs8900a.eth            cs8900a.eth,s
-	$(C1541) -attach $@ -write ../../cpu/6502/ethconfig/lan91c96.eth           lan91c96.eth,s
-	$(C1541) -attach $@ -write $(CC65_HOME)/mou/c64-1351.mou                   contiki.mou,s
-	$(C1541) -attach $@ -write $(CC65_HOME)/mou/c64-inkwell.mou                inkwell.mou,s
-	$(C1541) -attach $@ -write $(CC65_HOME)/mou/c64-joy.mou                    joy.mou,s
-	$(C1541) -attach $@ -write $(CC65_HOME)/mou/c64-pot.mou                    pot.mou,s
-	$(C1541) -attach $@ -write ../../examples/webserver/httpd-cfs/index.htm    index.htm,s
-	$(C1541) -attach $@ -write ../../examples/webserver/httpd-cfs/backgrnd.gif backgrnd.gif,s
-	$(C1541) -attach $@ -write ../../examples/webserver/httpd-cfs/contiki.gif  contiki.gif,s
-	$(C1541) -attach $@ -write ../../examples/webserver/httpd-cfs/notfound.htm notfound.htm,s
+	$(C1541) -attach $@ -write ../../cpu/6502/ethconfig/ethconfig.c64          ethconfig,p    >$(NULLDEV)
+	$(C1541) -attach $@ -write ../../cpu/6502/ipconfig/ipconfig.c64            ipconfig,p     >$(NULLDEV)
+	$(C1541) -attach $@ -write ../../examples/webbrowser/webbrowser.c64        webbrowser,p   >$(NULLDEV)
+	$(C1541) -attach $@ -write ../../examples/webbrowser-80col/webbrowser.c64  webbrowser80,p >$(NULLDEV)
+	$(C1541) -attach $@ -write ../../examples/wget/wget.c64                    wget,p         >$(NULLDEV)
+	$(C1541) -attach $@ -write ../../examples/irc/irc-client.c64               irc,p          >$(NULLDEV)
+	$(C1541) -attach $@ -write ../../examples/irc-80col/irc-client.c64         irc80,p        >$(NULLDEV)
+	$(C1541) -attach $@ -write ../../examples/webserver/webserver-example.c64  webserver,p    >$(NULLDEV)
+	$(C1541) -attach $@ -write ../../examples/telnet-server/telnet-server.c64  telnetd,p      >$(NULLDEV)
+	$(C1541) -attach $@ -write ../c64/default.cfg                              contiki.cfg,s  >$(NULLDEV)
+	$(C1541) -attach $@ -write ../../cpu/6502/ethconfig/cs8900a.eth            cs8900a.eth,s  >$(NULLDEV)
+	$(C1541) -attach $@ -write ../../cpu/6502/ethconfig/lan91c96.eth           lan91c96.eth,s >$(NULLDEV)
+	$(C1541) -attach $@ -write $(CC65)/c64/drv/mou/c64-1351.mou                contiki.mou,s  >$(NULLDEV)
+	$(C1541) -attach $@ -write $(CC65)/c64/drv/mou/c64-inkwell.mou             inkwell.mou,s  >$(NULLDEV)
+	$(C1541) -attach $@ -write $(CC65)/c64/drv/mou/c64-joy.mou                 joy.mou,s      >$(NULLDEV)
+	$(C1541) -attach $@ -write $(CC65)/c64/drv/mou/c64-pot.mou                 pot.mou,s      >$(NULLDEV)
+	$(C1541) -attach $@ -write ../../examples/webserver/httpd-cfs/index.htm    index.htm,s    >$(NULLDEV)
+	$(C1541) -attach $@ -write ../../examples/webserver/httpd-cfs/backgrnd.gif backgrnd.gif,s >$(NULLDEV)
+	$(C1541) -attach $@ -write ../../examples/webserver/httpd-cfs/contiki.gif  contiki.gif,s  >$(NULLDEV)
+	$(C1541) -attach $@ -write ../../examples/webserver/httpd-cfs/notfound.htm notfound.htm,s >$(NULLDEV)
 
 contiki-c64.d81: c64-makes
 	$(C1541) -format contiki,00 d81 $@
-	$(C1541) -attach $@ -write ../../cpu/6502/ethconfig/ethconfig.c64          ethconfig,p
-	$(C1541) -attach $@ -write ../../cpu/6502/ipconfig/ipconfig.c64            ipconfig,p
-	$(C1541) -attach $@ -write ../../examples/webbrowser/webbrowser.c64        webbrowser,p
-	$(C1541) -attach $@ -write ../../examples/webbrowser-80col/webbrowser.c64  webbrowser80,p
-	$(C1541) -attach $@ -write ../../examples/wget/wget.c64                    wget,p
-	$(C1541) -attach $@ -write ../../examples/irc/irc-client.c64               irc,p
-	$(C1541) -attach $@ -write ../../examples/irc-80col/irc-client.c64         irc80,p
-	$(C1541) -attach $@ -write ../../examples/webserver/webserver-example.c64  webserver,p
-	$(C1541) -attach $@ -write ../../examples/telnet-server/telnet-server.c64  telnetd,p
-	$(C1541) -attach $@ -write ../c64/default.cfg                              contiki.cfg,s
-	$(C1541) -attach $@ -write ../../cpu/6502/ethconfig/cs8900a.eth            cs8900a.eth,s
-	$(C1541) -attach $@ -write ../../cpu/6502/ethconfig/lan91c96.eth           lan91c96.eth,s
-	$(C1541) -attach $@ -write $(CC65_HOME)/mou/c64-1351.mou                   contiki.mou,s
-	$(C1541) -attach $@ -write $(CC65_HOME)/mou/c64-inkwell.mou                inkwell.mou,s
-	$(C1541) -attach $@ -write $(CC65_HOME)/mou/c64-joy.mou                    joy.mou,s
-	$(C1541) -attach $@ -write $(CC65_HOME)/mou/c64-pot.mou                    pot.mou,s
-	$(C1541) -attach $@ -write ../../examples/webserver/httpd-cfs/index.htm    index.htm,s
-	$(C1541) -attach $@ -write ../../examples/webserver/httpd-cfs/backgrnd.gif backgrnd.gif,s
-	$(C1541) -attach $@ -write ../../examples/webserver/httpd-cfs/contiki.gif  contiki.gif,s
-	$(C1541) -attach $@ -write ../../examples/webserver/httpd-cfs/notfound.htm notfound.htm,s
+	$(C1541) -attach $@ -write ../../cpu/6502/ethconfig/ethconfig.c64          ethconfig,p    >$(NULLDEV)
+	$(C1541) -attach $@ -write ../../cpu/6502/ipconfig/ipconfig.c64            ipconfig,p     >$(NULLDEV)
+	$(C1541) -attach $@ -write ../../examples/webbrowser/webbrowser.c64        webbrowser,p   >$(NULLDEV)
+	$(C1541) -attach $@ -write ../../examples/webbrowser-80col/webbrowser.c64  webbrowser80,p >$(NULLDEV)
+	$(C1541) -attach $@ -write ../../examples/wget/wget.c64                    wget,p         >$(NULLDEV)
+	$(C1541) -attach $@ -write ../../examples/irc/irc-client.c64               irc,p          >$(NULLDEV)
+	$(C1541) -attach $@ -write ../../examples/irc-80col/irc-client.c64         irc80,p        >$(NULLDEV)
+	$(C1541) -attach $@ -write ../../examples/webserver/webserver-example.c64  webserver,p    >$(NULLDEV)
+	$(C1541) -attach $@ -write ../../examples/telnet-server/telnet-server.c64  telnetd,p      >$(NULLDEV)
+	$(C1541) -attach $@ -write ../c64/default.cfg                              contiki.cfg,s  >$(NULLDEV)
+	$(C1541) -attach $@ -write ../../cpu/6502/ethconfig/cs8900a.eth            cs8900a.eth,s  >$(NULLDEV)
+	$(C1541) -attach $@ -write ../../cpu/6502/ethconfig/lan91c96.eth           lan91c96.eth,s >$(NULLDEV)
+	$(C1541) -attach $@ -write $(CC65)/c64/drv/mou/c64-1351.mou                contiki.mou,s  >$(NULLDEV)
+	$(C1541) -attach $@ -write $(CC65)/c64/drv/mou/c64-inkwell.mou             inkwell.mou,s  >$(NULLDEV)
+	$(C1541) -attach $@ -write $(CC65)/c64/drv/mou/c64-joy.mou                 joy.mou,s      >$(NULLDEV)
+	$(C1541) -attach $@ -write $(CC65)/c64/drv/mou/c64-pot.mou                 pot.mou,s      >$(NULLDEV)
+	$(C1541) -attach $@ -write ../../examples/webserver/httpd-cfs/index.htm    index.htm,s    >$(NULLDEV)
+	$(C1541) -attach $@ -write ../../examples/webserver/httpd-cfs/backgrnd.gif backgrnd.gif,s >$(NULLDEV)
+	$(C1541) -attach $@ -write ../../examples/webserver/httpd-cfs/contiki.gif  contiki.gif,s  >$(NULLDEV)
+	$(C1541) -attach $@ -write ../../examples/webserver/httpd-cfs/notfound.htm notfound.htm,s >$(NULLDEV)
 
 $(eval $(call makes,c128))
 
@@ -360,59 +358,59 @@ contiki-c128.zip: contiki-c128-1.d64 contiki-c128-2.d64 contiki-c128.d71 contiki
 
 contiki-c128-1.d64: c128-makes
 	$(C1541) -format contiki-1,00 d64 $@
-	$(C1541) -attach $@ -write ../../cpu/6502/ethconfig/ethconfig.c128         ethconfig,p
-	$(C1541) -attach $@ -write ../../cpu/6502/ipconfig/ipconfig.c128           ipconfig,p
-	$(C1541) -attach $@ -write ../../examples/webbrowser-80col/webbrowser.c128 webbrowser,p
-	$(C1541) -attach $@ -write ../../examples/wget/wget.c128                   wget,p
-	$(C1541) -attach $@ -write ../../examples/irc-80col/irc-client.c128        irc,p
-	$(C1541) -attach $@ -write ../c128/default.cfg                             contiki.cfg,s
-	$(C1541) -attach $@ -write ../../cpu/6502/ethconfig/cs8900a.eth            cs8900a.eth,s
-	$(C1541) -attach $@ -write ../../cpu/6502/ethconfig/lan91c96.eth           lan91c96.eth,s
+	$(C1541) -attach $@ -write ../../cpu/6502/ethconfig/ethconfig.c128         ethconfig,p    >$(NULLDEV)
+	$(C1541) -attach $@ -write ../../cpu/6502/ipconfig/ipconfig.c128           ipconfig,p     >$(NULLDEV)
+	$(C1541) -attach $@ -write ../../examples/webbrowser-80col/webbrowser.c128 webbrowser,p   >$(NULLDEV)
+	$(C1541) -attach $@ -write ../../examples/wget/wget.c128                   wget,p         >$(NULLDEV)
+	$(C1541) -attach $@ -write ../../examples/irc-80col/irc-client.c128        irc,p          >$(NULLDEV)
+	$(C1541) -attach $@ -write ../c128/default.cfg                             contiki.cfg,s  >$(NULLDEV)
+	$(C1541) -attach $@ -write ../../cpu/6502/ethconfig/cs8900a.eth            cs8900a.eth,s  >$(NULLDEV)
+	$(C1541) -attach $@ -write ../../cpu/6502/ethconfig/lan91c96.eth           lan91c96.eth,s >$(NULLDEV)
 
 contiki-c128-2.d64: c128-makes
 	$(C1541) -format contiki-3,00 d64 $@
-	$(C1541) -attach $@ -write ../../cpu/6502/ethconfig/ethconfig.c128         ethconfig,p
-	$(C1541) -attach $@ -write ../../cpu/6502/ipconfig/ipconfig.c128           ipconfig,p
-	$(C1541) -attach $@ -write ../../examples/webserver/webserver-example.c128 webserver,p
-	$(C1541) -attach $@ -write ../../examples/telnet-server/telnet-server.c128 telnetd,p
-	$(C1541) -attach $@ -write ../c128/default.cfg                             contiki.cfg,s
-	$(C1541) -attach $@ -write ../../cpu/6502/ethconfig/cs8900a.eth            cs8900a.eth,s
-	$(C1541) -attach $@ -write ../../cpu/6502/ethconfig/lan91c96.eth           lan91c96.eth,s
-	$(C1541) -attach $@ -write ../../examples/webserver/httpd-cfs/index.htm    index.htm,s
-	$(C1541) -attach $@ -write ../../examples/webserver/httpd-cfs/backgrnd.gif backgrnd.gif,s
-	$(C1541) -attach $@ -write ../../examples/webserver/httpd-cfs/contiki.gif  contiki.gif,s
-	$(C1541) -attach $@ -write ../../examples/webserver/httpd-cfs/notfound.htm notfound.htm,s
+	$(C1541) -attach $@ -write ../../cpu/6502/ethconfig/ethconfig.c128         ethconfig,p    >$(NULLDEV)
+	$(C1541) -attach $@ -write ../../cpu/6502/ipconfig/ipconfig.c128           ipconfig,p     >$(NULLDEV)
+	$(C1541) -attach $@ -write ../../examples/webserver/webserver-example.c128 webserver,p    >$(NULLDEV)
+	$(C1541) -attach $@ -write ../../examples/telnet-server/telnet-server.c128 telnetd,p      >$(NULLDEV)
+	$(C1541) -attach $@ -write ../c128/default.cfg                             contiki.cfg,s  >$(NULLDEV)
+	$(C1541) -attach $@ -write ../../cpu/6502/ethconfig/cs8900a.eth            cs8900a.eth,s  >$(NULLDEV)
+	$(C1541) -attach $@ -write ../../cpu/6502/ethconfig/lan91c96.eth           lan91c96.eth,s >$(NULLDEV)
+	$(C1541) -attach $@ -write ../../examples/webserver/httpd-cfs/index.htm    index.htm,s    >$(NULLDEV)
+	$(C1541) -attach $@ -write ../../examples/webserver/httpd-cfs/backgrnd.gif backgrnd.gif,s >$(NULLDEV)
+	$(C1541) -attach $@ -write ../../examples/webserver/httpd-cfs/contiki.gif  contiki.gif,s  >$(NULLDEV)
+	$(C1541) -attach $@ -write ../../examples/webserver/httpd-cfs/notfound.htm notfound.htm,s >$(NULLDEV)
 
 contiki-c128.d71: c128-makes
 	$(C1541) -format contiki,00 d71 $@
-	$(C1541) -attach $@ -write ../../cpu/6502/ethconfig/ethconfig.c128         ethconfig,p
-	$(C1541) -attach $@ -write ../../cpu/6502/ipconfig/ipconfig.c128           ipconfig,p
-	$(C1541) -attach $@ -write ../../examples/webbrowser-80col/webbrowser.c128 webbrowser,p
-	$(C1541) -attach $@ -write ../../examples/wget/wget.c128                   wget,p
-	$(C1541) -attach $@ -write ../../examples/irc-80col/irc-client.c128        irc,p
-	$(C1541) -attach $@ -write ../../examples/webserver/webserver-example.c128 webserver,p
-	$(C1541) -attach $@ -write ../../examples/telnet-server/telnet-server.c128 telnetd,p
-	$(C1541) -attach $@ -write ../c128/default.cfg                             contiki.cfg,s
-	$(C1541) -attach $@ -write ../../cpu/6502/ethconfig/cs8900a.eth            cs8900a.eth,s
-	$(C1541) -attach $@ -write ../../cpu/6502/ethconfig/lan91c96.eth           lan91c96.eth,s
-	$(C1541) -attach $@ -write ../../examples/webserver/httpd-cfs/index.htm    index.htm,s
-	$(C1541) -attach $@ -write ../../examples/webserver/httpd-cfs/backgrnd.gif backgrnd.gif,s
-	$(C1541) -attach $@ -write ../../examples/webserver/httpd-cfs/contiki.gif  contiki.gif,s
-	$(C1541) -attach $@ -write ../../examples/webserver/httpd-cfs/notfound.htm notfound.htm,s
+	$(C1541) -attach $@ -write ../../cpu/6502/ethconfig/ethconfig.c128         ethconfig,p    >$(NULLDEV)
+	$(C1541) -attach $@ -write ../../cpu/6502/ipconfig/ipconfig.c128           ipconfig,p     >$(NULLDEV)
+	$(C1541) -attach $@ -write ../../examples/webbrowser-80col/webbrowser.c128 webbrowser,p   >$(NULLDEV)
+	$(C1541) -attach $@ -write ../../examples/wget/wget.c128                   wget,p         >$(NULLDEV)
+	$(C1541) -attach $@ -write ../../examples/irc-80col/irc-client.c128        irc,p          >$(NULLDEV)
+	$(C1541) -attach $@ -write ../../examples/webserver/webserver-example.c128 webserver,p    >$(NULLDEV)
+	$(C1541) -attach $@ -write ../../examples/telnet-server/telnet-server.c128 telnetd,p      >$(NULLDEV)
+	$(C1541) -attach $@ -write ../c128/default.cfg                             contiki.cfg,s  >$(NULLDEV)
+	$(C1541) -attach $@ -write ../../cpu/6502/ethconfig/cs8900a.eth            cs8900a.eth,s  >$(NULLDEV)
+	$(C1541) -attach $@ -write ../../cpu/6502/ethconfig/lan91c96.eth           lan91c96.eth,s >$(NULLDEV)
+	$(C1541) -attach $@ -write ../../examples/webserver/httpd-cfs/index.htm    index.htm,s    >$(NULLDEV)
+	$(C1541) -attach $@ -write ../../examples/webserver/httpd-cfs/backgrnd.gif backgrnd.gif,s >$(NULLDEV)
+	$(C1541) -attach $@ -write ../../examples/webserver/httpd-cfs/contiki.gif  contiki.gif,s  >$(NULLDEV)
+	$(C1541) -attach $@ -write ../../examples/webserver/httpd-cfs/notfound.htm notfound.htm,s >$(NULLDEV)
 
 contiki-c128.d81: c128-makes
 	$(C1541) -format contiki,00 d81 $@
-	$(C1541) -attach $@ -write ../../cpu/6502/ethconfig/ethconfig.c128         ethconfig,p
-	$(C1541) -attach $@ -write ../../cpu/6502/ipconfig/ipconfig.c128           ipconfig,p
-	$(C1541) -attach $@ -write ../../examples/webbrowser-80col/webbrowser.c128 webbrowser,p
-	$(C1541) -attach $@ -write ../../examples/wget/wget.c128                   wget,p
-	$(C1541) -attach $@ -write ../../examples/irc-80col/irc-client.c128        irc,p
-	$(C1541) -attach $@ -write ../../examples/webserver/webserver-example.c128 webserver,p
-	$(C1541) -attach $@ -write ../../examples/telnet-server/telnet-server.c128 telnetd,p
-	$(C1541) -attach $@ -write ../c128/default.cfg                             contiki.cfg,s
-	$(C1541) -attach $@ -write ../../cpu/6502/ethconfig/cs8900a.eth            cs8900a.eth,s
-	$(C1541) -attach $@ -write ../../cpu/6502/ethconfig/lan91c96.eth           lan91c96.eth,s
-	$(C1541) -attach $@ -write ../../examples/webserver/httpd-cfs/index.htm    index.htm,s
-	$(C1541) -attach $@ -write ../../examples/webserver/httpd-cfs/backgrnd.gif backgrnd.gif,s
-	$(C1541) -attach $@ -write ../../examples/webserver/httpd-cfs/contiki.gif  contiki.gif,s
-	$(C1541) -attach $@ -write ../../examples/webserver/httpd-cfs/notfound.htm notfound.htm,s
+	$(C1541) -attach $@ -write ../../cpu/6502/ethconfig/ethconfig.c128         ethconfig,p    >$(NULLDEV)
+	$(C1541) -attach $@ -write ../../cpu/6502/ipconfig/ipconfig.c128           ipconfig,p     >$(NULLDEV)
+	$(C1541) -attach $@ -write ../../examples/webbrowser-80col/webbrowser.c128 webbrowser,p   >$(NULLDEV)
+	$(C1541) -attach $@ -write ../../examples/wget/wget.c128                   wget,p         >$(NULLDEV)
+	$(C1541) -attach $@ -write ../../examples/irc-80col/irc-client.c128        irc,p          >$(NULLDEV)
+	$(C1541) -attach $@ -write ../../examples/webserver/webserver-example.c128 webserver,p    >$(NULLDEV)
+	$(C1541) -attach $@ -write ../../examples/telnet-server/telnet-server.c128 telnetd,p      >$(NULLDEV)
+	$(C1541) -attach $@ -write ../c128/default.cfg                             contiki.cfg,s  >$(NULLDEV)
+	$(C1541) -attach $@ -write ../../cpu/6502/ethconfig/cs8900a.eth            cs8900a.eth,s  >$(NULLDEV)
+	$(C1541) -attach $@ -write ../../cpu/6502/ethconfig/lan91c96.eth           lan91c96.eth,s >$(NULLDEV)
+	$(C1541) -attach $@ -write ../../examples/webserver/httpd-cfs/index.htm    index.htm,s    >$(NULLDEV)
+	$(C1541) -attach $@ -write ../../examples/webserver/httpd-cfs/backgrnd.gif backgrnd.gif,s >$(NULLDEV)
+	$(C1541) -attach $@ -write ../../examples/webserver/httpd-cfs/contiki.gif  contiki.gif,s  >$(NULLDEV)
+	$(C1541) -attach $@ -write ../../examples/webserver/httpd-cfs/notfound.htm notfound.htm,s >$(NULLDEV)


### PR DESCRIPTION
The new cl65 option --print-target-path allows to get rid of CC65_HOME altogether.