### PR TITLE
Zoul: added firefly to motelist targets

### DIFF
--- a/tools/zolertia/motelist-zolertia
+++ b/tools/zolertia/motelist-zolertia
@@ -57,6 +57,8 @@ if( $Opt{board} eq "z1" ) {
   $Opt{board} = "Zolertia Z1";
 } elsif( $Opt{board} eq "remote" ) {
   $Opt{board} = "Zolertia RE-Mote platform";
+} elsif( $Opt{board} eq "firefly" ) {
+  $Opt{board} = "Zolertia Firefly platform";
 }
 
 my @devs = $Opt{method} eq "procfs" ? scan_procfs() : scan_sysfs();


### PR DESCRIPTION
This PR adds the Firefly to the motelist's targets list.