### PR TITLE
Fix duplicate register definition warnings for atmega256rfr2 + rf230bb

### DIFF
--- a/cpu/avr/radio/rf230bb/atmega256rfr2_registermap.h
+++ b/cpu/avr/radio/rf230bb/atmega256rfr2_registermap.h
@@ -89,7 +89,7 @@
 #define SR_CSMA_SEED_1         0x16e, 0x10, 4
 
 /* RF230 register assignments, for reference */
-#if 1
+#if 0
 //#define HAVE_REGISTER_MAP (1)
 /** Offset for register TRX_STATUS */
 //#define RG_TRX_STATUS                    (0x01)


### PR DESCRIPTION
I am working on a platform using the said combination and the build produces a bunch of
warnings about duplicate register definitions. Judging by the comment above the definitions it seems to me that someone forgot to exclude them from the radio registermap.

I am not sure if the attached simple fix is valid for all the toolchain versions but it works for me
using the recent avr-libc. Update: it is not.