### PR TITLE
Bug fix for uninitialized variable

### DIFF
--- a/core/net/mac/tsch/tsch-slot-operation.c
+++ b/core/net/mac/tsch/tsch-slot-operation.c
@@ -189,7 +189,7 @@ int
 tsch_get_lock(void)
 {
   if(!tsch_locked) {
-    static rtimer_clock_t busy_wait_time;
+    rtimer_clock_t busy_wait_time=0;
     
     int busy_wait = 0; /* Flag used for logging purposes */
     /* Make sure no new slot operation will start */

--- a/core/net/mac/tsch/tsch-slot-operation.c
+++ b/core/net/mac/tsch/tsch-slot-operation.c
@@ -189,7 +189,7 @@ int
 tsch_get_lock(void)
 {
   if(!tsch_locked) {
-    rtimer_clock_t busy_wait_time;
+    static rtimer_clock_t busy_wait_time;
     int busy_wait = 0; /* Flag used for logging purposes */
     /* Make sure no new slot operation will start */
     tsch_lock_requested = 1;

--- a/core/net/mac/tsch/tsch-slot-operation.c
+++ b/core/net/mac/tsch/tsch-slot-operation.c
@@ -190,6 +190,7 @@ tsch_get_lock(void)
 {
   if(!tsch_locked) {
     static rtimer_clock_t busy_wait_time;
+    
     int busy_wait = 0; /* Flag used for logging purposes */
     /* Make sure no new slot operation will start */
     tsch_lock_requested = 1;


### PR DESCRIPTION
change is made to busy_wait_time to be static.
this will solve the problem of
../../../core/net/mac/tsch/tsch-slot-operation.c: In function ‘tsch_get_lock’:
../../../core/net/mac/tsch/tsch-slot-operation.c:192:20: error: ‘busy_wait_time’ may be used uninitialized in this function
make[1]: *** [obj_z1/tsch-slot-operation.o] Error 1