### PR TITLE
use the arm-none-eabi toolchain by default

### DIFF
--- a/cpu/arm/stm32f103/Makefile.stm32f103
+++ b/cpu/arm/stm32f103/Makefile.stm32f103
@@ -40,14 +40,15 @@ CONTIKI_SOURCEFILES        += $(CONTIKI_TARGET_SOURCEFILES)
 
 THREADS =
 
+CROSS_COMPILE ?= arm-none-eabi-
 ### Compiler definitions
-CC       = arm-elf-gcc
-LD       = arm-elf-ld
-AS       = arm-elf-as
-AR       = arm-elf-ar
-NM       = arm-elf-nm
-OBJCOPY  = arm-elf-objcopy
-STRIP    = arm-elf-strip
+CC       = $(CROSS_COMPILE)gcc
+LD       = $(CROSS_COMPILE)ld
+AS       = $(CROSS_COMPILE)as
+AR       = $(CROSS_COMPILE)ar
+NM       = $(CROSS_COMPILE)nm
+OBJCOPY  = $(CROSS_COMPILE)objcopy
+STRIP    = $(CROSS_COMPILE)strip
 
 XSLTPROC=xsltproc
 


### PR DESCRIPTION
Since the InstantContiki does not include the arm-elf toolchain, we need to change it

Signed-off-by: Yong Li <sdliyong@gmail.com>