### PR TITLE
Fixed debug PRINTF definition in mqtt client

### DIFF
--- a/apps/mqtt/mqtt.c
+++ b/apps/mqtt/mqtt.c
@@ -65,7 +65,7 @@
 /*---------------------------------------------------------------------------*/
 #define DEBUG 0
 #if DEBUG
-#define PRINTF(...) PRINTF(__VA_ARGS__)
+#define PRINTF(...) printf(__VA_ARGS__)
 #else
 #define PRINTF(...)
 #endif


### PR DESCRIPTION
Fixed copy-paste typo in debug PRINTF definition of mqtt client