### PR TITLE
CC2538: Use the 32.768-kHz crystal if present

### DIFF
--- a/platform/cc2538dk/contiki-conf.h
+++ b/platform/cc2538dk/contiki-conf.h
@@ -65,6 +65,16 @@ typedef uint32_t rtimer_clock_t;
 /** @} */
 /*---------------------------------------------------------------------------*/
 /**
+ * \name CC2538 System Control configuration
+ *
+ * @{
+ */
+#ifndef SYS_CTRL_CONF_OSC32K_USE_XTAL
+#define SYS_CTRL_CONF_OSC32K_USE_XTAL   1 /**< Use the on-board 32.768-kHz crystal */
+#endif
+/** @} */
+/*---------------------------------------------------------------------------*/
+/**
  * \name Watchdog Timer configuration
  *
  * @{

--- a/platform/openmote-cc2538/contiki-conf.h
+++ b/platform/openmote-cc2538/contiki-conf.h
@@ -102,7 +102,16 @@ typedef uint32_t rtimer_clock_t;
 #define FLASH_CCA_CONF_BOOTLDR_BACKDOOR_ACTIVE_HIGH 0 /**< A logic low level activates the boot loader */
 #endif
 /** @} */
-
+/*---------------------------------------------------------------------------*/
+/**
+ * \name CC2538 System Control configuration
+ *
+ * @{
+ */
+#ifndef SYS_CTRL_CONF_OSC32K_USE_XTAL
+#define SYS_CTRL_CONF_OSC32K_USE_XTAL   1 /**< Use the on-board 32.768-kHz crystal */
+#endif
+/** @} */
 /*---------------------------------------------------------------------------*/
 /**
  * \name CFS configuration

--- a/platform/zoul/contiki-conf.h
+++ b/platform/zoul/contiki-conf.h
@@ -100,7 +100,16 @@ typedef uint32_t rtimer_clock_t;
 #define FLASH_CCA_CONF_BOOTLDR_BACKDOOR_ACTIVE_HIGH 0 /**< A logic low level activates the boot loader */
 #endif
 /** @} */
-
+/*---------------------------------------------------------------------------*/
+/**
+ * \name CC2538 System Control configuration
+ *
+ * @{
+ */
+#ifndef SYS_CTRL_CONF_OSC32K_USE_XTAL
+#define SYS_CTRL_CONF_OSC32K_USE_XTAL   1 /**< Use the on-board 32.768-kHz crystal */
+#endif
+/** @} */
 /*---------------------------------------------------------------------------*/
 /**
  * \name CFS configuration


### PR DESCRIPTION
Enable the 32.768-kHz crystal on all the CC2538 platforms where it is present in order to get a better time accuracy.

This should avoid new cases of #1817 for in-tree platforms.