### PR TITLE
TSCH port for CC26xx  

### DIFF
--- a/core/net/mac/tsch/README.md
+++ b/core/net/mac/tsch/README.md
@@ -38,6 +38,7 @@ It has been tested on the following platforms:
   * Zolertia Z1 (`z1`, tested in cooja only)
   * CC2538DK (`cc2538dk`, tested on hardware)
   * Zolertia Zoul (`zoul`, tested on hardware)
+  * CC2650 (`srf06-cc26xx`, tested on hardware)
 
 This implementation was present at the ETSI Plugtest
 event in Prague in July 2015, and did successfully inter-operate with all
@@ -78,7 +79,7 @@ Orchestra is implemented in:
 
 A simple TSCH+RPL example is included under `examples/ipv6/rpl-tsch`.
 To use TSCH, first make sure your platform supports it.
-Currently, `jn516x`, `sky`, `z1`, `cc2538dk` and `zoul` are the supported platforms.
+Currently, `jn516x`, `sky`, `z1`, `cc2538dk`, `zoul` and `srf06-cc26xx` are the supported platforms.
 To add your own, we refer the reader to the next section.
 
 To add TSCH to your application, first include the TSCH module from your makefile with:
@@ -164,7 +165,7 @@ Finally, one can also implement his own scheduler, centralized or distributed, b
 ## Porting TSCH to a new platform
 
 Porting TSCH to a new platform requires a few new features in the radio driver, a number of timing-related configuration paramters.
-The easiest is probably to start from one of the existing port: `jn516x`, `sky`, `z1`, `cc2538dk`, `zoul`.
+The easiest is probably to start from one of the existing port: `jn516x`, `sky`, `z1`, `cc2538dk`, `zoul`, `srf06-cc26xx`.
 
 ### Radio features required for TSCH
 

--- a/cpu/cc26xx-cc13xx/clock.c
+++ b/cpu/cc26xx-cc13xx/clock.c
@@ -118,6 +118,9 @@ clock_init(void)
   /* GPT0 / Timer B: One shot, PWM interrupt enable */
   HWREG(GPT0_BASE + GPT_O_TBMR) =
         ((TIMER_CFG_B_ONE_SHOT >> 8) & 0xFF) | GPT_TBMR_TBPWMIE;
+
+  /* enable sync with radio timer */
+  HWREGBITW(AON_RTC_BASE + AON_RTC_O_CTL, AON_RTC_CTL_RTC_UPD_EN_BITN) = 1;
 }
 /*---------------------------------------------------------------------------*/
 static void

--- a/cpu/cc26xx-cc13xx/dev/soc-rtc.c
+++ b/cpu/cc26xx-cc13xx/dev/soc-rtc.c
@@ -81,11 +81,13 @@ soc_rtc_init(void)
 
   ti_lib_aon_rtc_event_clear(AON_RTC_CH0);
   ti_lib_aon_rtc_event_clear(AON_RTC_CH1);
+  ti_lib_aon_rtc_event_clear(AON_RTC_CH2);
 
   /* Setup the wakeup event */
   ti_lib_aon_event_mcu_wake_up_set(AON_EVENT_MCU_WU0, AON_EVENT_RTC_CH0);
   ti_lib_aon_event_mcu_wake_up_set(AON_EVENT_MCU_WU1, AON_EVENT_RTC_CH1);
-  ti_lib_aon_rtc_combined_event_config(AON_RTC_CH0 | AON_RTC_CH1);
+  ti_lib_aon_event_mcu_wake_up_set(AON_EVENT_MCU_WU2, AON_EVENT_RTC_CH2);
+  ti_lib_aon_rtc_combined_event_config(AON_RTC_CH0 | AON_RTC_CH1 | AON_RTC_CH2);
 
   HWREG(AON_RTC_BASE + AON_RTC_O_SEC) = SOC_RTC_START_TICK_COUNT;
 
@@ -123,7 +125,7 @@ soc_rtc_get_next_trigger()
 void
 soc_rtc_schedule_one_shot(uint32_t channel, uint32_t ticks)
 {
-  if((channel != AON_RTC_CH0) && (channel != AON_RTC_CH1)) {
+  if((channel != AON_RTC_CH0) && (channel != AON_RTC_CH1) && (channel != AON_RTC_CH2)) {
     return;
   }
 
@@ -168,6 +170,12 @@ soc_rtc_isr(void)
     ti_lib_aon_rtc_channel_disable(AON_RTC_CH0);
     HWREG(AON_RTC_BASE + AON_RTC_O_EVFLAGS) = AON_RTC_EVFLAGS_CH0;
     rtimer_run_next();
+  }
+
+  if(ti_lib_aon_rtc_event_get(AON_RTC_CH2)) {
+    /* after sleep; since a rtimer is already scheduled, do nothing */
+    ti_lib_aon_rtc_channel_disable(AON_RTC_CH2);
+    HWREG(AON_RTC_BASE + AON_RTC_O_EVFLAGS) = AON_RTC_EVFLAGS_CH2;
   }
 
   ENERGEST_OFF(ENERGEST_TYPE_IRQ);

--- a/cpu/cc26xx-cc13xx/lpm.c
+++ b/cpu/cc26xx-cc13xx/lpm.c
@@ -77,12 +77,13 @@ LIST(modules_list);
  * Don't consider standby mode if the next AON RTC event is scheduled to fire
  * in less than STANDBY_MIN_DURATION rtimer ticks
  */
-#define STANDBY_MIN_DURATION  (RTIMER_SECOND >> 11)
-#define MINIMAL_SAFE_SCHEDUAL 8u
+#define STANDBY_MIN_DURATION (RTIMER_SECOND / 100) /* 10.0 ms */
+
+/* Wake up this much time earlier before the next rtimer */
+#define SLEEP_GUARD_TIME (RTIMER_SECOND / 1000) /* 1.0 ms */
+
 #define MAX_SLEEP_TIME        RTIMER_SECOND
-#define DEFAULT_SLEEP_TIME    RTIMER_SECOND
-/*---------------------------------------------------------------------------*/
-#define CLK_TO_RT(c) ((c) * (RTIMER_SECOND / CLOCK_SECOND))
+#define MINIMAL_SAFE_SCHEDULE 8u
 /*---------------------------------------------------------------------------*/
 /* Prototype of a function in clock.c. Called every time we come out of DS */
 void clock_update(void);
@@ -241,13 +242,123 @@ wake_up(void)
       module->wakeup();
     }
   }
