### PR TITLE
Make it easier to use the Non-Storing mode with the rpl-udp example

### DIFF
--- a/examples/ipv6/rpl-udp/project-conf.h
+++ b/examples/ipv6/rpl-udp/project-conf.h
@@ -60,10 +60,6 @@
 
 #define RPL_CONF_DEFAULT_ROUTE_INFINITE_LIFETIME 1
 
-#ifndef RPL_CONF_WITH_NON_STORING
-#define RPL_CONF_WITH_NON_STORING 0 /* Set this to run with non-storing mode */
-#endif /* RPL_CONF_WITH_NON_STORING */
-
 #if WITH_NON_STORING
 #undef RPL_NS_CONF_LINK_NUM
 #define RPL_NS_CONF_LINK_NUM 40 /* Number of links maintained at the root. Can be set to 0 at non-root nodes. */


### PR DESCRIPTION
In examples/ipv6/rpl-udp, the Non-Storing mode is not enabled properly by `make MAKE_WITH_NON_STORING=1`. You have to set 1 to `RPL_CONF_WITH_NON_STORING` in project-conf.h manually as well.

This PR fixes this situation. The solution is removing the `RPL_CONF_WITH_NON_STORING` definition block of project-conf.h.

According to the following block of core/net/rpl/rpl-private.h, we don't need to set `RPL_CONF_WITH_NON_STORING` explicitly if `RPL_CONF_MOP` is `RPL_MOP_NON_STORING`. For the rpl-udp example, `RPL_MOP_NON_STORING` is set to `RPL_CONF_MOP` if `WITH_NON_STORING` is 1, and this is the case when `make` runs with `MAKE_WITH_NON_STORING=1`.
```C
    202 /* RPL Mode of operation */
    203 #ifdef  RPL_CONF_MOP
    204 #define RPL_MOP_DEFAULT                 RPL_CONF_MOP
    205 #else /* RPL_CONF_MOP */
    206 #if RPL_WITH_MULTICAST
    207 #define RPL_MOP_DEFAULT                 RPL_MOP_STORING_MULTICAST
    208 #else
    209 #define RPL_MOP_DEFAULT                 RPL_MOP_STORING_NO_MULTICAST
    210 #endif /* RPL_WITH_MULTICAST */
    211 #endif /* RPL_CONF_MOP */
    212
   (snip)
    223 /*
    224  * Embed support for non-storing mode
    225  */
    226 #ifdef RPL_CONF_WITH_NON_STORING
    227 #define RPL_WITH_NON_STORING RPL_CONF_WITH_NON_STORING
    228 #else /* RPL_CONF_WITH_NON_STORING */
    229 /* By default: embed support for non-storing if and only if the configured MOP is non-storing */
    230 #define RPL_WITH_NON_STORING (RPL_MOP_DEFAULT == RPL_MOP_NON_STORING)
    231 #endif /* RPL_CONF_WITH_NON_STORING */
```