### PR TITLE
doxygen: Fix orphan modules

### DIFF
--- a/cpu/cc2538/dev/ecc-algorithm.c
+++ b/cpu/cc2538/dev/ecc-algorithm.c
@@ -29,7 +29,7 @@
  * SUCH DAMAGE.
  */
 /**
- * \addtogroup c2538-ecc-algo
+ * \addtogroup cc2538-ecc-algo
  * @{
  *
  * \file

--- a/cpu/cc2538/dev/ecc-curve.c
+++ b/cpu/cc2538/dev/ecc-curve.c
@@ -29,7 +29,7 @@
  * SUCH DAMAGE.
  */
 /**
- * \addtogroup c2538-ecc-curves
+ * \addtogroup cc2538-ecc-curves
  * @{
  */
 #include "contiki.h"

--- a/cpu/cc2538/dev/sha256.h
+++ b/cpu/cc2538/dev/sha256.h
@@ -37,7 +37,7 @@
  * \addtogroup cc2538-crypto
  * @{
  *
- * \defgroup cc2538-sha526 cc2538 SHA-256
+ * \defgroup cc2538-sha256 cc2538 SHA-256
  *
  * Driver for the cc2538 SHA-256 mode of the security core
  * @{

--- a/platform/srf06-cc26xx/srf06/board.c
+++ b/platform/srf06-cc26xx/srf06/board.c
@@ -29,7 +29,7 @@
  */
 /*---------------------------------------------------------------------------*/
 /**
- * \addtogroup sensortag-common-peripherals
+ * \addtogroup srf06-common-peripherals
  * @{
  *
  * \file


### PR DESCRIPTION
Fix a few typos that made some doxygen modules become orphans.