### PR TITLE
Cc26xx/cc13xx generic I2C library

### DIFF
--- a/platform/srf06-cc26xx/common/i2c.c
+++ b/platform/srf06-cc26xx/common/i2c.c
@@ -297,6 +297,12 @@ i2c_write_read(uint8_t *wdata, uint8_t wlen, uint8_t *rdata, uint8_t rlen)
   return success;
 }
 /*---------------------------------------------------------------------------*/
+bool
+i2c_write_single_read_multi(uint8_t wdata, uint8_t *buf, uint8_t len)
+{
+  return i2c_write_read(&wdata, 1, buf, len);
+}
+/*---------------------------------------------------------------------------*/
 void
 i2c_select(uint32_t new_pin_sda,
                  uint32_t new_pin_scl,

--- a/platform/srf06-cc26xx/common/i2c.c
+++ b/platform/srf06-cc26xx/common/i2c.c
@@ -85,7 +85,7 @@ accessible(void)
 }
 /*---------------------------------------------------------------------------*/
 void
-i2c_wakeup()
+i2c_wakeup(void)
 {
   PRINTF("I2C: Waking up\n");
   /* First, make sure the SERIAL PD is on */
@@ -104,7 +104,7 @@ i2c_wakeup()
 }
 /*---------------------------------------------------------------------------*/
 static bool
-i2c_status()
+i2c_status(void)
 {
   uint32_t status;
 
@@ -117,7 +117,7 @@ i2c_status()
 }
 /*---------------------------------------------------------------------------*/
 void
