### PR TITLE
Improved serialdump.c

### DIFF
--- a/tools/sky/serialdump.c
+++ b/tools/sky/serialdump.c
@@ -208,6 +208,8 @@ main(int argc, char **argv)
   options.c_cflag |= CS8;
 
   /* Raw input */
+  options.c_iflag &= ~(IGNBRK | BRKINT | PARMRK | ISTRIP
+                       | INLCR | IGNCR | ICRNL | IXON);
   options.c_lflag &= ~(ICANON | ECHO | ECHOE | ISIG);
   /* Raw output */
   options.c_oflag &= ~OPOST;

--- a/tools/sky/serialdump.c
+++ b/tools/sky/serialdump.c
@@ -281,6 +281,11 @@ main(int argc, char **argv)
         perror("could not read");
         exit(-1);
       }
+      if(n == 0) {
+        errno = EBADF;
+        perror("serial device disconnected");
+        exit(-1);
+      }
 
       for(i = 0; i < n; i++) {
         switch(mode) {

--- a/tools/sky/serialdump.c
+++ b/tools/sky/serialdump.c
@@ -8,6 +8,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
+#include <signal.h>
 
 #define BAUDRATE B115200
 #define BAUDRATE_S "115200"
@@ -82,9 +83,17 @@ print_hex_line(char *prefix, unsigned char *outbuf, int index)
   }
 }
 
+static void
+intHandler(int sig)
+{
+  exit(0);
+}
+
 int
 main(int argc, char **argv)
 {
+  signal(SIGINT, intHandler);
+
   struct termios options;
   fd_set mask, smask;
   int fd;


### PR DESCRIPTION
This PR fixes some issues we found when working with serialdump on our own Contiki fork.

First, it adresses the issue that serialdump sometimes injects newlines while running. This results from not configured `c_iflag` in terminos. Depending on your system it might be configured to replace carriage returns with newlines or vice versa. This results in excessive newlines in the terminal output and wrong output when transferring binary data. While at it I made sure to initialize all `c_iflag` values to make it work reproducible.

Second, it makes serialdump terminate when the serial device gets disconnected, e.g. when the USB cable is unplugged. The original behaviour was that serialdump runs indefinitely without recovering even when replugging the USB device.

Third, serialdump exits cleanly (returns 0) when terminated via `SIGINT` (`ctrl-c`). This is especially handy when used via `make login` as make will not assume anymore that the build failed.
