### PR TITLE
fix misplaced bracket causing compilation error when probing is disabled

### DIFF
--- a/core/net/rpl/rpl-dag.c
+++ b/core/net/rpl/rpl-dag.c
@@ -917,11 +917,11 @@ rpl_select_parent(rpl_dag_t *dag)
       /* Probe the best parent shortly in order to get a fresh estimate */
       dag->instance->urgent_probing_target = best;
       rpl_schedule_probing(dag->instance);
+    }
 #else /* RPL_WITH_PROBING */
       rpl_set_preferred_parent(dag, best);
       dag->rank = rpl_rank_via_parent(dag->preferred_parent);
 #endif /* RPL_WITH_PROBING */
-    }
   } else {
     rpl_set_preferred_parent(dag, NULL);
   }

--- a/core/net/rpl/rpl-dag.c
+++ b/core/net/rpl/rpl-dag.c
@@ -919,8 +919,8 @@ rpl_select_parent(rpl_dag_t *dag)
       rpl_schedule_probing(dag->instance);
     }
 #else /* RPL_WITH_PROBING */
-      rpl_set_preferred_parent(dag, best);
-      dag->rank = rpl_rank_via_parent(dag->preferred_parent);
+    rpl_set_preferred_parent(dag, best);
+    dag->rank = rpl_rank_via_parent(dag->preferred_parent);
 #endif /* RPL_WITH_PROBING */
   } else {
     rpl_set_preferred_parent(dag, NULL);


### PR DESCRIPTION
When configuring a project to not use RPL parent probing (ex: we set RPL_CONF_WITH_PROBING to 0 in our project configuration), a misplaced bracket causes a compilation error in function rpl_select_parent of the file core/net/rpl/rpl-dag.c.