### PR TITLE
core/net/rpl: Fix function declaration isn’t a prototype

### DIFF
--- a/core/net/rpl/rpl-ns.h
+++ b/core/net/rpl/rpl-ns.h
@@ -67,6 +67,6 @@ rpl_ns_node_t *rpl_ns_node_next(rpl_ns_node_t *item);
 rpl_ns_node_t *rpl_ns_get_node(const rpl_dag_t *dag, const uip_ipaddr_t *addr);
 int rpl_ns_is_node_reachable(const rpl_dag_t *dag, const uip_ipaddr_t *addr);
 void rpl_ns_get_node_global_addr(uip_ipaddr_t *addr, rpl_ns_node_t *node);
-void rpl_ns_periodic();
+void rpl_ns_periodic(void);
 
 #endif /* RPL_NS_H */


### PR DESCRIPTION
Fixes
```
In file included from ../../../contiki/core/net/rpl/rpl-private.h:48:0,
                 from ../../../contiki/core/net/mac/tsch/tsch-rpl.c:42:
../../../contiki/core/net/rpl/rpl-ns.h:70:1: warning: function declaration isn’t a prototype [-Wstrict-prototypes]
 void rpl_ns_periodic();
 ^~~~
```