### PR TITLE
ContikiMac: Schedule next cycle after last CCA check

### DIFF
--- a/core/net/mac/contikimac/contikimac.c
+++ b/core/net/mac/contikimac/contikimac.c
@@ -429,6 +429,13 @@ powercycle(struct rtimer *t, void *ptr)
         }
         powercycle_turn_radio_off();
       }
+
+      // If this is the last CCA check, avoid yielding and go straight to scheduling
+      // our next cycle
+      if (count == CCA_COUNT_MAX - 1) {
+          break;
+      }
+
       schedule_powercycle_fixed(t, RTIMER_NOW() + CCA_SLEEP_TIME);
       PT_YIELD(&pt);
     }


### PR DESCRIPTION
After the last CCA check, ContikiMac schedules another wake up and
yields.
When it wakes up again, it just schedules the next cycle check.

This wastes power and time, so once we are done with the last CCA check,
we immediately schedule the next cycle check and yield.
This saves us from performing an extra yield / sleep / wakeup cycle.

On a power meter, the 3rd spike seen after the first 2 CCA checks
disappears. On a muntjac (remote-like platform), this reduces our average power consumption by
~0.4mA.