+
+#if CC2650_FAST_RADIO_STARTUP
+  /*
+   * Trigger a switch to the XOSC, so that we can subsequently use the RF FS
+   */
+  oscillators_request_hf_xosc();
+#endif
+}
+/*---------------------------------------------------------------------------*/
+static int
+setup_sleep_mode(rtimer_clock_t *next_timer)
+{
+  lpm_registered_module_t *module;
+  uint8_t max_pm = LPM_MODE_MAX_SUPPORTED;
+
+  rtimer_clock_t now = RTIMER_NOW();
+  const rtimer_clock_t max_sleep = now + MAX_SLEEP_TIME;
+
+  /* next_timer will hold the time of the next system wakeup due to a timer*/
+  *next_timer = max_sleep;
+
+  /* Check if any events fired before we turned interrupts off. If so, abort */
+  if(LPM_MODE_MAX_SUPPORTED == LPM_MODE_AWAKE || process_nevents()) {
+    return LPM_MODE_AWAKE;
+  }
+
+  if(ti_lib_aon_rtc_channel_active(AON_RTC_CH0)) {
+    rtimer_clock_t next_rtimer;
+    /* find out the timer of the next rtimer interrupt */
+    next_rtimer = ti_lib_aon_rtc_compare_value_get(AON_RTC_CH0);
+    if(RTIMER_CLOCK_LT(next_rtimer, now + 2)) {
+      return LPM_MODE_AWAKE;
+    }
+    if(RTIMER_CLOCK_LT(next_rtimer, now + STANDBY_MIN_DURATION)) {
+      return LPM_MODE_SLEEP;
+    }
+    *next_timer = next_rtimer;
+  }
+
+  /* also find out the timer of the next etimer */
+  if(etimer_pending()) {
+    int32_t until_next_etimer;
+    rtimer_clock_t next_etimer;
+
+    until_next_etimer = (int32_t)etimer_next_expiration_time() - (int32_t)clock_time();
+    if(until_next_etimer < 1) {
+      return LPM_MODE_AWAKE;
+    }
+
+    next_etimer = soc_rtc_last_isr_time() + (until_next_etimer * (RTIMER_SECOND / CLOCK_SECOND));
+    if(RTIMER_CLOCK_LT(next_etimer, now + STANDBY_MIN_DURATION)) {
+      /* ensure that we schedule sleep a minimal number of ticks into the
+         future */
+      soc_rtc_schedule_one_shot(AON_RTC_CH1, now + MINIMAL_SAFE_SCHEDULE);
+      return LPM_MODE_SLEEP;
+    }
+
+    if(RTIMER_CLOCK_LT(max_sleep, next_etimer)) {
+      /* if max_pm is LPM_MODE_SLEEP, we could trigger the watchdog if we slept
+         for too long. */
+      if(RTIMER_CLOCK_LT(max_sleep, *next_timer)) {
+        soc_rtc_schedule_one_shot(AON_RTC_CH1, max_sleep);
+      }
+    } else {
+      /* Reschedule AON RTC CH1 to fire just in time for the next etimer event */
+      soc_rtc_schedule_one_shot(AON_RTC_CH1, next_etimer);
+    }
+
+    if(RTIMER_CLOCK_LT(next_etimer, *next_timer)) {
+      /* set `next_timer` to the time the first etimer fires */
+      *next_timer = next_etimer;
+    }
+  }
+
+  /* Collect max allowed PM permission from interested modules */
+  for(module = list_head(modules_list); module != NULL;
+      module = module->next) {
+    if(module->request_max_pm) {
+      uint8_t module_pm = module->request_max_pm();
+      if(module_pm < max_pm) {
+        max_pm = module_pm;
+      }
+    }
+  }
+
+  return max_pm;
+}
+/*---------------------------------------------------------------------------*/
+void
+lpm_sleep(void)
+{
+  ENERGEST_SWITCH(ENERGEST_TYPE_CPU, ENERGEST_TYPE_LPM);
+
+  /* We are only interested in IRQ energest while idle or in LPM */
+  ENERGEST_IRQ_RESTORE(irq_energest);
+
+  /* Just to be on the safe side, explicitly disable Deep Sleep */
+  HWREG(NVIC_SYS_CTRL) &= ~(NVIC_SYS_CTRL_SLEEPDEEP);
+
+  ti_lib_prcm_sleep();
+
+  /* Remember IRQ energest for next pass */
+  ENERGEST_IRQ_SAVE(irq_energest);
+
+  ENERGEST_SWITCH(ENERGEST_TYPE_LPM, ENERGEST_TYPE_CPU);
 }
 /*---------------------------------------------------------------------------*/
 static void