-i2c_shutdown()
+i2c_shutdown(void)
 {
   //PRINTF("I2C: Shutting down\n");
   /* If selected, deselect first */
@@ -344,7 +344,7 @@ i2c_select(uint32_t new_pin_sda,
 }
 /*---------------------------------------------------------------------------*/
 void
-i2c_deselect()
+i2c_deselect(void)
 {
   /* Deselect only if selected */
   if(selected_pin_sda != I2C_PIN_NOT_SET ||

--- a/platform/srf06-cc26xx/common/i2c.h
+++ b/platform/srf06-cc26xx/common/i2c.h
@@ -29,44 +29,50 @@
  */
 /*---------------------------------------------------------------------------*/
 /**
- * \addtogroup sensortag-cc26xx-peripherals
- * @{
+ * \author Andreas Urke <arurke@gmail.com>
  *
- * \defgroup sensortag-cc26xx-i2c SensorTag 2.0 I2C functions
+ * \defgroup cc26xx-cc13xx-i2c cc26xx/cc13xx Generic I2C functions
  * @{
  *
  * \file
- * Header file for the Sensortag-CC26xx I2C Driver
+ * Header file for the generic cc26xx/cc13xx I2C Driver
  */
 /*---------------------------------------------------------------------------*/
-#ifndef BOARD_I2C_H_
-#define BOARD_I2C_H_
+#ifndef I2C_H_
+#define I2C_H_
 /*---------------------------------------------------------------------------*/
 #include <stdint.h>
 #include <stdbool.h>
 /*---------------------------------------------------------------------------*/
-#define BOARD_I2C_INTERFACE_0     0
-#define BOARD_I2C_INTERFACE_1     1
+#define I2C_SPEED_NORMAL      false
+#define I2C_SPEED_FAST        true
+#define I2C_PULL_DOWN         IOC_IOPULL_DOWN
+#define I2C_PULL_UP           IOC_IOPULL_UP
+#define I2C_PULL_NO_PULL      IOC_NO_IOPULL
 /*---------------------------------------------------------------------------*/
 /**
- * \brief Put the I2C controller in a known state
+ * \brief Deselect I2C slave
  *
- * In this state, pins SDA and SCL will be under i2c control and pins SDA HP
- * and SCL HP will be configured as gpio inputs. This is equal to selecting
- * BOARD_I2C_INTERFACE_0, but without selecting a slave device address
+ * Sets selected pins to GPIO input and internal pull to configured pull.
+ * This is also called by i2c_shutdown(). Should be called by user
+ * after done with I2C read/write operations.
  */
-#define board_i2c_deselect() board_i2c_select(BOARD_I2C_INTERFACE_0, 0)
+void i2c_deselect();
 /*---------------------------------------------------------------------------*/
 /**
  * \brief Select an I2C slave
- * \param interface The I2C interface to be used (BOARD_I2C_INTERFACE_0 or _1)
- * \param slave_addr The slave's address
+ * \param new_pin_sda SDA pin IOID
+ * \param new_pin_scl SCL pin IOID
+ * \param new_slave_address The slave's address
+ * \param new_speed I2C speed, I2C_SPEED_NORMAL or I2C_SPEED_FAST
+ * \param new_pin_pull SCL & SDA pin internal pull to set at deselect/shutdown
+ *                     , valid values I2C_PULL_DOWN/UP/NO_PULL
  *
- * The various sensors on the sensortag are connected either on interface 0 or
- * 1. All sensors are connected to interface 0, with the exception of the MPU
- * that is connected to 1.
+ * Must be called before read/write commands
  */
-void board_i2c_select(uint8_t interface, uint8_t slave_addr);
+void i2c_select(uint32_t new_pin_sda, uint32_t new_pin_scl,
+                      uint8_t new_slave_address, bool new_speed,
+                      uint32_t new_pin_pull);
 
 /**
  * \brief Burst read from an I2C device
@@ -74,7 +80,7 @@ void board_i2c_select(uint8_t interface, uint8_t slave_addr);
  * \param len Number of bytes to read
  * \return True on success
  */
-bool board_i2c_read(uint8_t *buf, uint8_t len);
+bool i2c_read(uint8_t *buf, uint8_t len);
 
 /**
  * \brief Burst write to an I2C device
@@ -82,14 +88,14 @@ bool board_i2c_read(uint8_t *buf, uint8_t len);
  * \param len Number of bytes to write
  * \return True on success
  */
-bool board_i2c_write(uint8_t *buf, uint8_t len);
+bool i2c_write(uint8_t *buf, uint8_t len);
 
 /**
  * \brief Single write to an I2C device
  * \param data The byte to write
  * \return True on success
  */
-bool board_i2c_write_single(uint8_t data);
+bool i2c_write_single(uint8_t data);
 
 /**
  * \brief Write and read in one operation
@@ -99,7 +105,7 @@ bool board_i2c_write_single(uint8_t data);
  * \param rlen Number of bytes to read
  * \return True on success
  */
-bool board_i2c_write_read(uint8_t *wdata, uint8_t wlen, uint8_t *rdata,
+bool i2c_write_read(uint8_t *wdata, uint8_t wlen, uint8_t *rdata,
                           uint8_t rlen);
 
 /**
@@ -108,12 +114,12 @@ bool board_i2c_write_read(uint8_t *wdata, uint8_t wlen, uint8_t *rdata,
  * This function is called to wakeup and initialise the I2C.
  *
  * This function can be called explicitly, but it will also be called
- * automatically by board_i2c_select() when required. One of those two
+ * automatically by i2c_select() when required. One of those two
  * functions MUST be called before any other I2C operation after a chip
- * sleep / wakeup cycle or after a call to board_i2c_shutdown(). Failing to do
+ * sleep / wakeup cycle or after a call to i2c_shutdown(). Failing to do
  * so will lead to a bus fault.
  */
-void board_i2c_wakeup(void);
+void i2c_wakeup(void);
 
 /**
  * \brief Stops the I2C peripheral and restores pins to s/w control
@@ -121,11 +127,10 @@ void board_i2c_wakeup(void);
  * This function is called automatically by the board's LPM logic, but it
  * can also be called explicitly.
  */
-void board_i2c_shutdown(void);
+void i2c_shutdown(void);
 /*---------------------------------------------------------------------------*/
-#endif /* BOARD_I2C_H_ */
+#endif /* I2C_H_ */
 /*---------------------------------------------------------------------------*/
 /**
- * @}
  * @}
  */

--- a/platform/srf06-cc26xx/common/i2c.h
+++ b/platform/srf06-cc26xx/common/i2c.h
@@ -57,7 +57,7 @@
  * This is also called by i2c_shutdown(). Should be called by user
  * after done with I2C read/write operations.
  */
-void i2c_deselect();
+void i2c_deselect(void);
 /*---------------------------------------------------------------------------*/
 /**
  * \brief Select an I2C slave
@@ -115,8 +115,7 @@ bool i2c_write_read(uint8_t *wdata, uint8_t wlen, uint8_t *rdata,
  * \param len Number of bytes to read
  * \return True on success
  */
-bool
-i2c_write_single_read_multi(uint8_t wdata, uint8_t *buf, uint8_t len);
+bool i2c_write_single_read_multi(uint8_t wdata, uint8_t *buf, uint8_t len);
 
 /**
  * \brief Enables the I2C peripheral with defaults

--- a/platform/srf06-cc26xx/common/i2c.h
+++ b/platform/srf06-cc26xx/common/i2c.h
@@ -109,6 +109,16 @@ bool i2c_write_read(uint8_t *wdata, uint8_t wlen, uint8_t *rdata,
                           uint8_t rlen);
 
 /**
+ * \brief Write one byte and read len bytes in one operation
+ * \param wdata The byte to be written
+ * \param buf Pointer to the buffer where the read data will be stored
+ * \param len Number of bytes to read
+ * \return True on success
+ */
+bool
+i2c_write_single_read_multi(uint8_t wdata, uint8_t *buf, uint8_t len);
+
+/**
  * \brief Enables the I2C peripheral with defaults
  *
  * This function is called to wakeup and initialise the I2C.

--- a/platform/srf06-cc26xx/sensortag/Makefile.sensortag
+++ b/platform/srf06-cc26xx/sensortag/Makefile.sensortag
@@ -7,4 +7,4 @@ BOARD_SOURCEFILES += sensortag-sensors.c  sensor-common.c
 BOARD_SOURCEFILES += bmp-280-sensor.c tmp-007-sensor.c opt-3001-sensor.c
 BOARD_SOURCEFILES += hdc-1000-sensor.c mpu-9250-sensor.c button-sensor.c
 BOARD_SOURCEFILES += reed-relay.c ext-flash.c buzzer.c
-BOARD_SOURCEFILES += board.c board-spi.c board-i2c.c
+BOARD_SOURCEFILES += board.c board-spi.c i2c.c

--- a/platform/srf06-cc26xx/sensortag/bmp-280-sensor.c
+++ b/platform/srf06-cc26xx/sensortag/bmp-280-sensor.c
@@ -41,7 +41,7 @@
 #include "bmp-280-sensor.h"
 #include "sys/ctimer.h"
 #include "sensor-common.h"
-#include "board-i2c.h"
+#include "common/i2c.h"
 #include "ti-lib.h"
 
 #include <stdint.h>
@@ -151,7 +151,8 @@ static void
 select_on_bus(void)
 {
   /* Set up I2C */
-  board_i2c_select(BOARD_I2C_INTERFACE_0, BMP280_I2C_ADDRESS);
+  i2c_select(BOARD_IOID_SDA, BOARD_IOID_SCL, BMP280_I2C_ADDRESS,
+             I2C_SPEED_FAST, I2C_PULL_DOWN);
 }
 /*---------------------------------------------------------------------------*/
 /**

--- a/platform/srf06-cc26xx/sensortag/board.c
+++ b/platform/srf06-cc26xx/sensortag/board.c
@@ -42,8 +42,7 @@
 #include "lpm.h"
 #include "ti-lib.h"
 #include "board-peripherals.h"
-#include "board-i2c.h"
-
+#include "common/i2c.h"
 #include <stdint.h>
 #include <string.h>
 #include <stdbool.h>
@@ -79,7 +78,7 @@ shutdown_handler(uint8_t mode)
   }
 
   /* In all cases, stop the I2C */
-  board_i2c_shutdown();
+  i2c_shutdown();
 }
 /*---------------------------------------------------------------------------*/
 /*
@@ -141,7 +140,7 @@ board_init()
   while(!ti_lib_prcm_load_get());
 
   /* I2C controller */
-  board_i2c_wakeup();
+  i2c_wakeup();
 
   buzzer_init();
 

--- a/platform/srf06-cc26xx/sensortag/hdc-1000-sensor.c
+++ b/platform/srf06-cc26xx/sensortag/hdc-1000-sensor.c
@@ -41,8 +41,7 @@
 #include "lib/sensors.h"
 #include "hdc-1000-sensor.h"
 #include "sensor-common.h"
-#include "board-i2c.h"
-
+#include "common/i2c.h"
 #include "ti-lib.h"
 
 #include <stdint.h>
@@ -76,8 +75,10 @@
 #define HDC1000_VAL_CONFIG         0x1000 /* 14 bit, acquired in sequence */
 
 /* Sensor selection/deselection */
-#define SENSOR_SELECT()     board_i2c_select(BOARD_I2C_INTERFACE_0, SENSOR_I2C_ADDRESS)
-#define SENSOR_DESELECT()   board_i2c_deselect()
+#define SENSOR_SELECT()   i2c_select(BOARD_IOID_SDA, BOARD_IOID_SCL, \
+                                     SENSOR_I2C_ADDRESS, \
+                                     I2C_SPEED_FAST, I2C_PULL_DOWN);
+#define SENSOR_DESELECT() i2c_deselect()
 /*---------------------------------------------------------------------------*/
 /* Byte swap of 16-bit register value */
 #define HI_UINT16(a) (((a) >> 8) & 0xFF)
@@ -144,7 +145,7 @@ start(void)
   if(success) {
     SENSOR_SELECT();
 
-    success = board_i2c_write_single(HDC1000_REG_TEMP);
+    success = i2c_write_single(HDC1000_REG_TEMP);
     SENSOR_DESELECT();
   }
 }
