### PR TITLE
Change on DIO trickle timer condition for DIO sending

### DIFF
--- a/core/net/rpl/rpl-timers.c
+++ b/core/net/rpl/rpl-timers.c
@@ -174,7 +174,7 @@ handle_dio_timer(void *ptr)
 
   if(instance->dio_send) {
     /* send DIO if counter is less than desired redundancy */
-    if(instance->dio_redundancy != 0 && instance->dio_counter < instance->dio_redundancy) {
+    if(instance->dio_redundancy == 0 || instance->dio_counter < instance->dio_redundancy) {
 #if RPL_CONF_STATS
       instance->dio_totsend++;
 #endif /* RPL_CONF_STATS */


### PR DESCRIPTION
The two changes are into the condition for the transmission of DIO. The third is commented in the code.
1) The first is to be compliant to the RFC6550 that says: "In RPL, when k (i.e. DIORedundancyConstant) has the value of 0x00, this is to be treated as a redundancy constant of infinity in RPL, i.e., Trickle never suppresses messages). So, when the  instance->dio_redundancy is equal to 0, we can't suppress DIO transmission. This is the way to allow user to disable DIO suppression.
2) If we don't want to set the default route lifetime to infinite, in the case of a very large network (nodes > 40), there will be a high probability that instance->dio_counter is greater than instance->dio_redundancy. In this case the node will not send DIO anymore in the future (more so if this node is the root). So, other nodes will not receive anymore DIO from this node, and this node will be removed from the NB list. So, when we reach the maximum doubling of DIO interval, it is recommended to send DIO anyway to keep other nodes updated about this node.
3) Another possible change alternative to this is to multiply instance->dio_redundancy to the difference between actual interval and minimum interval (the longer the interval, the more numerous will be the received DIO... we can't keep the redundancy constant to a "constant" value!!!!).

In any case it is recommended to keep the RPL_CONF_DIO_REDUNDANCY high (>= nodes) when the network contains a large number of nodes.
