### PR TITLE
Print CC2538 info on boot

### DIFF
--- a/cpu/cc2538/Makefile.cc2538
+++ b/cpu/cc2538/Makefile.cc2538
@@ -51,7 +51,7 @@ CONTIKI_CPU_DIRS += ../arm/common/dbg-io
 CONTIKI_CPU_DIRS += ../cc253x/usb/common ../cc253x/usb/common/cdc-acm
 
 ### CPU-dependent source files
-CONTIKI_CPU_SOURCEFILES += clock.c rtimer-arch.c uart.c watchdog.c
+CONTIKI_CPU_SOURCEFILES += soc.c clock.c rtimer-arch.c uart.c watchdog.c
 CONTIKI_CPU_SOURCEFILES += nvic.c cpu.c sys-ctrl.c gpio.c ioc.c spi.c adc.c
 CONTIKI_CPU_SOURCEFILES += crypto.c aes.c ecb.c cbc.c ctr.c cbc-mac.c gcm.c
 CONTIKI_CPU_SOURCEFILES += ccm.c sha256.c

--- a/cpu/cc2538/dev/sys-ctrl.c
+++ b/cpu/cc2538/dev/sys-ctrl.c
@@ -50,6 +50,26 @@
 #define SYS_CTRL_OSCS   SYS_CTRL_CLOCK_CTRL_OSC32K
 #endif
 /*---------------------------------------------------------------------------*/
