### PR TITLE
DAD: Remove useless "if" that tests if the source address is unspecified

### DIFF
--- a/core/net/ipv6/uip-nd6.c
+++ b/core/net/ipv6/uip-nd6.c
@@ -157,7 +157,27 @@ create_llao(uint8_t *llao, uint8_t type) {
 }
 
 /*------------------------------------------------------------------*/
-
+ /**
+ * Neighbor Solicitation Processing
+ *
+ * The NS can be received in 3 cases (procedures):
+ * - sender is performing DAD (ip src = unspecified, no SLLAO option)
+ * - sender is performing NUD (ip dst = unicast)
+ * - sender is performing address resolution (ip dest = solicited node mcast
+ * address)
+ *
+ * We do:
+ * - if the tgt belongs to me, reply, otherwise ignore
+ * - if i was performing DAD for the same address, two cases:
+ * -- I already sent a NS, hence I win
+ * -- I did not send a NS yet, hence I lose
+ *
+ * If we need to send a NA in response (i.e. the NS was done for NUD, or
+ * address resolution, or DAD and there is a conflict), we do it in this
+ * function: set src, dst, tgt address in the three cases, then for all cases
+ * set the rest, including  SLLAO
+ *
+ */
 #if UIP_ND6_SEND_NA
 static void
 ns_input(void)

--- a/core/net/ipv6/uip-nd6.c
+++ b/core/net/ipv6/uip-nd6.c
@@ -238,9 +238,9 @@ ns_input(void)
 
   addr = uip_ds6_addr_lookup(&UIP_ND6_NS_BUF->tgtipaddr);
   if(addr != NULL) {
-#if UIP_ND6_DEF_MAXDADNS > 0
     if(uip_is_addr_unspecified(&UIP_IP_BUF->srcipaddr)) {
       /* DAD CASE */
+#if UIP_ND6_DEF_MAXDADNS > 0
 #if UIP_CONF_IPV6_CHECKS
       if(!uip_is_addr_solicited_node(&UIP_IP_BUF->destipaddr)) {
         PRINTF("NS received is bad\n");
@@ -258,9 +258,7 @@ ns_input(void)
         goto discard;
       }
 #else /* UIP_ND6_DEF_MAXDADNS > 0 */
-    if(uip_is_addr_unspecified(&UIP_IP_BUF->srcipaddr)) {
-      /* DAD CASE */
-      goto discard;
+      goto discard;  /* DAD CASE */
 #endif /* UIP_ND6_DEF_MAXDADNS > 0 */
     }
 #if UIP_CONF_IPV6_CHECKS

--- a/core/net/ipv6/uip-nd6.h
+++ b/core/net/ipv6/uip-nd6.h
@@ -336,30 +336,6 @@ typedef struct uip_nd6_opt_redirected_hdr {
  * @{
  */
  /**
- * \brief Process a neighbor solicitation
- *
- * The NS can be received in 3 cases (procedures):
- * - sender is performing DAD (ip src = unspecified, no SLLAO option)
- * - sender is performing NUD (ip dst = unicast)
- * - sender is performing address resolution (ip dest = solicited node mcast
- * address)
- *
- * We do:
- * - if the tgt belongs to me, reply, otherwise ignore
- * - if i was performing DAD for the same address, two cases:
- * -- I already sent a NS, hence I win
- * -- I did not send a NS yet, hence I lose
- *
- * If we need to send a NA in response (i.e. the NS was done for NUD, or
- * address resolution, or DAD and there is a conflict), we do it in this
- * function: set src, dst, tgt address in the three cases, then for all cases
- * set the rest, including  SLLAO
- *
- */
-void
-uip_nd6_ns_input(void);
-
-/**
  * \brief Send a neighbor solicitation, send a Neighbor Advertisement
  * \param src pointer to the src of the NS if known
  * \param dest pointer to ip address to send the NS, for DAD or ADDR Resol,


### PR DESCRIPTION
No need to do the unspecified address twice.
# if UIP_ND6_DEF_MAXDADNS > 0

```
if(uip_is_addr_unspecified(&UIP_IP_BUF->srcipaddr)) {
  /* DAD CASE */
   ..........
```
# else /\* UIP_ND6_DEF_MAXDADNS > 0 */

```
if(uip_is_addr_unspecified(&UIP_IP_BUF->srcipaddr)) {
  /* DAD CASE */
  goto discard; 
```
# endif /\* UIP_ND6_DEF_MAXDADNS > 0 */

this logic will bring confusion, especially when someone try to understand the implementation of other ND functions (NUD, address resolution)  .
