### PR TITLE
Coffee: minor enhancements

### DIFF
--- a/core/cfs/cfs.h
+++ b/core/cfs/cfs.h
@@ -68,7 +68,9 @@ typedef CFS_CONF_OFFSET_TYPE cfs_offset_t;
 #endif
 
 struct cfs_dir {
-  char dummy_space[32];
+  /* Iteration state, which is implementation-defined and should not be
+     accessed externally. */
+  char state[32];
 };
 
 struct cfs_dirent {

--- a/platform/native/cfs-coffee-arch.h
+++ b/platform/native/cfs-coffee-arch.h
@@ -55,7 +55,6 @@
 #define COFFEE_LOG_SIZE			8192
 #define COFFEE_LOG_TABLE_LIMIT		256
 #define COFFEE_MICRO_LOGS		0
-#define COFFEE_IO_SEMANTICS		1
 
 #define COFFEE_WRITE(buf, size, offset)				\
 		xmem_pwrite((char *)(buf), (size), COFFEE_START + (offset))

--- a/platform/sky/cfs-coffee-arch.h
+++ b/platform/sky/cfs-coffee-arch.h
@@ -59,7 +59,6 @@
 #endif
 #define COFFEE_LOG_SIZE			1024
 
-#define COFFEE_IO_SEMANTICS		1
 #define COFFEE_APPEND_ONLY		0
 #define COFFEE_MICRO_LOGS		1
 


### PR DESCRIPTION
* Simplify Coffee by changing certain CPP conditionals to C conditionals, which should be possible for the compiler to optimize based on their constant values.
* Remove the I/O semantics conditional because it is good to have consistent API across Coffee ports.
* Change the struct cfs_dir internal variable name to something more sensible.
* Minor clean up of the source code.