@@ -161,7 +162,7 @@ read_data()
   if(success) {
     SENSOR_SELECT();
 
-    success = board_i2c_read((uint8_t *)&data, sizeof(data));
+    success = i2c_read((uint8_t *)&data, sizeof(data));
     SENSOR_DESELECT();
 
     /* Store temperature */

--- a/platform/srf06-cc26xx/sensortag/mpu-9250-sensor.c
+++ b/platform/srf06-cc26xx/sensortag/mpu-9250-sensor.c
@@ -41,8 +41,7 @@
 #include "mpu-9250-sensor.h"
 #include "sys/rtimer.h"
 #include "sensor-common.h"
-#include "board-i2c.h"
-
+#include "common/i2c.h"
 #include "ti-lib.h"
 
 #include <stdint.h>
@@ -200,8 +199,10 @@
 #define MPU_MOVEMENT      0x40
 /*---------------------------------------------------------------------------*/
 /* Sensor selection/deselection */
-#define SENSOR_SELECT()     board_i2c_select(BOARD_I2C_INTERFACE_1, SENSOR_I2C_ADDRESS)
-#define SENSOR_DESELECT()   board_i2c_deselect()
+#define SENSOR_SELECT()   i2c_select(BOARD_IOID_SDA_HP, BOARD_IOID_SCL_HP, \
+                                     SENSOR_I2C_ADDRESS, \
+                                     I2C_SPEED_FAST, I2C_PULL_UP)
+#define SENSOR_DESELECT() i2c_deselect()
 /*---------------------------------------------------------------------------*/
 /* Delay */
 #define delay_ms(i) (ti_lib_cpu_delay(8000 * (i)))

