### PR TITLE
galileo: Shrink pinmux array

### DIFF
--- a/platform/galileo/drivers/galileo-gen2-pinmux.c
+++ b/platform/galileo/drivers/galileo-gen2-pinmux.c
@@ -576,7 +576,7 @@ int
 galileo_brd_to_cpu_gpio_pin(unsigned pin, bool *sus)
 {
   static const int SUS = 0x100;
-  unsigned pins[GALILEO_NUM_PINS] = {
+  unsigned pins[GALILEO_NUM_DIGITAL_PINS] = {
           3,       4,       5,       6,
     SUS | 4,       8,       9, SUS | 0,
     SUS | 1, SUS | 2,       2, SUS | 3,


### PR DESCRIPTION
The pins array in galileo-gen2-pinmux.c:galileo_brd_to_cpu_gpio_pin is
unnecessarily large.  This patch reduces its size.