-deep_sleep(void)
+deep_sleep(rtimer_clock_t next_timer)
 {
   uint32_t domains = LOCKABLE_DOMAINS;
   lpm_registered_module_t *module;
+
+#if CC2650_FAST_RADIO_STARTUP
+  /* schedule a wakeup briefly before the next etimer/rtimer to wake up the system */
+  soc_rtc_schedule_one_shot(AON_RTC_CH2, next_timer - SLEEP_GUARD_TIME);
+#endif
 
   /*
    * Notify all registered modules that we are dropping to mode X. We do not
@@ -304,7 +415,8 @@ deep_sleep(void)
    * turn back off.
    *
    * If the radio is on, we won't even reach here, and if it's off the HF
-   * clock source should already be the HF RC.
+   * clock source should already be the HF RC, unless CC2650_FAST_RADIO_STARTUP
+   * is defined.
    *
    * Nevertheless, request the switch to the HF RC explicitly here.
    */
@@ -370,128 +482,29 @@ deep_sleep(void)
    * unpending events so the handlers can fire
    */
   wake_up();
-}
-/*---------------------------------------------------------------------------*/
-static void
-safe_schedule_rtimer(rtimer_clock_t time, rtimer_clock_t now, int pm)
-{
-  rtimer_clock_t min_sleep;
-  rtimer_clock_t max_sleep;
 
-  min_sleep = now + MINIMAL_SAFE_SCHEDUAL;
-  max_sleep = now + MAX_SLEEP_TIME;
-
-  if(RTIMER_CLOCK_LT(time, min_sleep)) {
-    /* ensure that we schedule sleep a minimal number of ticks into the
-       future */
-    soc_rtc_schedule_one_shot(AON_RTC_CH1, min_sleep);
-  } else if((pm == LPM_MODE_SLEEP) && RTIMER_CLOCK_LT(max_sleep, time)) {
-    /* if max_pm is LPM_MODE_SLEEP, we could trigger the watchdog if we slept
-       for too long. */
-    soc_rtc_schedule_one_shot(AON_RTC_CH1, max_sleep);
-  } else {
-    soc_rtc_schedule_one_shot(AON_RTC_CH1, time);
-  }
-}
-/*---------------------------------------------------------------------------*/
-static int
-setup_sleep_mode(void)
-{
-  rtimer_clock_t et_distance = 0;
-
-  lpm_registered_module_t *module;
-  int max_pm;
-  int module_pm;
-  int etimer_is_pending;
-  rtimer_clock_t now;
-  rtimer_clock_t et_time;
-  rtimer_clock_t next_trig;
-
-  max_pm = LPM_MODE_MAX_SUPPORTED;
-  now = RTIMER_NOW();
-
-  if((LPM_MODE_MAX_SUPPORTED == LPM_MODE_AWAKE) || process_nevents()) {
-    return LPM_MODE_AWAKE;
-  }
-
-  etimer_is_pending = etimer_pending();
-
-  if(etimer_is_pending) {
-    et_distance = CLK_TO_RT(etimer_next_expiration_time() - clock_time());
-
-    if(RTIMER_CLOCK_LT(et_distance, 1)) {
-      /* there is an etimer which is already expired; we shouldn't go to
-         sleep at all */
-      return LPM_MODE_AWAKE;
-    }
-  }
-
-  next_trig = soc_rtc_get_next_trigger();
-  if(RTIMER_CLOCK_LT(next_trig, now + STANDBY_MIN_DURATION)) {
-    return LPM_MODE_SLEEP;
-  }
-
-  /* Collect max allowed PM permission from interested modules */
-  for(module = list_head(modules_list); module != NULL;
-      module = module->next) {
-    if(module->request_max_pm) {
-      module_pm = module->request_max_pm();
-      if(module_pm < max_pm) {
-        max_pm = module_pm;
-      }
-    }
-  }
-
-  /* Reschedule AON RTC CH1 to fire just in time for the next etimer event */
-  if(etimer_is_pending) {
-    et_time = soc_rtc_last_isr_time() + et_distance;
-
-    safe_schedule_rtimer(et_time, now, max_pm);
-  } else {
-    /* set a maximal sleep period if no etimers are queued */
-    soc_rtc_schedule_one_shot(AON_RTC_CH1, now + DEFAULT_SLEEP_TIME);
-  }
-
-  return max_pm;
+  ti_lib_int_master_enable();
 }
 /*---------------------------------------------------------------------------*/
 void
 lpm_drop()
 {
   uint8_t max_pm;
+  rtimer_clock_t next_timer;
 
   /* Critical. Don't get interrupted! */
   ti_lib_int_master_disable();
 
-  max_pm = setup_sleep_mode();
+  max_pm = setup_sleep_mode(&next_timer);
 
   /* Drop */
   if(max_pm == LPM_MODE_SLEEP) {
     lpm_sleep();
   } else if(max_pm == LPM_MODE_DEEP_SLEEP) {
-    deep_sleep();
+    deep_sleep(next_timer);
   }
 
   ti_lib_int_master_enable();
-}
-/*---------------------------------------------------------------------------*/
-void
-lpm_sleep(void)
-{
-  ENERGEST_SWITCH(ENERGEST_TYPE_CPU, ENERGEST_TYPE_LPM);
-
-  /* We are only interested in IRQ energest while idle or in LPM */
-  ENERGEST_IRQ_RESTORE(irq_energest);
-
-  /* Just to be on the safe side, explicitly disable Deep Sleep */
-  HWREG(NVIC_SYS_CTRL) &= ~(NVIC_SYS_CTRL_SLEEPDEEP);
-
-  ti_lib_prcm_sleep();
-
-  /* Remember IRQ energest for next pass */
-  ENERGEST_IRQ_SAVE(irq_energest);
-
-  ENERGEST_SWITCH(ENERGEST_TYPE_LPM, ENERGEST_TYPE_CPU);
 }
 /*---------------------------------------------------------------------------*/
 void
