### PR TITLE
Added generic relay driver for the zoul-based platforms

### DIFF
--- a/examples/zolertia/zoul/Makefile
+++ b/examples/zolertia/zoul/Makefile
@@ -9,7 +9,7 @@ CONTIKI_PROJECT += test-zonik
 
 CONTIKI_TARGET_SOURCEFILES += tsl2563.c sht25.c bmpx8x.c motion-sensor.c
 CONTIKI_TARGET_SOURCEFILES += adc-sensors.c weather-meter.c grove-gyro.c
-CONTIKI_TARGET_SOURCEFILES += rgb-bl-lcd.c pm10-sensor.c iaq.c zonik.c
+CONTIKI_TARGET_SOURCEFILES += rgb-bl-lcd.c pm10-sensor.c iaq.c zonik.c relay.c
 
 all: $(CONTIKI_PROJECT)
 

--- a/examples/zolertia/zoul/test-relay.c
+++ b/examples/zolertia/zoul/test-relay.c
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2016, Zolertia <http://www.zolertia.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * This file is part of the Contiki operating system.
+ *
+ */
+/**
+ * \addtogroup zoul-examples
+ * @{
+ *
+ * \defgroup zoul-relay-test A simple program to test a generic relay
+ *
+ * Demonstrates the use of a generic relay, connected by default at the ADC1
+ * connector of the RE-Mote
+ *
+ * @{
+ *
+ * \file
+ *         A quick program to test a generic relay
+ * \author
+ *         Antonio Lignan <alinan@zolertia.com>
+ */
+/*---------------------------------------------------------------------------*/
+#include <stdio.h>
+#include "contiki.h"
+#include "dev/relay.h"
+#include "lib/sensors.h"
+/*---------------------------------------------------------------------------*/
+PROCESS(remote_relay_process, "Generic relay test");
+AUTOSTART_PROCESSES(&remote_relay_process);
+/*---------------------------------------------------------------------------*/
+static struct etimer et;
+/*---------------------------------------------------------------------------*/
+PROCESS_THREAD(remote_relay_process, ev, data)
+{
+  PROCESS_BEGIN();
+  SENSORS_ACTIVATE(relay);
+
+  /* Activate the relay and wait for 5 seconds */
+  relay.value(RELAY_ON);
+  etimer_set(&et, CLOCK_SECOND * 5);
+  printf("\nRelay: switch should be ON --> %u\n", relay.status(SENSORS_ACTIVE));
+  PROCESS_WAIT_EVENT_UNTIL(etimer_expired(&et));
+
+  /* Now turn off and wait 5 seconds more */
+  relay.value(RELAY_OFF);
+  etimer_set(&et, CLOCK_SECOND * 5);
+  printf("Relay: switch should be OFF --> %u\n\n", relay.status(SENSORS_ACTIVE));
+  PROCESS_WAIT_EVENT_UNTIL(etimer_expired(&et));
+
+  /* Let it spin and toggle each second */
+  while(1) {
+    etimer_set(&et, CLOCK_SECOND);
+    PROCESS_WAIT_EVENT_UNTIL(etimer_expired(&et));
+    relay.value(RELAY_TOGGLE);
+    printf("Relay: switch is now --> %u\n", relay.status(SENSORS_ACTIVE));
+  }
+  PROCESS_END();
+}
+/*---------------------------------------------------------------------------*/
+/**
+ * @}
+ * @}
+ */

