### PR TITLE
Doxygen Fix

### DIFF
--- a/platform/zoul/remote-reva/power-mgmt.h
+++ b/platform/zoul/remote-reva/power-mgmt.h
@@ -152,29 +152,29 @@ typedef enum {
  * @{
  */
 /** \brief Initializes the Power Management driver
- * \return \c   PM_SUCCESS if initialized, else \c PM_ERROR
+ * \return PM_SUCCESS if initialized, else PM_ERROR
  */
 int8_t pm_init(void);
 /* -------------------------------------------------------------------------- */
 /** \brief Enable the shutdown mode, periodically driven by the Nano Timer
- * \return \c   PM_SUCCESS if successful, else \c PM_ERROR
+ * \return PM_SUCCESS if successful, else PM_ERROR
  */
 int8_t pm_enable_timer(void);
 /* -------------------------------------------------------------------------- */
 /** \brief Disable the Nano Timer
- * \return \c   PM_SUCCESS if successful, else \c PM_ERROR
+ * \return PM_SUCCESS if successful, else  PM_ERROR
  */
 int8_t pm_disable_timer(void);
 /* -------------------------------------------------------------------------- */
 /** \brief Get the current state of the power management module
  * \param state Pointer to a variable to save the state
- * \return \c   PM_SUCCESS if successful, else \c PM_ERROR
+ * \return PM_SUCCESS if successful, else  PM_ERROR
  */
 int8_t pm_get_state(uint8_t *state);
 /* -------------------------------------------------------------------------- */
 /** \brief Get the firmware version of the power management module
  * \param state Pointer to a variable to save the state
- * \return \c   PM_SUCCESS if successful, else \c PM_ERROR
+ * \return PM_SUCCESS if successful, else  PM_ERROR
  */
 int8_t pm_get_firmware_version(uint8_t *state);
 /* -------------------------------------------------------------------------- */


### PR DESCRIPTION
this minor fixation to avoid Doxygen bug, which appears when doing this in the documented code:
/**
/* \exception \c text
*/
void foo();