--- a/platform/srf06-cc26xx/sensortag/opt-3001-sensor.c
+++ b/platform/srf06-cc26xx/sensortag/opt-3001-sensor.c
@@ -41,8 +41,8 @@
 #include "opt-3001-sensor.h"
 #include "sys/ctimer.h"
 #include "ti-lib.h"
-#include "board-i2c.h"
 #include "sensor-common.h"
+#include "common/i2c.h"
 
 #include <stdint.h>
 #include <stdbool.h>
@@ -135,7 +135,8 @@ static void
 select_on_bus(void)
 {
   /* Select slave and set clock rate */
-  board_i2c_select(BOARD_I2C_INTERFACE_0, OPT3001_I2C_ADDRESS);
+  i2c_select(BOARD_IOID_SDA, BOARD_IOID_SCL, OPT3001_I2C_ADDRESS,
+             I2C_SPEED_FAST, I2C_PULL_DOWN);
 }
 /*---------------------------------------------------------------------------*/
 static void
@@ -151,7 +152,6 @@ notify_ready(void *not_used)
   select_on_bus();
 
   sensor_common_read_reg(REG_CONFIGURATION, (uint8_t *)&val, REGISTER_LENGTH);
-
   if(val & CONFIG_CRF) {
     sensors_changed(&opt_3001_sensor);
     state = SENSOR_STATE_DATA_READY;
@@ -183,7 +183,6 @@ enable_sensor(bool enable)
     /* Writing CONFIG_DISABLE to M bits will not clear CRF bits */
     state = SENSOR_STATE_SLEEPING | had_data_ready;
   }
