### PR TITLE
Improve RPL extension headers handling

### DIFF
--- a/core/net/rpl/rpl-ext-header.c
+++ b/core/net/rpl/rpl-ext-header.c
@@ -154,8 +154,8 @@ rpl_verify_hbh_header(int uip_ext_opt_offset)
 
   if((down && !sender_closer) || (!down && sender_closer)) {
     PRINTF("RPL: Loop detected - senderrank: %d my-rank: %d sender_closer: %d\n",
-	   sender_rank, instance->current_dag->rank,
-	   sender_closer);
+           sender_rank, instance->current_dag->rank,
+           sender_closer);
     /* Attempt to repair the loop by sending a unicast DIO back to the sender
      * so that it gets a fresh update of our rank. */
     if(sender != NULL) {
@@ -197,7 +197,11 @@ rpl_srh_get_next_hop(uip_ipaddr_t *ipaddr)
     switch(*uip_next_hdr) {
       case UIP_PROTO_HBHO:
       case UIP_PROTO_DESTO:
-      case UIP_PROTO_FRAG:
+        /*
+         * As per RFC 2460, only the Hop-by-Hop Options header and
+         * Destination Options header can appear before the Routing
+         * header.
+         */
         /* Move to next header */
         uip_next_hdr = &UIP_EXT_BUF->next;
         uip_ext_len += (UIP_EXT_BUF->len << 3) + 8;
@@ -244,7 +248,11 @@ rpl_process_srh_header(void)
     switch(*uip_next_hdr) {
       case UIP_PROTO_HBHO:
       case UIP_PROTO_DESTO:
-      case UIP_PROTO_FRAG:
+        /*
+         * As per RFC 2460, only the Hop-by-Hop Options header and
+         * Destination Options header can appear before the Routing
+         * header.
+         */
         /* Move to next header */
         uip_next_hdr = &UIP_EXT_BUF->next;
         uip_ext_len += (UIP_EXT_BUF->len << 3) + 8;

--- a/core/net/rpl/rpl-ext-header.c
+++ b/core/net/rpl/rpl-ext-header.c
@@ -195,12 +195,6 @@ rpl_srh_get_next_hop(uip_ipaddr_t *ipaddr)
   /* Look for routing header */
   while(uip_next_hdr != NULL && *uip_next_hdr != UIP_PROTO_ROUTING) {
     switch(*uip_next_hdr) {
-      case UIP_PROTO_TCP:
-      case UIP_PROTO_UDP:
-      case UIP_PROTO_ICMP6:
-      case UIP_PROTO_NONE:
-        uip_next_hdr = NULL;
-        break;
       case UIP_PROTO_HBHO:
       case UIP_PROTO_DESTO:
       case UIP_PROTO_FRAG:
@@ -211,6 +205,7 @@ rpl_srh_get_next_hop(uip_ipaddr_t *ipaddr)
         uip_next_hdr = &UIP_EXT_BUF->next;
         break;
       default:
+        uip_next_hdr = NULL;
         break;
     }
   }
@@ -249,12 +244,6 @@ rpl_process_srh_header(void)
   /* Look for routing header */
   while(uip_next_hdr != NULL && *uip_next_hdr != UIP_PROTO_ROUTING) {
     switch(*uip_next_hdr) {
-      case UIP_PROTO_TCP:
-      case UIP_PROTO_UDP:
-      case UIP_PROTO_ICMP6:
-      case UIP_PROTO_NONE:
-        uip_next_hdr = NULL;
-        break;
       case UIP_PROTO_HBHO:
       case UIP_PROTO_DESTO:
       case UIP_PROTO_FRAG:
@@ -265,6 +254,7 @@ rpl_process_srh_header(void)
         uip_next_hdr = &UIP_EXT_BUF->next;
         break;
       default:
+        uip_next_hdr = NULL;
         break;
     }
   }

--- a/core/net/rpl/rpl-ext-header.c
+++ b/core/net/rpl/rpl-ext-header.c
@@ -199,10 +199,8 @@ rpl_srh_get_next_hop(uip_ipaddr_t *ipaddr)
       case UIP_PROTO_DESTO:
       case UIP_PROTO_FRAG:
         /* Move to next header */
-        if(uip_next_hdr != &UIP_IP_BUF->proto) {
-          uip_ext_len += (UIP_EXT_BUF->len << 3) + 8;
-        }
         uip_next_hdr = &UIP_EXT_BUF->next;
+        uip_ext_len += (UIP_EXT_BUF->len << 3) + 8;
         break;
       default:
         uip_next_hdr = NULL;
@@ -248,10 +246,8 @@ rpl_process_srh_header(void)
       case UIP_PROTO_DESTO:
       case UIP_PROTO_FRAG:
         /* Move to next header */
-        if(uip_next_hdr != &UIP_IP_BUF->proto) {
-          uip_ext_len += (UIP_EXT_BUF->len << 3) + 8;
-        }
         uip_next_hdr = &UIP_EXT_BUF->next;
+        uip_ext_len += (UIP_EXT_BUF->len << 3) + 8;
         break;
       default:
         uip_next_hdr = NULL;
@@ -679,10 +675,8 @@ rpl_remove_header(void)
          * UIP_PROTO_DESTO. Otherwise, we'll return.
          */
         /* Move to next header */
-        if(uip_next_hdr != &UIP_IP_BUF->proto) {
-          uip_ext_len += (UIP_EXT_BUF->len << 3) + 8;
-        }
         uip_next_hdr = &UIP_EXT_BUF->next;
+        uip_ext_len += (UIP_EXT_BUF->len << 3) + 8;
     default:
       return;
     }


### PR DESCRIPTION
This PR addresses mainly two bugs in `rpl-ext-header.c`.

 1. The system crashes or falls into an infinite loop when it encounters an unsupported protocol header
(roughly speaking).
 2. A RPL header to be processed is not handled properly unless it comes just after an IPv6 header.

You can confirm the first one with a packet unsupported by Contiki. For example, on sending a simple UDP-Lite packet to a mote running on Cooja, Cooja crashes by SIGSEGV. When the mote runs with Non-Storing mode enabled, Cooja stalls because the mote does not release CPU.

For the second bug, I used a packet which had a Destination Options header followed by a RPL Routing header. The Destination Options header had only one PadN option. Contiki was not able to find the RPL Routing header.