### PR TITLE
CC26xx: Make sure UART buffers are flushed before sleeping

### DIFF
--- a/cpu/cc26xx-cc13xx/lpm.c
+++ b/cpu/cc26xx-cc13xx/lpm.c
@@ -51,6 +51,7 @@
 #include "dev/watchdog.h"
 #include "dev/soc-rtc.h"
 #include "dev/oscillators.h"
+#include "cc26xx-uart.h"
 
 #include <stdint.h>
 #include <string.h>
@@ -333,6 +334,9 @@ setup_sleep_mode(rtimer_clock_t *next_timer)
 void
 lpm_sleep(void)
 {
+  /* Make sure UART buffers are flushed */
+  while(cc26xx_uart_busy() == UART_BUSY);
+
   ENERGEST_SWITCH(ENERGEST_TYPE_CPU, ENERGEST_TYPE_LPM);
 
   /* We are only interested in IRQ energest while idle or in LPM */


### PR DESCRIPTION
This fixes a problem with corrupted characters occasionally appearing in UART output.