### PR TITLE
Fix the source address selection for multicast packets

### DIFF
--- a/core/net/ip/uip-udp-packet.c
+++ b/core/net/ip/uip-udp-packet.c
@@ -57,7 +57,7 @@ uip_udp_packet_send(struct uip_udp_conn *c, const void *data, int len)
     memmove(&uip_buf[UIP_LLH_LEN + UIP_IPUDPH_LEN], data, len);
     uip_process(UIP_UDP_SEND_CONN);
 
-#if UIP_CONF_IPV6_MULTICAST
+#if UIP_IPV6_MULTICAST
   /* Let the multicast engine process the datagram before we send it */
   if(uip_is_addr_mcast_routable(&uip_udp_conn->ripaddr)) {
     UIP_MCAST6.out();

--- a/core/net/ipv6/multicast/README.md
+++ b/core/net/ipv6/multicast/README.md
@@ -98,7 +98,7 @@ In order to extend multicast with a new engine, perform the following steps:
 - Open `uip-mcast6.h` and add a section in the `#if` spree. This aims to
   configure the uIPv6 core. More specifically, you need to:
   * Specify if you want to put RPL in MOP3 by defining
-      `RPL_CONF_MULTICAST`: 1: MOP 3, 0: non-multicast MOP
+      `RPL_WITH_MULTICAST`: 1: MOP 3, 0: non-multicast MOP
   * Define your engine details
 
             #define UIP_MCAST6             foo_driver

--- a/core/net/ipv6/multicast/uip-mcast6.h
+++ b/core/net/ipv6/multicast/uip-mcast6.h
@@ -147,15 +147,15 @@ struct uip_mcast6_driver {
 #if UIP_MCAST6_ENGINE
 
 /* Enable Multicast hooks in the uip6 core */
-#define UIP_CONF_IPV6_MULTICAST 1
+#define UIP_IPV6_MULTICAST 1
 
 #if UIP_MCAST6_ENGINE == UIP_MCAST6_ENGINE_ROLL_TM
-#define RPL_CONF_MULTICAST     0        /* Not used by trickle */
+#define RPL_WITH_MULTICAST     0        /* Not used by trickle */
 #define UIP_CONF_IPV6_ROLL_TM  1        /* ROLL Trickle ICMP type support */
 
 #define UIP_MCAST6             roll_tm_driver
 #elif UIP_MCAST6_ENGINE == UIP_MCAST6_ENGINE_SMRF
-#define RPL_CONF_MULTICAST     1
+#define RPL_WITH_MULTICAST     1
 
 #define UIP_MCAST6             smrf_driver
 #else
@@ -168,7 +168,7 @@ extern const struct uip_mcast6_driver UIP_MCAST6;
 /*---------------------------------------------------------------------------*/
 /* Configuration Checks */
 /*---------------------------------------------------------------------------*/
-#if RPL_CONF_MULTICAST && (!UIP_CONF_IPV6_RPL)
+#if RPL_WITH_MULTICAST && (!UIP_CONF_IPV6_RPL)
 #error "The selected Multicast mode requires UIP_CONF_IPV6_RPL != 0"
 #error "Check the value of UIP_CONF_IPV6_RPL in conf files."
 #endif

--- a/core/net/ipv6/uip-ds6.c
+++ b/core/net/ipv6/uip-ds6.c
@@ -48,6 +48,7 @@
 #include "lib/random.h"
 #include "net/ipv6/uip-nd6.h"
 #include "net/ipv6/uip-ds6.h"
+#include "net/ipv6/multicast/uip-mcast6.h"
 #include "net/ip/uip-packetqueue.h"
 
 #define DEBUG DEBUG_NONE

--- a/core/net/ipv6/uip6.c
+++ b/core/net/ipv6/uip6.c
@@ -451,7 +451,7 @@ uip_init(void)
   }
 #endif /* UIP_UDP */
 
-#if UIP_CONF_IPV6_MULTICAST
+#if UIP_IPV6_MULTICAST
   UIP_MCAST6.init();
 #endif
 }
@@ -1192,7 +1192,7 @@ uip_process(uint8_t flag)
    * All multicast engines must hook in here. After this function returns, we
    * expect UIP_BUF to be unmodified
    */
-#if UIP_CONF_IPV6_MULTICAST
+#if UIP_IPV6_MULTICAST
   if(uip_is_addr_mcast_routable(&UIP_IP_BUF->destipaddr)) {
     if(UIP_MCAST6.in() == UIP_MCAST6_ACCEPT) {
       /* Deliver up the stack */
@@ -1202,7 +1202,7 @@ uip_process(uint8_t flag)
       goto drop;
     }
   }
-#endif /* UIP_CONF_IPV6_MULTICAST */
+#endif /* UIP_IPV6_MULTICAST */
 
   /* TBD Some Parameter problem messages */
   if(!uip_ds6_is_my_addr(&UIP_IP_BUF->destipaddr) &&
@@ -1276,7 +1276,7 @@ uip_process(uint8_t flag)
   uip_ext_bitmap = 0;
 #endif /* UIP_CONF_ROUTER */
 
-#if UIP_CONF_IPV6_MULTICAST
+#if UIP_IPV6_MULTICAST
   process:
 #endif
 

--- a/core/net/ipv6/uip6.c
+++ b/core/net/ipv6/uip6.c
@@ -1202,7 +1202,7 @@ uip_process(uint8_t flag)
       goto drop;
     }
   }