@@ -512,7 +525,7 @@ lpm_init()
   list_init(modules_list);
 
   /* Always wake up on any DIO edge detection */
-  ti_lib_aon_event_mcu_wake_up_set(AON_EVENT_MCU_WU2, AON_EVENT_IO);
+  ti_lib_aon_event_mcu_wake_up_set(AON_EVENT_MCU_WU3, AON_EVENT_IO);
 }
 /*---------------------------------------------------------------------------*/
 void

--- a/cpu/cc26xx-cc13xx/rf-core/ieee-mode.c
+++ b/cpu/cc26xx-cc13xx/rf-core/ieee-mode.c
@@ -1190,7 +1190,8 @@ pending_packet(void)
 
   /* Go through all RX buffers and check their status */
   do {
-    if(entry->status == DATA_ENTRY_STATUS_FINISHED) {
+    if(entry->status == DATA_ENTRY_STATUS_FINISHED
+        || entry->status == DATA_ENTRY_STATUS_BUSY) {
       rv = 1;
       if(!poll_mode) {
         process_poll(&rf_core_process);
@@ -1289,10 +1290,18 @@ off(void)
    * Just in case there was an ongoing RX (which started after we begun the
    * shutdown sequence), we don't want to leave the buffer in state == ongoing
    */
-  ((rfc_dataEntry_t *)rx_buf_0)->status = DATA_ENTRY_STATUS_PENDING;
-  ((rfc_dataEntry_t *)rx_buf_1)->status = DATA_ENTRY_STATUS_PENDING;
-  ((rfc_dataEntry_t *)rx_buf_2)->status = DATA_ENTRY_STATUS_PENDING;
-  ((rfc_dataEntry_t *)rx_buf_3)->status = DATA_ENTRY_STATUS_PENDING;
+  if(((rfc_dataEntry_t *)rx_buf_0)->status == DATA_ENTRY_STATUS_BUSY) {
+    ((rfc_dataEntry_t *)rx_buf_0)->status = DATA_ENTRY_STATUS_PENDING;
+  }
+  if(((rfc_dataEntry_t *)rx_buf_1)->status == DATA_ENTRY_STATUS_BUSY) {
+    ((rfc_dataEntry_t *)rx_buf_1)->status = DATA_ENTRY_STATUS_PENDING;
+  }
+  if(((rfc_dataEntry_t *)rx_buf_2)->status == DATA_ENTRY_STATUS_BUSY) {
+    ((rfc_dataEntry_t *)rx_buf_2)->status = DATA_ENTRY_STATUS_PENDING;
+  }
+  if(((rfc_dataEntry_t *)rx_buf_3)->status == DATA_ENTRY_STATUS_BUSY) {
+    ((rfc_dataEntry_t *)rx_buf_3)->status = DATA_ENTRY_STATUS_PENDING;
+  }
 
   return RF_CORE_CMD_OK;
 }

--- a/cpu/cc26xx-cc13xx/rf-core/ieee-mode.c
+++ b/cpu/cc26xx-cc13xx/rf-core/ieee-mode.c
@@ -601,7 +601,7 @@ init_rf_params(void)
   cmd->frameFiltOpt.defaultPend = 0;
   cmd->frameFiltOpt.bPendDataReqOnly = 0;
   cmd->frameFiltOpt.bPanCoord = 0;
-  cmd->frameFiltOpt.maxFrameVersion = 1;
+  cmd->frameFiltOpt.maxFrameVersion = 2;
   cmd->frameFiltOpt.bStrictLenFilter = 0;
 
   /* Receive all frame types */

--- a/cpu/cc26xx-cc13xx/rf-core/ieee-mode.c
+++ b/cpu/cc26xx-cc13xx/rf-core/ieee-mode.c
@@ -847,7 +847,7 @@ prepare(const void *payload, unsigned short payload_len)
   int len = MIN(payload_len, TX_BUF_PAYLOAD_LEN);
 
   memcpy(&tx_buf[TX_BUF_HDR_LEN], payload, len);
-  return RF_CORE_CMD_OK;
+  return 0;
 }
 /*---------------------------------------------------------------------------*/
 static int

--- a/cpu/cc26xx-cc13xx/rf-core/prop-mode.c
+++ b/cpu/cc26xx-cc13xx/rf-core/prop-mode.c
@@ -683,7 +683,7 @@ transmit(unsigned short transmit_len)
   rx_off_prop();
 
   /* Enable the LAST_COMMAND_DONE interrupt to wake us up */
-  rf_core_cmd_done_en(false);
+  rf_core_cmd_done_en(false, false);
 
   ret = rf_core_send_cmd((uint32_t)cmd_tx_adv, &cmd_status);
 
@@ -728,7 +728,7 @@ transmit(unsigned short transmit_len)
    * Disable LAST_FG_COMMAND_DONE interrupt. We don't really care about it
    * except when we are transmitting
    */
-  rf_core_cmd_done_dis();
+  rf_core_cmd_done_dis(false);
 
   /* Workaround. Set status to IDLE */
   cmd_tx_adv->status = RF_CORE_RADIO_OP_STATUS_IDLE;
@@ -933,7 +933,7 @@ on(void)
     }
   }
 
