### PR TITLE
OpenMote: Convenient flashing via OpenUSBs

### DIFF
--- a/platform/openmote-cc2538/Makefile.openmote-cc2538
+++ b/platform/openmote-cc2538/Makefile.openmote-cc2538
@@ -1,5 +1,10 @@
 # openmote-cc2538 platform makefile
 
+### Allow the OpenMote-CC2538 platform to support different CC2538 chip revisions
+ifeq ($(findstring REV_A1,$(BOARD_REVISION)),REV_A1)
+    CFLAGS+=-DCC2538_DEV_CONF=CC2538_DEV_CC2538SF23
+endif
+
 ifndef CONTIKI
   $(error CONTIKI not defined! You must specify where CONTIKI resides!)
 endif
@@ -31,7 +36,17 @@ MODULES += core/net core/net/mac \
            core/net/llsec core/net/llsec/noncoresec
 
 PYTHON = python
-BSL_FLAGS += -e -w -v -b 450000
+BSL_FLAGS += -e -w -v -b 450000 --bootloader-invert-lines
+
+ifndef USBDEVPREFIX
+  USBDEVPREFIX=/dev/ttyUSB
+endif
+
+ifndef MOTE
+  MOTE=0
+endif
+
+PORT := $(USBDEVPREFIX)$(MOTE)
 
 ifdef PORT
   BSL_FLAGS += -p $(PORT)
@@ -48,3 +63,10 @@ else
 	                               sort -g | head -1))
 	$(PYTHON) $(BSL) $(BSL_FLAGS) $(BSL_ADDRESS_ARG) $<
 endif
+
+SERIALDUMP = $(CONTIKI)/tools/sky/serialdump-linux 
+login:
+	$(SERIALDUMP) -b115200 $(PORT)
+
+grabserial:
+	grabserial -t -d "$(PORT)"


### PR DESCRIPTION
Using OpenUSBs (aka OpenBattery2), OpenMotes can now be flashed without enabling the bootloader backdoor manually. It works fine with these changes.
