### PR TITLE
TSCH: add RADIO_DELAY_BEFORE_DETECT to rx guard time when waiting for a packet to be received

### DIFF
--- a/core/net/mac/tsch/tsch-slot-operation.c
+++ b/core/net/mac/tsch/tsch-slot-operation.c
@@ -580,7 +580,7 @@ PT_THREAD(tsch_tx_slot(struct pt *pt, struct rtimer *t))
               tsch_radio_on(TSCH_RADIO_CMD_ON_WITHIN_TIMESLOT);
               /* Wait for ACK to come */
               BUSYWAIT_UNTIL_ABS(NETSTACK_RADIO.receiving_packet(),
-                  tx_start_time, tx_duration + tsch_timing[tsch_ts_rx_ack_delay] + tsch_timing[tsch_ts_ack_wait]);
+                  tx_start_time, tx_duration + tsch_timing[tsch_ts_rx_ack_delay] + tsch_timing[tsch_ts_ack_wait] + RADIO_DELAY_BEFORE_DETECT);
               TSCH_DEBUG_TX_EVENT();
 
               ack_start_time = RTIMER_NOW() - RADIO_DELAY_BEFORE_DETECT;
@@ -753,7 +753,7 @@ PT_THREAD(tsch_rx_slot(struct pt *pt, struct rtimer *t))
     if(!packet_seen) {
       /* Check if receiving within guard time */
       BUSYWAIT_UNTIL_ABS((packet_seen = NETSTACK_RADIO.receiving_packet()),
-          current_slot_start, tsch_timing[tsch_ts_rx_offset] + tsch_timing[tsch_ts_rx_wait]);
+          current_slot_start, tsch_timing[tsch_ts_rx_offset] + tsch_timing[tsch_ts_rx_wait] + RADIO_DELAY_BEFORE_DETECT);
     }
     if(!packet_seen) {
       /* no packets on air */

--- a/platform/srf06-cc26xx/contiki-conf.h
+++ b/platform/srf06-cc26xx/contiki-conf.h
@@ -346,9 +346,8 @@ typedef uint32_t rtimer_clock_t;
 /* Delay between GO signal and start listening.
  * This value is so small because the radio is constantly on within each timeslot. */
 #define RADIO_DELAY_BEFORE_RX ((unsigned)US_TO_RTIMERTICKS(15))
-/* Delay between the SFD finishes arriving and it is detected in software.
- * Not important on this platform as it uses hardware timestamps for SFD */
-#define RADIO_DELAY_BEFORE_DETECT ((unsigned)US_TO_RTIMERTICKS(0))
+/* Delay between the SFD finishes arriving and it is detected in software. */
+#define RADIO_DELAY_BEFORE_DETECT ((unsigned)US_TO_RTIMERTICKS(352))
 
 /* Timer conversion; radio is running at 4 MHz */
 #define RADIO_TIMER_SECOND   4000000u


### PR DESCRIPTION
This essentially fixes the guard time for ACK packets in TSCH. The default guard time led to a large number of missed ACKs because the first call to `receiving_packet()` returns with 352 usec delay on CC26xx, and the unadjusted ACK guard time is just 400 usec.