### PR TITLE
cc2538: uart: Fix garbled output occurring upon lpm_enter()

### DIFF
--- a/cpu/cc2538/dev/uart.c
+++ b/cpu/cc2538/dev/uart.c
@@ -230,9 +230,7 @@ permit_pm1(void)
   const uart_regs_t *regs;
 
   for(regs = &uart_regs[0]; regs < &uart_regs[UART_INSTANCE_COUNT]; regs++) {
-    /* Note: UART_FR.TXFE reads 0 if the UART clock is gated. */
-    if((REG(SYS_CTRL_RCGCUART) & regs->sys_ctrl_rcgcuart_uart) != 0 &&
-       (REG(regs->base + UART_FR) & UART_FR_TXFE) == 0) {
+    if((REG(regs->base + UART_FR) & UART_FR_BUSY) != 0) {
       return false;
     }
   }


### PR DESCRIPTION
`lpm_enter()` must not enter PM1+ if the UART is transmitting. Otherwise, the UART clock gets disabled, and its TX is broken.

The commit b8b54a033c67e2dbb98dabda6d1b4c9e64d5db90 from #408 had already partially fixed this issue, but it could still occur while transmitting stop bits because, contrary to `UART_FR.BUSY`, `UART_FR.TXFE` takes only the data bits into account, not the stop bits.