### PR TITLE
Add CC1350 support

### DIFF
--- a/cpu/cc26xx-cc13xx/rf-core/rf-core.c
+++ b/cpu/cc26xx-cc13xx/rf-core/rf-core.c
@@ -97,6 +97,8 @@
 #define cc26xx_rf_cpe0_isr RFCCPE0IntHandler
 #define cc26xx_rf_cpe1_isr RFCCPE1IntHandler
 /*---------------------------------------------------------------------------*/
+typedef ChipType_t chip_type_t;
+/*---------------------------------------------------------------------------*/
 /* Remember the last Radio Op issued to the radio */
 static rfc_radioOp_t *last_radio_op = NULL;
 /*---------------------------------------------------------------------------*/
@@ -371,7 +373,7 @@ uint8_t
 rf_core_set_modesel()
 {
   uint8_t rv = RF_CORE_CMD_ERROR;
-  ChipType_t chip_type = ti_lib_chipinfo_get_chip_type();
+  chip_type_t chip_type = ti_lib_chipinfo_get_chip_type();
 
   if(chip_type == CHIP_TYPE_CC2650) {
     HWREG(PRCM_BASE + PRCM_O_RFCMODESEL) = PRCM_RFCMODESEL_CURR_MODE5;
@@ -381,6 +383,9 @@ rf_core_set_modesel()
     rv = RF_CORE_CMD_OK;
   } else if(chip_type == CHIP_TYPE_CC1310) {
     HWREG(PRCM_BASE + PRCM_O_RFCMODESEL) = PRCM_RFCMODESEL_CURR_MODE3;
+    rv = RF_CORE_CMD_OK;
+  } else if(chip_type == CHIP_TYPE_CC1350) {
+    HWREG(PRCM_BASE + PRCM_O_RFCMODESEL) = PRCM_RFCMODESEL_CURR_MODE5;
     rv = RF_CORE_CMD_OK;
   }
 

--- a/platform/srf06-cc26xx/README.md
+++ b/platform/srf06-cc26xx/README.md
@@ -13,7 +13,8 @@ platform supports two different boards:
 The CPU code, common for both platforms, can be found under `$(CONTIKI)/cpu/cc26xx-cc13xx`.
 The port was developed and tested with CC2650s, but the intention is for it to
 work with the CC2630 as well. Thus, bug reports are welcome for both chips.
-Bear in mind that the CC2630 does not have BLE capability.
+Bear in mind that the CC2630 does not have BLE capability. Similar rules apply
+in terms of CC13xx chips.
 
 This port is only meant to work with 7x7mm chips
 
@@ -185,6 +186,15 @@ then to modify `board.h` in order to cross the RX and TX DIO mappings. (TX to
 the jumper configuration on P408 as discussed in
 [this thread](https://e2e.ti.com/support/wireless_connectivity/f/158/p/411992/1483824#1483824)
 on E2E. For this to work, you need to set `BOARD_CONF_DEBUGGER_DEVPACK` to 0.
+
+IEEE vs Sub-GHz operation
+=========================
+The platform supports both modes of operation, provided the chip also has the
+respective capability. If you specify nothing, the platform will default to
+Sub-GHz mode for CC13xx devices, IEEE mode otherwise. To force IEEE mode, you
+need to add this line to your `project-conf.h`.
+
+    #define CC13XX_CONF_PROP_MODE 0
 
 Low Power Operation
 ===================

--- a/platform/srf06-cc26xx/contiki-conf.h
+++ b/platform/srf06-cc26xx/contiki-conf.h
@@ -89,7 +89,18 @@
 #define NETSTACK_CONF_FRAMER  framer_802154
 #endif
 
+/*
+ * Auto-configure Prop-mode radio if we are running on CC13xx, unless the
+ * project has specified otherwise. Depending on the final mode, determine a
+ * default channel (again, if unspecified) and configure RDC params
+ */
 #if CPU_FAMILY_CC13XX
+#ifndef CC13XX_CONF_PROP_MODE
+#define CC13XX_CONF_PROP_MODE 1
+#endif /* CC13XX_CONF_PROP_MODE */
+#endif /* CPU_FAMILY_CC13XX */
+
+#if CC13XX_CONF_PROP_MODE
 #define NETSTACK_CONF_RADIO        prop_mode_driver
 
 #ifndef RF_CORE_CONF_CHANNEL

--- a/platform/srf06-cc26xx/contiki-main.c
+++ b/platform/srf06-cc26xx/contiki-main.c
@@ -190,6 +190,11 @@ main(void)
   printf("With DriverLib v%u.%u\n", DRIVERLIB_RELEASE_GROUP,
          DRIVERLIB_RELEASE_BUILD);
   printf(BOARD_STRING "\n");
+  printf("IEEE 802.15.4: %s, Sub-GHz: %s, BLE: %s, Prop: %s\n",
+         ti_lib_chipinfo_supports_ieee_802_15_4() == true ? "Yes" : "No",
+         ti_lib_chipinfo_chip_family_is_cc13xx() == true ? "Yes" : "No",
+         ti_lib_chipinfo_supports_ble() == true ? "Yes" : "No",
+         ti_lib_chipinfo_supports_proprietary() == true ? "Yes" : "No");
 
   process_start(&etimer_process, NULL);
   ctimer_init();


### PR DESCRIPTION
This pull adds support for the CC1350.

We only focus on CPU capability here.

Board support to follow in a separate pull request. We've got a little bit of work to do before we can properly support CC1350 boards, eg the brand new CC1350 LP (LAUNCHXL-CC1350). The main reason for this is that we need to make RF front-end / bias more configurable and we also need a clever way to support antenna switches, which is what the CC1350LP uses.