### PR TITLE
cc26xx-cc13xx: Add iBeacon support

### DIFF
--- a/cpu/cc26xx-cc13xx/rf-core/rf-ble.c
+++ b/cpu/cc26xx-cc13xx/rf-core/rf-ble.c
@@ -73,6 +73,9 @@
 #define BLE_ADV_NAME_BUF_LEN        32
 #define BLE_ADV_PAYLOAD_BUF_LEN     64
 #define BLE_UUID_SIZE               16
+/**iBeacons macros*/
+#define IBEACON_ADV_HEAD              {0x02,0x01,0x06,0x1A,0xFF,0x4C,0x00,0x02,0x15} /*iBeacon Header, 9 bytes*/
+#define IBEACON_ADV_HEAD_LEN          9
 /*---------------------------------------------------------------------------*/
 static unsigned char ble_params_buf[32] CC_ALIGN(4);
 static uint8_t ble_mode_on = RF_BLE_IDLE;
@@ -80,6 +83,9 @@ static struct etimer ble_adv_et;
 static uint8_t payload[BLE_ADV_PAYLOAD_BUF_LEN];
 static int p = 0;
 static int i;
+#ifdef IBEACON_ENABLED
+static uint8_t uuid[BLE_UUID_SIZE] = IBEACON_CONF_UUID;
+#endif
 /*---------------------------------------------------------------------------*/
 typedef struct default_ble_tx_power_s {
    uint16_t ib:6;
@@ -94,6 +100,10 @@ static default_ble_tx_power_t tx_power = { 0x29, 0x00, 0x00, 0x00 };
 static struct ble_beacond_config {
   clock_time_t interval;
   char adv_name[BLE_ADV_NAME_BUF_LEN];
+#ifdef IBEACON_ENABLED
+  uint16_t major;
+  uint16_t minor;
+#endif
 } beacond_config = { .interval = BLE_ADV_INTERVAL };
 /*---------------------------------------------------------------------------*/
 /* BLE overrides */
@@ -156,6 +166,7 @@ send_ble_adv_nc(int channel, uint8_t *adv_payload, int adv_payload_len)
   return RF_CORE_CMD_OK;
 }
 /*---------------------------------------------------------------------------*/
+#ifndef IBEACON_ENABLED
 void
 rf_ble_beacond_config(clock_time_t interval, const char *name)
 {
@@ -176,6 +187,23 @@ rf_ble_beacond_config(clock_time_t interval, const char *name)
     beacond_config.interval = interval;
   }
 }
+#else
+/*---------------------------------------------------------------------------*/
+void
+rf_ble_beacond_config(clock_time_t interval, uint16_t major, uint16_t minor)
+{
+  if(RF_BLE_ENABLED == 0) {
+    return;
+  }
+
+  beacond_config.major=major;
+  beacond_config.minor=minor;
+
+  if(interval != 0) {
+    beacond_config.interval = interval;
+  }
+}
+#endif
 /*---------------------------------------------------------------------------*/
 uint8_t
 rf_ble_beacond_start()
@@ -188,9 +216,11 @@ rf_ble_beacond_start()
     return RF_CORE_CMD_ERROR;
   }
 
+#ifndef IBEACON_ENABLED
   if(beacond_config.adv_name[0] == 0) {
     return RF_CORE_CMD_ERROR;
   }
+#endif
 
   ble_mode_on = RF_BLE_IDLE;
 
@@ -250,14 +280,14 @@ PROCESS_THREAD(rf_ble_beacon_process, ev, data)
   int j;
   uint32_t cmd_status;
   bool interrupts_disabled;
