### PR TITLE
Fix PROP mode channel switching

### DIFF
--- a/cpu/cc26xx-cc13xx/rf-core/prop-mode.c
+++ b/cpu/cc26xx-cc13xx/rf-core/prop-mode.c
@@ -1104,7 +1104,7 @@ set_value(radio_param_t param, radio_value_t value)
     rv = RADIO_RESULT_ERROR;
   }
 
-  if(rx_on_prop() != RF_CORE_CMD_OK) {
+  if(soft_on_prop() != RF_CORE_CMD_OK) {
     PRINTF("set_value: rx_on_prop() failed\n");
     rv = RADIO_RESULT_ERROR;
   }


### PR DESCRIPTION
If `NETSTACK_CONF_RADIO.set_value(RADIO_PARAM_CHANNEL, ...)` is called when radio is on, it will fail to apply the channel change, because it won't re-send `CMD_PROP_RADIO_DIV_SETUP` and `CMD_PROP_FS`. This commit fixes this condition, by making sure the correct commands are sent to the radio.