### PR TITLE
cc2538: aes: Fix possibly missing result available status

### DIFF
--- a/core/net/llsec/noncoresec/noncoresec.c
+++ b/core/net/llsec/noncoresec/noncoresec.c
@@ -195,7 +195,7 @@ parse(void)
   packetbuf_set_datalen(packetbuf_datalen() - MIC_LEN);
   
   if(!aead(result, 0)) {
-    PRINTF("noncoresec: received unauthentic frame %"PRIu32"\n",
+    PRINTF("noncoresec: received unauthentic frame %lu\n",
         anti_replay_get_counter());
     return FRAMER_FAILED;
   }
@@ -228,7 +228,7 @@ parse(void)
     anti_replay_init_info(info);
   } else {
     if(anti_replay_was_replayed(info)) {
-       PRINTF("noncoresec: received replayed frame %"PRIu32"\n",
+       PRINTF("noncoresec: received replayed frame %lu\n",
            anti_replay_get_counter());
        return FRAMER_FAILED;
     }

--- a/cpu/cc2538/dev/aes.c
+++ b/cpu/cc2538/dev/aes.c
@@ -226,21 +226,20 @@ aes_auth_crypt_start(uint32_t ctrl, uint8_t key_area, const void *iv,
         REG(AES_CTRL_ALG_SEL) = 0x00000000;
         return CRYPTO_DMA_BUS_ERROR;
       }
+
+      /* Clear interrupt status */
+      REG(AES_CTRL_INT_CLR) = AES_CTRL_INT_CLR_DMA_IN_DONE;
     }
   }
 
-  /* Clear interrupt status */
-  REG(AES_CTRL_INT_CLR) = AES_CTRL_INT_CLR_DMA_IN_DONE |
-                          AES_CTRL_INT_CLR_RESULT_AV;
+  /* Enable result available bit in interrupt enable */
+  REG(AES_CTRL_INT_EN) = AES_CTRL_INT_EN_RESULT_AV;
 
   if(process != NULL) {
     crypto_register_process_notification(process);
     nvic_interrupt_unpend(NVIC_INT_AES);
     nvic_interrupt_enable(NVIC_INT_AES);
   }
-
-  /* Enable result available bit in interrupt enable */
-  REG(AES_CTRL_INT_EN) = AES_CTRL_INT_EN_RESULT_AV;
 
   if(data_len != 0) {
     /* Configure DMAC


### PR DESCRIPTION
Depending on the use case and on the timings, `auth_crypt_check_status()` sometimes never reported an available result, leading to a deadlock of any protothread waiting for this event, and to a `WDT` reset if a protothread was polling it.

This was caused by `aes_auth_crypt_start()` clearing the result available interrupt after operations that may rightfully trigger it, leading to a missed interrupt.

This PR also fixes build errors discovered in `noncoresec` with `DEBUG` set to `1` while investigating this issue. Even if `noncoresec` is removed soon, it's better to fix this in the meantime.