### PR TITLE
JN516x: Exception handler causing infinite loop

### DIFF
--- a/platform/jn516x/dev/exceptions.c
+++ b/platform/jn516x/dev/exceptions.c
@@ -182,7 +182,6 @@ vEXC_Register(void)
   BUS_ERROR = (uint32)exception_handler;
   UNALIGNED_ACCESS = (uint32)exception_handler;
   ILLEGAL_INSTRUCTION = (uint32)exception_handler;
-  SYSCALL = (uint32)exception_handler;
   TRAP = (uint32)exception_handler;
   GENERIC = (uint32)exception_handler;
   STACK_OVERFLOW = (uint32)exception_handler;
@@ -207,11 +206,6 @@ vException_UnalignedAccess(uint32 *pu32Stack, eExceptionType eType)
 }
 PUBLIC void
 vException_IllegalInstruction(uint32 *pu32Stack, eExceptionType eType)
-{
-  exception_handler(pu32Stack, eType);
-}
-PUBLIC void
-vException_SysCall(uint32 *pu32Stack, eExceptionType eType)
 {
   exception_handler(pu32Stack, eType);
 }

--- a/platform/jn516x/dev/exceptions.c
+++ b/platform/jn516x/dev/exceptions.c
@@ -354,6 +354,9 @@ exception_handler(uint32 *pu32Stack, eExceptionType eType)
   }
 #endif
 
+  if(eType == E_EXC_SYSCALL)
+    return;
+
 #if EXCEPTION_STALLS_SYSTEM
   while(1) {
   }

--- a/platform/jn516x/dev/exceptions.c
+++ b/platform/jn516x/dev/exceptions.c
@@ -182,6 +182,7 @@ vEXC_Register(void)
   BUS_ERROR = (uint32)exception_handler;
   UNALIGNED_ACCESS = (uint32)exception_handler;
   ILLEGAL_INSTRUCTION = (uint32)exception_handler;
+  SYSCALL = (uint32)exception_handler;
   TRAP = (uint32)exception_handler;
   GENERIC = (uint32)exception_handler;
   STACK_OVERFLOW = (uint32)exception_handler;
@@ -206,6 +207,11 @@ vException_UnalignedAccess(uint32 *pu32Stack, eExceptionType eType)
 }
 PUBLIC void
 vException_IllegalInstruction(uint32 *pu32Stack, eExceptionType eType)
+{
+  exception_handler(pu32Stack, eType);
+}
+PUBLIC void
+vException_SysCall(uint32 *pu32Stack, eExceptionType eType)
 {
   exception_handler(pu32Stack, eType);
 }

--- a/platform/jn516x/dev/exceptions.c
+++ b/platform/jn516x/dev/exceptions.c
@@ -354,7 +354,7 @@ exception_handler(uint32 *pu32Stack, eExceptionType eType)
   }
 #endif
 
-  if(eType == E_EXC_SYSCALL){
+  if(eType == E_EXC_SYSCALL) {
     return;
   }
 

--- a/platform/jn516x/dev/exceptions.c
+++ b/platform/jn516x/dev/exceptions.c
@@ -354,8 +354,9 @@ exception_handler(uint32 *pu32Stack, eExceptionType eType)
   }
 #endif
 
-  if(eType == E_EXC_SYSCALL)
+  if(eType == E_EXC_SYSCALL){
     return;
+  }
 
 #if EXCEPTION_STALLS_SYSTEM
   while(1) {


### PR DESCRIPTION
This issue was reported some time ago ([jn516x platform: Software Reset raising exception](https://sourceforge.net/p/contiki/mailman/message/34612894/)) and I ran into it. By removing the exception handler for SYSCALLs the JN516x restarts as expected.