### PR TITLE
CC26xx: change default TSCH guard time to 1.8ms

### DIFF
--- a/platform/srf06-cc26xx/contiki-conf.h
+++ b/platform/srf06-cc26xx/contiki-conf.h
@@ -66,8 +66,8 @@
 #endif
 
 /*
- * Disable turning off HF oscillator when the radio is off:
- * You need to set this in order to use TSCH, disable to save more energy.
+ * If set, the systems keeps the HF crystal oscillator on even when the radio is off.
+ * You need to set this to 1 to use TSCH with its default 2.2ms or larger guard time.
  */
 #ifndef CC2650_FAST_RADIO_STARTUP
 #define CC2650_FAST_RADIO_STARTUP               0
@@ -373,12 +373,22 @@ typedef uint32_t rtimer_clock_t;
 #define TSCH_CONF_TIMESYNC_REMOVE_JITTER 0
 #endif
 
+#ifndef TSCH_CONF_BASE_DRIFT_PPM
 /* The drift compared to "true" 10ms slots.
-   Enable adaptive sync to enable compensation for this. */
+ * Enable adaptive sync to enable compensation for this. */
 #define TSCH_CONF_BASE_DRIFT_PPM -977
+#endif
 
 /* 10 times per second */
-#define TSCH_CONF_ASSOCIATION_CHANNEL_SWITCH_FREQUENCY 10
+#ifndef TSCH_CONF_CHANNEL_SCAN_DURATION
+#define TSCH_CONF_CHANNEL_SCAN_DURATION (CLOCK_SECOND / 10)
+#endif
+
+/* Slightly reduce the TSCH guard time (from 2200 usec to 1800 usec) to make sure
+ * the CC26xx radio has sufficient time to start up. */
+#ifndef TSCH_CONF_RX_WAIT
+#define TSCH_CONF_RX_WAIT 1800
+#endif
 
 /** @} */
 /*---------------------------------------------------------------------------*/


### PR DESCRIPTION
This change enables to run TSCH on CC26xx without application-specific configuration settings (i.e. without setting `CC2650_FAST_RADIO_STARTUP` to 1).

It fixes two real problems:
1) The early wakeup due to `CC2650_FAST_RADIO_STARTUP` requires additional energy compared to the "normal" wakeup at the start of an active TSCH slot.
2) Since `CC2650_FAST_RADIO_STARTUP` is not the default setting, it means that TSCH applications have to be explicitly ported to CC26xx by adding an application-specific setting. This is potentially confusing to new users. It is also not a good design since this approach would not scale well (in terms of more platforms).

The change introduces slightly "nonstandard" TSCH guard times for this platform. Numerous experiments have shown that slightly reducing the TSCH guard time while keeping the other Contiki TSCH configuration settings unchanged (or even changed, but not extensively) does not have bad effects on interoperability and packet delivery rate, but instead helps to save energy. For example, the 6tisch RFC 7554 talks about even smaller 1ms guard time: https://datatracker.ietf.org/doc/rfc7554/?include_text=1