-#endif /* UIP_IPV6_CONF_MULTICAST */
+#endif /* UIP_CONF_IPV6_MULTICAST */
 
   /* TBD Some Parameter problem messages */
   if(!uip_ds6_is_my_addr(&UIP_IP_BUF->destipaddr) &&

--- a/core/net/rpl/rpl-dag.c
+++ b/core/net/rpl/rpl-dag.c
@@ -1435,7 +1435,7 @@ rpl_process_dio(uip_ipaddr_t *from, rpl_dio_t *dio)
   rpl_dag_t *dag, *previous_dag;
   rpl_parent_t *p;
 
-#if RPL_CONF_MULTICAST
+#if RPL_WITH_MULTICAST
   /* If the root is advertising MOP 2 but we support MOP 3 we can still join
    * In that scenario, we suppress DAOs for multicast targets */
   if(dio->mop < RPL_MOP_STORING_NO_MULTICAST) {

--- a/core/net/rpl/rpl-icmp6.c
+++ b/core/net/rpl/rpl-icmp6.c
@@ -92,7 +92,7 @@ void RPL_DEBUG_DAO_OUTPUT(rpl_parent_t *);
 
 static uint8_t dao_sequence = RPL_LOLLIPOP_INIT;
 
-#if RPL_CONF_MULTICAST
+#if RPL_WITH_MULTICAST
 static uip_mcast6_route_t *mcast_group;
 #endif
 /*---------------------------------------------------------------------------*/
@@ -755,7 +755,7 @@ dao_input_storing(void)
   PRINT6ADDR(&prefix);
   PRINTF("\n");
 
-#if RPL_CONF_MULTICAST
+#if RPL_WITH_MULTICAST
   if(uip_is_addr_mcast_global(&prefix)) {
     mcast_group = uip_mcast6_route_add(&prefix);
     if(mcast_group) {
@@ -845,7 +845,7 @@ dao_input_storing(void)
   rep->state.lifetime = RPL_LIFETIME(instance, lifetime);
   RPL_ROUTE_CLEAR_NOPATH_RECEIVED(rep);
 
-#if RPL_CONF_MULTICAST
+#if RPL_WITH_MULTICAST
 fwd_dao:
 #endif
 

--- a/core/net/rpl/rpl-private.h
+++ b/core/net/rpl/rpl-private.h
@@ -203,11 +203,11 @@
 #ifdef  RPL_CONF_MOP
 #define RPL_MOP_DEFAULT                 RPL_CONF_MOP
 #else /* RPL_CONF_MOP */
-#if RPL_CONF_MULTICAST
+#if RPL_WITH_MULTICAST
 #define RPL_MOP_DEFAULT                 RPL_MOP_STORING_MULTICAST
 #else
 #define RPL_MOP_DEFAULT                 RPL_MOP_STORING_NO_MULTICAST
-#endif /* RPL_CONF_MULTICAST */
+#endif /* RPL_WITH_MULTICAST */
 #endif /* RPL_CONF_MOP */
 
 /*
@@ -248,7 +248,7 @@
 #define RPL_IS_NON_STORING(instance) (RPL_WITH_NON_STORING && ((instance) != NULL) && ((instance)->mop == RPL_MOP_NON_STORING))
 
 /* Emit a pre-processor error if the user configured multicast with bad MOP */
-#if RPL_CONF_MULTICAST && (RPL_MOP_DEFAULT != RPL_MOP_STORING_MULTICAST)
+#if RPL_WITH_MULTICAST && (RPL_MOP_DEFAULT != RPL_MOP_STORING_MULTICAST)
 #error "RPL Multicast requires RPL_MOP_DEFAULT==3. Check contiki-conf.h"
 #endif
 

--- a/core/net/rpl/rpl-private.h
+++ b/core/net/rpl/rpl-private.h
@@ -207,7 +207,7 @@
 #define RPL_MOP_DEFAULT                 RPL_MOP_STORING_MULTICAST
 #else
 #define RPL_MOP_DEFAULT                 RPL_MOP_STORING_NO_MULTICAST
-#endif /* UIP_IPV6_MULTICAST_RPL */
+#endif /* RPL_CONF_MULTICAST */
 #endif /* RPL_CONF_MOP */
 
 /*

--- a/core/net/rpl/rpl-timers.c
+++ b/core/net/rpl/rpl-timers.c
@@ -256,7 +256,7 @@ static void
 handle_dao_timer(void *ptr)
 {
   rpl_instance_t *instance;
-#if RPL_CONF_MULTICAST
+#if RPL_WITH_MULTICAST
   uip_mcast6_route_t *mcast_route;
   uint8_t i;
 #endif
@@ -275,7 +275,7 @@ handle_dao_timer(void *ptr)
     /* Set the route lifetime to the default value. */
     dao_output(instance->current_dag->preferred_parent, instance->default_lifetime);
 
-#if RPL_CONF_MULTICAST
+#if RPL_WITH_MULTICAST
     /* Send DAOs for multicast prefixes only if the instance is in MOP 3 */
     if(instance->mop == RPL_MOP_STORING_MULTICAST) {
       /* Send a DAO for own multicast addresses */

--- a/core/net/rpl/rpl.c
+++ b/core/net/rpl/rpl.c
@@ -114,7 +114,7 @@ rpl_purge_routes(void)
   uip_ds6_route_t *r;
   uip_ipaddr_t prefix;
   rpl_dag_t *dag;
-#if RPL_CONF_MULTICAST
+#if RPL_WITH_MULTICAST
   uip_mcast6_route_t *mcast_route;
 #endif
 
@@ -159,7 +159,7 @@ rpl_purge_routes(void)
     }
   }
 
-#if RPL_CONF_MULTICAST
+#if RPL_WITH_MULTICAST
   mcast_route = uip_mcast6_route_list_head();
 
   while(mcast_route != NULL) {
@@ -178,7 +178,7 @@ void
 rpl_remove_routes(rpl_dag_t *dag)
 {
   uip_ds6_route_t *r;
-#if RPL_CONF_MULTICAST
+#if RPL_WITH_MULTICAST
   uip_mcast6_route_t *mcast_route;
 #endif
 
@@ -193,7 +193,7 @@ rpl_remove_routes(rpl_dag_t *dag)
     }
   }
 
-#if RPL_CONF_MULTICAST
+#if RPL_WITH_MULTICAST
   mcast_route = uip_mcast6_route_list_head();
 
   while(mcast_route != NULL) {

--- a/examples/ipv6/multicast/intermediate.c
+++ b/examples/ipv6/multicast/intermediate.c
@@ -47,7 +47,7 @@
 #include "contiki-net.h"
 #include "net/ipv6/multicast/uip-mcast6.h"
 
-#if !NETSTACK_CONF_WITH_IPV6 || !UIP_CONF_ROUTER || !UIP_CONF_IPV6_MULTICAST || !UIP_CONF_IPV6_RPL
+#if !NETSTACK_CONF_WITH_IPV6 || !UIP_CONF_ROUTER || !UIP_IPV6_MULTICAST || !UIP_CONF_IPV6_RPL
 #error "This example can not work with the current contiki configuration"
 #error "Check the values of: NETSTACK_CONF_WITH_IPV6, UIP_CONF_ROUTER, UIP_CONF_IPV6_RPL"
 #endif

--- a/examples/ipv6/multicast/root.c
+++ b/examples/ipv6/multicast/root.c
@@ -63,7 +63,7 @@ static struct uip_udp_conn * mcast_conn;
 static char buf[MAX_PAYLOAD_LEN];
 static uint32_t seq_id;
 
-#if !NETSTACK_CONF_WITH_IPV6 || !UIP_CONF_ROUTER || !UIP_CONF_IPV6_MULTICAST || !UIP_CONF_IPV6_RPL
+#if !NETSTACK_CONF_WITH_IPV6 || !UIP_CONF_ROUTER || !UIP_IPV6_MULTICAST || !UIP_CONF_IPV6_RPL
 #error "This example can not work with the current contiki configuration"
 #error "Check the values of: NETSTACK_CONF_WITH_IPV6, UIP_CONF_ROUTER, UIP_CONF_IPV6_RPL"
 #endif

--- a/examples/ipv6/multicast/sink.c
+++ b/examples/ipv6/multicast/sink.c
@@ -57,7 +57,7 @@ static uint16_t count;
 
 #define UIP_IP_BUF   ((struct uip_ip_hdr *)&uip_buf[UIP_LLH_LEN])
 
-#if !NETSTACK_CONF_WITH_IPV6 || !UIP_CONF_ROUTER || !UIP_CONF_IPV6_MULTICAST || !UIP_CONF_IPV6_RPL
+#if !NETSTACK_CONF_WITH_IPV6 || !UIP_CONF_ROUTER || !UIP_IPV6_MULTICAST || !UIP_CONF_IPV6_RPL
 #error "This example can not work with the current contiki configuration"
 #error "Check the values of: NETSTACK_CONF_WITH_IPV6, UIP_CONF_ROUTER, UIP_CONF_IPV6_RPL"
 #endif


### PR DESCRIPTION
This PR fixes an issue that a link-local address is used as the source address of a packet destined to a routable multicast address. You can see this issue with `examples/ipv6/multicast/multicast.csc`. Multicast packets to `ff1e::89:abcd` have a link-local address, `fe80::212:7401:1:101`, as their source address. After applying the change, their source address become `fd00::212:7401:1:101`.

I found this issue has been reported with Issue #1292. As per @g-oikonomou comment on #1292, I replaced `UIP_CONF_IPV6_MULTICAST` with `UIP_IPV6_MULTICAST`. In addition, I renamed `RPL_CONF_MULTICAST` to `RPL_WITH_MULTICAST` because it doesn't seem to be a user configuration, either.


