### PR TITLE
Check if interrupt is enabled before calls its handler

### DIFF
--- a/cpu/cc26xx-cc13xx/dev/gpio-interrupt.c
+++ b/cpu/cc26xx-cc13xx/dev/gpio-interrupt.c
@@ -80,7 +80,7 @@ gpio_interrupt_init()
 void
 gpio_interrupt_isr(void)
 {
-  uint32_t pin_mask;
+  uint32_t pin_mask, enabled;
   uint8_t i;
 
   ENERGEST_ON(ENERGEST_TYPE_IRQ);
@@ -95,7 +95,10 @@ gpio_interrupt_isr(void)
   for(i = 0; i < NUM_IO_MAX; i++) {
     /* Call the handler if there is one registered for this event */
     if((pin_mask & (1 << i)) && handlers[i] != NULL) {
-      handlers[i](i);
+      enabled = HWREG(IOC_BASE + IOC_O_IOCFG0 + (i * 4)) & IOC_IOCFG0_EDGE_IRQ_EN;
+      if (enabled) {
+        handlers[i](i);
+      }
     }
   }
 


### PR DESCRIPTION
I have an interrupt that I enable/disable as necessary, but with my test setup the pin is always receiving the edges that would generate an interrupt if enabled. When I press a button (which has its interrupt enabled), the interrupt handler checks the event flags and calls all interrupts with active events. Because my edge events happen so frequently (~10 kHz) it will sometimes mark my disabled interrupt as having an event, and so its handler will be called.

This pull request checks that the interrupt is actually enabled before calls its handler.