### PR TITLE
frame802154: comply with IEEE 802.15.4-2015 on PAN ID Field Handling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -162,3 +162,4 @@ env:
   - BUILD_TYPE='slip-radio' MAKE_TARGETS='cooja'
   - BUILD_TYPE='llsec' MAKE_TARGETS='cooja'
   - BUILD_TYPE='compile-avr' BUILD_CATEGORY='compile' BUILD_ARCH='avr-rss2'
+  - BUILD_TYPE='ieee802154'

--- a/core/net/mac/frame802154.c
+++ b/core/net/mac/frame802154.c
@@ -146,19 +146,40 @@ frame802154_has_panid(frame802154_fcf_t *fcf, int *has_src_pan_id, int *has_dest
   }
 
   if(fcf->frame_version == FRAME802154_IEEE802154E_2012) {
-    /* IEEE 802.15.4e-2012, Table 2a, PAN ID Compression */
-    if(!fcf->panid_compression) {
-      if(fcf->dest_addr_mode) {
-        /* Use destination PAN ID if destination address is present */
-        dest_pan_id = 1;
-      } else if(fcf->src_addr_mode) {
-        /* Only src address, include src PAN ID */
-        src_pan_id = 1;
-      }
-    } else if((fcf->dest_addr_mode == 0) && (fcf->src_addr_mode == 0)) {
-      /* No address included: PAN ID compression flag changes meaning */
+    /*
+     * IEEE 802.15.4-2015
+     * Table 7-2, PAN ID Compression value for frame version 0b10
+     */
+    if((fcf->dest_addr_mode == FRAME802154_NOADDR &&
+        fcf->src_addr_mode == FRAME802154_NOADDR &&
+        fcf->panid_compression == 1) ||
+       (fcf->dest_addr_mode != FRAME802154_NOADDR &&
+        fcf->src_addr_mode == FRAME802154_NOADDR &&
+        fcf->panid_compression == 0) ||
+       (fcf->dest_addr_mode == FRAME802154_LONGADDRMODE &&
+        fcf->src_addr_mode == FRAME802154_LONGADDRMODE &&
+        fcf->panid_compression == 0) ||
+       ((fcf->dest_addr_mode == FRAME802154_SHORTADDRMODE &&
+         fcf->src_addr_mode != FRAME802154_NOADDR) ||
+        (fcf->dest_addr_mode != FRAME802154_NOADDR &&
+         fcf->src_addr_mode == FRAME802154_SHORTADDRMODE)) ){
       dest_pan_id = 1;
     }
+
+    if(fcf->panid_compression == 0 &&
+       ((fcf->dest_addr_mode == FRAME802154_NOADDR &&
+         fcf->src_addr_mode == FRAME802154_LONGADDRMODE) ||
+        (fcf->dest_addr_mode == FRAME802154_NOADDR &&
+         fcf->src_addr_mode == FRAME802154_SHORTADDRMODE) ||
+        (fcf->dest_addr_mode == FRAME802154_SHORTADDRMODE &&
+         fcf->src_addr_mode == FRAME802154_SHORTADDRMODE) ||
+        (fcf->dest_addr_mode == FRAME802154_SHORTADDRMODE &&
+         fcf->src_addr_mode == FRAME802154_LONGADDRMODE) ||
+        (fcf->dest_addr_mode == FRAME802154_LONGADDRMODE &&
+         fcf->src_addr_mode == FRAME802154_SHORTADDRMODE))) {
+      src_pan_id = 1;
+    }
+
   } else {
     /* No PAN ID in ACK */
     if(fcf->frame_type != FRAME802154_ACKFRAME) {

--- a/core/net/mac/frame802154.c
+++ b/core/net/mac/frame802154.c
@@ -184,7 +184,7 @@ frame802154_has_panid(frame802154_fcf_t *fcf, int *has_src_pan_id, int *has_dest
     /* No PAN ID in ACK */
     if(fcf->frame_type != FRAME802154_ACKFRAME) {
       if(!fcf->panid_compression && fcf->src_addr_mode & 3) {
-        /* If compressed, don't inclue source PAN ID */
+        /* If compressed, don't include source PAN ID */
         src_pan_id = 1;
       }
       if(fcf->dest_addr_mode & 3) {

--- a/regression-tests/25-ieee802154/01-panid-handling.csc
+++ b/regression-tests/25-ieee802154/01-panid-handling.csc
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<simconf>
+  <project EXPORT="discard">[APPS_DIR]/mrm</project>
+  <project EXPORT="discard">[APPS_DIR]/mspsim</project>
+  <project EXPORT="discard">[APPS_DIR]/avrora</project>
+  <project EXPORT="discard">[APPS_DIR]/serial_socket</project>
+  <project EXPORT="discard">[APPS_DIR]/collect-view</project>
+  <project EXPORT="discard">[APPS_DIR]/powertracker</project>
+  <project EXPORT="discard">[APPS_DIR]/radiologger-headless</project>
+  <simulation>
+    <title>My simulation</title>
+    <randomseed>123456</randomseed>
+    <motedelay_us>1000000</motedelay_us>
+    <radiomedium>
+      org.contikios.cooja.radiomediums.UDGM
+      <transmitting_range>50.0</transmitting_range>
+      <interference_range>100.0</interference_range>
+      <success_ratio_tx>1.0</success_ratio_tx>
+      <success_ratio_rx>1.0</success_ratio_rx>
+    </radiomedium>
+    <events>
+      <logoutput>40000</logoutput>
+    </events>
+    <motetype>
+      org.contikios.cooja.contikimote.ContikiMoteType
+      <identifier>mtype740</identifier>
+      <description>Cooja Mote Type #1</description>
+      <source>[CONTIKI_DIR]/regression-tests/25-ieee802154/code/test-panid-handling.c</source>
+      <commands>make test-panid-handling.cooja TARGET=cooja</commands>
+      <moteinterface>org.contikios.cooja.interfaces.Position</moteinterface>
+      <moteinterface>org.contikios.cooja.interfaces.Battery</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiVib</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiMoteID</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiRS232</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiBeeper</moteinterface>
+      <moteinterface>org.contikios.cooja.interfaces.RimeAddress</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiIPAddress</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiRadio</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiButton</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiPIR</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiClock</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiLED</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiCFS</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiEEPROM</moteinterface>
+      <moteinterface>org.contikios.cooja.interfaces.Mote2MoteRelations</moteinterface>
+      <moteinterface>org.contikios.cooja.interfaces.MoteAttributes</moteinterface>
+      <symbols>false</symbols>
+    </motetype>
+    <mote>
+      <interface_config>
+        org.contikios.cooja.interfaces.Position
+        <x>57.636765279141336</x>
+        <y>56.661654369889035</y>
+        <z>0.0</z>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.contikimote.interfaces.ContikiMoteID
+        <id>1</id>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.contikimote.interfaces.ContikiRadio
+        <bitrate>250.0</bitrate>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.contikimote.interfaces.ContikiEEPROM
+        <eeprom>AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==</eeprom>
+      </interface_config>
+      <motetype_identifier>mtype740</motetype_identifier>
+    </mote>
+  </simulation>
+  <plugin>
+    org.contikios.cooja.plugins.ScriptRunner
+    <plugin_config>
+      <scriptfile>[CONFIG_DIR]/js/01-panid-handling.js</scriptfile>
+      <active>true</active>
+    </plugin_config>
+    <width>495</width>
+    <z>0</z>
+    <height>525</height>
+    <location_x>279</location_x>
+    <location_y>2</location_y>
+  </plugin>
+  <plugin>
+    org.contikios.cooja.plugins.SimControl
+    <width>280</width>
+    <z>1</z>
+    <height>160</height>
+    <location_x>-2</location_x>
+    <location_y>0</location_y>
+  </plugin>
+</simconf>
+

--- a/regression-tests/25-ieee802154/Makefile
+++ b/regression-tests/25-ieee802154/Makefile
@@ -1,0 +1,1 @@
+include ../Makefile.simulation-test

--- a/regression-tests/25-ieee802154/README.md
+++ b/regression-tests/25-ieee802154/README.md
@@ -1,0 +1,23 @@
+# Regression Tests of IEEE 802.15.4 Fundamentals
+
+## 01-panid-handling
+
+Test return values by `frame802154_has_panid()` in
+[frame802154.c](../../core/net/mac/frame802154.c).
+
+### Test Code
+
+A test vector is implemented in
+[test-panid-handling.c](./code/test-panid-handling.c) according to Section
+7.2.1.5, IEEE 802.15.4-2015. The testee mote outputs a test result to the
+console with the prefix, `"=check-me="`.
+
+[01-panid-handling.js](./js/01-panid-handling.js) examines each console output
+containing `"=check-me="`. If it finds `"DONE"` without having had any
+`"FAILED"`, the test is considered SUCCESS, `log.testOK()` is called. Otherwise,
+FAILED.
+
+### References
+
+* https://standards.ieee.org/findstds/standard/802.15.4-2015.html
+* https://github.com/contiki-os/contiki/pull/1914

--- a/regression-tests/25-ieee802154/code/Makefile
+++ b/regression-tests/25-ieee802154/code/Makefile
@@ -1,0 +1,8 @@
+all: test-panid-handling
+
+APPS   += unit-test
+CFLAGS += -DPROJECT_CONF_H=\"project-conf.h\"
+
+CONTIKI = ../../..
+CONTIKI_WITH_IPV6 = 1
+include $(CONTIKI)/Makefile.include

--- a/regression-tests/25-ieee802154/code/project-conf.h
+++ b/regression-tests/25-ieee802154/code/project-conf.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2016, Yasuyuki Tanaka
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#define UNIT_TEST_PRINT_FUNCTION test_print_report

--- a/regression-tests/25-ieee802154/code/test-panid-handling.c
+++ b/regression-tests/25-ieee802154/code/test-panid-handling.c
@@ -1,0 +1,319 @@
+/*
+ * Copyright (c) 2016, Yasuyuki Tanaka
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "contiki.h"
+#include "unit-test.h"
+#include "net/mac/frame802154.h"
+
+#include <stdio.h>
+
+#define VERBOSE 0
+
+PROCESS(test_process, "frame802154.c test");
+AUTOSTART_PROCESSES(&test_process);
+
+typedef enum {SUCCESS, FAILURE} result_t;
+typedef enum {NO_ADDR, SHORT, LONG} addr_mode_t;
+typedef enum {NOT_PRESENT, PRESENT} panid_mode_t;
+typedef enum {OFF, ON} panid_cmpr_mode_t;
+
+typedef struct {
+  addr_mode_t dest_addr_mode;
+  addr_mode_t src_addr_mode;
+  panid_mode_t dest_panid_mode;
+  panid_mode_t src_panid_mode;
+  panid_cmpr_mode_t panid_cmpr_mode;
+} panid_test_def;
+
+/* IEEE 802.15.4-2015, the itemization in Section 7.2.1.5 */
+/* This is applied to frames but Acknowledge */
+static panid_test_def panid_table_0b00_0b01[] = {
+  /* dest_addr, src_addr, dest_panid,  src_panid,   panid_cmp */
+  //{  NO_ADDR,   NO_ADDR,  UNDEFINED,   UNDEFINED,   OFF},
+  //{  NO_ADDR,   NO_ADDR,  UNDEFINED,   UNDEFINED,   ON},
+  {  SHORT,     SHORT,    PRESENT,     NOT_PRESENT, ON},
+  {  LONG,      SHORT,    PRESENT,     NOT_PRESENT, ON},
+  {  SHORT,     LONG,     PRESENT,     NOT_PRESENT, ON},
+  {  LONG,      LONG,     PRESENT,     NOT_PRESENT, ON},
+  {  SHORT,     SHORT,    PRESENT,     PRESENT,     OFF},
+  {  LONG,      SHORT,    PRESENT,     PRESENT,     OFF},
+  {  SHORT,     LONG,     PRESENT,     PRESENT,     OFF},
+  {  LONG,      LONG,     PRESENT,     PRESENT,     OFF},
+  {  SHORT,     NO_ADDR,  PRESENT,     NOT_PRESENT, OFF},
+  {  LONG,      NO_ADDR,  PRESENT,     NOT_PRESENT, OFF},
+  {  NO_ADDR,   SHORT,    NOT_PRESENT, PRESENT,     OFF},
+  {  NO_ADDR,   LONG,     NOT_PRESENT, PRESENT,     OFF},
+  //{  SHORT,     NO_ADDR,  UNDEFINED,   UNDEFINED,   ON},
+  //{  LONG,      NO_ADDR,  UNDEFINED,   UNDEFINED,   ON},
+  //{  NO_ADDR,   SHORT,    UNDEFINED,   UNDEFINED,   ON},
+  //{  NO_ADDR,   LONG,     UNDEFINED,   UNDEFINED,   ON},
+};
+
+
+/* IEEE 802.15.4-2015, Table 7-2 in Section 7.2.1.5 */
+static panid_test_def panid_table_0b10[] = {
+  /* dest_addr, src_addr, dest_panid,  src_panid,   panid_cmp */
+  {  NO_ADDR,   NO_ADDR,  NOT_PRESENT, NOT_PRESENT, OFF}, // index 0,  row-1
+  {  NO_ADDR,   NO_ADDR,  PRESENT,     NOT_PRESENT, ON},  // index 1,  row-2
+  {  SHORT,     NO_ADDR,  PRESENT,     NOT_PRESENT, OFF}, // index 2,  row-3-1
+  {  SHORT,     NO_ADDR,  NOT_PRESENT, NOT_PRESENT, ON},  // index 3,  row-4-1
+  {  NO_ADDR,   SHORT,    NOT_PRESENT, PRESENT,     OFF}, // index 4,  row-5-1
+  {  NO_ADDR,   SHORT,    NOT_PRESENT, NOT_PRESENT, ON},  // index 5   row-6-1
+  {  LONG,      LONG,     PRESENT,     NOT_PRESENT, OFF}, // index 6,  row-7
+  {  LONG,      LONG,     NOT_PRESENT, NOT_PRESENT, ON},  // index 7,  row-8
+  {  SHORT,     SHORT,    PRESENT,     PRESENT,     OFF}, // index 8,  row-9,  *1
+  {  SHORT,     LONG,     PRESENT,     PRESENT,     OFF}, // index 9,  row-10, *1
+  {  LONG,      SHORT,    PRESENT,     PRESENT,     OFF}, // index 10, row-11, *1
+  {  SHORT,     LONG,     PRESENT,     NOT_PRESENT, ON},  // index 11, row-12, *2
+  {  LONG,      SHORT,    PRESENT,     NOT_PRESENT, ON},  // index 12, row-13, *2
+  {  SHORT,     SHORT,    PRESENT,     NOT_PRESENT, ON},  // index 13, row-14, *2
+  {  LONG,      NO_ADDR,  PRESENT,     NOT_PRESENT, OFF}, // index 14, row-3-2
+  {  LONG,      NO_ADDR,  NOT_PRESENT, NOT_PRESENT, ON},  // index 15, row-4-2
+  {  NO_ADDR,   LONG,     NOT_PRESENT, PRESENT,     OFF}, // index 16, row-5-2
+  {  NO_ADDR,   LONG,     NOT_PRESENT, NOT_PRESENT, ON},  // index 17, row-6-2
+  /* *1: contradict row-12 in Table 2a of IEEE 802.15.4e-2012 */
+  /* *2: contradict row-13 in Table 2a of IEEE 802.15.4e-2012 */
+};
+
+typedef void (*setup_fcf_p)(const panid_test_def *, frame802154_fcf_t *);
+
+
+UNIT_TEST_REGISTER(panid_frame_ver_0b00, "PAN ID Cmpr Handing (frame-ver: 0b00)");
+UNIT_TEST_REGISTER(panid_frame_ver_0b01, "PAN ID Cmpr Handing (frame-ver: 0b01)");
+UNIT_TEST_REGISTER(panid_frame_ver_0b10, "PAN ID Cmpr Handing (frame-ver: 0b10)");
+
+
+static void
+test_print_report(const unit_test_t *utp)
+{
+  printf("=check-me= ");
+  if(utp->result == unit_test_failure) {
+    printf("FAILED   - %s: at test index %d\n", utp->descr, utp->exit_line);
+  } else {
+    printf("SUCEEDED - %s\n", utp->descr);
+  }
+}
+
+static void
+setup_addr_mode(addr_mode_t mode, uint8_t *addr_mode)
+{
+  switch(mode) {
+  case NO_ADDR:
+    *addr_mode = FRAME802154_NOADDR;
+    break;
+  case SHORT:
+    *addr_mode = FRAME802154_SHORTADDRMODE;
+    break;
+  case LONG:
+    *addr_mode = FRAME802154_LONGADDRMODE;
+    break;
+  default:
+    break;
+  }
+}
+
+static void
+setup_panid_cmpr_mode(panid_cmpr_mode_t panid_cmpr_mode, frame802154_fcf_t *fcf)
+{
+  switch(panid_cmpr_mode) {
+  case OFF:
+    fcf->panid_compression = 0;
+    break;
+  case ON:
+    fcf->panid_compression = 1;
+    break;
+  default:
+    break;
+  }
+}
+
+static void
+setup_frame802154_2003_fcf(const panid_test_def *t, frame802154_fcf_t *fcf)
+{
+  fcf->frame_version = FRAME802154_IEEE802154_2003;
+  fcf->frame_type = FRAME802154_DATAFRAME;
+
+  setup_addr_mode(t->dest_addr_mode, &fcf->dest_addr_mode);
+  setup_addr_mode(t->src_addr_mode, &fcf->src_addr_mode);
+  setup_panid_cmpr_mode(t->panid_cmpr_mode, fcf);
+}
+
+static void
+setup_frame802154_2006_fcf(const panid_test_def *t, frame802154_fcf_t *fcf)
+{
+  fcf->frame_version = FRAME802154_IEEE802154_2006;
+  fcf->frame_type = FRAME802154_DATAFRAME;
+
+  setup_addr_mode(t->dest_addr_mode, &fcf->dest_addr_mode);
+  setup_addr_mode(t->src_addr_mode, &fcf->src_addr_mode);
+  setup_panid_cmpr_mode(t->panid_cmpr_mode, fcf);
+}
+
+
+static void
+setup_frame802154_2015_fcf(const panid_test_def *t, frame802154_fcf_t *fcf)
+{
+  fcf->frame_version = FRAME802154_IEEE802154E_2012;
+
+  setup_addr_mode(t->dest_addr_mode, &fcf->dest_addr_mode);
+  setup_addr_mode(t->src_addr_mode, &fcf->src_addr_mode);
+  setup_panid_cmpr_mode(t->panid_cmpr_mode, fcf);
+}
+
+static int
+panid_run_test(const panid_test_def table[], size_t table_size,
+               setup_fcf_p setup_fcf)
+{
+  int i;
+  int num_of_tests = table_size / sizeof(panid_test_def);
+  frame802154_fcf_t fcf;
+  int has_src_pan_id, has_dest_pan_id;
+  const panid_test_def *test;
+  result_t result;
+
+  for(i = 0; i < num_of_tests; i++) {
+    test = &table[i];
+    setup_fcf(test, &fcf);
+    has_src_pan_id = 0;
+    has_dest_pan_id = 0;
+
+    frame802154_has_panid(&fcf, &has_src_pan_id, &has_dest_pan_id);
+
+    result = FAILURE;
+    switch(test->dest_panid_mode) {
+    case NOT_PRESENT:
+      if(has_dest_pan_id == 0) {
+        result = SUCCESS;
+      }
+      break;
+    case PRESENT:
+      if(has_dest_pan_id == 1) {
+        result = SUCCESS;
+      }
+      break;
+    }
+
+    if(result == SUCCESS) {
+      result = FAILURE;
+      switch(test->src_panid_mode) {
+      case NOT_PRESENT:
+        if(has_src_pan_id == 0) {
+          result = SUCCESS;
+        }
+        break;
+      case PRESENT:
+        if(has_src_pan_id == 1) {
+          result = SUCCESS;
+        }
+        break;
+      }
+    }
+
+#if VERBOSE == 1
+    printf("%d, %d, %d, %d, %d\n",
+           test->dest_addr_mode,
+           test->src_addr_mode,
+           has_dest_pan_id,
+           has_src_pan_id,
+           test->panid_cmpr_mode);
+#else
+    printf("%s", result == SUCCESS ? "." : "E");
+#endif
+    if(result == FAILURE) {
+      break;
+    }
+  }
+  printf("\n");
+  return i;
+}
+
+UNIT_TEST(panid_frame_ver_0b00)
+{
+  int index;
+  int num_of_tests = sizeof(panid_table_0b00_0b01) / sizeof(panid_test_def);
+
+  UNIT_TEST_BEGIN();
+
+  UNIT_TEST_ASSERT((index = panid_run_test(panid_table_0b00_0b01,
+                                           sizeof(panid_table_0b00_0b01),
+                                           setup_frame802154_2003_fcf)) ==
+                   num_of_tests);
+
+  UNIT_TEST_END();
+  utp->exit_line = index;
+}
+
+UNIT_TEST(panid_frame_ver_0b01)
+{
+  int index;
+  int num_of_tests = sizeof(panid_table_0b00_0b01) / sizeof(panid_test_def);
+
+  UNIT_TEST_BEGIN();
+
+  UNIT_TEST_ASSERT((index = panid_run_test(panid_table_0b00_0b01,
+                                           sizeof(panid_table_0b00_0b01),
+                                           setup_frame802154_2006_fcf)) ==
+                   num_of_tests);
+
+  UNIT_TEST_END();
+  utp->exit_line = index;
+}
+
+UNIT_TEST(panid_frame_ver_0b10)
+{
+  int index;
+  int num_of_tests = sizeof(panid_table_0b10) / sizeof(panid_test_def);
+
+  UNIT_TEST_BEGIN();
+
+  UNIT_TEST_ASSERT((index = panid_run_test(panid_table_0b10,
+                                           sizeof(panid_table_0b10),
+                                           setup_frame802154_2015_fcf)) ==
+                   num_of_tests);
+
+  UNIT_TEST_END();
+  utp->exit_line = index;
+}
+
+PROCESS_THREAD(test_process, ev, data)
+{
+  PROCESS_BEGIN();
+
+  printf("Run unit-test\n");
+  printf("---\n");
+
+  UNIT_TEST_RUN(panid_frame_ver_0b00);
+  UNIT_TEST_RUN(panid_frame_ver_0b01);
+  UNIT_TEST_RUN(panid_frame_ver_0b10);
+
+  printf("=check-me= DONE\n");
+  PROCESS_END();
+}

--- a/regression-tests/25-ieee802154/js/01-panid-handling.js
+++ b/regression-tests/25-ieee802154/js/01-panid-handling.js
@@ -1,0 +1,21 @@
+TIMEOUT(10000, log.testFailed());
+
+while(true) {
+    YIELD();
+
+    log.log(time + " " + id + " "+ msg + "\n");
+    
+    if(msg.contains("=check-me=") == false) {
+        continue;
+    }
+
+    if(msg.contains("FAILED")) {
+        log.testFailed();
+    }
+
+    if(msg.contains("DONE")) {
+        log.testOK();
+        break;
+    }
+    
+}


### PR DESCRIPTION
# Summary

`frame802154_has_panid()`  is not fully compliant with IEEE 802.15.4-2015 [1] for frames of the frame version 0b10. This is because the current implementation is based on Table 2a in IEEE 802.15.4e-2012 [2], which "cannot specify all aspects of how the PAN ID Compression field is to be used", according to a document [3].

For example, in the case where the source address is an extended address, the destination is a short address, and the PAN ID Compression is 0, the Source PAN ID is present as per IEEE 802.15.4-2015. On the other hand, as per IEEE 802.15.4e-2012, the Source PAN ID is not present, which is the case where the Source address is present, the Destination address is present, and PAN ID Compression is 0.

This PR aims for rewriting `frame802154_has_panid()` with reference to Table 7-2 of IEEE 802.15.4-2015. 

This is related to #1723.

[1] IEEE 802.15.4-2015 https://standards.ieee.org/findstds/standard/802.15.4-2015.html
[2] IEEE 802.15.4e-2012 https://standards.ieee.org/findstds/standard/802.15.4e-2012.html
[3] Proper PAN ID Field Settings for 802.15.4-2015: https://mentor.ieee.org/802.15/dcn/15/15-15-0911-01-0mag-proper-pan-id-field-settings-for-802-15-4-2015.docx

# Notice
This may affect interopeability with previous versions of Contiki, although keeping the current implementation could cause an issue on communication with an other implementation.

# Test
The test code has moved under "regression-tests/25-ieee802154/".  You can run the test as follows:
```shell
$ cd regression-tests/25-ieee802154
$ make
Running test 01-panid-handling with random Seed 1: ...... OK
```
The following information is obsolete:

\<obsolete\>
With `examples/unit-test/frame802154`, you can test `frame802154_has_panid()`. Run `make` under the directory. You'll have an executable file named `test.native`.

Here is the result of `test.native` with the current implementation of 'frame802154_has_panid()`:
```shell
$ ./test.native
Contiki-3.x-2925-g672d603 started with IPV6, RPL
Rime started with address 1.2.3.4.5.6.7.8
MAC nullmac RDC nullrdc NETWORK sicslowpan
Tentative link-local IPv6 address fe80:0000:0000:0000:0302:0304:0506:0708
Run unit-test

---
............
SUCEEDED - PAN ID Cmpr Handing (frame-ver: 0b00)
............
SUCEEDED - PAN ID Cmpr Handing (frame-ver: 0b01)
........E
FAILED   - PAN ID Cmpr Handing (frame-ver: 0b10): at test index 8
```

After applying the patch, the test called "PAN ID Cmpr Handing (frame-ver: 0b10)" passed.

```shell
$ ./test.native
Contiki-3.x-2928-ge68a530 started with IPV6, RPL
Rime started with address 1.2.3.4.5.6.7.8
MAC nullmac RDC nullrdc NETWORK sicslowpan
Tentative link-local IPv6 address fe80:0000:0000:0000:0302:0304:0506:0708
Run unit-test

---
............
SUCEEDED - PAN ID Cmpr Handing (frame-ver: 0b00)
............
SUCEEDED - PAN ID Cmpr Handing (frame-ver: 0b01)
..................
SUCEEDED - PAN ID Cmpr Handing (frame-ver: 0b10)

```
\</obsolete\>