-  rf_core_setup_interrupts();
+  rf_core_setup_interrupts(false);
 
   /*
    * Trigger a switch to the XOSC, so that we can subsequently use the RF FS

--- a/cpu/cc26xx-cc13xx/rf-core/prop-mode.c
+++ b/cpu/cc26xx-cc13xx/rf-core/prop-mode.c
@@ -634,7 +634,7 @@ prepare(const void *payload, unsigned short payload_len)
   int len = MIN(payload_len, TX_BUF_PAYLOAD_LEN);
 
   memcpy(&tx_buf[TX_BUF_HDR_LEN], payload, len);
-  return RF_CORE_CMD_OK;
+  return 0;
 }
 /*---------------------------------------------------------------------------*/
 static int

--- a/cpu/cc26xx-cc13xx/rf-core/rf-core.c
+++ b/cpu/cc26xx-cc13xx/rf-core/rf-core.c
@@ -92,6 +92,8 @@
 #define ENABLED_IRQS (RX_FRAME_IRQ | ERROR_IRQ)
 #endif
 
+#define ENABLED_IRQS_POLL_MODE (ENABLED_IRQS & ~(RX_FRAME_IRQ | ERROR_IRQ))
+
 #define cc26xx_rf_cpe0_isr RFCCPE0IntHandler
 #define cc26xx_rf_cpe1_isr RFCCPE1IntHandler
 /*---------------------------------------------------------------------------*/
@@ -100,6 +102,10 @@ static rfc_radioOp_t *last_radio_op = NULL;
 /*---------------------------------------------------------------------------*/
 /* A struct holding pointers to the primary mode's abort() and restore() */
 static const rf_core_primary_mode_t *primary_mode = NULL;
+/*---------------------------------------------------------------------------*/
+/* Radio timer (RAT) offset as compared to the rtimer counter (RTC) */
+int32_t rat_offset = 0;
+static bool rat_offset_known = false;
 /*---------------------------------------------------------------------------*/
 PROCESS(rf_core_process, "CC13xx / CC26xx RF driver");
 /*---------------------------------------------------------------------------*/
@@ -265,6 +271,66 @@ rf_core_power_up()
   return RF_CORE_CMD_OK;
 }
 /*---------------------------------------------------------------------------*/
+uint8_t
+rf_core_start_rat(void)
+{
+  uint32_t cmd_status;
+  rfc_CMD_SYNC_START_RAT_t cmd_start;
+
+  /* Start radio timer (RAT) */
+  rf_core_init_radio_op((rfc_radioOp_t *)&cmd_start, sizeof(cmd_start), CMD_SYNC_START_RAT);
+
+  /* copy the value and send back */
+  cmd_start.rat0 = rat_offset;
+
+  if(rf_core_send_cmd((uint32_t)&cmd_start, &cmd_status) != RF_CORE_CMD_OK) {
+    PRINTF("rf_core_get_rat_rtc_offset: SYNC_START_RAT fail, CMDSTA=0x%08lx\n",
+           cmd_status);
+    return RF_CORE_CMD_ERROR;
+  }
+
+  /* Wait until done (?) */
+  if(rf_core_wait_cmd_done(&cmd_start) != RF_CORE_CMD_OK) {
+    PRINTF("rf_core_cmd_ok: SYNC_START_RAT wait, CMDSTA=0x%08lx, status=0x%04x\n",
+           cmd_status, cmd_start.status);
+    return RF_CORE_CMD_ERROR;
+  }
+
+  return RF_CORE_CMD_OK;
+}
+/*---------------------------------------------------------------------------*/
+uint8_t
+rf_core_stop_rat(void)
+{
+  rfc_CMD_SYNC_STOP_RAT_t cmd_stop;
+  uint32_t cmd_status;
+
+  rf_core_init_radio_op((rfc_radioOp_t *)&cmd_stop, sizeof(cmd_stop), CMD_SYNC_STOP_RAT);
+
+  int ret = rf_core_send_cmd((uint32_t)&cmd_stop, &cmd_status);
+  if(ret != RF_CORE_CMD_OK) {
+    PRINTF("rf_core_get_rat_rtc_offset: SYNC_STOP_RAT fail, ret %d CMDSTA=0x%08lx\n",
+           ret, cmd_status);
+    return ret;
+  }
+
+  /* Wait until done */
+  ret = rf_core_wait_cmd_done(&cmd_stop);
+  if(ret != RF_CORE_CMD_OK) {
+    PRINTF("rf_core_cmd_ok: SYNC_STOP_RAT wait, CMDSTA=0x%08lx, status=0x%04x\n",
+        cmd_status, cmd_stop.status);
+    return ret;
+  }
+
+  if(!rat_offset_known) {
+    /* save the offset, but only if this is the first time */
+    rat_offset_known = true;
+    rat_offset = cmd_stop.rat0;
+  }
+
+  return RF_CORE_CMD_OK;
+}
+/*---------------------------------------------------------------------------*/
 void
 rf_core_power_down()
 {
@@ -279,6 +345,8 @@ rf_core_power_down()
     /* need to send FS_POWERDOWN or analog components will use power */
     fs_powerdown();
   }