+int
+sys_ctrl_get_reset_cause(void)
+{
+  return (REG(SYS_CTRL_CLOCK_STA) & SYS_CTRL_CLOCK_STA_RST) >>
+         SYS_CTRL_CLOCK_STA_RST_S;
+}
+/*---------------------------------------------------------------------------*/
+const char *
+sys_ctrl_get_reset_cause_str(void)
+{
+  static const char *reset_cause[] = {
+    "POR",
+    "External reset",
+    "WDT",
+    "CLD or software reset"
+  };
+
+  return reset_cause[sys_ctrl_get_reset_cause()];
+}
+/*---------------------------------------------------------------------------*/
 void
 sys_ctrl_init()
 {

--- a/cpu/cc2538/dev/sys-ctrl.h
+++ b/cpu/cc2538/dev/sys-ctrl.h
@@ -115,6 +115,11 @@
 #define SYS_CTRL_CLOCK_STA_OSC32K_CALDIS    0x02000000
 #define SYS_CTRL_CLOCK_STA_OSC32K           0x01000000
 #define SYS_CTRL_CLOCK_STA_RST              0x00C00000
+#define SYS_CTRL_CLOCK_STA_RST_S            22
+#define SYS_CTRL_CLOCK_STA_RST_POR          0
+#define SYS_CTRL_CLOCK_STA_RST_EXT          1
+#define SYS_CTRL_CLOCK_STA_RST_WDT          2
+#define SYS_CTRL_CLOCK_STA_RST_CLD_SW       3
 #define SYS_CTRL_CLOCK_STA_SOURCE_CHANGE    0x00100000
 #define SYS_CTRL_CLOCK_STA_XOSC_STB         0x00080000
 #define SYS_CTRL_CLOCK_STA_HSOSC_STB        0x00040000
@@ -302,6 +307,17 @@
 /** \name SysCtrl functions
  * @{
  */
+
+/** \brief Gets the cause of the last reset
+ * \return A \c SYS_CTRL_CLOCK_STA_RST_x reset cause
+ */
+int sys_ctrl_get_reset_cause(void);
+
+/** \brief Gets a string describing the cause of the last reset
+ * \return Last reset cause as a string
+ */
+const char *sys_ctrl_get_reset_cause_str(void);
+
 /** \brief Initialises the System Control Driver. The main purpose of this
  * function is to power up and select clocks and oscillators
  * \note This function depends on ioc_init() having been called beforehand. */

--- a/cpu/cc2538/soc.c
+++ b/cpu/cc2538/soc.c
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2016, Benoît Thébaudeau <benoit.thebaudeau.dev@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+/**
+ * \addtogroup cc2538-soc
+ * @{
+ *
+ * \file
+ * Implementation of the cc2538 SoC driver
+ */
+#include "contiki-conf.h"
+#include "dev/rom-util.h"
+#include "dev/sys-ctrl.h"
+#include "reg.h"
+#include "soc.h"
+
+#include <stdint.h>
+#include <stdio.h>
+/*----------------------------------------------------------------------------*/
+#define DIECFG0         0x400d3014
+#define DIECFG0_SRAM_SIZE_OFS   7
+#define DIECFG0_SRAM_SIZE_SZ    3
+#define DIECFG0_SRAM_SIZE_MSK   (((1 << DIECFG0_SRAM_SIZE_SZ) - 1) << \
+                                 DIECFG0_SRAM_SIZE_OFS)
+#define DIECFG2         0x400d301c
+#define DIECFG2_DIE_REV_OFS     8
+#define DIECFG2_DIE_REV_SZ      8
+#define DIECFG2_DIE_REV_MSK     (((1 << DIECFG2_DIE_REV_SZ) - 1) << \
+                                 DIECFG2_DIE_REV_OFS)
+#define DIECFG2_AES_EN          0x00000002
+#define DIECFG2_PKA_EN          0x00000001
+/*----------------------------------------------------------------------------*/
+uint8_t
+soc_get_rev(void)
+{
+  uint8_t rev = (REG(DIECFG2) & DIECFG2_DIE_REV_MSK) >> DIECFG2_DIE_REV_OFS;
+
+  /* PG1.0 is encoded as 0x00. */
+  if(!(rev >> 4))
+    rev += 0x10;
+  return rev;
+}
+/*----------------------------------------------------------------------------*/
+uint32_t
+soc_get_sram_size(void)
+{
+  uint32_t size_code = (REG(DIECFG0) & DIECFG0_SRAM_SIZE_MSK) >>
+                       DIECFG0_SRAM_SIZE_OFS;
+
+  return size_code <= 1 ? (2 - size_code) << 13 : 32 << 10;
+}
+/*----------------------------------------------------------------------------*/
+uint32_t
+soc_get_features(void)
+{
+  return REG(DIECFG2) & (DIECFG2_AES_EN | DIECFG2_PKA_EN);
+}
+/*----------------------------------------------------------------------------*/
+void
+soc_print_info(void)
+{
+  uint8_t rev = soc_get_rev();
+  uint32_t features = soc_get_features();
+
+  printf("CC2538: ID: 0x%04lx, rev.: PG%d.%d, Flash: %lu KiB, SRAM: %lu KiB, "
+           "AES/SHA: %u, ECC/RSA: %u\n"
+         "System clock: %lu Hz\n"
+         "I/O clock: %lu Hz\n"
+         "Reset cause: %s\n",
+         rom_util_get_chip_id(),
+         rev >> 4, rev & 0x0f,
+         rom_util_get_flash_size() >> 10,
+         soc_get_sram_size() >> 10,
+         !!(features & SOC_FEATURE_AES_SHA),
+         !!(features & SOC_FEATURE_ECC_RSA),
+         sys_ctrl_get_sys_clock(),
+         sys_ctrl_get_io_clock(),
+         sys_ctrl_get_reset_cause_str());
+}
+
+/** @} */

