### PR TITLE
galileo: Add process to perform DHCP configuration

### DIFF
--- a/platform/galileo/contiki-main.c
+++ b/platform/galileo/contiki-main.c
@@ -65,9 +65,9 @@ app_main(void)
   process_init();
   procinit_init();
   ctimer_init();
-  autostart_start(autostart_processes);
-
   eth_init();
+
+  autostart_start(autostart_processes);
 
   while(1) {
     process_run();

--- a/platform/galileo/net/eth-conf.c
+++ b/platform/galileo/net/eth-conf.c
@@ -29,8 +29,10 @@
  */
 
 #include "eth-conf.h"
+#include <stdio.h>
 #include "net/eth-proc.h"
 #include "contiki-net.h"
+#include "net/ip/dhcpc.h"
 #include "net/linkaddr.h"
 
 #if NETSTACK_CONF_WITH_IPV6
@@ -43,6 +45,8 @@ const linkaddr_t linkaddr_null = { { 0, 0, 0, 0, 0, 0 } };
 #define GATEWAY_IP      SUBNET_IP, 1
 #define NAMESERVER_IP   GATEWAY_IP
 #endif
+
+PROCESS(dhcp_process, "DHCP");
 
 /*---------------------------------------------------------------------------*/
 void
@@ -70,5 +74,52 @@ eth_init(void)
 #endif
 
   process_start(&eth_process, NULL);
+  /* Comment out the following line to disable DHCP and simply use the static
+   * IP configuration setup above.
+   */
+  process_start(&dhcp_process, NULL);
+}
+/*---------------------------------------------------------------------------*/
+PROCESS_THREAD(dhcp_process, ev, data)
+{
+  PROCESS_BEGIN();
+
+  dhcpc_init(uip_lladdr.addr, sizeof(uip_lladdr.addr));
+
+  printf("Requesting DHCP configuration...\n");
+  dhcpc_request();
+
+  while(1) {
+    PROCESS_WAIT_EVENT();
+
+    if(ev == tcpip_event || ev == PROCESS_EVENT_TIMER) {
+      dhcpc_appcall(ev, data);
+    } else if(ev == PROCESS_EVENT_EXIT) {
+      process_exit(&dhcp_process);
+    }
+  }
+
+  PROCESS_END();
+}
+/*---------------------------------------------------------------------------*/
+void
+dhcpc_configured(const struct dhcpc_state *s)
+{
+  uip_sethostaddr(&s->ipaddr);
+  uip_setnetmask(&s->netmask);
+  uip_setdraddr(&s->default_router);
+  uip_nameserver_update(&s->dnsaddr, UIP_NAMESERVER_INFINITE_LIFETIME);
+  printf("DHCP configured:\n");
+  printf(" - Host IP:        %d.%d.%d.%d\n", uip_ipaddr_to_quad(&s->ipaddr));
+  printf(" - Netmask:        %d.%d.%d.%d\n", uip_ipaddr_to_quad(&s->netmask));
+  printf(" - Default router: %d.%d.%d.%d\n",
+         uip_ipaddr_to_quad(&s->default_router));
+  printf(" - DNS server:     %d.%d.%d.%d\n", uip_ipaddr_to_quad(&s->dnsaddr));
+}
+/*---------------------------------------------------------------------------*/
+void
+dhcpc_unconfigured(const struct dhcpc_state *s)
+{
+  printf("DHCP unconfigured.\n");
 }
 /*---------------------------------------------------------------------------*/


### PR DESCRIPTION
This patch adds a process that is started automatically to request DHCP
configuration.  It also moves the IP configuration ahead of autostart processes
in case some autostart process depends on the IP configuration.