+
+  rf_core_stop_rat();
 
   /* Shut down the RFCORE clock domain in the MCU VD */
   ti_lib_prcm_domain_disable(PRCM_DOMAIN_RFCORE);
@@ -329,22 +397,6 @@ rf_core_set_modesel()
 }
 /*---------------------------------------------------------------------------*/
 uint8_t
-rf_core_start_rat()
-{
-  uint32_t cmd_status;
-
-  /* Start radio timer (RAT) */
-  if(rf_core_send_cmd(CMDR_DIR_CMD(CMD_START_RAT), &cmd_status)
-     != RF_CORE_CMD_OK) {
-    PRINTF("rf_core_apply_patches: START_RAT fail, CMDSTA=0x%08lx\n",
-           cmd_status);
-    return RF_CORE_CMD_ERROR;
-  }
-
-  return RF_CORE_CMD_OK;
-}
-/*---------------------------------------------------------------------------*/
-uint8_t
 rf_core_boot()
 {
   if(rf_core_power_up() != RF_CORE_CMD_OK) {
@@ -366,10 +418,31 @@ rf_core_boot()
   return RF_CORE_CMD_OK;
 }
 /*---------------------------------------------------------------------------*/
+uint8_t
+rf_core_restart_rat(void)
+{
+  if(rf_core_stop_rat() != RF_CORE_CMD_OK) {
+    PRINTF("rf_core_restart_rat: rf_core_stop_rat() failed\n");
+
+    return RF_CORE_CMD_ERROR;
+  }
+
+  if(rf_core_start_rat() != RF_CORE_CMD_OK) {
+    PRINTF("rf_core_restart_rat: rf_core_start_rat() failed\n");
+
+    rf_core_power_down();
+
+    return RF_CORE_CMD_ERROR;
+  }
+
+  return RF_CORE_CMD_OK;
+}
+/*---------------------------------------------------------------------------*/
 void
-rf_core_setup_interrupts()
+rf_core_setup_interrupts(bool poll_mode)
 {
   bool interrupts_disabled;
+  const uint32_t enabled_irqs = poll_mode ? ENABLED_IRQS_POLL_MODE : ENABLED_IRQS;
 
   /* We are already turned on by the caller, so this should not happen */
   if(!rf_core_is_accessible()) {
@@ -384,7 +457,7 @@ rf_core_setup_interrupts()
   HWREG(RFC_DBELL_NONBUF_BASE + RFC_DBELL_O_RFCPEISL) = ERROR_IRQ;
 
   /* Acknowledge configured interrupts */
-  HWREG(RFC_DBELL_NONBUF_BASE + RFC_DBELL_O_RFCPEIEN) = ENABLED_IRQS;
+  HWREG(RFC_DBELL_NONBUF_BASE + RFC_DBELL_O_RFCPEIEN) = enabled_irqs;
 
   /* Clear interrupt flags, active low clear(?) */
   HWREG(RFC_DBELL_NONBUF_BASE + RFC_DBELL_O_RFCPEIFG) = 0x0;
@@ -400,18 +473,20 @@ rf_core_setup_interrupts()
 }
 /*---------------------------------------------------------------------------*/
 void
-rf_core_cmd_done_en(bool fg)
+rf_core_cmd_done_en(bool fg, bool poll_mode)
 {
   uint32_t irq = fg ? IRQ_LAST_FG_COMMAND_DONE : IRQ_LAST_COMMAND_DONE;
+  const uint32_t enabled_irqs = poll_mode ? ENABLED_IRQS_POLL_MODE : ENABLED_IRQS;
 
-  HWREG(RFC_DBELL_NONBUF_BASE + RFC_DBELL_O_RFCPEIFG) = ENABLED_IRQS;
-  HWREG(RFC_DBELL_NONBUF_BASE + RFC_DBELL_O_RFCPEIEN) = ENABLED_IRQS | irq;
+  HWREG(RFC_DBELL_NONBUF_BASE + RFC_DBELL_O_RFCPEIFG) = enabled_irqs;
+  HWREG(RFC_DBELL_NONBUF_BASE + RFC_DBELL_O_RFCPEIEN) = enabled_irqs | irq;
 }
 /*---------------------------------------------------------------------------*/
 void
-rf_core_cmd_done_dis()
+rf_core_cmd_done_dis(bool poll_mode)
 {
-  HWREG(RFC_DBELL_NONBUF_BASE + RFC_DBELL_O_RFCPEIEN) = ENABLED_IRQS;
+  const uint32_t enabled_irqs = poll_mode ? ENABLED_IRQS_POLL_MODE : ENABLED_IRQS;
+  HWREG(RFC_DBELL_NONBUF_BASE + RFC_DBELL_O_RFCPEIEN) = enabled_irqs;
 }
 /*---------------------------------------------------------------------------*/
 rfc_radioOp_t *

--- a/cpu/cc26xx-cc13xx/rf-core/rf-core.h
+++ b/cpu/cc26xx-cc13xx/rf-core/rf-core.h
@@ -228,6 +228,9 @@ typedef struct rf_core_primary_mode_s {
 #define RF_CORE_COMMAND_PROTOCOL_IEEE                    0x2000
 #define RF_CORE_COMMAND_PROTOCOL_PROP                    0x3000
 /*---------------------------------------------------------------------------*/
+/* Radio timer register */
+#define RATCNT  0x00000004
+/*---------------------------------------------------------------------------*/
 /* Make the main driver process visible to mode drivers */
 PROCESS_NAME(rf_core_process);
 /*---------------------------------------------------------------------------*/
@@ -311,6 +314,24 @@ uint8_t rf_core_set_modesel(void);
 uint8_t rf_core_start_rat(void);
 
 /**
+ * \brief Stop the CM0 RAT synchronously
+ * \return RF_CORE_CMD_OK or RF_CORE_CMD_ERROR
+ *
+ * This function is not strictly necessary, but through calling it it's possibly
+ * to learn the RAT / RTC offset, which useful to get accurate radio timestamps.
+ */
+uint8_t rf_core_stop_rat(void);
+
+/**
+ * \brief Restart the CM0 RAT
+ * \return RF_CORE_CMD_OK or RF_CORE_CMD_ERROR
+ *
+ * This function restarts the CM0 RAT and therefore resynchornizes it with RTC.
+ * To achieve good timing accuracy, it should be called periodically.
+ */
+uint8_t rf_core_restart_rat(void);
+
+/**
  * \brief Boot the RF Core
  * \return RF_CORE_CMD_OK or RF_CORE_CMD_ERROR
  *
@@ -327,19 +348,20 @@ uint8_t rf_core_boot(void);
 /**
  * \brief Setup RF core interrupts
  */
-void rf_core_setup_interrupts(void);
+void rf_core_setup_interrupts(bool poll_mode);
 
 /**
  * \brief Enable interrupt on command done.
  * \param fg set true to enable irq on foreground command done and false for
  * background commands or if not in ieee mode.
+ * \param poll_mode true if the driver is in poll mode
  *
  * This is used within TX routines in order to be able to sleep the CM3 and
  * wake up after TX has finished
  *
  * \sa rf_core_cmd_done_dis()
  */
-void rf_core_cmd_done_en(bool fg);
+void rf_core_cmd_done_en(bool fg, bool poll_mode);
 
 /**
  * \brief Disable the LAST_CMD_DONE and LAST_FG_CMD_DONE interrupts.
@@ -348,7 +370,7 @@ void rf_core_cmd_done_en(bool fg);
  *
  * \sa rf_core_cmd_done_en()
  */
-void rf_core_cmd_done_dis(void);
+void rf_core_cmd_done_dis(bool poll_mode);
 
 /**
  * \brief Returns a pointer to the most recent proto-dependent Radio Op

--- a/cpu/cc26xx-cc13xx/rtimer-arch.h
+++ b/cpu/cc26xx-cc13xx/rtimer-arch.h
@@ -50,6 +50,21 @@
 #define RTIMER_ARCH_SECOND 65536
 /*---------------------------------------------------------------------------*/
 rtimer_clock_t rtimer_arch_now(void);
+
+/* HW oscillator frequency is 32 kHz, not 64 kHz and RTIMER_NOW() never returns
+ * an odd value; so US_TO_RTIMERTICKS always rounds to the nearest even number.
+ */
+#define US_TO_RTIMERTICKS(US)  (2 * ((US) >= 0 ?                        \
+                               (((int32_t)(US) * (RTIMER_ARCH_SECOND / 2) + 500000) / 1000000L) :      \
+                                ((int32_t)(US) * (RTIMER_ARCH_SECOND / 2) - 500000) / 1000000L))
+
+#define RTIMERTICKS_TO_US(T)   ((T) >= 0 ?                     \
+                               (((int32_t)(T) * 1000000L + ((RTIMER_ARCH_SECOND) / 2)) / (RTIMER_ARCH_SECOND)) : \
+                               ((int32_t)(T) * 1000000L - ((RTIMER_ARCH_SECOND) / 2)) / (RTIMER_ARCH_SECOND))
+
+/* A 64-bit version because the 32-bit one cannot handle T >= 4295 ticks.
+   Intended only for positive values of T. */
+#define RTIMERTICKS_TO_US_64(T)  ((uint32_t)(((uint64_t)(T) * 1000000 + ((RTIMER_ARCH_SECOND) / 2)) / (RTIMER_ARCH_SECOND)))
 /*---------------------------------------------------------------------------*/
 #endif /* RTIMER_ARCH_H_ */
 /*---------------------------------------------------------------------------*/

