### PR TITLE
radio-mod lib very usefull for cc2420 radio configs in multihop or mesh network

### DIFF
--- a/apps/config-radio/Makefile.config-radio
+++ b/apps/config-radio/Makefile.config-radio
@@ -1,0 +1,1 @@
+config-radio_src = cc2420-radio.c

--- a/apps/config-radio/README.md
+++ b/apps/config-radio/README.md
@@ -1,0 +1,76 @@
+# RADIO MOD
+
+## CC2420 Radio Configurations Library.
+
+
+### Problem:
+
+1. Tired of setting custom Channel and Transmission ranges in number of nodes?
+
+2. Often forget to change Channel or Transmission range in one of node in network and wonder why it is not functioning?
+
+3. want to set Channel and Transmission ranges in single step for whole network?, also want to set a quit different configurations for one or more nodes ?
+
+
+### Solution:
+Include the library in your application and set the desired channel and TX power for your network thats it!.
+
+## Abstract
+The RADIO MOD library uses very small code footprints. Very light weight and usefull when creating multi hops or mesh network.
+This library enhance the cc2420 radio methods. it uses `cc2420_set_txpower(radioChannel_tx_power);`, `cc2420_set_channel(radioChannel);`.
+
+## Setup:
+
+Include the library in your application `Makefile`
+
+```sh
+APPS += config-radio
+```
+
+call the methods with approperiate settings.
+
+## Global Configurations:
+
+1) Change the channel or TX power of all the nodes which includes this library.
+
+In file
+
+	~/Contiki/app/config-radio/cc2420-radio.c
+
+Change the values of following variables.
+
+	uint8_t radioChannel = 26;  		// default channel
+	uint8_t radioChannel_tx_power = 31; // default power
+
+in your application add these method.
+
+	set_cc2420_txpower(0);	// setting zero will use predefined configurations in `cc2420-radio.c` file
+	set_cc2420_channel(0);	// I want all the motes use the channel 26 defined in library.
+
+## Local Configurations:
+
+2) Change the channel or TX power of only that node which includes this library.
+
+in your application add these method with custom values.
+
+	set_cc2420_txpower(3);	// I want TX power to be 3 at mote B
+	set_cc2420_channel(15);	// I want channel 15 to used at mote B
+
+## Author
+Kaleem Ullah <mscs14059@itu.edu.pk>
+
+Kaleem Ullah <kaleemullah360@live.com>
+
+## Usage
+### Case 1:	
+> zero is passed in power/channel function i.e set_cc2420_txpower(0); will use predefined channel number in cc2420-radio lib
+
+### Case 2:
+> a custom value is passed in power/channel function i.e set_cc2420_txpower(13); will use channel 13.
+
+### Case 3:
+> not using both/eithere of power/channel setting function will set Contiki OS default configurations i.e channel 26, tx power 31.
+
+For more information, see the Contiki website:
+
+[http://contiki-os.org](http://contiki-os.org)

--- a/apps/config-radio/cc2420-radio.c
+++ b/apps/config-radio/cc2420-radio.c
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2011-2012, Swedish Institute of Computer Science.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * This file is part of the Contiki operating system.
+ */
+
+/**
+ * \file
+ *
+ *  cc2420-radio.c
+ *
+ * \author
+ *
+ *	Kaleem Ullah <mscs14059@itu.edu.pk>
+ *	Kaleem Ullah <kaleemullah360@live.com>
+ *
+ * \Usage
+ *
+ *	Case 1:	zero is passed in power/channel function i.e set_cc2420_txpower(0); will use predefined channel number in cc2420-radio lib.
+ *	Case 2:	a custom value is passed in power/channel function i.e set_cc2420_txpower(13); will use channel 13.
+ *	Case 3:	not using both/eithere of power/channel setting function will set Contiki OS default configurations i.e channel 26, tx power 31.
+ */
+
+/* -------- Set Radio Powers --------------- */
+
+#include <cc2420-radio.h>
+
+/*|Power (dBm)|PA_LEVEL|Power (mW)|
+* |0          |  31    |1.0000    |
+* |-0.0914    |  30    |0.9792    |
+* |-25.0000   |  3     |0.0032    |
+* |-28.6970   |  2     |0.0013    |
+* |-32.9840   |  1     |0.0005    |
+* |-37.9170   |  0     |0.0002    |
+*/ 
+uint8_t radioChannel = 26;  // default channel
+uint8_t radioChannel_tx_power = 31; // default power
+
+void set_cc2420_channel(custom_radioChannel){
+	/* channel */
+	if(!custom_radioChannel == 0){
+		radioChannel = custom_radioChannel;
+	}
+	cc2420_set_channel(radioChannel);
+	printf("CC2420 Radio channel %d\n", cc2420_get_channel());
+}
+
+
+void set_cc2420_txpower(custom_radioChannel_tx_power){
+	/* tx power */
+	if(!custom_radioChannel_tx_power == 0){
+		radioChannel_tx_power = custom_radioChannel_tx_power;
+	}
+	cc2420_set_txpower(radioChannel_tx_power);
+	printf("CC2420 Radio TX power %d\n", cc2420_get_txpower());
+}
+
+/* -------- End Set Radio Powers ------------ */

--- a/apps/config-radio/cc2420-radio.h
+++ b/apps/config-radio/cc2420-radio.h
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2011-2012, Swedish Institute of Computer Science.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * This file is part of the Contiki operating system.
+ */
+ /**
+ * \file
+ *
+ *  cc2420-radio.h
+ *
+ * \author
+ *
+ *	Kaleem Ullah <mscs14059@itu.edu.pk>
+ *	Kaleem Ullah <kaleemullah360@live.com>
+ *
+ * \Usage
+ *
+ *	Case 1:	zero is passed in power/channel function i.e set_cc2420_txpower(0); will use predefined channel number in cc2420-radio lib.
+ *	Case 2:	a custom value is passed in power/channel function i.e set_cc2420_txpower(13); will use channel 13.
+ *	Case 3:	not using both/eithere of power/channel setting function will set Contiki OS default configurations i.e channel 26, tx power 31.
+ */
+
+/*|Power (dBm)|PA_LEVEL|Power (mW)|
+* |0          |  31    |1.0000    |
+* |-0.0914    |  30    |0.9792    |
+* |-25.0000   |  3     |0.0032    |
+* |-28.6970   |  2     |0.0013    |
+* |-32.9840   |  1     |0.0005    |
+* |-37.9170   |  0     |0.0002    |
+*/
+
+#include <stdio.h>
+#include <cc2420.h>
+
+#ifndef CC2420_RADIO_CONFIG_H
+#define CC2420_RADIO_CONFIG_H
+
+void set_cc2420_channel();
+void set_cc2420_txpower();
+
+#endif /* CC2420_RADIO_CONFIG_H */


### PR DESCRIPTION
# RADIO MOD

## CC2420 Radio Configurations Library.


### Problem:

1. Tired of setting custom Channel and Transmission ranges in number of nodes?

2. Often forget to change Channel or Transmission range in one of node in network and wonder why it is not functioning?

3. want to set Channel and Transmission ranges in single step for whole network?, also want to set a quit different configurations for one or more nodes ?


### Solution:
Include the library in your application and set the desired channel and TX power for your network thats it!.

## Abstract
The RADIO MOD library uses very small code footprints. Very light weight and usefull when creating multi hops or mesh network.
This library enhance the cc2420 radio methods. it uses `cc2420_set_txpower(radioChannel_tx_power);`, `cc2420_set_channel(radioChannel);`.

## Setup:

Include the library in your application `Makefile`

```sh
APPS += config-radio
```

call the methods with approperiate settings.

## Global Configurations:

1) Change the channel or TX power of all the nodes which includes this library.

In file

	~/Contiki/app/config-radio/cc2420-radio.c

Change the values of following variables.

	uint8_t radioChannel = 26;  		// default channel
	uint8_t radioChannel_tx_power = 31; // default power

in your application add these method.

	set_cc2420_txpower(0);	// setting zero will use predefined configurations in `cc2420-radio.c` file
	set_cc2420_channel(0);	// I want all the motes use the channel 26 defined in library.

## Local Configurations:

2) Change the channel or TX power of only that node which includes this library.

in your application add these method with custom values.

	set_cc2420_txpower(3);	// I want TX power to be 3 at mote B
	set_cc2420_channel(15);	// I want channel 15 to used at mote B

## Usage
### Case 1:	
> zero is passed in power/channel function i.e set_cc2420_txpower(0); will use predefined channel number in cc2420-radio lib

### Case 2:
> a custom value is passed in power/channel function i.e set_cc2420_txpower(13); will use channel 13.

### Case 3:
> not using both/eithere of power/channel setting function will set Contiki OS default configurations i.e channel 26, tx power 31.