-
   sensor_common_write_reg(REG_CONFIGURATION, (uint8_t *)&val, REGISTER_LENGTH);
 }
 /*---------------------------------------------------------------------------*/

--- a/platform/srf06-cc26xx/sensortag/sensor-common.c
+++ b/platform/srf06-cc26xx/sensortag/sensor-common.c
@@ -37,7 +37,7 @@
  */
 /*---------------------------------------------------------------------------*/
 #include "sensor-common.h"
-#include "board-i2c.h"
+#include "common/i2c.h"
 /*---------------------------------------------------------------------------*/
 /* Data to use when an error occurs */
 #define ERROR_DATA                         0xCC
@@ -47,7 +47,7 @@ static uint8_t buffer[32];
 bool
 sensor_common_read_reg(uint8_t addr, uint8_t *buf, uint8_t len)
 {
-  return board_i2c_write_read(&addr, 1, buf, len);
+  return i2c_write_read(&addr, 1, buf, len);
 }
 /*---------------------------------------------------------------------------*/
 bool
@@ -64,7 +64,7 @@ sensor_common_write_reg(uint8_t addr, uint8_t *buf, uint8_t len)
   len++;
 
   /* Send data */
-  return board_i2c_write(buffer, len);
+  return i2c_write(buffer, len);
 }
 /*---------------------------------------------------------------------------*/
 void

--- a/platform/srf06-cc26xx/sensortag/sensor-common.h
+++ b/platform/srf06-cc26xx/sensortag/sensor-common.h
@@ -42,10 +42,9 @@
 #ifndef SENSOR_H
 #define SENSOR_H
 /*---------------------------------------------------------------------------*/
-#include "board-i2c.h"
-
 #include <stdbool.h>
 #include <stdint.h>
+#include "common/i2c.h"
 /*---------------------------------------------------------------------------*/
 /**
  * \brief Reads a sensor's register over I2C

--- a/platform/srf06-cc26xx/sensortag/tmp-007-sensor.c
+++ b/platform/srf06-cc26xx/sensortag/tmp-007-sensor.c
@@ -40,8 +40,8 @@
 #include "lib/sensors.h"
 #include "tmp-007-sensor.h"
 #include "sys/ctimer.h"
-#include "board-i2c.h"
 #include "sensor-common.h"
+#include "common/i2c.h"
 #include "ti-lib.h"
 
 #include <stdint.h>
@@ -88,7 +88,9 @@
 
 #define SWAP(v) ((LO_UINT16(v) << 8) | HI_UINT16(v))
 /*---------------------------------------------------------------------------*/
-#define SELECT() board_i2c_select(BOARD_I2C_INTERFACE_0, SENSOR_I2C_ADDRESS)
+#define SELECT() i2c_select(BOARD_IOID_SDA, BOARD_IOID_SCL, \
+                            SENSOR_I2C_ADDRESS, I2C_SPEED_FAST, \
+                            I2C_PULL_DOWN)
 /*---------------------------------------------------------------------------*/
 static uint8_t buf[DATA_SIZE];
 static uint16_t val;


### PR DESCRIPTION
This PR modify the existing sensortag-specific board-i2c library to become generic and move it to /common/i2c.[c|h]. Usage is similar as before, i.e. user must call i2c_select() before i2c operations and should call i2c_deselect() afterwards. Added possibility to specify bus speed: i2c_select() now requires SCL & SDA pin IOID, bus speed (normal or fast), slave address and pin pull (internal pull to set at shutdown/deselect).
Usage of underlying I2C functions has been mostly carried over from the board-specific version. As I don't feel 100 % confident on the TI I2C library any reviews are welcome - in particular i2c_deselect() which has a somewhat different approach than the previous version.

Updated sensortag sensors to use the new library. Also added i2c_write_single_read_multi() for reading registers, which is a common task - this could replace sensor_common_read_reg() in sensor-common.c.

Tested on cc2650 sensortag.
