### PR TITLE
zoul/remote-revb: initialize unused pins to minimize current draw

### DIFF
--- a/platform/zoul/contiki-main.c
+++ b/platform/zoul/contiki-main.c
@@ -169,8 +169,8 @@ main(void)
    * slip_input_byte instead
    */
 #if UART_CONF_ENABLE
-  uart_init(0);
-  uart_init(1);
+  /* Only enable the UART to be used by serial line */
+  uart_init(SERIAL_LINE_CONF_UART);
   uart_set_input(SERIAL_LINE_CONF_UART, serial_line_input_byte);
 #endif
 

--- a/platform/zoul/remote-revb/board.h
+++ b/platform/zoul/remote-revb/board.h
@@ -433,6 +433,13 @@
  * a microSD in the slot, or when connected to disable the microSD to save power
  * @{
  */
+#ifdef PLATFORM_CONF_WITH_MICRO_SD
+#define PLATFORM_WITH_MICRO_SD PLATFORM_CONF_WITH_MICRO_SD
+#else
+#define PLATFORM_WITH_MICRO_SD 1
+#endif
+
+#if PLATFORM_WITH_MICRO_SD
 #define USD_CLK_PORT             SPI1_CLK_PORT
 #define USD_CLK_PIN              SPI1_CLK_PIN
 #define USD_MOSI_PORT            SPI1_TX_PORT
@@ -443,6 +450,7 @@
 #define USD_CSN_PIN              7
 #define USD_SEL_PORT             GPIO_A_NUM
 #define USD_SEL_PIN              6
+#endif
 /** @} */
 /*---------------------------------------------------------------------------*/
 /**


### PR DESCRIPTION
This is a **work in progress** to reduce the current draw from pins not used, please feel free to drop any comment or suggestion!

Testing with the `examples/zolertia/zoul/zoul-demo` with the following changes:

- `NETSTACK_MAC.off(1);` in [L128](https://github.com/contiki-os/contiki/blob/master/examples/zolertia/zoul/zoul-demo.c#L128) commented out
- `PROCESS_YIELD();` in [L145](https://github.com/contiki-os/contiki/blob/master/examples/zolertia/zoul/zoul-demo.c#L145) changed to `PROCESS_WAIT_EVENT_UNTIL(0)`
- `NullRDC` commented out in [project-conf.h](https://github.com/contiki-os/contiki/blob/master/examples/zolertia/zoul/project-conf.h#L44)

So far in PM2 the current drops from 2.73mA to 0.672mA, but some work is still required.  There is around 500uA consumed by the XTAL oscillator (32KHz), as gatting the pads reduces the current consumption to 50uA.  Dropping to PM3 yields around 32uA.

The values are measured on the battery input of the RE-Mote.