--- a/cpu/cc2538/soc.h
+++ b/cpu/cc2538/soc.h
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2016, Benoît Thébaudeau <benoit.thebaudeau.dev@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+/**
+ * \addtogroup cc2538
+ * @{
+ *
+ * \defgroup cc2538-soc cc2538 SoC
+ *
+ * Driver for the cc2538 SoC
+ * @{
+ *
+ * \file
+ * Header file with macro and function declarations for the cc2538 SoC
+ */
+#ifndef SOC_H_
+#define SOC_H_
+
+#include "contiki-conf.h"
+
+#include <stdint.h>
+/*----------------------------------------------------------------------------*/
+/** \name SoC features
+ * @{
+ */
+#define SOC_FEATURE_AES_SHA     0x00000002 /**< Security HW AES/SHA */
+#define SOC_FEATURE_ECC_RSA     0x00000001 /**< Security HW ECC/RSA */
+/** @} */
+/*----------------------------------------------------------------------------*/
+/** \name SoC functions
+ * @{
+ */
+
+/** \brief Gets the SoC revision
+ * \return The SoC revision as a byte with nibbles representing the major and
+ * minor revisions
+ */
+uint8_t soc_get_rev(void);
+
+/** \brief Gets the SRAM size of the SoC
+ * \return The SRAM size in bytes
+ */
+uint32_t soc_get_sram_size(void);
+
+/** \brief Gets the hardware features of the SoC that are enabled
+ * \return The enabled hardware features as a bitmask of \c SOC_FEATURE_x values
+ */
+uint32_t soc_get_features(void);
+
+/** \brief Prints SoC information */
+void soc_print_info(void);
+
+/** @} */
+
+#endif /* SOC_H_ */
+
+/**
+ * @}
+ * @}
+ */

--- a/platform/cc2538dk/contiki-main.c
+++ b/platform/cc2538dk/contiki-main.c
@@ -64,6 +64,7 @@
 #include "net/ip/tcpip.h"
 #include "net/ip/uip.h"
 #include "net/mac/frame802154.h"
+#include "soc.h"
 #include "cpu.h"
 #include "reg.h"
 #include "ieee-addr.h"
@@ -185,6 +186,9 @@ main(void)
 
   PUTS(CONTIKI_VERSION_STRING);
   PUTS(BOARD_STRING);
+#if STARTUP_CONF_VERBOSE
+  soc_print_info();
+#endif
 
   PRINTF(" Net: ");
   PRINTF("%s\n", NETSTACK_NETWORK.name);

--- a/platform/openmote-cc2538/contiki-main.c
+++ b/platform/openmote-cc2538/contiki-main.c
@@ -67,6 +67,7 @@
 #include "net/ip/tcpip.h"
 #include "net/ip/uip.h"
 #include "net/mac/frame802154.h"
+#include "soc.h"
 #include "cpu.h"
 #include "reg.h"
 #include "ieee-addr.h"
@@ -181,6 +182,9 @@ main(void)
 
   PUTS(CONTIKI_VERSION_STRING);
   PUTS(BOARD_STRING);
+#if STARTUP_CONF_VERBOSE
+  soc_print_info();
+#endif
 
   random_init(0);
 

--- a/platform/zoul/contiki-main.c
+++ b/platform/zoul/contiki-main.c
@@ -65,6 +65,7 @@
 #include "net/ip/tcpip.h"
 #include "net/ip/uip.h"
 #include "net/mac/frame802154.h"
+#include "soc.h"
 #include "cpu.h"
 #include "reg.h"
 #include "ieee-addr.h"
@@ -185,6 +186,9 @@ main(void)
 
   PUTS(CONTIKI_VERSION_STRING);
   PUTS(BOARD_STRING);
+#if STARTUP_CONF_VERBOSE
+  soc_print_info();
+#endif
 
   /* Initialise the H/W RNG engine. */
   random_init(0);


### PR DESCRIPTION
Print the following SoC information upon startup with `STARTUP_CONF_VERBOSE`:
 - chip ID,
 - revision,
 - Flash memory size,
 - SRAM size,
 - enabled hardware features (AES/SHA, ECC/RSA),
 - system clock frequency,
 - I/O clock frequency,
 - reset cause.

This makes it possible to have most useful information at hand without having to search for it. This can also be useful for debug logs.

With these changes, the first lines printed on boot look like this:
```
Contiki-3.x-2605-g9845973
Zolertia Firefly platform
CC2538: ID: 0xb964, rev.: PG2.0, Flash: 512 KiB, SRAM: 32 KiB, AES/SHA: 1, ECC/RSA: 1
System clock: 16000000 Hz
I/O clock: 16000000 Hz
Reset cause: POR
Rime configured with address 0f:0c
 Net: Rime
 MAC: CSMA
 RDC: nullrdc
```