-
+  uint8_t ibeacon_head[IBEACON_ADV_HEAD_LEN]= IBEACON_ADV_HEAD;
+  int tx_power;
   PROCESS_BEGIN();
 
   while(1) {
     etimer_set(&ble_adv_et, beacond_config.interval);
 
     PROCESS_WAIT_EVENT_UNTIL(etimer_expired(&ble_adv_et) || ev == PROCESS_EVENT_EXIT);
-
     if(ev == PROCESS_EVENT_EXIT) {
       PROCESS_EXIT();
     }
@@ -267,6 +297,7 @@ PROCESS_THREAD(rf_ble_beacon_process, ev, data)
 
     /* device info */
     memset(payload, 0, BLE_ADV_PAYLOAD_BUF_LEN);
+#ifndef IBEACON_ENABLED
     payload[p++] = 0x02;          /* 2 bytes */
     payload[p++] = BLE_ADV_TYPE_DEVINFO;
     payload[p++] = 0x1a;          /* LE general discoverable + BR/EDR */
@@ -275,7 +306,19 @@ PROCESS_THREAD(rf_ble_beacon_process, ev, data)
     memcpy(&payload[p], beacond_config.adv_name,
            strlen(beacond_config.adv_name));
     p += strlen(beacond_config.adv_name);
-
+#else
+    for(i = 0; i < IBEACON_ADV_HEAD_LEN; i++) {
+        payload[p++] = ( ibeacon_head[i] );
+    }
+    for(i = 0; i < BLE_UUID_SIZE ; i++) {
+        payload[p++] = uuid[i];
+    }
+    payload[p++] = beacond_config.major;
+    payload[p++] = beacond_config.minor;
+    NETSTACK_RADIO.get_value(RADIO_PARAM_TXPOWER, &tx_power);
+    payload[p++] = tx_power;
+    PRINTF("rf_ble_beacon_process: power tx %i\n",tx_power);
+#endif
     for(i = 0; i < BLE_ADV_MESSAGES; i++) {
       /*
        * Under ContikiMAC, some IEEE-related operations will be called from an

--- a/cpu/cc26xx-cc13xx/rf-core/rf-ble.c
+++ b/cpu/cc26xx-cc13xx/rf-core/rf-ble.c
@@ -314,7 +314,9 @@ PROCESS_THREAD(rf_ble_beacon_process, ev, data)
         payload[p++] = uuid[i];
     }
     payload[p++] = beacond_config.major;
+    payload[p++] = (beacond_config.major << 8);
     payload[p++] = beacond_config.minor;
+    payload[p++] = (beacond_config.minor << 8);
     NETSTACK_RADIO.get_value(RADIO_PARAM_TXPOWER, &tx_power);
     payload[p++] = tx_power;
     PRINTF("rf_ble_beacon_process: power tx %i\n",tx_power);

--- a/cpu/cc26xx-cc13xx/rf-core/rf-ble.h
+++ b/cpu/cc26xx-cc13xx/rf-core/rf-ble.h
@@ -53,6 +53,11 @@
 #else
 #define RF_BLE_ENABLED 1
 #endif
+#ifdef IBEACON_CONF_ENABLED
+#define IBEACON_ENABLED IBEACON_CONF_ENABLED
+#else
+#define IBEACON_ENABLED 0
+#endif
 /*---------------------------------------------------------------------------*/
 #define RF_BLE_IDLE   0
 #define RF_BLE_ACTIVE 1
@@ -66,8 +71,11 @@
  * this function can be used to configure a single parameter at a time if so
  * desired.
  */
+#ifndef IBEACON_ENABLED
 void rf_ble_beacond_config(clock_time_t interval, const char *name);
-
+#else
+void rf_ble_beacond_config(clock_time_t interval, uint16_t major, uint16_t minor);
+#endif
 /**
  * \brief Start the BLE advertisement/beacon daemon
  * \return RF_CORE_CMD_OK: Success, RF_CORE_CMD_ERROR: Failure


### PR DESCRIPTION
This commit add support for [iBeacons](https://en.wikipedia.org/wiki/IBeacon)

To enable it, you must define:
```
#define IBEACON_CONF_ENABLED     1
#define IBEACON_CONF_UUID { 0xF0, 0xF1, 0xF2, 0xF3, 0xF4, 0xF5, 0xF6, 0xF7, 0xF8, 0xF9, 0xFA, 0xFB, 0xFC, 0xFD, 0xFE, 0xFF }
```
Of course with a valid UUID.