### PR TITLE
CC26xx: always request HF crystal oscillator at radio on()

### DIFF
--- a/cpu/cc26xx-cc13xx/rf-core/ieee-mode.c
+++ b/cpu/cc26xx-cc13xx/rf-core/ieee-mode.c
@@ -1222,13 +1222,11 @@ on(void)
     return RF_CORE_CMD_OK;
   }
 
-#if !CC2650_FAST_RADIO_STARTUP
   /*
    * Request the HF XOSC as the source for the HF clock. Needed before we can
    * use the FS. This will only request, it will _not_ perform the switch.
    */
   oscillators_request_hf_xosc();
-#endif
 
   if(rf_is_on()) {
     PRINTF("on: We were on. PD=%u, RX=0x%04x \n", rf_core_is_accessible(),

--- a/platform/srf06-cc26xx/contiki-main.c
+++ b/platform/srf06-cc26xx/contiki-main.c
@@ -149,11 +149,6 @@ main(void)
   /* Set the LF XOSC as the LF system clock source */
   oscillators_select_lf_xosc();
 
-#if CC2650_FAST_RADIO_STARTUP
-  /* Also request HF XOSC to start up */
-  oscillators_request_hf_xosc();
-#endif
-
   lpm_init();
 
   board_init();


### PR DESCRIPTION
This fixes a problem that appears when CC2650_FAST_RADIO_STARTUP is set to 1: radio `on()` could occasionally be called without requesting HF crystal oscillator before trying to use it, leading to reboots.

This change unconditionally requested the HF crystal oscillator in `on()`, which is very fast in case the oscillator already has been requested before and is ready.