--- a/platform/zoul/dev/relay.c
+++ b/platform/zoul/dev/relay.c
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2016, Zolertia - http://www.zolertia.com
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ */
+/*---------------------------------------------------------------------------*/
+/**
+ * \addtogroup zoul-relay
+ * @{
+ *
+ * \file
+ *  Driver for a relay actuator
+ */
+/*---------------------------------------------------------------------------*/
+#include "contiki.h"
+#include "relay.h"
+#include "dev/gpio.h"
+#include "lib/sensors.h"
+#include "dev/ioc.h"
+/*---------------------------------------------------------------------------*/
+#define RELAY_PORT_BASE          GPIO_PORT_TO_BASE(RELAY_PORT)
+#define RELAY_PIN_MASK           GPIO_PIN_MASK(RELAY_PIN)
+/*---------------------------------------------------------------------------*/
+static uint8_t enabled;
+/*---------------------------------------------------------------------------*/
+static int
+relay_on(void)
+{
+  if(enabled) {
+    GPIO_SET_PIN(RELAY_PORT_BASE, RELAY_PIN_MASK);
+    return RELAY_SUCCESS;
+  }
+  return RELAY_ERROR;
+}
+/*---------------------------------------------------------------------------*/
+static int
+relay_off(void)
+{
+  if(enabled) {
+    GPIO_CLR_PIN(RELAY_PORT_BASE, RELAY_PIN_MASK);
+    return RELAY_SUCCESS;
+  }
+  return RELAY_ERROR;
+}
+/*---------------------------------------------------------------------------*/
+static int
+status(int type)
+{
+  switch(type) {
+  case SENSORS_ACTIVE:
+    return GPIO_READ_PIN(RELAY_PORT_BASE, RELAY_PIN_MASK);
+  case SENSORS_READY:
+    return enabled;
+  }
+  return RELAY_ERROR;
+}
+/*---------------------------------------------------------------------------*/
+static int
+value(int type)
+{
+  switch(type) {
+    case RELAY_OFF:
+      return relay_on();
+    case RELAY_ON:
+      return relay_off();
+    case RELAY_TOGGLE:
+      if(status(SENSORS_ACTIVE)) {
+        return relay_off();
+      } else {
+        return relay_on();
+      }
+    default:
+      return RELAY_ERROR;
+  }
+}
+/*---------------------------------------------------------------------------*/
+static int
+configure(int type, int value)
+{
+  if(type != SENSORS_ACTIVE) {
+    return RELAY_ERROR;
+  }
+
+  if(value) {
+    GPIO_SOFTWARE_CONTROL(RELAY_PORT_BASE, RELAY_PIN_MASK);
+    GPIO_SET_OUTPUT(RELAY_PORT_BASE, RELAY_PIN_MASK);
+    ioc_set_over(RELAY_PORT, RELAY_PIN, IOC_OVERRIDE_OE);
+    GPIO_CLR_PIN(RELAY_PORT_BASE, RELAY_PIN_MASK);
+    enabled = 1;
+    return RELAY_SUCCESS;
+  }
+
+  GPIO_SET_INPUT(RELAY_PORT_BASE, RELAY_PIN_MASK);
+  enabled = 0;
+  return RELAY_SUCCESS;
+}
+/*---------------------------------------------------------------------------*/
+SENSORS_SENSOR(relay, RELAY_ACTUATOR, value, configure, status);
+/*---------------------------------------------------------------------------*/
+/** @} */

--- a/platform/zoul/dev/relay.h
+++ b/platform/zoul/dev/relay.h
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2016, Zolertia - http://www.zolertia.com
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * This file is part of the Contiki operating system.
+ *
+ */
+/*---------------------------------------------------------------------------*/
+/**
+ * \addtogroup zoul-sensors
+ * @{
+ *
+ * \defgroup zoul-relay Generic relay driver
+ *
+ * Driver for a generic relay driver
+ * @{
+ *
+ * \file
+ * Header file for the generic relay driver
+ */
+/*---------------------------------------------------------------------------*/
+#ifndef RELAY_H_
+#define RELAY_H_
+/* -------------------------------------------------------------------------- */
+/**
+ * \name Relay default pin and port
+ * @{
+ */
+#ifdef RELAY_CONF_PIN
+#define RELAY_PIN        RELAY_CONF_PIN
+#else
+#define RELAY_PIN        5
+#endif
+#ifdef RELAY_CONF_PORT
+#define RELAY_PORT       RELAY_CONF_PORT
+#else
+#define RELAY_PORT       GPIO_A_NUM
+#endif
+/** @} */
+/* -------------------------------------------------------------------------- */
+/**
+ * \name Relay available commands
+ * @{
+ */
+#define RELAY_OFF          0x00
+#define RELAY_ON           0x01
+#define RELAY_TOGGLE       0x02
+/** @} */
+/* -------------------------------------------------------------------------- */
+/**
+ * \name Relay return types
+ * @{
+ */
+#define RELAY_ERROR             (-1)
+#define RELAY_SUCCESS           0x00
+/** @} */
+/* -------------------------------------------------------------------------- */
+#define RELAY_ACTUATOR "Generic Relay"
+/* -------------------------------------------------------------------------- */
+extern const struct sensors_sensor relay;
+/* -------------------------------------------------------------------------- */
+/* -------------------------------------------------------------------------- */
+#endif /* RELAY_H_ */
+/* -------------------------------------------------------------------------- */
+/**
+ * @}
+ * @}
+ */


### PR DESCRIPTION
This is a simple driver I often get asked to provide.  It basically allows to connect a common relay module (such as this one from [Phidget](http://www.phidgets.com/products.php?category=9&product_id=3052_1) or this one from [Seeedstudio](https://www.seeedstudio.com/item_detail.html?p_id=769)).