### PR TITLE
MSP430/F2xxx: fix ubr msb byte being hardcoded to zero

### DIFF
--- a/cpu/msp430/f2xxx/uart0.c
+++ b/cpu/msp430/f2xxx/uart0.c
@@ -146,8 +146,8 @@ uart0_init(unsigned long ubr)
   UCA0CTL1 |= UCSWRST;            /* Hold peripheral in reset state */
   UCA0CTL1 |= UCSSEL_2;           /* CLK = SMCLK */
 
-  UCA0BR0 = ubr;                 /* 8MHz/115200 = 69 = 0x45 */
-  UCA0BR1 = 0x00;
+  UCA0BR0 = ((uint8_t *)&ubr)[0]; /* 8MHz/115200 = 69 = 0x45 */
+  UCA0BR1 = ((uint8_t *)&ubr)[1];
   UCA0MCTL = UCBRS_3;             /* Modulation UCBRSx = 3 */
 
   P3DIR &= ~0x20;                 /* P3.5 = USCI_A0 RXD as input */


### PR DESCRIPTION
This PR request fixes UART0 initialization with a hard-coded UBR's MSB register to zero, preventing baudrates like 9600 from properly being configured.  Tested for 115200 and 9600 baud rates, using any of the Z1 test examples with putty configured for the tested baudrates.