### PR TITLE
cc26xx ieee mode rf driver: fixes and features required for TSCH

### DIFF
--- a/core/net/http-socket/http-socket.c
+++ b/core/net/http-socket/http-socket.c
@@ -350,7 +350,7 @@ parse_url(const char *url, char *host, uint16_t *portptr, char *path)
   }
 
   /* check if host is null terminated */
-  if (!memchr(host, 0, MAX_HOSTLEN)) {
+  if(!memchr(host, 0, MAX_HOSTLEN)) {
     return 0;
   }
 
@@ -419,11 +419,11 @@ event(struct tcp_socket *tcps, void *ptr,
       tcp_socket_send_str(tcps, "Host: ");
       /* If we have IPv6 host, add the '[' and the ']' characters
          to the host. As in rfc2732. */
-      if (memchr(host, ':', MAX_HOSTLEN)) {
+      if(memchr(host, ':', MAX_HOSTLEN)) {
         tcp_socket_send_str(tcps, "[");
       }
       tcp_socket_send_str(tcps, host);
-      if (memchr(host, ':', MAX_HOSTLEN)) {
+      if(memchr(host, ':', MAX_HOSTLEN)) {
         tcp_socket_send_str(tcps, "]");
       }
       tcp_socket_send_str(tcps, "\r\n");

--- a/cpu/cc26xx-cc13xx/rf-core/ieee-mode.c
+++ b/cpu/cc26xx-cc13xx/rf-core/ieee-mode.c
@@ -176,6 +176,7 @@ static const output_config_t output_power[] = {
   {-21, 0x07, 0x03, 0x0c },
 };
 
+static int8_t rssi;
 #define OUTPUT_CONFIG_COUNT (sizeof(output_power) / sizeof(output_config_t))
 
 /* Max and Min Output Power in dBm */
@@ -888,7 +889,6 @@ release_data_entry(void)
 static int
 read_frame(void *buf, unsigned short buf_len)
 {
-  int8_t rssi;
   int len = 0;
   rfc_dataEntryGeneral_t *entry = (rfc_dataEntryGeneral_t *)rx_read_entry;
 
@@ -1189,6 +1189,9 @@ get_value(radio_param_t param, radio_value_t *value)
     } else {
       return RADIO_RESULT_OK;
     }
+  case RADIO_PARAM_LAST_RSSI:
+    *value = rssi;
+    return RADIO_RESULT_OK;
   case RADIO_CONST_CHANNEL_MIN:
     *value = IEEE_MODE_CHANNEL_MIN;
     return RADIO_RESULT_OK;

--- a/cpu/cc26xx-cc13xx/rf-core/ieee-mode.c
+++ b/cpu/cc26xx-cc13xx/rf-core/ieee-mode.c
@@ -1445,7 +1445,6 @@ const struct radio_driver ieee_mode_driver = {
   set_object,
 };
 /*---------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------*/
 /* Enable or disable radio interrupts (both FIFOP and SFD timer capture) */
 static void
 set_poll_mode(uint8_t enable)

--- a/cpu/cc26xx-cc13xx/rf-core/rf-core.c
+++ b/cpu/cc26xx-cc13xx/rf-core/rf-core.c
@@ -345,6 +345,9 @@ rf_core_start_rat()
     return RF_CORE_CMD_ERROR;
   }
 
+  HWREG(RFC_RAT_BASE + RFC_RAT_O_RATCNT) = 0;
+  HWREG(AON_RTC_BASE + AON_RTC_O_SEC) = 0;
+  HWREG(AON_RTC_BASE + AON_RTC_O_SUBSEC) = 0;
   return RF_CORE_CMD_OK;
 }
 /*---------------------------------------------------------------------------*/

--- a/cpu/cc26xx-cc13xx/rf-core/rf-core.h
+++ b/cpu/cc26xx-cc13xx/rf-core/rf-core.h
@@ -231,6 +231,8 @@ typedef struct rf_core_primary_mode_s {
 /* Make the main driver process visible to mode drivers */
 PROCESS_NAME(rf_core_process);
 /*---------------------------------------------------------------------------*/
+#define RFC_RAT_O_RATCNT                                            0x00000004
+/*---------------------------------------------------------------------------*/
 extern uint8_t volatile poll_mode;
 /**
  * \brief Check whether the RF core is accessible

--- a/cpu/cc26xx-cc13xx/rf-core/rf-core.h
+++ b/cpu/cc26xx-cc13xx/rf-core/rf-core.h
@@ -231,6 +231,7 @@ typedef struct rf_core_primary_mode_s {
 /* Make the main driver process visible to mode drivers */
 PROCESS_NAME(rf_core_process);
 /*---------------------------------------------------------------------------*/
+extern uint8_t volatile poll_mode;
 /**
  * \brief Check whether the RF core is accessible
  * \retval RF_CORE_ACCESSIBLE The core is powered and ready for access


### PR DESCRIPTION
these are features required by the TSCH port.

the (non-tsch) examples seem to still be working after these changes.