### PR TITLE
Make set_bits_in_byte() static

### DIFF
--- a/core/net/rime/chameleon-bitopt.c
+++ b/core/net/rime/chameleon-bitopt.c
@@ -169,7 +169,7 @@ header_size(const struct packetbuf_attrlist *a)
   return size;
 }
 /*---------------------------------------------------------------------------*/
-void CC_INLINE
+static void CC_INLINE
 set_bits_in_byte(uint8_t *target, int bitpos, uint8_t val, int vallen)
 {
   unsigned short shifted_val;


### PR DESCRIPTION
Will not link otherwise on compilers supporting inline (e.g. on native linux) :

```
contiki-native.a(chameleon-bitop): In Funktion `set_bits':
/home/blackdigi/workspace-cdt/contiki/examples/multi-threading//../../core/net/rime/chameleon-bitopt.c:192: Nicht definierter Verweis auf `set_bits_in_byte'
/home/blackdigi/workspace-cdt/contiki/examples/multi-threading//../../core/net/rime/chameleon-bitopt.c:202: Nicht definierter Verweis auf `set_bits_in_byte'
/home/blackdigi/workspace-cdt/contiki/examples/multi-threading//../../core/net/rime/chameleon-bitopt.c:208: Nicht definierter Verweis auf `set_bits_in_byte'
/home/blackdigi/workspace-cdt/contiki/examples/multi-threading//../../core/net/rime/chameleon-bitopt.c:212: Nicht definierter Verweis auf `set_bits_in_byte'
collect2: error: ld returned 1 exit status
make: *** [multi-threading.native] Fehler 1
../../Makefile.include:280: die Regel für Ziel „multi-threading.native“ scheiterte
```