### PR TITLE
Improved TSCH sequence number handling

### DIFF
--- a/core/net/mac/framer-802154.c
+++ b/core/net/mac/framer-802154.c
@@ -86,14 +86,16 @@ create_frame(int type, int do_create)
   params.fcf.frame_pending = packetbuf_attr(PACKETBUF_ATTR_PENDING);
   if(packetbuf_holds_broadcast()) {
     params.fcf.ack_required = 0;
+    /* Suppress seqno on broadcast if supported (frame v2 or more) */
+    params.fcf.sequence_number_suppression = FRAME802154_VERSION >= FRAME802154_IEEE802154E_2012;
   } else {
     params.fcf.ack_required = packetbuf_attr(PACKETBUF_ATTR_MAC_ACK);
+    params.fcf.sequence_number_suppression = FRAME802154_SUPPR_SEQNO;
   }
   /* We do not compress PAN ID in outgoing frames, i.e. include one PAN ID (dest by default)
    * There is one exception, seemingly a typo in Table 2a: rows 2 and 3: when there is no
    * source nor destination address, we have dest PAN ID iff compression is *set*. */
   params.fcf.panid_compression = 0;
-  params.fcf.sequence_number_suppression = FRAME802154_SUPPR_SEQNO;
 
   /* Insert IEEE 802.15.4 version bits. */
   params.fcf.frame_version = FRAME802154_VERSION;

--- a/core/net/mac/tsch/tsch-packet.c
+++ b/core/net/mac/tsch/tsch-packet.c
@@ -189,7 +189,7 @@ tsch_packet_parse_eack(const uint8_t *buf, int buf_size,
 /*---------------------------------------------------------------------------*/
 /* Create an EB packet */
 int
-tsch_packet_create_eb(uint8_t *buf, int buf_size, uint8_t seqno,
+tsch_packet_create_eb(uint8_t *buf, int buf_size,
     uint8_t *hdr_len, uint8_t *tsch_sync_ie_offset)
 {
   int ret = 0;
@@ -210,8 +210,7 @@ tsch_packet_create_eb(uint8_t *buf, int buf_size, uint8_t seqno,
   p.fcf.frame_version = FRAME802154_IEEE802154E_2012;
   p.fcf.src_addr_mode = FRAME802154_LONGADDRMODE;
   p.fcf.dest_addr_mode = FRAME802154_SHORTADDRMODE;
-  p.seq = seqno;
-  p.fcf.sequence_number_suppression = FRAME802154_SUPPR_SEQNO;
+  p.fcf.sequence_number_suppression = 1;
   /* It is important not to compress PAN ID, as this would result in not including either
    * source nor destination PAN ID, leaving potential joining devices unaware of the PAN ID. */
   p.fcf.panid_compression = 0;

--- a/core/net/mac/tsch/tsch-packet.h
+++ b/core/net/mac/tsch/tsch-packet.h
@@ -94,7 +94,7 @@ int tsch_packet_parse_eack(const uint8_t *buf, int buf_size,
     uint8_t seqno, frame802154_t *frame, struct ieee802154_ies *ies, uint8_t *hdr_len);
 /* Create an EB packet */
 int tsch_packet_create_eb(uint8_t *buf, int buf_size,
-    uint8_t seqno, uint8_t *hdr_len, uint8_t *tsch_sync_ie_ptr);
+    uint8_t *hdr_len, uint8_t *tsch_sync_ie_ptr);
 /* Update ASN in EB packet */
 int tsch_packet_update_eb(uint8_t *buf, int buf_size, uint8_t tsch_sync_ie_offset);
 /* Parse EB and extract ASN and join priority */


### PR DESCRIPTION
This PR does two things, in TSCH:
* move from ad-hoc seqno handling to the generic and standard-compliant mac-sequence module
* use sequence numbers only for unicast packets. We suppress it in broadcast. This has two benefits, (1) slows down the pace at which seqnos wrap and (2) save one byte in broadcast frames.

Together with https://github.com/contiki-os/contiki/pull/1738 this avoids spurious duplicate drops.