### PR TITLE
Fix for compilation with clang - issue reported by Olaf Bergmann

### DIFF
--- a/core/net/rpl/rpl-timers.c
+++ b/core/net/rpl/rpl-timers.c
@@ -84,11 +84,13 @@ handle_periodic_timer(void *ptr)
   rpl_dag_t *dag = rpl_get_any_dag();
 
   rpl_purge_dags();
-  if(dag != NULL && RPL_IS_STORING(dag->instance)) {
-    rpl_purge_routes();
-  }
-  if(dag != NULL && RPL_IS_NON_STORING(dag->instance)) {
-    rpl_ns_periodic();
+  if(dag != NULL) {
+    if(RPL_IS_STORING(dag->instance)) {
+      rpl_purge_routes();
+    }
+    if(RPL_IS_NON_STORING(dag->instance)) {
+      rpl_ns_periodic();
+    }
   }
   rpl_recalculate_ranks();
 


### PR DESCRIPTION
Clang seems not to discover that the statement is always false (while GCC does) and therefore complains about lack of the function called within the always false block e.g. rpl_ns_periodic();. Olaf Bergmann reported it to me and I got the same problem compiling with clang on my OS-X. This fix the issue.