### PR TITLE
x86: Support configurable UART baud rate and fix initialization

### DIFF
--- a/cpu/x86/drivers/legacy_pc/uart-16x50.c
+++ b/cpu/x86/drivers/legacy_pc/uart-16x50.c
@@ -141,15 +141,27 @@ SYSCALLS_DEFINE(uart_16x50_tx, uart_16x50_driver_t c_this, uint8_t c)
 }
 /*---------------------------------------------------------------------------*/
 /**
+ * \brief Perform common initialization that must precede per-port
+ *        initialization.
+ */
+/*---------------------------------------------------------------------------*/
+void
+uart_16x50_init(void)
+{
+  SYSCALLS_INIT(uart_16x50_setup);
+  SYSCALLS_INIT(uart_16x50_tx);
+}
+/*---------------------------------------------------------------------------*/
+/**
  * \brief          Initialize an MMIO-programmable 16X50 UART.
  * \param c_this   Structure that will be initialized to represent the device.
  * \param pci_addr PCI address of device.
  * \param dl       Divisor setting to configure the baud rate.
  */
 void
-uart_16x50_init(uart_16x50_driver_t ATTR_KERN_ADDR_SPACE *c_this,
-                pci_config_addr_t pci_addr,
-                uint16_t dl)
+uart_16x50_init_port(uart_16x50_driver_t ATTR_KERN_ADDR_SPACE *c_this,
+                     pci_config_addr_t pci_addr,
+                     uint16_t dl)
 {
   uart_16x50_driver_t loc_c_this;
 
@@ -157,9 +169,7 @@ uart_16x50_init(uart_16x50_driver_t ATTR_KERN_ADDR_SPACE *c_this,
    * firmware during boot.
    */
   pci_init(c_this, pci_addr, UART_MMIO_SZ, 0, 0);
-  SYSCALLS_INIT(uart_16x50_setup);
   SYSCALLS_AUTHZ(uart_16x50_setup, *c_this);
-  SYSCALLS_INIT(uart_16x50_tx);
   SYSCALLS_AUTHZ(uart_16x50_tx, *c_this);
 
   prot_domains_copy_dcd(&loc_c_this, c_this);

--- a/cpu/x86/drivers/legacy_pc/uart-16x50.h
+++ b/cpu/x86/drivers/legacy_pc/uart-16x50.h
@@ -35,9 +35,11 @@
 
 typedef pci_driver_t uart_16x50_driver_t;
 
-void uart_16x50_init(uart_16x50_driver_t ATTR_KERN_ADDR_SPACE *c_this,
-                     pci_config_addr_t pci_addr,
-                     uint16_t dl);
+void uart_16x50_init(void);
+
+void uart_16x50_init_port(uart_16x50_driver_t ATTR_KERN_ADDR_SPACE *c_this,
+                          pci_config_addr_t pci_addr,
+                          uint16_t dl);
 
 void uart_16x50_tx(uart_16x50_driver_t c_this, uint8_t c);
 

--- a/cpu/x86/drivers/quarkX1000/uart.c
+++ b/cpu/x86/drivers/quarkX1000/uart.c
@@ -35,10 +35,10 @@
 PROT_DOMAINS_ALLOC(uart_16x50_driver_t, quarkX1000_uart0);
 PROT_DOMAINS_ALLOC(uart_16x50_driver_t, quarkX1000_uart1);
 
-/* Divisor setting for 115200 baud from section 18.2.2 of Intel Quark SoC
- * X1000 Datasheet.
+/* UART base frequency from section 18.2.2 of Intel Quark SoC X1000
+ * Datasheet.
  */
-#define QUARK_X1000_UART_DL_115200 24
+#define QUARK_X1000_UART_FBASE 44236800
 
 /*---------------------------------------------------------------------------*/
 /**
@@ -46,8 +46,9 @@ PROT_DOMAINS_ALLOC(uart_16x50_driver_t, quarkX1000_uart1);
  * \param dev Device to initialize.
  */
 void
-quarkX1000_uart_init(quarkX1000_uart_dev_t dev)
+quarkX1000_uart_init(quarkX1000_uart_dev_t dev, unsigned baud)
 {
+  uint16_t dl;
   pci_config_addr_t pci_addr;
   uart_16x50_driver_t ATTR_KERN_ADDR_SPACE *drv;
 
@@ -67,7 +68,9 @@ quarkX1000_uart_init(quarkX1000_uart_dev_t dev)
     drv = &quarkX1000_uart1;
     PROT_DOMAINS_INIT_ID(quarkX1000_uart1);
   }
-  uart_16x50_init(drv, pci_addr, QUARK_X1000_UART_DL_115200);
+  /* Divisor setting from section 18.2.2 of Intel Quark SoC X1000 Datasheet. */
+  dl = QUARK_X1000_UART_FBASE / (16 * baud);
+  uart_16x50_init(drv, pci_addr, dl);
 }
 /*---------------------------------------------------------------------------*/
 /**

--- a/cpu/x86/drivers/quarkX1000/uart.c
+++ b/cpu/x86/drivers/quarkX1000/uart.c
@@ -42,11 +42,21 @@ PROT_DOMAINS_ALLOC(uart_16x50_driver_t, quarkX1000_uart1);
 
 /*---------------------------------------------------------------------------*/
 /**
+ * \brief Perform common initialization that must precede per-port
+ *        initialization.
+ */
+void
+quarkX1000_uart_init(void)
+{
+  uart_16x50_init();
+}
+/*---------------------------------------------------------------------------*/
+/**
  * \brief     Initialize a UART.
  * \param dev Device to initialize.
  */
 void
-quarkX1000_uart_init(quarkX1000_uart_dev_t dev, unsigned baud)
+quarkX1000_uart_init_port(quarkX1000_uart_dev_t dev, unsigned baud)
 {
   uint16_t dl;
   pci_config_addr_t pci_addr;
@@ -70,7 +80,7 @@ quarkX1000_uart_init(quarkX1000_uart_dev_t dev, unsigned baud)
   }
   /* Divisor setting from section 18.2.2 of Intel Quark SoC X1000 Datasheet. */
   dl = QUARK_X1000_UART_FBASE / (16 * baud);
-  uart_16x50_init(drv, pci_addr, dl);
+  uart_16x50_init_port(drv, pci_addr, dl);
 }
 /*---------------------------------------------------------------------------*/
 /**

--- a/cpu/x86/drivers/quarkX1000/uart.h
+++ b/cpu/x86/drivers/quarkX1000/uart.h
@@ -38,7 +38,7 @@ typedef enum {
   QUARK_X1000_UART_1
 } quarkX1000_uart_dev_t;
 
-void quarkX1000_uart_init(quarkX1000_uart_dev_t dev);
+void quarkX1000_uart_init(quarkX1000_uart_dev_t dev, unsigned baud);
 void quarkX1000_uart_tx(quarkX1000_uart_dev_t dev, uint8_t c);
 
 #endif /* CPU_X86_DRIVERS_QUARKX1000_UART_H_ */

