### PR TITLE
Renamed driver and reworked to support both TSL2561/TSL2563

### DIFF
--- a/examples/zolertia/zoul/Makefile
+++ b/examples/zolertia/zoul/Makefile
@@ -1,13 +1,13 @@
 DEFINES+=PROJECT_CONF_H=\"project-conf.h\"
 
-CONTIKI_PROJECT = zoul-demo test-tsl2563 test-sht25 test-servo.c
+CONTIKI_PROJECT = zoul-demo test-tsl256x test-sht25 test-servo.c
 CONTIKI_PROJECT += test-bmp085-bmp180 test-motion test-rotation-sensor
 CONTIKI_PROJECT += test-grove-light-sensor test-grove-loudness-sensor
 CONTIKI_PROJECT += test-weather-meter test-grove-gyro test-lcd test-iaq
 CONTIKI_PROJECT += test-pm10-sensor test-vac-sensor test-aac-sensor
 CONTIKI_PROJECT += test-zonik test-dht22.c test-ac-dimmer.c
 
-CONTIKI_TARGET_SOURCEFILES += tsl2563.c sht25.c bmpx8x.c motion-sensor.c
+CONTIKI_TARGET_SOURCEFILES += tsl256x.c sht25.c bmpx8x.c motion-sensor.c
 CONTIKI_TARGET_SOURCEFILES += adc-sensors.c weather-meter.c grove-gyro.c
 CONTIKI_TARGET_SOURCEFILES += rgb-bl-lcd.c pm10-sensor.c iaq.c zonik.c relay.c
 CONTIKI_TARGET_SOURCEFILES += dht22.c servo.c ac-dimmer.c

--- a/platform/zoul/dev/tsl256x.c
+++ b/platform/zoul/dev/tsl256x.c
@@ -29,11 +29,11 @@
  */
 /*---------------------------------------------------------------------------*/
 /**
- * \addtogroup zoul-tsl2563-sensor
+ * \addtogroup zoul-tsl256x-sensor
  * @{
  *
  * \file
- *  Driver for the external TSL2563 light sensor
+ *  Driver for the external TSL256X light sensor
  *
  * \author
  *         Antonio Lignan <alinan@zolertia.com>
@@ -45,7 +45,7 @@
 #include "dev/gpio.h"
 #include "dev/zoul-sensors.h"
 #include "lib/sensors.h"
-#include "tsl2563.h"
+#include "tsl256x.h"
 /*---------------------------------------------------------------------------*/
 #define DEBUG 0
 #if DEBUG
@@ -54,14 +54,14 @@
 #define PRINTF(...)
 #endif
 /*---------------------------------------------------------------------------*/
-#define TSL2563_INT_PORT_BASE  GPIO_PORT_TO_BASE(I2C_INT_PORT)
-#define TSL2563_INT_PIN_MASK   GPIO_PIN_MASK(I2C_INT_PIN)
+#define TSL256X_INT_PORT_BASE  GPIO_PORT_TO_BASE(I2C_INT_PORT)
+#define TSL256X_INT_PIN_MASK   GPIO_PIN_MASK(I2C_INT_PIN)
 /*---------------------------------------------------------------------------*/
 static uint8_t enabled;
 static uint8_t gain;
 static uint8_t timming;
 /*---------------------------------------------------------------------------*/
-void (*tsl2563_int_callback)(uint8_t value);
+void (*tsl256x_int_callback)(uint8_t value);
 /*---------------------------------------------------------------------------*/
 static uint16_t
 calculate_lux(uint8_t *buf)
@@ -80,13 +80,13 @@ calculate_lux(uint8_t *buf)
   buffer[1] = (buf[3] << 8 | (buf[2]));
 
   switch(timming) {
-  case TSL2563_TIMMING_INTEG_402MS:
+  case TSL256X_TIMMING_INTEG_402MS:
     chscale = (1 << CH_SCALE);
     break;
-  case TSL2563_TIMMING_INTEG_101MS:
+  case TSL256X_TIMMING_INTEG_101MS:
     chscale = CHSCALE_TINT1;
     break;
-  case TSL2563_TIMMING_INTEG_13_7MS:
+  case TSL256X_TIMMING_INTEG_13_7MS:
     chscale = CHSCALE_TINT0;
     break;
   }
@@ -132,135 +132,135 @@ calculate_lux(uint8_t *buf)
 }
 /*---------------------------------------------------------------------------*/
 static int