--- a/platform/srf06-cc26xx/contiki-conf.h
+++ b/platform/srf06-cc26xx/contiki-conf.h
@@ -329,6 +329,55 @@ typedef uint32_t uip_stats_t;
  */
 typedef uint32_t rtimer_clock_t;
 #define RTIMER_CLOCK_DIFF(a, b)     ((int32_t)((a) - (b)))
+
+/* --------------------------------------------------------------------- */
+/* TSCH related defines */
+
+/* Delay between GO signal and SFD */
+#define RADIO_DELAY_BEFORE_TX ((unsigned)US_TO_RTIMERTICKS(81))
+/* Delay between GO signal and start listening.
+ * This value is so small because the radio is constantly on within each timeslot. */
+#define RADIO_DELAY_BEFORE_RX ((unsigned)US_TO_RTIMERTICKS(15))
+/* Delay between the SFD finishes arriving and it is detected in software.
+ * Not important on this platform as it uses hardware timestamps for SFD */
+#define RADIO_DELAY_BEFORE_DETECT ((unsigned)US_TO_RTIMERTICKS(0))
+
+/* Timer conversion; radio is running at 4 MHz */
+#define RADIO_TIMER_SECOND   4000000u
+#if (RTIMER_SECOND % 256) || (RADIO_TIMER_SECOND % 256)
+#error RADIO_TO_RTIMER macro must be fixed!
+#endif
+#define RADIO_TO_RTIMER(X)   ((uint32_t)(((uint64_t)(X) * (RTIMER_SECOND / 256)) / (RADIO_TIMER_SECOND / 256)))
+#define USEC_TO_RADIO(X)     ((X) * 4)
+
+/* The PHY header (preamble + SFD, 4+1 bytes) duration is equivalent to 10 symbols */
+#define RADIO_IEEE_802154_PHY_HEADER_DURATION_USEC 160
+
+/* Do not turn off TSCH within a timeslot: not enough time */
+#define TSCH_CONF_RADIO_ON_DURING_TIMESLOT 1
+
+/* Disable TSCH frame filtering */
+#define TSCH_CONF_HW_FRAME_FILTERING	0
+
+/* Disable turning off HF oscillator when radio is off;
+   enable this for TSCH, disable to save more energy. */
+#ifndef CC2650_FAST_RADIO_STARTUP
+#define CC2650_FAST_RADIO_STARTUP     1
+#endif
+
+/* Use hardware timestamps */
+#ifndef TSCH_CONF_RESYNC_WITH_SFD_TIMESTAMPS
+#define TSCH_CONF_RESYNC_WITH_SFD_TIMESTAMPS 1
+#define TSCH_CONF_TIMESYNC_REMOVE_JITTER 0
+#endif
+
+/* The drift compared to "true" 10ms slots.
+   Enable adaptive sync to enable compensation for this. */
+#define TSCH_CONF_BASE_DRIFT_PPM -977
+
+/* 10 times per second */
+#define TSCH_CONF_ASSOCIATION_CHANNEL_SWITCH_FREQUENCY 10
+
 /** @} */
 /*---------------------------------------------------------------------------*/
 /* board.h assumes that basic configuration is done */