--- a/cpu/x86/drivers/quarkX1000/uart.h
+++ b/cpu/x86/drivers/quarkX1000/uart.h
@@ -38,7 +38,8 @@ typedef enum {
   QUARK_X1000_UART_1
 } quarkX1000_uart_dev_t;
 
-void quarkX1000_uart_init(quarkX1000_uart_dev_t dev, unsigned baud);
+void quarkX1000_uart_init(void);
+void quarkX1000_uart_init_port(quarkX1000_uart_dev_t dev, unsigned baud);
 void quarkX1000_uart_tx(quarkX1000_uart_dev_t dev, uint8_t c);
 
 #endif /* CPU_X86_DRIVERS_QUARKX1000_UART_H_ */

--- a/platform/galileo/contiki-main.c
+++ b/platform/galileo/contiki-main.c
@@ -86,10 +86,11 @@ main(void)
   quarkX1000_imr_conf();
 #endif
   irq_init();
+  quarkX1000_uart_init();
   /* Initialize UART connected to Galileo Gen1 3.5mm audio-style jack or
    * Galileo Gen2 FTDI header
    */
-  quarkX1000_uart_init(QUARK_X1000_UART_1, 115200);
+  quarkX1000_uart_init_port(QUARK_X1000_UART_1, 115200);
   clock_init();
   rtimer_init();
 

--- a/platform/galileo/contiki-main.c
+++ b/platform/galileo/contiki-main.c
@@ -86,8 +86,10 @@ main(void)
   quarkX1000_imr_conf();
 #endif
   irq_init();
-  /* Initialize UART connected to Galileo Gen2 FTDI header */
-  quarkX1000_uart_init(QUARK_X1000_UART_1);
+  /* Initialize UART connected to Galileo Gen1 3.5mm audio-style jack or
+   * Galileo Gen2 FTDI header
+   */
+  quarkX1000_uart_init(QUARK_X1000_UART_1, 115200);
   clock_init();
   rtimer_init();
 


### PR DESCRIPTION
The first patch extends the Intel Quark X1000 SoC UART initialization API to accept a numeric baud rate specification.  This is useful for projects that require configuring a serial port with a particular baud rate.

The second patch fixes UART system call authorization initialization for applications that initialize both UARTs.