-tsl2563_read_reg(uint8_t reg, uint8_t *buf, uint8_t regNum)
+tsl256x_read_reg(uint8_t reg, uint8_t *buf, uint8_t regNum)
 {
   i2c_master_enable();
-  if(i2c_single_send(TSL2563_ADDR, reg) == I2C_MASTER_ERR_NONE) {
+  if(i2c_single_send(TSL256X_ADDR, reg) == I2C_MASTER_ERR_NONE) {
     while(i2c_master_busy());
-    if(i2c_burst_receive(TSL2563_ADDR, buf, regNum) == I2C_MASTER_ERR_NONE) {
-      return TSL2563_SUCCESS;
+    if(i2c_burst_receive(TSL256X_ADDR, buf, regNum) == I2C_MASTER_ERR_NONE) {
+      return TSL256X_SUCCESS;
     }
   }
-  return TSL2563_ERROR;
+  return TSL256X_ERROR;
 }
 /*---------------------------------------------------------------------------*/
 static int
-tsl2563_write_reg(uint8_t *buf, uint8_t num)
+tsl256x_write_reg(uint8_t *buf, uint8_t num)
 {
   if((buf == NULL) || (num <= 0)) {
-    PRINTF("TSL2563: invalid write values\n");
-    return TSL2563_ERROR;
+    PRINTF("TSL256X: invalid write values\n");
+    return TSL256X_ERROR;
   }
 
   i2c_master_enable();
-  if(i2c_burst_send(TSL2563_ADDR, buf, num) == I2C_MASTER_ERR_NONE) {
-    return TSL2563_SUCCESS;
+  if(i2c_burst_send(TSL256X_ADDR, buf, num) == I2C_MASTER_ERR_NONE) {
+    return TSL256X_SUCCESS;
   }
-  return TSL2563_ERROR;
+  return TSL256X_ERROR;
 }
 /*---------------------------------------------------------------------------*/
 static int
-tsl2563_on(void)
+tsl256x_on(void)
 {
   uint8_t buf[2];
-  buf[0] = (TSL2563_COMMAND + TSL2563_CONTROL);
-  buf[1] = TSL2563_CONTROL_POWER_ON;
+  buf[0] = (TSL256X_COMMAND + TSL256X_CONTROL);
+  buf[1] = TSL256X_CONTROL_POWER_ON;
 
-  if(tsl2563_write_reg(buf, 2) == I2C_MASTER_ERR_NONE) {
-    if(i2c_single_receive(TSL2563_ADDR, &buf[0]) == I2C_MASTER_ERR_NONE) {
-      if((buf[0] & 0x0F) == TSL2563_CONTROL_POWER_ON) {
-        PRINTF("TSL2563: powered on\n");
-        return TSL2563_SUCCESS;
+  if(tsl256x_write_reg(buf, 2) == I2C_MASTER_ERR_NONE) {
+    if(i2c_single_receive(TSL256X_ADDR, &buf[0]) == I2C_MASTER_ERR_NONE) {
+      if((buf[0] & 0x0F) == TSL256X_CONTROL_POWER_ON) {
+        PRINTF("TSL256X: powered on\n");
+        return TSL256X_SUCCESS;
       }
     }
   }
 
-  PRINTF("TSL2563: failed to power on\n");
-  return TSL2563_ERROR;
+  PRINTF("TSL256X: failed to power on\n");
+  return TSL256X_ERROR;
 }
 /*---------------------------------------------------------------------------*/
 static int
-tsl2563_id_register(uint8_t *buf)
+tsl256x_id_register(uint8_t *buf)
 {
-  if(tsl2563_read_reg((TSL2563_COMMAND + TSL2563_ID_REG),
-                      buf, 1) == TSL2563_SUCCESS) {
-    PRINTF("TSL2563: partnum/revnum 0x%02X\n", *buf);
-    return TSL2563_SUCCESS;
+  if(tsl256x_read_reg((TSL256X_COMMAND + TSL256X_ID_REG),
+                      buf, 1) == TSL256X_SUCCESS) {
+    PRINTF("TSL256X: partnum/revnum 0x%02X\n", *buf);
+    return TSL256X_SUCCESS;
   }
 
-  return TSL2563_ERROR;
+  return TSL256X_ERROR;
 }
 /*---------------------------------------------------------------------------*/
 static int
-tsl2563_off(void)
+tsl256x_off(void)
 {
   uint8_t buf[2];
-  buf[0] = (TSL2563_COMMAND + TSL2563_CONTROL);
-  buf[1] = TSL2563_CONTROL_POWER_OFF;
+  buf[0] = (TSL256X_COMMAND + TSL256X_CONTROL);
+  buf[1] = TSL256X_CONTROL_POWER_OFF;
 
-  if(tsl2563_write_reg(buf, 2) == I2C_MASTER_ERR_NONE) {
-    PRINTF("TSL2563: powered off\n");
-    return TSL2563_SUCCESS;
+  if(tsl256x_write_reg(buf, 2) == I2C_MASTER_ERR_NONE) {
+    PRINTF("TSL256X: powered off\n");
+    return TSL256X_SUCCESS;
   }
 
-  PRINTF("TSL2563: failed to power off\n");
-  return TSL2563_ERROR;
+  PRINTF("TSL256X: failed to power off\n");
+  return TSL256X_ERROR;
 }
 /*---------------------------------------------------------------------------*/
 static int
-tsl2563_clear_interrupt(void)
+tsl256x_clear_interrupt(void)
 {
-  uint8_t buf = (TSL2563_COMMAND + TSL2563_CLEAR_INTERRUPT);
-  if(tsl2563_write_reg(&buf, 1) != I2C_MASTER_ERR_NONE) {
-    PRINTF("TSL2563: failed to clear the interrupt\n");
-    return TSL2563_ERROR;
+  uint8_t buf = (TSL256X_COMMAND + TSL256X_CLEAR_INTERRUPT);
+  if(tsl256x_write_reg(&buf, 1) != I2C_MASTER_ERR_NONE) {
+    PRINTF("TSL256X: failed to clear the interrupt\n");
+    return TSL256X_ERROR;
   }
-  return TSL2563_SUCCESS;
+  return TSL256X_SUCCESS;
 }
 /*---------------------------------------------------------------------------*/
 static int
-tsl2563_read_sensor(uint16_t *lux)
+tsl256x_read_sensor(uint16_t *lux)
 {
   uint8_t buf[4];
 
   /* This is hardcoded to use word write/read operations */
-  if(tsl2563_read_reg((TSL2563_COMMAND + TSL2563_D0LOW),
-                      &buf[0], 2) == TSL2563_SUCCESS) {
-    if(tsl2563_read_reg((TSL2563_COMMAND + TSL2563_D1LOW),
-                        &buf[2], 2) == TSL2563_SUCCESS) {
+  if(tsl256x_read_reg((TSL256X_COMMAND + TSL256X_D0LOW),
+                      &buf[0], 2) == TSL256X_SUCCESS) {
+    if(tsl256x_read_reg((TSL256X_COMMAND + TSL256X_D1LOW),
+                        &buf[2], 2) == TSL256X_SUCCESS) {
 
-      PRINTF("TSL2563: CH0 0x%02X%02X CH1 0x%02X%02X\n", buf[1], buf[0],
+      PRINTF("TSL256X: CH0 0x%02X%02X CH1 0x%02X%02X\n", buf[1], buf[0],
              buf[3], buf[2]);
       *lux = calculate_lux(buf);
-      return TSL2563_SUCCESS;
+      return TSL256X_SUCCESS;
     }
   }
-  PRINTF("TSL2563: failed to read\n");
-  return TSL2563_ERROR;
+  PRINTF("TSL256X: failed to read\n");
+  return TSL256X_ERROR;
 }
 /*---------------------------------------------------------------------------*/
-PROCESS(tsl2563_int_process, "TSL2563 interrupt process handler");
+PROCESS(tsl256x_int_process, "TSL256X interrupt process handler");
 /*---------------------------------------------------------------------------*/
-PROCESS_THREAD(tsl2563_int_process, ev, data)
+PROCESS_THREAD(tsl256x_int_process, ev, data)
 {
   PROCESS_EXITHANDLER();
   PROCESS_BEGIN();
 
   while(1) {
     PROCESS_YIELD_UNTIL(ev == PROCESS_EVENT_POLL);
-    tsl2563_clear_interrupt();
-    tsl2563_int_callback(0);
+    tsl256x_clear_interrupt();
+    tsl256x_int_callback(0);
   }
   PROCESS_END();
 }
 /*---------------------------------------------------------------------------*/
 static void
-tsl2563_interrupt_handler(uint8_t port, uint8_t pin)
+tsl256x_interrupt_handler(uint8_t port, uint8_t pin)
 {
   /* There's no alert/interruption flag to check, clear the interruption by
    * writting to the CLEAR bit in the COMMAND register
    */
-  process_poll(&tsl2563_int_process);
+  process_poll(&tsl256x_int_process);
 }
 /*---------------------------------------------------------------------------*/
 static int
@@ -268,185 +268,185 @@ configure(int type, int value)
 {
   uint8_t buf[3];
 
-  if((type != TSL2563_ACTIVE) && (type != TSL2563_INT_OVER) &&
-     (type != TSL2563_INT_BELOW) && (type != TSL2563_INT_DISABLE) &&
-     (type != TSL2563_TIMMING_CFG)) {
-    PRINTF("TSL2563: invalid start value\n");
-    return TSL2563_ERROR;
+  if((type != TSL256X_ACTIVE) && (type != TSL256X_INT_OVER) &&
+     (type != TSL256X_INT_BELOW) && (type != TSL256X_INT_DISABLE) &&
+     (type != TSL256X_TIMMING_CFG)) {
+    PRINTF("TSL256X: invalid start value\n");
+    return TSL256X_ERROR;
   }
 
   /* As default the power-on values of the sensor are gain 1X, 402ms integration
    * time (not nominal), with manual control disabled
    */
 
-  if(type == TSL2563_ACTIVE) {
+  if(type == TSL256X_ACTIVE) {
     if(value) {
       i2c_init(I2C_SDA_PORT, I2C_SDA_PIN, I2C_SCL_PORT, I2C_SCL_PIN,
                I2C_SCL_NORMAL_BUS_SPEED);
 
       /*  Initialize interrupts handlers */
-      tsl2563_int_callback = NULL;
+      tsl256x_int_callback = NULL;
 
       /* Power on the sensor and check for the part number */
-      if(tsl2563_on() == TSL2563_SUCCESS) {
-        if(tsl2563_id_register(&buf[0]) == TSL2563_SUCCESS) {
-          if((buf[0] & TSL2563_ID_PARTNO_MASK) == TSL2563_EXPECTED_PARTNO) {
+      if(tsl256x_on() == TSL256X_SUCCESS) {
+        if(tsl256x_id_register(&buf[0]) == TSL256X_SUCCESS) {
+          if((buf[0] & TSL256X_ID_PARTNO_MASK) == TSL256X_EXPECTED_PARTNO) {
 
             /* Read the timming/gain configuration */
-            if(tsl2563_read_reg((TSL2563_COMMAND + TSL2563_TIMMING),
-                                &buf[0], 1) == TSL2563_SUCCESS) {
-              gain = buf[0] & TSL2563_TIMMING_GAIN;
-              timming = buf[0] & TSL2563_TIMMING_INTEG_MASK;
-              PRINTF("TSL2563: enabled, timming %u gain %u\n", timming, gain);
+            if(tsl256x_read_reg((TSL256X_COMMAND + TSL256X_TIMMING),
+                                &buf[0], 1) == TSL256X_SUCCESS) {
+              gain = buf[0] & TSL256X_TIMMING_GAIN;
+              timming = buf[0] & TSL256X_TIMMING_INTEG_MASK;
+              PRINTF("TSL256X: enabled, timming %u gain %u\n", timming, gain);
 
               /* Restart the over interrupt threshold */
-              buf[0] = (TSL2563_COMMAND + TSL2563_THRHIGHLOW);
+              buf[0] = (TSL256X_COMMAND + TSL256X_THRHIGHLOW);
               buf[1] = 0xFF;
               buf[2] = 0xFF;
 
-              if(tsl2563_write_reg(buf, 3) != TSL2563_SUCCESS) {
-                PRINTF("TSL2563: failed to clear over interrupt\n");
-                return TSL2563_ERROR;
+              if(tsl256x_write_reg(buf, 3) != TSL256X_SUCCESS) {
+                PRINTF("TSL256X: failed to clear over interrupt\n");
+                return TSL256X_ERROR;
               }
 
               /* Restart the below interrupt threshold */
-              buf[0] = (TSL2563_COMMAND + TSL2563_THRLOWLOW);
+              buf[0] = (TSL256X_COMMAND + TSL256X_THRLOWLOW);
               buf[1] = 0x00;
               buf[2] = 0x00;
 
-              if(tsl2563_write_reg(buf, 3) != TSL2563_SUCCESS) {
-                PRINTF("TSL2563: failed to clear below interrupt\n");
-                return TSL2563_ERROR;
+              if(tsl256x_write_reg(buf, 3) != TSL256X_SUCCESS) {
+                PRINTF("TSL256X: failed to clear below interrupt\n");
+                return TSL256X_ERROR;
               }
 
               /* Clear any pending interrupt */
-              if(tsl2563_clear_interrupt() == TSL2563_SUCCESS) {
+              if(tsl256x_clear_interrupt() == TSL256X_SUCCESS) {
                 enabled = 1;
-                return TSL2563_SUCCESS;
+                return TSL256X_SUCCESS;
               }
             }
           }
         }
       }
-      return TSL2563_ERROR;
+      return TSL256X_ERROR;
     } else {
-      if(tsl2563_off() == TSL2563_SUCCESS) {
-        PRINTF("TSL2563: stopped\n");
+      if(tsl256x_off() == TSL256X_SUCCESS) {
+        PRINTF("TSL256X: stopped\n");
         enabled = 0;
-        return TSL2563_SUCCESS;
+        return TSL256X_SUCCESS;
       }
-      return TSL2563_ERROR;
+      return TSL256X_ERROR;
     }
   }
 
   if(!enabled) {
-    PRINTF("TSL2563: sensor not started\n");
-    return TSL2563_ERROR;
+    PRINTF("TSL256X: sensor not started\n");
+    return TSL256X_ERROR;
   }
 
-  if(type == TSL2563_INT_DISABLE) {
+  if(type == TSL256X_INT_DISABLE) {
 
     /* Ensure the GPIO doesn't generate more interrupts, this may affect others
      * I2C digital sensors using the bus and sharing this pin, so an user may
      * comment the line below
      */
-    GPIO_DISABLE_INTERRUPT(TSL2563_INT_PORT_BASE, TSL2563_INT_PIN_MASK);
+    GPIO_DISABLE_INTERRUPT(TSL256X_INT_PORT_BASE, TSL256X_INT_PIN_MASK);
 
     /* This also wipes out the persistance value, to be reconfigured when
      * enabling back the interruption
      */
-    buf[0] = (TSL2563_COMMAND + TSL2563_INTERRUPT);
-    buf[1] = TSL2563_INTR_DISABLED;
+    buf[0] = (TSL256X_COMMAND + TSL256X_INTERRUPT);
+    buf[1] = TSL256X_INTR_DISABLED;
 
-    if(tsl2563_write_reg(buf, 2) != TSL2563_SUCCESS) {
-      PRINTF("TSL2563: failed to disable the interrupt\n");
-      return TSL2563_ERROR;
+    if(tsl256x_write_reg(buf, 2) != TSL256X_SUCCESS) {
+      PRINTF("TSL256X: failed to disable the interrupt\n");
+      return TSL256X_ERROR;
     }
-    return TSL2563_SUCCESS;
+    return TSL256X_SUCCESS;
   }
 
   /* Configure the timming and gain */
-  if(type == TSL2563_TIMMING_CFG) {
-    if((value != TSL2563_G16X_402MS) && (value != TSL2563_G1X_402MS) &&
-       (value != TSL2563_G1X_101MS) && (value != TSL2563_G1X_13_7MS)) {
-      PRINTF("TSL2563: invalid timming configuration values\n");
-      return TSL2563_ERROR;
+  if(type == TSL256X_TIMMING_CFG) {
+    if((value != TSL256X_G16X_402MS) && (value != TSL256X_G1X_402MS) &&
+       (value != TSL256X_G1X_101MS) && (value != TSL256X_G1X_13_7MS)) {
+      PRINTF("TSL256X: invalid timming configuration values\n");
+      return TSL256X_ERROR;
     }
 
-    buf[0] = (TSL2563_COMMAND + TSL2563_TIMMING);
+    buf[0] = (TSL256X_COMMAND + TSL256X_TIMMING);
     buf[1] = value;
 
-    if(tsl2563_write_reg(buf, 2) == TSL2563_SUCCESS) {
-      if(value == TSL2563_G16X_402MS) {
+    if(tsl256x_write_reg(buf, 2) == TSL256X_SUCCESS) {
+      if(value == TSL256X_G16X_402MS) {
         gain = 1;
       }
 
       switch(value) {
-      case TSL2563_G16X_402MS:
-      case TSL2563_G1X_402MS:
-        timming = TSL2563_TIMMING_INTEG_402MS;
+      case TSL256X_G16X_402MS:
+      case TSL256X_G1X_402MS:
+        timming = TSL256X_TIMMING_INTEG_402MS;
         break;
-      case TSL2563_G1X_101MS:
-        timming = TSL2563_TIMMING_INTEG_101MS;
+      case TSL256X_G1X_101MS:
+        timming = TSL256X_TIMMING_INTEG_101MS;
         break;
-      case TSL2563_G1X_13_7MS:
-        timming = TSL2563_TIMMING_INTEG_13_7MS;
+      case TSL256X_G1X_13_7MS:
+        timming = TSL256X_TIMMING_INTEG_13_7MS;
         break;
       }
 
-      PRINTF("TSL2563: new timming %u gain %u\n", timming, gain);
-      return TSL2563_SUCCESS;
+      PRINTF("TSL256X: new timming %u gain %u\n", timming, gain);
+      return TSL256X_SUCCESS;
     }
-    PRINTF("TSL2563: failed to configure timming\n");
-    return TSL2563_ERROR;
+    PRINTF("TSL256X: failed to configure timming\n");
+    return TSL256X_ERROR;
   }
 
   /* From here we handle the interrupt configuration, it requires the interrupt
-   * callback handler to have been previously set using the TSL2563_REGISTER_INT
+   * callback handler to have been previously set using the TSL256X_REGISTER_INT
    * macro
    */
 
   buf[1] = ((uint8_t *)&value)[0];
   buf[2] = ((uint8_t *)&value)[1];
 
-  if(type == TSL2563_INT_OVER) {
-    buf[0] = (TSL2563_COMMAND + TSL2563_THRHIGHLOW);
-  } else if(type == TSL2563_INT_BELOW) {
-    buf[0] = (TSL2563_COMMAND + TSL2563_THRLOWLOW);
+  if(type == TSL256X_INT_OVER) {
+    buf[0] = (TSL256X_COMMAND + TSL256X_THRHIGHLOW);
+  } else if(type == TSL256X_INT_BELOW) {
+    buf[0] = (TSL256X_COMMAND + TSL256X_THRLOWLOW);
   }
 
-  if(tsl2563_write_reg(buf, 3) != TSL2563_SUCCESS) {
-    PRINTF("TSL2563: failed to set interrupt level\n");
-    return TSL2563_ERROR;
+  if(tsl256x_write_reg(buf, 3) != TSL256X_SUCCESS) {
+    PRINTF("TSL256X: failed to set interrupt level\n");
+    return TSL256X_ERROR;
   }
 
   /* Now configure the interruption register (level interrupt, 2 integration
    * cycles after threshold has been reached (roughly 804ms if timming is 402ms)
    */
-  buf[0] = (TSL2563_COMMAND + TSL2563_INTERRUPT);
-  buf[1] = (TSL2563_INTR_LEVEL << TSL2563_INTR_SHIFT);
-  buf[1] += TSL2563_INT_PERSIST_2_CYCLES;
+  buf[0] = (TSL256X_COMMAND + TSL256X_INTERRUPT);
+  buf[1] = (TSL256X_INTR_LEVEL << TSL256X_INTR_SHIFT);
+  buf[1] += TSL256X_INT_PERSIST_2_CYCLES;
 
-  if(tsl2563_write_reg(buf, 2) != TSL2563_SUCCESS) {
-    PRINTF("TSL2563: failed to enable interrupt\n");
-    return TSL2563_ERROR;
+  if(tsl256x_write_reg(buf, 2) != TSL256X_SUCCESS) {
+    PRINTF("TSL256X: failed to enable interrupt\n");
+    return TSL256X_ERROR;
   }
 
   /* Configure the interrupts pins */
-  GPIO_SOFTWARE_CONTROL(TSL2563_INT_PORT_BASE, TSL2563_INT_PIN_MASK);
-  GPIO_SET_INPUT(TSL2563_INT_PORT_BASE, TSL2563_INT_PIN_MASK);
+  GPIO_SOFTWARE_CONTROL(TSL256X_INT_PORT_BASE, TSL256X_INT_PIN_MASK);
+  GPIO_SET_INPUT(TSL256X_INT_PORT_BASE, TSL256X_INT_PIN_MASK);
 
   /* Pull-up resistor, detect falling edge */
-  GPIO_DETECT_EDGE(TSL2563_INT_PORT_BASE, TSL2563_INT_PIN_MASK);
-  GPIO_TRIGGER_SINGLE_EDGE(TSL2563_INT_PORT_BASE, TSL2563_INT_PIN_MASK);
-  GPIO_DETECT_FALLING(TSL2563_INT_PORT_BASE, TSL2563_INT_PIN_MASK);
-  gpio_register_callback(tsl2563_interrupt_handler, I2C_INT_PORT, I2C_INT_PIN);
+  GPIO_DETECT_EDGE(TSL256X_INT_PORT_BASE, TSL256X_INT_PIN_MASK);
+  GPIO_TRIGGER_SINGLE_EDGE(TSL256X_INT_PORT_BASE, TSL256X_INT_PIN_MASK);
+  GPIO_DETECT_FALLING(TSL256X_INT_PORT_BASE, TSL256X_INT_PIN_MASK);
+  gpio_register_callback(tsl256x_interrupt_handler, I2C_INT_PORT, I2C_INT_PIN);
 
   /* Spin process until an interrupt is received */
-  process_start(&tsl2563_int_process, NULL);
+  process_start(&tsl256x_int_process, NULL);
 
   /* Enable interrupts */
-  GPIO_ENABLE_INTERRUPT(TSL2563_INT_PORT_BASE, TSL2563_INT_PIN_MASK);
+  GPIO_ENABLE_INTERRUPT(TSL256X_INT_PORT_BASE, TSL256X_INT_PIN_MASK);
 
   /* The RE-Mote revision A has this pin shared and with a pull-down resistor,
    * for other platforms (like the firefly), change to enable pull-up internal
@@ -455,8 +455,8 @@ configure(int type, int value)
   ioc_set_over(I2C_INT_PORT, I2C_INT_PIN, IOC_OVERRIDE_PUE);
   nvic_interrupt_enable(I2C_INT_VECTOR);
 
-  PRINTF("TSL2563: Interrupt configured\n");
-  return TSL2563_SUCCESS;
+  PRINTF("TSL256X: Interrupt configured\n");
+  return TSL256X_SUCCESS;
 }
 /*---------------------------------------------------------------------------*/
 static int
@@ -476,19 +476,19 @@ value(int type)
   uint16_t lux;
 
   if(!enabled) {
-    PRINTF("TSL2563: sensor not started\n");
-    return TSL2563_ERROR;
+    PRINTF("TSL256X: sensor not started\n");
+    return TSL256X_ERROR;
   }
 
-  if(type == TSL2563_VAL_READ) {
-    if(tsl2563_read_sensor(&lux) != TSL2563_ERROR) {
+  if(type == TSL256X_VAL_READ) {
+    if(tsl256x_read_sensor(&lux) != TSL256X_ERROR) {
       return lux;
     }
-    PRINTF("TSL2563: fail to read\n");
+    PRINTF("TSL256X: fail to read\n");
   }
-  return TSL2563_ERROR;
+  return TSL256X_ERROR;
 }
 /*---------------------------------------------------------------------------*/
-SENSORS_SENSOR(tsl2563, TSL2563_SENSOR, value, configure, status);
+SENSORS_SENSOR(tsl256x, TSL256X_SENSOR, value, configure, status);
 /*---------------------------------------------------------------------------*/
 /** @} */

--- a/platform/zoul/dev/tsl256x.h
+++ b/platform/zoul/dev/tsl256x.h
@@ -34,98 +34,125 @@
  * \addtogroup zoul-sensors
  * @{
  *
- * \defgroup zoul-tsl2563-sensor TSL2563 Sensor
+ * \defgroup zoul-tsl256x-sensor TSL256X Sensor
  *
- * Driver for the TSL2563 sensor
+ * Driver for the TSL256X sensor
  *
- * The TSL2563 driver returns the converted light value value in lux
+ * The TSL256X driver returns the converted light value value in lux
  * @{
  *
  * \file
- * Header file for the external TSL2563 Sensor Driver
+ * Header file for the external TSL256X Sensor Driver
  *
  * \author
  *         Antonio Lignan <alinan@zolertia.com>
  *         Toni Lozano <tlozano@zolertia.com>
  */
 /*---------------------------------------------------------------------------*/
-#ifndef TSL2563_H_
-#define TSL2563_H_
+#ifndef TSL256X_H_
+#define TSL256X_H_
 #include <stdio.h>
 #include "lib/sensors.h"
 #include "dev/zoul-sensors.h"
 #include "i2c.h"
 /* -------------------------------------------------------------------------- */
 /**
- * \name TSL2563 digital Light sensor address and registers
+ * \name TSL256x digital Light sensor specific model information
  * @{
  */
-/* -------------------------------------------------------------------------- */
-#define TSL2563_ADDR                  0x39
-/* -------------------------------------------------------------------------- */
-#define TSL2563_CONTROL               0x00
-#define TSL2563_TIMMING               0x01
-#define TSL2563_THRLOWLOW             0x02
-#define TSL2563_THRLOWHIGH            0x03
-#define TSL2563_THRHIGHLOW            0x04
-#define TSL2563_THRHIGHHIGH           0x05
-#define TSL2563_INTERRUPT             0x06
-#define TSL2563_CRC                   0x08
-#define TSL2563_ID_REG                0x0A
-#define TSL2563_D0LOW                 0x0C
-#define TSL2563_D0HIGH                0x0D
-#define TSL2563_D1LOW                 0x0E
-#define TSL2563_D1HIGH                0x0F
-/* -------------------------------------------------------------------------- */
-/* Uses the word read/write operation protocol */
-#define TSL2563_COMMAND               0xA0
-#define TSL2563_CLEAR_INTERRUPT       0x40
-/* -------------------------------------------------------------------------- */
-#define TSL2563_CONTROL_POWER_ON      0x03
-#define TSL2563_CONTROL_POWER_OFF     0x00
-#define TSL2563_TIMMING_GAIN          0x10
-#define TSL2563_TIMMING_MANUAL        0x08
-#define TSL2563_TIMMING_INTEG_MANUAL  0x03
-#define TSL2563_TIMMING_INTEG_402MS   0x02
-#define TSL2563_TIMMING_INTEG_101MS   0x01
-#define TSL2563_TIMMING_INTEG_13_7MS  0x00
-#define TSL2563_TIMMING_INTEG_MASK    0x03
+/* This driver supports the TSL2563 (Zolertia) and the TSL2561 (Grove) */
+#define TSL2561_SENSOR_REF            0
+#define TSL2563_SENSOR_REF            1
 
-#define TSL2563_G16X_402MS (TSL2563_TIMMING_INTEG_402MS + TSL2563_TIMMING_GAIN)
-#define TSL2563_G1X_402MS                            TSL2563_TIMMING_INTEG_402MS
-#define TSL2563_G1X_101MS                            TSL2563_TIMMING_INTEG_101MS
-#define TSL2563_G1X_13_7MS                          TSL2563_TIMMING_INTEG_13_7MS
-
-#define TSL2563_INTR_SHIFT            0x04
-#define TSL2563_INTR_DISABLED         0x00
-#define TSL2563_INTR_LEVEL            0x01
-#define TSL2563_INTR_SMB_ALERT        0x02
-#define TSL2563_INTR_TEST             0x03
-
-#define TSL2563_INT_PERSIST_EVERY     0x00
-#define TSL2563_INT_PERSIST_ANY       0x01
-#define TSL2563_INT_PERSIST_2_CYCLES  0x02
-#define TSL2563_INT_PERSIST_3_CYCLES  0x03
-#define TSL2563_INT_PERSIST_4_CYCLES  0x04
-#define TSL2563_INT_PERSIST_5_CYCLES  0x05
-#define TSL2563_INT_PERSIST_6_CYCLES  0x06
-#define TSL2563_INT_PERSIST_7_CYCLES  0x07
-#define TSL2563_INT_PERSIST_8_CYCLES  0x08
-#define TSL2563_INT_PERSIST_9_CYCLES  0x09
-#define TSL2563_INT_PERSIST_10_CYCLES 0x0A
-#define TSL2563_INT_PERSIST_11_CYCLES 0x0B
-#define TSL2563_INT_PERSIST_12_CYCLES 0x0C
-#define TSL2563_INT_PERSIST_13_CYCLES 0x0D
-#define TSL2563_INT_PERSIST_14_CYCLES 0x0E
-#define TSL2563_INT_PERSIST_15_CYCLES 0x0F
-
-#define TSL2563_ID_PARTNO_MASK        0xF0
-#define TSL2563_ID_REV_MASK           0x0F
+/* The TSL2563 (from Zolertia) has a different part number than the TSL2561 from
+ * Grove (digital light sensor)
+ */
 #define TSL2563_EXPECTED_PARTNO       0x30
+#define TSL2561_EXPECTED_PARTNO       0x50
+
+#ifndef TSL256X_CONF_REF
+#define TSL256X_REF                   TSL2561_SENSOR_REF
+#else
+#define TSL256X_REF                   TSL256X_CONF_REF
+#endif
+
+#if TSL256X_CONF_REF == TSL2561_SENSOR
+#define TSL256X_ADDR                  0x29
+#define TSL256X_EXPECTED_PARTNO       TSL2561_EXPECTED_PARTNO
+#else
+#define TSL256X_ADDR                  0x39
+#define TSL256X_EXPECTED_PARTNO       TSL2563_EXPECTED_PARTNO
+#endif
+
 /** @} */
 /* -------------------------------------------------------------------------- */
 /**
- * \name TSL2563 convertion and calibration values
+ * \name TSL256X digital Light registers
+ * @{
+ */
+/* -------------------------------------------------------------------------- */
+#define TSL256X_CONTROL               0x00
+#define TSL256X_TIMMING               0x01
+#define TSL256X_THRLOWLOW             0x02
+#define TSL256X_THRLOWHIGH            0x03
+#define TSL256X_THRHIGHLOW            0x04
+#define TSL256X_THRHIGHHIGH           0x05
+#define TSL256X_INTERRUPT             0x06
+#define TSL256X_CRC                   0x08
+#define TSL256X_ID_REG                0x0A
+#define TSL256X_D0LOW                 0x0C
+#define TSL256X_D0HIGH                0x0D
+#define TSL256X_D1LOW                 0x0E
+#define TSL256X_D1HIGH                0x0F
+/* -------------------------------------------------------------------------- */
+/* Uses the word read/write operation protocol */
+#define TSL256X_COMMAND               0xA0
+#define TSL256X_CLEAR_INTERRUPT       0x40
+/* -------------------------------------------------------------------------- */
+#define TSL256X_CONTROL_POWER_ON      0x03
+#define TSL256X_CONTROL_POWER_OFF     0x00
+#define TSL256X_TIMMING_GAIN          0x10
+#define TSL256X_TIMMING_MANUAL        0x08
+#define TSL256X_TIMMING_INTEG_MANUAL  0x03
+#define TSL256X_TIMMING_INTEG_402MS   0x02
+#define TSL256X_TIMMING_INTEG_101MS   0x01
+#define TSL256X_TIMMING_INTEG_13_7MS  0x00
+#define TSL256X_TIMMING_INTEG_MASK    0x03
+
+#define TSL256X_G16X_402MS (TSL256X_TIMMING_INTEG_402MS + TSL256X_TIMMING_GAIN)
+#define TSL256X_G1X_402MS                            TSL256X_TIMMING_INTEG_402MS
+#define TSL256X_G1X_101MS                            TSL256X_TIMMING_INTEG_101MS
+#define TSL256X_G1X_13_7MS                          TSL256X_TIMMING_INTEG_13_7MS
+
+#define TSL256X_INTR_SHIFT            0x04
+#define TSL256X_INTR_DISABLED         0x00
+#define TSL256X_INTR_LEVEL            0x01
+#define TSL256X_INTR_SMB_ALERT        0x02
+#define TSL256X_INTR_TEST             0x03
+
+#define TSL256X_INT_PERSIST_EVERY     0x00
+#define TSL256X_INT_PERSIST_ANY       0x01
+#define TSL256X_INT_PERSIST_2_CYCLES  0x02
+#define TSL256X_INT_PERSIST_3_CYCLES  0x03
+#define TSL256X_INT_PERSIST_4_CYCLES  0x04
+#define TSL256X_INT_PERSIST_5_CYCLES  0x05
+#define TSL256X_INT_PERSIST_6_CYCLES  0x06
+#define TSL256X_INT_PERSIST_7_CYCLES  0x07
+#define TSL256X_INT_PERSIST_8_CYCLES  0x08
+#define TSL256X_INT_PERSIST_9_CYCLES  0x09
+#define TSL256X_INT_PERSIST_10_CYCLES 0x0A
+#define TSL256X_INT_PERSIST_11_CYCLES 0x0B
+#define TSL256X_INT_PERSIST_12_CYCLES 0x0C
+#define TSL256X_INT_PERSIST_13_CYCLES 0x0D
+#define TSL256X_INT_PERSIST_14_CYCLES 0x0E
+#define TSL256X_INT_PERSIST_15_CYCLES 0x0F
+
+#define TSL256X_ID_PARTNO_MASK        0xF0
+#define TSL256X_ID_REV_MASK           0x0F
+/** @} */
+/* -------------------------------------------------------------------------- */
+/**
+ * \name TSL256X convertion and calibration values
  * @{
  */
 
@@ -163,33 +190,33 @@
 /** @} */
 /* -------------------------------------------------------------------------- */
 /**
- * \name Callback function to handle the TSL2563 alarm interrupt and macro
+ * \name Callback function to handle the TSL256X alarm interrupt and macro
  * @{
  */
-#define TSL2563_REGISTER_INT(ptr) tsl2563_int_callback = ptr;
-extern void (*tsl2563_int_callback)(uint8_t value);
+#define TSL256X_REGISTER_INT(ptr) tsl256x_int_callback = ptr;
+extern void (*tsl256x_int_callback)(uint8_t value);
 /** @} */
 /* -------------------------------------------------------------------------- */
 /**
- * \name TSL2563 return and command values
+ * \name TSL256X return and command values
  * @{
  */
-#define TSL2563_SUCCESS         0x00
-#define TSL2563_LIGHT           0x01
-#define TSL2563_ERROR             -1
+#define TSL256X_SUCCESS         0x00
+#define TSL256X_LIGHT           0x01
+#define TSL256X_ERROR             -1
 
-#define TSL2563_ACTIVE          SENSORS_ACTIVE
-#define TSL2563_INT_OVER        HW_INT_OVER_THRS
-#define TSL2563_INT_BELOW       HW_INT_BELOW_THRS
-#define TSL2563_INT_DISABLE     HW_INT_DISABLE
-#define TSL2563_TIMMING_CFG     (HW_INT_DISABLE + 1)
+#define TSL256X_ACTIVE          SENSORS_ACTIVE
+#define TSL256X_INT_OVER        HW_INT_OVER_THRS
+#define TSL256X_INT_BELOW       HW_INT_BELOW_THRS
+#define TSL256X_INT_DISABLE     HW_INT_DISABLE
+#define TSL256X_TIMMING_CFG     (HW_INT_DISABLE + 1)
 
-#define TSL2563_VAL_READ        0x01
+#define TSL256X_VAL_READ        0x01
 /** @} */
 /* -------------------------------------------------------------------------- */
-#define TSL2563_SENSOR "TSL2563 Light Sensor"
+#define TSL256X_SENSOR "TSL256X Light Sensor"
 /* -------------------------------------------------------------------------- */
-extern const struct sensors_sensor tsl2563;
+extern const struct sensors_sensor tsl256x;
 /* -------------------------------------------------------------------------- */
 #endif
 /* -------------------------------------------------------------------------- */


### PR DESCRIPTION
This PR extends the existing light sensor driver to support both TSL2563 and TSL2561, the later one used in Seeedstudio's grove digital light sensor and currently tested.