--- a/platform/srf06-cc26xx/contiki-main.c
+++ b/platform/srf06-cc26xx/contiki-main.c
@@ -59,6 +59,7 @@
 #include "uart.h"
 #include "sys/clock.h"
 #include "sys/rtimer.h"
+#include "sys/node-id.h"
 #include "lib/sensors.h"
 #include "button-sensor.h"
 #include "dev/serial-line.h"
@@ -67,6 +68,8 @@
 #include "driverlib/driverlib_release.h"
 
 #include <stdio.h>
+/*---------------------------------------------------------------------------*/
+unsigned short node_id = 0;
 /*---------------------------------------------------------------------------*/
 /** \brief Board specific iniatialisation */
 void board_init(void);
@@ -123,6 +126,10 @@ set_rf_params(void)
     printf("%02x\n", linkaddr_node_addr.u8[i]);
   }
 #endif
+
+  /* also set the global node id */
+  node_id = short_addr;
+  printf(" Node ID: %d\n", node_id);
 }
 /*---------------------------------------------------------------------------*/
 /**

--- a/platform/srf06-cc26xx/contiki-main.c
+++ b/platform/srf06-cc26xx/contiki-main.c
@@ -149,6 +149,11 @@ main(void)
   /* Set the LF XOSC as the LF system clock source */
   oscillators_select_lf_xosc();
 
+#if CC2650_FAST_RADIO_STARTUP
+  /* Also request HF XOSC to start up */
+  oscillators_request_hf_xosc();
+#endif
+
   lpm_init();
 
   board_init();


### PR DESCRIPTION
This pull request adds a full-featured (HW timetamps, polling mode, etc.) TSCH port on CC26xx. This port has been tested for several months in a small testbed with custom CC26xx SoC based devices at the University of Bristol.

Depends on #1708 and #1684 (#1708 is used as the base branch, and some cherry-picked commits included from #1684).

Fixes #1615.