### PR TITLE
Add IPv6 over BLE support for SensorTag CC26xx platform

### DIFF
--- a/core/net/ipv6/uip-nd6.c
+++ b/core/net/ipv6/uip-nd6.c
@@ -517,10 +517,16 @@ na_input(void)
       if(nd6_opt_llao == NULL || !extract_lladdr_from_llao_aligned(&lladdr_aligned)) {
         goto discard;
       }
+
+#if NETSTACK_RADIO != ble_mode
+      /**
+       * The neighbor table is not needed in ble mode
+       */
       if(nbr_table_update_lladdr((const linkaddr_t *)lladdr, (const linkaddr_t *)&lladdr_aligned, 1) == 0) {
         /* failed to update the lladdr */
         goto discard;
       }
+#endif
 
       if(is_solicited) {
         nbr->state = NBR_REACHABLE;

--- a/cpu/cc26xx-cc13xx/Makefile.cc26xx-cc13xx
+++ b/cpu/cc26xx-cc13xx/Makefile.cc26xx-cc13xx
@@ -61,7 +61,7 @@ endif
 CLEAN += symbols.c symbols.h *.d *.elf *.hex
 
 ### CPU-dependent directories
-CONTIKI_CPU_DIRS = . dev rf-core rf-core/api $(TI_XXWARE_STARTUP_DIR)
+CONTIKI_CPU_DIRS = . dev rf-core rf-core/api rf-core/ble-hal $(TI_XXWARE_STARTUP_DIR) net
 
 ### Use the existing debug I/O in cpu/arm/common
 CONTIKI_CPU_DIRS += ../arm/common/dbg-io
@@ -72,7 +72,9 @@ CONTIKI_CPU_SOURCEFILES += contiki-watchdog.c aux-ctrl.c
 CONTIKI_CPU_SOURCEFILES += putchar.c ieee-addr.c batmon-sensor.c adc-sensor.c
 CONTIKI_CPU_SOURCEFILES += slip-arch.c slip.c cc26xx-uart.c lpm.c
 CONTIKI_CPU_SOURCEFILES += gpio-interrupt.c oscillators.c
-CONTIKI_CPU_SOURCEFILES += rf-core.c rf-ble.c ieee-mode.c
+CONTIKI_CPU_SOURCEFILES += rf-core.c
+CONTIKI_CPU_SOURCEFILES += rf-ble.c ieee-mode.c
+CONTIKI_CPU_SOURCEFILES += ble-mode.c ble-hal-cc26xx.c ble-addr.c rf-ble-cmd.c 
 CONTIKI_CPU_SOURCEFILES += random.c soc-trng.c
 
 DEBUG_IO_SOURCEFILES += dbg-printf.c dbg-snprintf.c dbg-sprintf.c strformat.c

--- a/cpu/cc26xx-cc13xx/Makefile.cc26xx-cc13xx
+++ b/cpu/cc26xx-cc13xx/Makefile.cc26xx-cc13xx
@@ -75,6 +75,7 @@ CONTIKI_CPU_SOURCEFILES += gpio-interrupt.c oscillators.c
 CONTIKI_CPU_SOURCEFILES += rf-core.c
 CONTIKI_CPU_SOURCEFILES += rf-ble.c ieee-mode.c
 CONTIKI_CPU_SOURCEFILES += ble-mode.c ble-hal-cc26xx.c ble-addr.c rf-ble-cmd.c 
+CONTIKI_CPU_SOURCEFILES += ble-mac.c
 CONTIKI_CPU_SOURCEFILES += random.c soc-trng.c
 
 DEBUG_IO_SOURCEFILES += dbg-printf.c dbg-snprintf.c dbg-sprintf.c strformat.c

--- a/cpu/cc26xx-cc13xx/ble-addr.c
+++ b/cpu/cc26xx-cc13xx/ble-addr.c
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2016, Michael Spoerk
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Author: Michael Spoerk <mi.spoerk@gmail.com>
+ *
+ */
+/*---------------------------------------------------------------------------*/
+#include "contiki-conf.h"
+#include "net/linkaddr.h"
+#include "ble-addr.h"
+#include <string.h>
+
+/*---------------------------------------------------------------------------*/
+void
+ble_addr_cpy_to(uint8_t *dst)
+{
+  int i;
+  uint8_t *location = (uint8_t *)BLE_ADDR_LOCATION;
+
+  for(i = 0; i < BLE_ADDR_SIZE; i++) {
+    dst[i] = location[BLE_ADDR_SIZE - 1 - i];
+  }
+}
+/*---------------------------------------------------------------------------*/
+void
+ble_addr_to_eui64(uint8_t *dst, uint8_t *src)
+{
+  memcpy(dst, src, 3);
+  dst[3] = 0xFF;
+  dst[4] = 0xFE;
+  memcpy(&dst[5], &src[3], 3);
+}
+/*---------------------------------------------------------------------------*/
+void
+ble_eui64_addr_cpy_to(uint8_t *dst)
+{
+  uint8_t ble_addr[BLE_ADDR_SIZE];
+  ble_addr_cpy_to(ble_addr);
+  ble_addr_to_eui64(dst, ble_addr);
+}

--- a/cpu/cc26xx-cc13xx/ble-addr.h
+++ b/cpu/cc26xx-cc13xx/ble-addr.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2016, Michael Spoerk
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Author: Michael Spoerk <mi.spoerk@gmail.com>
+ *
+ */
+/*---------------------------------------------------------------------------*/
+#ifndef BLE_ADDR_H_
+#define BLE_ADDR_H_
+/*---------------------------------------------------------------------------*/
+#include "contiki-conf.h"
+#include <stdint.h>
+/*---------------------------------------------------------------------------*/
+/* primary BLE address location */
+#define BLE_ADDR_LOCATION   0x500012E8
+
+/* BLE device address size */
+#define BLE_ADDR_SIZE 6
+
+/*---------------------------------------------------------------------------*/
+/* Type of BLE device address */
+typedef enum {
+  BLE_ADDR_TYPE_PUBLIC,
+  BLE_ADDR_TYPE_RANDOM
+} ble_addr_type_t;
+
+/*---------------------------------------------------------------------------*/
+void ble_addr_cpy_to(uint8_t *dst);
+
+void ble_addr_to_eui64(uint8_t *dst, uint8_t *src);
+
+void ble_eui64_addr_cpy_to(uint8_t *dst);
+/*---------------------------------------------------------------------------*/
+
+#endif /* BLE_ADDR_H_ */

--- a/cpu/cc26xx-cc13xx/dev/ble-hal.h
+++ b/cpu/cc26xx-cc13xx/dev/ble-hal.h
@@ -1,0 +1,312 @@
+/*
+ * Copyright (c) 2016, Michael Spoerk
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Author: Michael Spoerk <mi.spoerk@gmail.com>
+ *
+ */
+/*---------------------------------------------------------------------------*/
+
+#ifndef BLE_HAL_H_
+#define BLE_HAL_H_
+
+#include <stddef.h>
+#include "ble-addr.h"
+
+/*---------------------------------------------------------------------------*/
+/* Advertisement channel definitions                                         */
+#define BLE_ADV_DATA_LEN         31
+#define BLE_SCAN_RESP_DATA_LEN   31
+#define BLE_ADV_CHANNEL_1        37
+#define BLE_ADV_CHANNEL_1_MASK   0b001
+#define BLE_ADV_CHANNEL_2        38
+#define BLE_ADV_CHANNEL_2_MASK   0b010
+#define BLE_ADV_CHANNEL_3        39
+#define BLE_ADV_CHANNEL_3_MASK   0b100
+#define BLE_ADV_INTERVAL_MIN     0x0020
+#define BLE_ADV_INTERVAL_MAX     0x4000
+/*---------------------------------------------------------------------------*/
+/* Data channel definitions                                                  */
+#define BLE_DATA_CHANNEL_MIN     0
+#define BLE_DATA_CHANNEL_MAX     36
+/* Types of data PDU frames                                                  */
+#define BLE_DATA_PDU_LLID_DATA_FRAGMENT     0b01
+#define BLE_DATA_PDU_LLID_DATA_MESSAGE      0b10
+#define BLE_DATA_PDU_LLID_CONTROL           0b11
+/*---------------------------------------------------------------------------*/
+/* Return values for functions of ble_controller_driver implementations      */
+typedef enum {
+  BLE_RESULT_OK,
+  BLE_RESULT_NOT_SUPPORTED,
+  BLE_RESULT_INVALID_PARAM,
+  BLE_RESULT_ERROR
+} ble_result_t;
+
+/*---------------------------------------------------------------------------*/
+/* Advertising modes of BLE */
+typedef enum {
+  /* connectable undirected advertising */
+  BLE_ADV_IND,
+
+  /* connectable directed advertising (high duty cycle) */
+  BLE_ADV_DIR_IND_HDC,
+
+  /* scannable undirected advertising */
+  BLE_ADV_SCAN_IND,
+
+  /* non connectable undirected advertising */
+  BLE_ADV_NONCONN_IND,
+
+  /* connectable directed advertising (low duty cycle) */
+  BLE_ADV_DIR_IND_LDC
+} ble_adv_type_t;
+
+/*---------------------------------------------------------------------------*/
+/* Scanning modes of BLE */
+typedef enum {
+  BLE_SCAN_PASSIVE,
+  BLE_SCAN_ACTIVE
+} ble_scan_type_t;
+
+/*---------------------------------------------------------------------------*/
+/* List of packets to be sent by RDC layer */
+struct ble_buf_list {
+  struct ble_buf_list *next;
+  struct queuebuf *buf;
+  void *ptr;
+};
+
+/*---------------------------------------------------------------------------*/
+/* Extension of the RADIO_PARAM fields for the BLE radios                    */
+enum {
+  /* start with 100 to be sure to not interfere with the standard values*/
+
+  /*-----------------------------------------------------------------------*/
+  /* BLE controller general                                                */
+  /* The bluetooth device address */
+  RADIO_CONST_BLE_BD_ADDR = 100,
+
+  /* the size of a single BLE command buffer */
+  RADIO_CONST_BLE_BUFFER_SIZE,
+
+  /* the amount of single BLE command buffers */
+  RADIO_CONST_BLE_BUFFER_AMOUNT,
+
+  /*-----------------------------------------------------------------------*/
+  /* BLE advertisement                                                     */
+
+  /* minimum advertisement interval
+   * value can range from RADIO_CONST_BLE_ADV_INTERVAL_MIN to
+   * RADIO_CONST_BLE_ADV_INTERVAL_MAX and must not be greater than
+   * RADIO_RARAM_BLE_ADV_INTERVAL_MAX */
+  RADIO_PARAM_BLE_ADV_INTERVAL,
+
+  /* minimum advertisement interval according to standard */
+  RADIO_CONST_BLE_ADV_INTERVAL_MIN,
+
+  /* maximum advertisement interval according to standard */
+  RADIO_CONST_BLE_ADV_INTERVAL_MAX,
+
+  /* BLE advertisement type (directed/undirected, ...) */
+  RADIO_PARAM_BLE_ADV_TYPE,
+
+  /* type of own address during advertisement */
+  RADIO_PARAM_BLE_ADV_OWN_ADDR_TYPE,
+
+  /* advertisement channel map */
+  RADIO_PARAM_BLE_ADV_CHANNEL_MAP,
+
+  /* advertisement payload */
+  RADIO_PARAM_BLE_ADV_PAYLOAD,
+
+  /* scan response payload */
+  RADIO_PARAM_BLE_ADV_SCAN_RESPONSE,
+
+  /* 1: enable advertisement / 0: disable advertisement */
+  RADIO_PARAM_BLE_ADV_ENABLE
+};
+
+/*---------------------------------------------------------------------------*/
+/**
+ * The structure of a ble radio controller driver in Contiki.
+ */
+struct ble_hal_driver {
+
+  /*------------------------------------------------------------------------*/
+  /* GENERAL COMMANDS                                                       */
+  /**
+   *  Resets the BLE controller
+   */
+  ble_result_t (*reset)(void);
+
+  /**
+   * Reads the static BLE device address.
+   *
+   * \param addr the static device address
+   */
+  ble_result_t (*read_bd_addr)(uint8_t *addr);
+
+  /**
+   * Reads the size of the data buffers.
+   *
+   * \param buf_len the length of a single data buffer
+   * \param num_buf the number of data buffers
+   */
+  ble_result_t (*read_buffer_size) (unsigned int *buf_len,
+                                    unsigned int *num_buf);
+
+  /*------------------------------------------------------------------------*/
+  /* ADVERTISING COMMANDS                                                   */
+  /**
+   * Sets the parameter for advertising.
+   *
+   * \param adv_interval advertising interval
+   *                     (interval = adv_interval * 0.625 ms)
+   * \param type type of advertising
+   * \param own_addr_type indicator if own address is public/random
+   * \param adv_channel_map map of advertising channels to use
+   */
+  ble_result_t (*set_adv_param) (unsigned int adv_interval,
+                                 ble_adv_type_t type,
+                                 ble_addr_type_t own_addr_type,
+                                 unsigned short adv_channel_map);
+
+  /**
+   * Reads the used power on the advertisement channels.
+   *
+   * \param power the used power in dBm
+   */
+  ble_result_t (*read_adv_channel_tx_power) (short *power);
+
+  /**
+   * Sets the advertising data.
+   *
+   * \param data_len the length of the advertising data
+   * \param data the data to advertise
+   */
+  ble_result_t (*set_adv_data) (unsigned short data_len,
+                                char *data);
+
+  /**
+   * Sets the scan response data.
+   *
+   * \param data_len the length of the scan response data
+   * \param data the data of a scan response
+   */
+  ble_result_t (*set_scan_resp_data) (unsigned short data_len,
+                                      char *data);
+
+  /**
+   * Enables/disables advertising.
+   *
+   * \param enable if 1 then enable advertising, otherwise disable
+   */
+  ble_result_t (*set_adv_enable) (unsigned short enable);
+
+  /*------------------------------------------------------------------------*/
+  /* SCANNING COMMANDS                                                      */
+  /**
+   * Sets the parameter for scanning.
+   *
+   * \param type scan mode
+   * \param scan_interval scan interval (interval = scan_interval * 0.625 ms)
+   * \param scan_window scan window (window = scan_window * 0.625 ms)
+   * \param own_addr_type indicator if own address is public/random
+   */
+  ble_result_t (*set_scan_param) (ble_scan_type_t type,
+                                  unsigned int scan_interval,
+                                  unsigned int scan_window,
+                                  ble_addr_type_t own_addr_type);
+
+  /**
+   * Enables/disables scanning.
+   *
+   * \param enable 1: enable scanning, otherwise disable
+   * \param filter_duplicates: 1: filter duplicates, otherwise no filtering
+   */
+  ble_result_t (*set_scan_enable) (unsigned short enable,
+                                   unsigned short filter_duplicates);
+
+  /*------------------------------------------------------------------------*/
+  /* INITIATING COMMANDS                                                    */
+  /**
+   * Initiates the creation of a BLE connection.
+   *
+   * \param scan_interval scan interval (interval = scan_interval * 0.625 ms)
+   * \param scan_window scan window (window = scan_window * 0.625 ms)
+   * \param peer_addr_type indicator if peer address is public/random
+   * \param peer_addr ble address of the device to connect to
+   * \param own_addr_type indicator if own address is public/random
+   * \param conn_interval connection interval
+   *                      (interval = conn_interval * 1.25 ms)
+   * \param conn_latency slave latency
+   * \param supervision_timeout (timeout = supervision_timeout * 10 ms)
+   */
+  ble_result_t (*create_connection) (unsigned int scan_interval,
+                                     unsigned int scan_window,
+                                     ble_addr_type_t peer_addr_type,
+                                     uint8_t *peer_addr,
+                                     ble_addr_type_t own_addr_type,
+                                     unsigned int conn_interval,
+                                     unsigned int conn_latency,
+                                     unsigned int supervision_timeout);
+
+  /**
+   * Cancels the initiation of a BLE connection.
+   */
+  ble_result_t (*create_connection_cancel) (void);
+
+  /*------------------------------------------------------------------------*/
+  /* CONNECTION COMMANDS                                                    */
+  /**
+   * Updates the connection parameters.
+   * \param conn_interval connection interval
+   *                      (interval = conn_interval * 1.25 ms)
+   * \param conn_latency slave latency
+   * \param supervision_timeout (timeout = supervision_timeout * 10 ms)
+   */
+  ble_result_t (*connection_update) (unsigned int connection_handle,
+                                     unsigned int conn_interval,
+                                     unsigned int conn_latency,
+                                     unsigned int supervision_timeout);
+
+  /**
+   * Disconnects the connection.
+   *
+   * \param connection_handle
+   * \param reason see error codes of Bluetooth specification
+   */
+  ble_result_t (*disconnect) (unsigned int connection_handle,
+                              unsigned short reason);
+
+  ble_result_t (*send) (void *buf, unsigned short buf_len);
+
+  ble_result_t (*send_list) (struct ble_buf_list *list);
+};
+
+#endif /* BLE_HAL_H_ */

--- a/cpu/cc26xx-cc13xx/net/ble-mac.c
+++ b/cpu/cc26xx-cc13xx/net/ble-mac.c
@@ -1,0 +1,538 @@
+/*
+ * Copyright (c) 2016, Michael Spoerk
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Author: Michael Spoerk <mi.spoerk@gmail.com>
+ *
+ */
+/*---------------------------------------------------------------------------*/
+
+#include "ble-hal.h"
+#include "net/packetbuf.h"
+#include "net/netstack.h"
+#include "net/ip/uip.h"
+
+#include "sys/etimer.h"
+
+#include "lib/memb.h"
+#include "lib/list.h"
+
+#include <string.h>
+
+/*---------------------------------------------------------------------------*/
+#define DEBUG 1
+#if DEBUG
+#include <stdio.h>
+#define PRINTF(...) printf(__VA_ARGS__)
+#define PRINTADDR(addr) PRINTF("%02X:%02X:%02X:%02X:%02X:%02X", ((uint8_t *)addr)[0], ((uint8_t *)addr)[1], ((uint8_t *)addr)[2], ((uint8_t *)addr)[3], ((uint8_t *)addr)[4], ((uint8_t *)addr)[5])
+#else
+#define PRINTF(...)
+#define PRINTADDR(addr)
+#endif
+/*---------------------------------------------------------------------------*/
+#define BLE_DEVICE_NAME "TI Sensortag"
+#define BLE_SLAVE_CONN_INTERVAL_MIN  0x0150
+#define BLE_SLAVE_CONN_INTERVAL_MAX  0x01F0
+
+#define L2CAP_SIGNAL_CHANNEL 0x0005
+#define L2CAP_FLOW_CHANNEL   0x0041
+
+#define L2CAP_CODE_CONN_REQ    0x14
+#define L2CAP_CODE_CONN_RSP    0x15
+#define L2CAP_CODE_CREDIT      0x16
+
+#define L2CAP_NODE_MTU         1280
+#define L2CAP_NODE_FRAG_LEN     255
+#define L2CAP_NODE_INIT_CREDITS   8
+#define L2CAP_CREDIT_THRESHOLD    2
+
+#define L2CAP_FIRST_HEADER_SIZE         6
+#define L2CAP_FIRST_FRAGMENT_SIZE   (L2CAP_NODE_FRAG_LEN - L2CAP_FIRST_HEADER_SIZE)
+#define L2CAP_SUBSEQ_HEADER_SIZE        4
+#define L2CAP_SUBSEQ_FRAGMENT_SIZE  (L2CAP_NODE_FRAG_LEN - L2CAP_SUBSEQ_HEADER_SIZE)
+#define L2CAP_TRANSMISSION_DELAY    (CLOCK_SECOND / 64)
+/*---------------------------------------------------------------------------*/
+/* BLE controller */
+/* public device address of BLE controller */
+static uint8_t ble_addr[BLE_ADDR_SIZE];
+
+/* length of a single BLE controller buffer */
+static int buffer_len;
+/* Number of buffers available at the BLE controller */
+static int num_buffer;
+/*---------------------------------------------------------------------------*/
+/* L2CAP fragmentation buffers and utilities                                 */
+
+typedef struct {
+  /* L2CAP Service Data Unit (SDU) */
+  uint8_t sdu[L2CAP_NODE_MTU];
+  /* length of the L2CAP SDU */
+  uint16_t sdu_length;
+  /* index of the first byte not sent yet */
+  uint16_t current_index;
+} l2cap_buffer_t;
+
+static l2cap_buffer_t tx_buffer;
+static l2cap_buffer_t rx_buffer;
+/*---------------------------------------------------------------------------*/
+PROCESS(ble_mac_process, "BLE MAC process");
+/*---------------------------------------------------------------------------*/
+typedef struct {
+  uint16_t cid;
+  uint16_t mtu;
+  uint16_t mps;
+  uint16_t credits;
+} ble_mac_l2cap_channel_t;
+
+static ble_mac_l2cap_channel_t l2cap_router;
+static ble_mac_l2cap_channel_t l2cap_node;
+/*---------------------------------------------------------------------------*/
+static uint8_t
+init_adv_data(char *adv_data)
+{
+  uint8_t adv_data_len = 0;
+  memset(adv_data, 0x00, BLE_ADV_DATA_LEN);
+  /* BLE flags */
+  adv_data[adv_data_len++] = 2;
+  adv_data[adv_data_len++] = 0x01;
+  adv_data[adv_data_len++] = 0x05;     /* LE limited  (no BR/EDR support) */
+  /* TX power level */
+  adv_data[adv_data_len++] = 2;
+  adv_data[adv_data_len++] = 0x0A;
+  adv_data[adv_data_len++] = 0;        /* 0 dBm */
+  /* service UUIDs (16-bit identifiers) */
+  adv_data[adv_data_len++] = 3;
+  adv_data[adv_data_len++] = 0x03;
+  adv_data[adv_data_len++] = 0x20;
+  adv_data[adv_data_len++] = 0x18;     /* only IP support service exposed */
+  /* service UUIDs (32-bit identifiers) */
+  adv_data[adv_data_len++] = 1;
+  adv_data[adv_data_len++] = 0x05;     /* empty list */
+  /* service UUIDs (128-bit identifiers) */
+  adv_data[adv_data_len++] = 1;
+  adv_data[adv_data_len++] = 0x07;     /* empty list */
+  return adv_data_len;
+}
+/*---------------------------------------------------------------------------*/
+static uint8_t
+init_scan_resp_data(char *scan_resp_data)
+{
+  uint8_t scan_resp_data_len = 0;
+  memset(scan_resp_data, 0x00, BLE_SCAN_RESP_DATA_LEN);
+  /* complete device name */
+  scan_resp_data[scan_resp_data_len++] = 1 + strlen(BLE_DEVICE_NAME);
+  scan_resp_data[scan_resp_data_len++] = 0x09;
+  memcpy(&scan_resp_data[scan_resp_data_len],
+         BLE_DEVICE_NAME, strlen(BLE_DEVICE_NAME));
+  scan_resp_data_len += strlen(BLE_DEVICE_NAME);
+  /* slave connection interval range */
+  scan_resp_data[scan_resp_data_len++] = 5;
+  scan_resp_data[scan_resp_data_len++] = 0x12;
+  scan_resp_data[scan_resp_data_len++] = (BLE_SLAVE_CONN_INTERVAL_MIN & 0xFF);
+  scan_resp_data[scan_resp_data_len++] = ((BLE_SLAVE_CONN_INTERVAL_MIN >> 8) & 0xFF);
+  scan_resp_data[scan_resp_data_len++] = (BLE_SLAVE_CONN_INTERVAL_MAX & 0xFF);
+  scan_resp_data[scan_resp_data_len++] = ((BLE_SLAVE_CONN_INTERVAL_MAX >> 8) & 0xFF);
+
+  return scan_resp_data_len;
+}
+/*---------------------------------------------------------------------------*/
+static void
+init(void)
+{
+  uint8_t adv_data_len, scan_resp_data_len;
+  char adv_data[BLE_ADV_DATA_LEN];
+  char scan_resp_data[BLE_SCAN_RESP_DATA_LEN];
+
+  PRINTF("[ ble-mac ] init()\n");
+
+  /* initialize the L2CAP connection parameter */
+  l2cap_node.cid = L2CAP_FLOW_CHANNEL;
+  l2cap_node.credits = L2CAP_NODE_INIT_CREDITS;
+  l2cap_node.mps = (L2CAP_NODE_FRAG_LEN - L2CAP_SUBSEQ_HEADER_SIZE);
+  l2cap_node.mtu = L2CAP_NODE_MTU;
+
+  /* Initialize the BLE controller */
+  NETSTACK_RADIO.init();
+  NETSTACK_RADIO.get_object(RADIO_CONST_BLE_BD_ADDR, &ble_addr, BLE_ADDR_SIZE);
+  NETSTACK_RADIO.get_value(RADIO_CONST_BLE_BUFFER_SIZE, &buffer_len);
+  NETSTACK_RADIO.get_value(RADIO_CONST_BLE_BUFFER_AMOUNT, &num_buffer);
+
+  PRINTF("ble-mac init() BLE-addr: ");
+  PRINTADDR(ble_addr);
+
+  /* set the advertisement parameter */
+  NETSTACK_RADIO.set_value(RADIO_PARAM_BLE_ADV_INTERVAL, 0x0800);
+  NETSTACK_RADIO.set_value(RADIO_PARAM_BLE_ADV_TYPE, BLE_ADV_DIR_IND_LDC);
+  NETSTACK_RADIO.set_value(RADIO_PARAM_BLE_ADV_OWN_ADDR_TYPE, BLE_ADDR_TYPE_PUBLIC);
+  NETSTACK_RADIO.set_value(RADIO_PARAM_BLE_ADV_CHANNEL_MAP, 0x01);
+
+  adv_data_len = init_adv_data(adv_data);
+  scan_resp_data_len = init_scan_resp_data(scan_resp_data);
+
+  /* set advertisement payload & scan response */
+  NETSTACK_RADIO.set_object(RADIO_PARAM_BLE_ADV_PAYLOAD, adv_data, adv_data_len);
+  NETSTACK_RADIO.set_object(RADIO_PARAM_BLE_ADV_SCAN_RESPONSE, scan_resp_data, scan_resp_data_len);
+
+  /* enable advertisement */
+  NETSTACK_RADIO.set_value(RADIO_PARAM_BLE_ADV_ENABLE, 1);
+
+  NETSTACK_MAC.on();
+}
+/*---------------------------------------------------------------------------*/
+static void
+send(mac_callback_t sent_callback, void *ptr)
+{
+  uint16_t data_len = packetbuf_datalen();
+
+  if(tx_buffer.current_index != 0) {
+    PRINTF("ble_mac send() another L2CAP message is currently processed\n");
+    mac_call_sent_callback(sent_callback, ptr, MAC_TX_COLLISION, 0);
+    return;
+  }
+
+  if(data_len > L2CAP_NODE_MTU) {
+    PRINTF("ble_mac send() message is too long\n");
+    mac_call_sent_callback(sent_callback, ptr, MAC_TX_ERR, 0);
+    return;
+  }
+
+  PRINTF("ble_mac send() sending %d bytes\n", data_len);
+
+  tx_buffer.sdu_length = data_len;
+  memcpy(tx_buffer.sdu, packetbuf_dataptr(), data_len);
+  mac_call_sent_callback(sent_callback, ptr, MAC_TX_DEFERRED, 1);
+  process_poll(&ble_mac_process);
+}
+/*---------------------------------------------------------------------------*/
+void
+l2cap_conn_req(uint8_t *data)
+{
+  uint8_t identifier;
+  uint16_t len;
+  uint16_t le_psm;
+  uint8_t resp_data[26];
+
+  identifier = data[0];
+  memcpy(&len, &data[1], 2);
+
+  if(len != 10) {
+    PRINTF("l2cap_conn_req: invalid len: %d\n", len);
+    return;
+  }
+
+  /* parse L2CAP connection data */
+  memcpy(&le_psm, &data[3], 2);
+  memcpy(&l2cap_router.cid, &data[5], 2);
+  memcpy(&l2cap_router.mtu, &data[7], 2);
+  memcpy(&l2cap_router.mps, &data[9], 2);
+  memcpy(&l2cap_router.credits, &data[11], 2);
+
+  /* create L2CAP connection response */
+  /* length */
+  resp_data[0] = 0x0E;
+  resp_data[1] = 0x00;
+
+  /* channel ID */
+  resp_data[2] = 0x05;
+  resp_data[3] = 0x00;
+
+  /* code */
+  resp_data[4] = L2CAP_CODE_CONN_RSP;
+
+  /* identifier */
+  resp_data[5] = identifier;
+
+  /* cmd length */
+  resp_data[6] = 0x0A;
+  resp_data[7] = 0x00;
+
+  /* node channel information */
+  memcpy(&resp_data[8], &l2cap_node.cid, 2);
+  memcpy(&resp_data[10], &l2cap_node.mtu, 2);
+  memcpy(&resp_data[12], &l2cap_node.mps, 2);
+  memcpy(&resp_data[14], &l2cap_node.credits, 2);
+
+  /* result */
+  memset(&resp_data[16], 0x00, 2);
+
+  packetbuf_copyfrom((void *)resp_data, 18);
+  NETSTACK_RDC.send(NULL, NULL);
+}
+/*---------------------------------------------------------------------------*/
+void
+l2cap_credit(uint8_t *data)
+{
+  uint16_t len;
+  uint16_t cid;
+  uint16_t credits;
+
+/*  uint8_t  identifier = data[0]; */
+  memcpy(&len, &data[1], 2);
+
+  if(len != 4) {
+    PRINTF("process_l2cap_credit: invalid len: %d\n", len);
+    return;
+  }
+
+  /* parse L2CAP credit data */
+  memcpy(&cid, &data[3], 2);
+  memcpy(&credits, &data[5], 2);
+
+  l2cap_router.credits += credits;
+}
+/*---------------------------------------------------------------------------*/
+static void
+l2cap_frame_signal_channel(uint8_t *data, uint8_t data_len)
+{
+  if(data[4] == L2CAP_CODE_CONN_REQ) {
+    l2cap_conn_req(&data[5]);
+  } else if(data[4] == L2CAP_CODE_CREDIT) {
+    l2cap_credit(&data[5]);
+  } else {
+    PRINTF("l2cap_frame_signal_channel: unknown signal channel code: %d\n", data[4]);
+  }
+}
+/*---------------------------------------------------------------------------*/
+static void
+l2cap_frame_flow_channel(uint8_t *data, uint16_t data_len)
+{
+  uint16_t frame_len;
+  uint16_t payload_len;
+
+  if(data_len < 4) {
+    PRINTF("l2cap_frame: illegal L2CAP frame data_len: %d\n", data_len);
+    /* a L2CAP frame has a minimum length of 4 */
+    return;
+  }
+
+  if(rx_buffer.sdu_length == 0) {
+    /* handle first fragment */
+    memcpy(&frame_len, &data[0], 2);
+    memcpy(&rx_buffer.sdu_length, &data[4], 2);
+    payload_len = frame_len - 2;
+
+    memcpy(rx_buffer.sdu, &data[6], payload_len);
+    rx_buffer.current_index = payload_len;
+  } else {
+    /* subsequent fragment */
+    memcpy(&frame_len, &data[0], 2);
+    payload_len = frame_len;
+
+    memcpy(&rx_buffer.sdu[rx_buffer.current_index], &data[4], payload_len);
+    rx_buffer.current_index += payload_len;
+  }
+
+  if((rx_buffer.sdu_length > 0) &&
+     (rx_buffer.sdu_length == rx_buffer.current_index)) {
+    /* do not use packetbuf_copyfrom here because the packetbuf_attr
+     * must not be cleared */
+    memcpy(packetbuf_dataptr(), rx_buffer.sdu, rx_buffer.sdu_length);
+    packetbuf_set_datalen(rx_buffer.sdu_length);
+    NETSTACK_LLSEC.input();
+
+    /* reset counters */
+    rx_buffer.sdu_length = 0;
+    rx_buffer.current_index = 0;
+  }
+}
+/*---------------------------------------------------------------------------*/
+static void
+send_l2cap_credit()
+{
+  uint8_t len = 4;
+  uint8_t data[12];
+
+  /* create L2CAP credit */
+  /* length */
+  data[0] = len + 4;
+  data[1] = 0x00;
+
+  /* channel ID */
+  data[2] = 0x05;
+  data[3] = 0x00;
+
+  /* code */
+  data[4] = L2CAP_CODE_CREDIT;
+  /* identifier */
+  data[5] = 0xFF;
+  /* cmd length */
+  data[6] = len;
+  data[7] = 0x00;
+
+  memcpy(&data[8], &l2cap_node.cid, 2);
+  data[10] = L2CAP_NODE_INIT_CREDITS & 0xFF;
+  data[11] = L2CAP_NODE_INIT_CREDITS >> 8;
+
+  packetbuf_copyfrom((void *)data, len + 8);
+  NETSTACK_RDC.send(NULL, NULL);
+}
+/*---------------------------------------------------------------------------*/
+static void
+input(void)
+{
+  uint8_t *data = (uint8_t *)packetbuf_dataptr();
+  uint8_t len = packetbuf_datalen();
+  uint16_t channel_id;
+
+  memcpy(&channel_id, &data[2], 2);
+
+  PRINTF("ble-mac input: %d bytes\n", len);
+
+  if(len > 0) {
+    if(channel_id == L2CAP_SIGNAL_CHANNEL) {
+      l2cap_frame_signal_channel(data, len);
+    } else if(channel_id == L2CAP_FLOW_CHANNEL) {
+      l2cap_frame_flow_channel(data, len);
+      /* decrease the credits of the router */
+      l2cap_node.credits--;
+      if(l2cap_node.credits <= L2CAP_CREDIT_THRESHOLD) {
+        send_l2cap_credit();
+        l2cap_node.credits += L2CAP_NODE_INIT_CREDITS;
+      }
+    } else {
+      PRINTF("ble-mac input: unknown L2CAP channel: %x\n", channel_id);
+      return;
+    }
+  }
+}
+/*---------------------------------------------------------------------------*/
+static int
+on(void)
+{
+  PRINTF("[ ble-mac ] on()\n");
+  process_start(&ble_mac_process, NULL);
+  return NETSTACK_RDC.on();
+}
+/*---------------------------------------------------------------------------*/
+static int
+off(int keep_radio_on)
+{
+  PRINTF("[ ble-mac ] off()\n");
+  process_exit(&ble_mac_process);
+  return NETSTACK_RDC.off(keep_radio_on);
+}
+/*---------------------------------------------------------------------------*/
+const struct mac_driver ble_mac_driver = {
+  "ble_mac",
+  init,
+  send,
+  input,
+  on,
+  off,
+  NULL,
+};
+
+static struct etimer l2cap_timer;
+/*---------------------------------------------------------------------------*/
+PROCESS_THREAD(ble_mac_process, ev, data)
+{
+  uint16_t data_len;
+  uint16_t frame_len;
+
+  uint16_t num_buffer;
+
+  PROCESS_BEGIN();
+
+  while(1) {
+    PROCESS_YIELD();
+    if(ev == PROCESS_EVENT_POLL) {
+      if(tx_buffer.sdu_length > 0) {
+        NETSTACK_RADIO.get_value(RADIO_CONST_BLE_BUFFER_AMOUNT, &num_buffer);
+        if(num_buffer > 0) {
+          /* transmit data */
+          packetbuf_clear();
+
+          /* create L2CAP header for first L2CAP fragment */
+          packetbuf_hdralloc(L2CAP_FIRST_HEADER_SIZE);
+          /* length of the payload transmitted by this fragment */
+          data_len = MIN(tx_buffer.sdu_length, L2CAP_FIRST_FRAGMENT_SIZE);
+          frame_len = data_len + 2;
+
+          memcpy(packetbuf_hdrptr(), &frame_len, 2);
+          memcpy(packetbuf_hdrptr() + 2, &l2cap_router.cid, 2);
+          memcpy(packetbuf_hdrptr() + 4, &tx_buffer.sdu_length, 2);
+
+          /* copy payload */
+          memcpy(packetbuf_dataptr(), tx_buffer.sdu, data_len);
+          packetbuf_set_datalen(data_len);
+          tx_buffer.current_index += data_len;
+
+          /* send L2CAP fragment */
+          NETSTACK_RDC.send(NULL, NULL);
+          /* decrement the packets available at the router by 1 */
+          l2cap_router.credits--;
+
+          if(tx_buffer.current_index == tx_buffer.sdu_length) {
+            tx_buffer.current_index = 0;
+          } else {
+            etimer_set(&l2cap_timer, L2CAP_TRANSMISSION_DELAY);
+          }
+        } else {
+          /* no buffer is free, wait and try later */
+          etimer_set(&l2cap_timer, L2CAP_TRANSMISSION_DELAY);
+        }
+      }
+    } else if((ev == PROCESS_EVENT_TIMER) && (data == &l2cap_timer)) {
+      if(tx_buffer.sdu_length > 0) {
+        NETSTACK_RADIO.get_value(RADIO_CONST_BLE_BUFFER_AMOUNT, &num_buffer);
+        if(num_buffer > 0) {
+          packetbuf_clear();
+
+          /* create L2CAP header for subsequent L2CAP fragment */
+          packetbuf_hdralloc(L2CAP_SUBSEQ_HEADER_SIZE);
+          /* length of the fragment */
+          data_len = MIN((tx_buffer.sdu_length - tx_buffer.current_index),
+                         L2CAP_SUBSEQ_FRAGMENT_SIZE);
+          frame_len = data_len;
+          memcpy(packetbuf_hdrptr(), &frame_len, 2);
+          memcpy(packetbuf_hdrptr() + 2, &l2cap_router.cid, 2);
+
+          /* copy payload */
+          memcpy(packetbuf_dataptr(),
+                 &tx_buffer.sdu[tx_buffer.current_index],
+                 data_len);
+          packetbuf_set_datalen(data_len);
+          tx_buffer.current_index += data_len;
+
+          /* send L2CAP fragment */
+          NETSTACK_RDC.send(NULL, NULL);
+
+          if(tx_buffer.current_index == tx_buffer.sdu_length) {
+            tx_buffer.current_index = 0;
+          } else {
+            etimer_set(&l2cap_timer, L2CAP_TRANSMISSION_DELAY);
+          }
+        } else {
+          /* no buffer is free, wait and try later */
+          etimer_set(&l2cap_timer, L2CAP_TRANSMISSION_DELAY);
+        }
+      }
+    }
+  }
+  PROCESS_END();
+}

--- a/cpu/cc26xx-cc13xx/net/ble-mac.c
+++ b/cpu/cc26xx-cc13xx/net/ble-mac.c
@@ -45,7 +45,7 @@
 #include <string.h>
 
 /*---------------------------------------------------------------------------*/
-#define DEBUG 1
+#define DEBUG 0
 #if DEBUG
 #include <stdio.h>
 #define PRINTF(...) printf(__VA_ARGS__)

--- a/cpu/cc26xx-cc13xx/rf-core/ble-hal/ble-hal-cc26xx.c
+++ b/cpu/cc26xx-cc13xx/rf-core/ble-hal/ble-hal-cc26xx.c
@@ -1,0 +1,983 @@
+/*
+ * Copyright (c) 2016, Michael Spoerk
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Author: Michael Spoerk <mi.spoerk@gmail.com>
+ *
+ */
+/*---------------------------------------------------------------------------*/
+
+#include "ble-hal.h"
+#include "rf-core/ble-hal/rf-ble-cmd.h"
+#include "lpm.h"
+
+#include "sys/process.h"
+
+#include "dev/oscillators.h"
+
+#include "ble-addr.h"
+
+#include "net/netstack.h"
+#include "net/packetbuf.h"
+
+#include "rf-core/api/data_entry.h"
+#include "rf-core/rf-core.h"
+#include "rf-core/api/ble_cmd.h"
+#include "lib/memb.h"
+#include "lib/list.h"
+
+#include <string.h>
+
+/*---------------------------------------------------------------------------*/
+#define DEBUG 0
+#if DEBUG
+#include <stdio.h>
+#define PRINTF(...) printf(__VA_ARGS__)
+#else
+#define PRINTF(...)
+#endif
+/*---------------------------------------------------------------------------*/
+/**
+ * \brief Returns the current status of a running Radio Op command
+ * \param a A pointer with the buffer used to initiate the command
+ * \return The value of the Radio Op buffer's status field
+ *
+ * This macro can be used to e.g. return the status of a previously
+ * initiated background operation, or of an immediate command
+ */
+#define CMD_GET_STATUS(a) (((rfc_radioOp_t *)a)->status)
+/*---------------------------------------------------------------------------*/
+/**
+ * The location of the primary BLE device address (public BLE address)
+ */
+#define BLE_ADDR_LOCATION   0x500012E8
+/*---------------------------------------------------------------------------*/
+typedef uint32_t rf_ticks_t;
+/*---------------------------------------------------------------------------*/
+/* ADVERTISING                                                               */
+typedef struct {
+  rf_ticks_t interval;
+  ble_adv_type_t type;
+  ble_addr_type_t own_addr_type;
+  uint8_t channel_map;
+} ble_adv_param_t;
+
+/* advertising parameter */
+static ble_adv_param_t adv_param;
+
+/* advertising data */
+static uint8_t adv_data_len;
+static uint8_t adv_data[BLE_ADV_DATA_LEN];
+
+/* scan response data */
+static uint8_t scan_resp_data_len;
+static uint8_t scan_resp_data[BLE_SCAN_RESP_DATA_LEN];
+
+/* timing values */
+static rf_ticks_t adv_event_next;
+/*---------------------------------------------------------------------------*/
+/* CONNECTION                                                                */
+#define CONN_EVENT_NUM_DATA_CHANNELS       37
+#define CONN_EVENT_WINDOW_WIDENING       3000   /* 0.75 ms */
+
+typedef struct {
+  uint8_t initiator_address[6];
+  uint32_t access_address;
+  uint8_t crc_init_0;
+  uint8_t crc_init_1;
+  uint8_t crc_init_2;
+  rf_ticks_t win_size;
+  rf_ticks_t win_offset;
+  rf_ticks_t interval;
+  uint16_t latency;
+  rf_ticks_t timeout;
+  uint64_t channel_map;
+  uint8_t num_used_channels;
+  uint8_t hop;
+  uint8_t sca;
+  rf_ticks_t window_widening;
+  rf_ticks_t timestamp;
+} ble_conn_param_t;
+
+/* connection parameter */
+static ble_conn_param_t conn_param;
+
+typedef struct {
+  uint64_t channel_map;
+  uint16_t counter;
+  uint8_t num_used_channels;
+} ble_conn_channel_update_t;
+
+static ble_conn_channel_update_t conn_channel_update;
+
+typedef struct {
+  /* connection event counter */
+  uint16_t counter;
+
+  /* result code of the last connection event */
+  uint16_t last_status;
+
+  /* unmapped data mapped_channel */
+  uint8_t unmapped_channel;
+
+  /* used data mapped_channel */
+  uint8_t mapped_channel;
+
+  /* start of the connection event */
+  rf_ticks_t start;
+
+  /* start of the next connection event */
+  rf_ticks_t next_start;
+} ble_conn_event_t;
+
+/* connection event data */
+static ble_conn_event_t conn_event;
+static rf_ticks_t first_conn_event_anchor;
+/*---------------------------------------------------------------------------*/
+/* RX data queue (all received packets are stored in the same queue)         */
+#define BLE_RX_BUF_DATA_LEN 60
+#define BLE_RX_BUF_OVERHEAD 8
+#define BLE_RX_BUF_LEN      (BLE_RX_BUF_DATA_LEN + BLE_RX_BUF_OVERHEAD)
+#define BLE_RX_NUM_BUF      20
+
+static uint8_t rx_bufs[BLE_RX_NUM_BUF][BLE_RX_BUF_LEN] CC_ALIGN(4);
+
+static dataQueue_t rx_data_queue = { 0 };
+static uint8_t *current_rx_entry;
+/*---------------------------------------------------------------------------*/
+/* TX data queue (data channel packets are stored in the same queue)         */
+#define BLE_TX_BUF_DATA_LEN 27
+#define BLE_TX_BUF_OVERHEAD  9
+#define BLE_TX_BUF_LEN      (BLE_TX_BUF_OVERHEAD + BLE_TX_BUF_DATA_LEN)
+#define BLE_TX_NUM_BUF      60
+
+#define BLE_BUFFER_SIZE    255  /* maximum size of the data buffer */
+
+typedef struct tx_buf_s {
+  /* pointer to the next element, needed for using LIST */
+  struct tx_buf_s *next;
+  /* data of the tx_buffer (including the 9 byte header) */
+  uint8_t data[BLE_TX_BUF_LEN];
+  /* flag indicating if the entry was already queued to the radio core */
+  uint8_t queued;
+} tx_buf_t;
+
+static dataQueue_t tx_data_queue = { 0 };
+
+/* list af all dynamically allocated tx buffers, which are used */
+LIST(tx_buffers_queued);
+/* memory block for allocation of tx buffers */
+MEMB(tx_buffers, tx_buf_t, BLE_TX_NUM_BUF);
+/*---------------------------------------------------------------------------*/
+typedef enum {
+  BLE_CONTROLLER_STATE_STANDBY,
+  BLE_CONTROLLER_STATE_ADVERTISING,
+  BLE_CONTROLLER_STATE_SCANNING,
+  BLE_CONTROLLER_STATE_INITIATING,
+  BLE_CONTROLLER_STATE_CONN_MASTER,
+  BLE_CONTROLLER_STATE_CONN_SLAVE
+} ble_controller_state_t;
+
+/* The link layer state of the ble controller */
+static ble_controller_state_t state = BLE_CONTROLLER_STATE_STANDBY;
+/*---------------------------------------------------------------------------*/
+/* RF core buffers                                                           */
+#define RF_CMD_BUFFER_SIZE    128
+#define RF_PARAM_BUFFER_SIZE   80
+/* buffer for all commands to the RF core */
+static uint8_t cmd_buf[RF_CMD_BUFFER_SIZE];
+/* buffer for all command parameters to the RF core */
+static uint8_t param_buf[RF_PARAM_BUFFER_SIZE];
+/* buffer for all command output */
+static uint8_t output_buf[RF_PARAM_BUFFER_SIZE];
+/*---------------------------------------------------------------------------*/
+/* Types of LL control PDUs                                                  */
+#define BLE_LL_CONN_UPDATE_REQ              0x00
+#define BLE_LL_CHANNEL_MAP_REQ              0x01
+#define BLE_LL_TERMINATE_IND                0x02
+#define BLE_LL_ENC_REQ                      0x03
+#define BLE_LL_ENC_RSP                      0x04
+#define BLE_LL_START_ENC_REQ                0x05
+#define BLE_LL_START_ENC_RSP                0x06
+#define BLE_LL_UNKNOWN_RSP                  0x07
+#define BLE_LL_FEATURE_REQ                  0x08
+#define BLE_LL_FEATURE_RSP                  0x09
+#define BLE_LL_PAUSE_ENC_REQ                0x0A
+#define BLE_LL_PAUSE_ENC_RSP                0x0B
+#define BLE_LL_VERSION_IND                  0x0C
+#define BLE_LL_REJECT_IND                   0x0D
+#define BLE_LL_SLAVE_FEATURE_REQ            0x0E
+#define BLE_LL_CONN_PARAM_REQ               0x0F
+#define BLE_LL_CONN_PARAM_RSP               0x10
+#define BLE_LL_REJECT_IND_EXT               0x11
+#define BLE_LL_PING_REQ                     0x12
+#define BLE_LL_PING_RSP                     0x13
+/*---------------------------------------------------------------------------*/
+/* controller specific LL fields                                             */
+#define BLE_VERSION_4_0                     6
+#define BLE_VERSION_4_1                     7
+#define BLE_VERSION_4_2                     8
+#define BLE_VERSION_NR        BLE_VERSION_4_1
+
+#define BLE_COMPANY_ID                 0xFFFF
+#define BLE_SUB_VERSION_NR             0xBEEF
+/*---------------------------------------------------------------------------*/
+/* LPM                                                                       */
+/*---------------------------------------------------------------------------*/
+static uint8_t
+request(void)
+{
+  if(rf_core_is_accessible()) {
+    return LPM_MODE_SLEEP;
+  }
+
+  return LPM_MODE_MAX_SUPPORTED;
+}
+/*---------------------------------------------------------------------------*/
+LPM_MODULE(cc26xx_ble_lpm_module, request, NULL, NULL, LPM_DOMAIN_NONE);
+/*---------------------------------------------------------------------------*/
+
+/*---------------------------------------------------------------------------*/
+PROCESS(ble_hal_process, "BLE/CC26xx process");
+/*---------------------------------------------------------------------------*/
+static void
+setup_buffers(void)
+{
+  rfc_dataEntry_t *entry;
+  uint8_t i;
+
+  /* setup circular RX buffer */
+  rx_data_queue.pCurrEntry = rx_bufs[0];
+  rx_data_queue.pLastEntry = NULL;
+  current_rx_entry = rx_bufs[0];
+
+  /* initialize each individual rx buffer entry */
+  for(i = 0; i < BLE_RX_NUM_BUF; i++) {
+    memset(rx_bufs[i], 0x00, BLE_RX_BUF_LEN);
+    entry = (rfc_dataEntry_t *)rx_bufs[i];
+    entry->pNextEntry = rx_bufs[(i + 1) % BLE_RX_NUM_BUF];
+    entry->config.lenSz = 1;
+    entry->length = BLE_RX_BUF_LEN - BLE_RX_BUF_OVERHEAD;
+  }
+
+  /* TX buffers are allocated on demand */
+  memb_init(&tx_buffers);
+  list_init(tx_buffers_queued);
+}
+/*---------------------------------------------------------------------------*/
+static ble_result_t
+reset(void)
+{
+  /* register low power module */
+  lpm_register_module(&cc26xx_ble_lpm_module);
+
+  /* set the mode in the rf core */
+  rf_core_set_modesel();
+
+  setup_buffers();
+
+  oscillators_request_hf_xosc();
+
+  if(!rf_core_is_accessible()) {
+    /* boot the rf core */
+    if(rf_core_boot() != RF_CORE_CMD_OK) {
+      PRINTF("ble_controller_reset() could not boot rf-core\n");
+      return BLE_RESULT_ERROR;
+    }
+
+    rf_core_setup_interrupts(0);
+    oscillators_switch_to_hf_xosc();
+
+    if(rf_ble_cmd_setup_ble_mode() != RF_BLE_CMD_OK) {
+      PRINTF("could not setup rf-core to BLE mode\n");
+      return BLE_RESULT_ERROR;
+    }
+  }
+
+  state = BLE_CONTROLLER_STATE_STANDBY;
+
+  /* start the BLE controller process, if it is not currently running */
+  if(!process_is_running(&ble_hal_process)) {
+    process_start(&ble_hal_process, NULL);
+  }
+  return BLE_RESULT_OK;
+}
+/*---------------------------------------------------------------------------*/
+static ble_result_t
+read_bd_addr(uint8_t *addr)
+{
+  ble_addr_cpy_to(addr);
+  return BLE_RESULT_OK;
+}
+/*---------------------------------------------------------------------------*/
+static ble_result_t
+read_buffer_size(unsigned int *buf_len,
+                 unsigned int *num_buf)
+{
+  uint16_t ll_bufs = memb_numfree(&tx_buffers);
+  uint16_t buffers = (uint8_t)ll_bufs / 10;
+  uint16_t buffer_size = BLE_BUFFER_SIZE;
+
+  memcpy(buf_len, &buffer_size, 2);
+  memcpy(num_buf, &buffers, 2);
+  return BLE_RESULT_OK;
+}
+/*---------------------------------------------------------------------------*/
+static ble_result_t
+set_adv_param(unsigned int adv_int, ble_adv_type_t type,
+              ble_addr_type_t own_type, unsigned short adv_map)
+{
+  /* convert the adv_int according to BLE standard to rf core ticks */
+  adv_param.interval = adv_int * 2500;
+  adv_param.type = type;
+  adv_param.own_addr_type = own_type;
+  adv_param.channel_map = adv_map;
+
+  return BLE_RESULT_OK;
+}
+/*---------------------------------------------------------------------------*/
+static ble_result_t
+read_adv_channel_tx_power(short *power)
+{
+  return BLE_RESULT_NOT_SUPPORTED;
+}
+/*---------------------------------------------------------------------------*/
+static ble_result_t
+set_adv_data(unsigned short data_len, char *data)
+{
+  if(data_len > BLE_ADV_DATA_LEN) {
+    return BLE_RESULT_INVALID_PARAM;
+  }
+  adv_data_len = data_len;
+  memcpy(adv_data, data, data_len);
+  return BLE_RESULT_OK;
+}
+/*---------------------------------------------------------------------------*/
+static ble_result_t
+set_scan_resp_data(unsigned short data_len, char *data)
+{
+  if(data_len > BLE_SCAN_RESP_DATA_LEN) {
+    return BLE_RESULT_INVALID_PARAM;
+  }
+  scan_resp_data_len = data_len;
+  memcpy(scan_resp_data, data, data_len);
+  return BLE_RESULT_OK;
+}
+/*---------------------------------------------------------------------------*/
+static ble_result_t
+set_adv_enable(unsigned short enable)
+{
+  if((enable == 1) && (state == BLE_CONTROLLER_STATE_STANDBY)) {
+    state = BLE_CONTROLLER_STATE_ADVERTISING;
+
+    /* start the timer for advertising events */
+    adv_event_next = rf_core_read_current_rf_ticks() + adv_param.interval;
+    rf_core_start_timer_comp(adv_event_next);
+
+    return BLE_RESULT_OK;
+  } else if((enable != 1) && (state == BLE_CONTROLLER_STATE_ADVERTISING)) {
+    state = BLE_CONTROLLER_STATE_STANDBY;
+
+    return BLE_RESULT_OK;
+  }
+  return BLE_RESULT_NOT_SUPPORTED;
+}
+/*---------------------------------------------------------------------------*/
+static ble_result_t
+set_scan_param(ble_scan_type_t type,
+               unsigned int scan_interval,
+               unsigned int scan_window,
+               ble_addr_type_t own_addr_type)
+{
+  return BLE_RESULT_NOT_SUPPORTED;
+}
+/*---------------------------------------------------------------------------*/
+static ble_result_t
+set_scan_enable(unsigned short enable,
+                unsigned short filter_duplicates)
+{
+  return BLE_RESULT_NOT_SUPPORTED;
+}
+/*---------------------------------------------------------------------------*/
+static ble_result_t
+create_connection(unsigned int scan_interval,
+                  unsigned int scan_window,
+                  ble_addr_type_t peer_addr_type,
+                  uint8_t *peer_addr,
+                  ble_addr_type_t own_addr_type,
+                  unsigned int conn_interval,
+                  unsigned int conn_latency,
+                  unsigned int supervision_timeout)
+{
+  return BLE_RESULT_NOT_SUPPORTED;
+}
+/*---------------------------------------------------------------------------*/
+static ble_result_t
+create_connection_cancel(void)
+{
+  return BLE_RESULT_NOT_SUPPORTED;
+}
+/*---------------------------------------------------------------------------*/
+static ble_result_t
+connection_update(unsigned int connection_handle,
+                  unsigned int conn_interval,
+                  unsigned int conn_latency,
+                  unsigned int supervision_timeout)
+{
+  return BLE_RESULT_NOT_SUPPORTED;
+}
+/*---------------------------------------------------------------------------*/
+static ble_result_t
+disconnect(unsigned int connection_handle,
+           unsigned short reason)
+{
+  state = BLE_CONTROLLER_STATE_STANDBY;
+
+  return BLE_RESULT_NOT_SUPPORTED;
+}
+/*---------------------------------------------------------------------------*/
+static tx_buf_t *
+prepare_tx_buf()
+{
+  tx_buf_t *tx_buf;
+
+  /* allocate a TX buffer */
+  tx_buf = memb_alloc(&tx_buffers);
+  if(tx_buf != NULL) {
+    memset(tx_buf, 0, sizeof(tx_buf_t));
+    list_add(tx_buffers_queued, tx_buf);
+  }
+  return tx_buf;
+}
+/*---------------------------------------------------------------------------*/
+static void
+prepare_tx_buf_payload(tx_buf_t *tx_buf, void *buf,
+                       unsigned short buf_len, unsigned short frame_type)
+{
+
+  uint8_t length = MIN(buf_len, 27);
+
+  rfc_dataEntryGeneral_t *e = (rfc_dataEntryGeneral_t *)tx_buf->data;
+
+  /* the buffer length does not contain the frame type byte */
+  e->length = length + 1;
+  e->config.lenSz = 1;
+  e->pNextEntry = NULL;
+  e->status = DATA_ENTRY_PENDING;
+
+  tx_buf->queued = 0;
+
+  /* set the frame type */
+  memset(&tx_buf->data[8], frame_type, 1);
+
+  /* set frame payload */
+  memcpy(&tx_buf->data[9], buf, length);
+}
+/*---------------------------------------------------------------------------*/
+static ble_result_t
+send(void *buf, unsigned short buf_len)
+{
+  tx_buf_t *tx_buf;
+  uint16_t i;
+  uint8_t frame_type;
+  uint8_t *data = (uint8_t *)buf;
+
+  if((state != BLE_CONTROLLER_STATE_CONN_SLAVE) && (BLE_CONTROLLER_STATE_CONN_MASTER)) {
+    /* init not finished */
+    return BLE_RESULT_ERROR;
+  }
+
+  for(i = 0; i < buf_len; i += 27) {
+    tx_buf = prepare_tx_buf();
+    if(tx_buf == NULL) {
+      PRINTF("send() could not allocate TX buffer\n");
+      return BLE_RESULT_ERROR;
+    }
+
+    if(i == 0) {
+      frame_type = BLE_DATA_PDU_LLID_DATA_MESSAGE;
+    } else {
+      frame_type = BLE_DATA_PDU_LLID_DATA_FRAGMENT;
+    }
+
+    prepare_tx_buf_payload(tx_buf, &data[i], (buf_len - i), frame_type);
+  }
+  return BLE_RESULT_OK;
+}
+/*---------------------------------------------------------------------------*/
+static ble_result_t
+send_list(struct ble_buf_list *list)
+{
+  return BLE_RESULT_NOT_SUPPORTED;
+}
+/*---------------------------------------------------------------------------*/
+const struct ble_hal_driver ble_hal =
+{
+  reset,
+  read_bd_addr,
+  read_buffer_size,
+  set_adv_param,
+  read_adv_channel_tx_power,
+  set_adv_data,
+  set_scan_resp_data,
+  set_adv_enable,
+  set_scan_param,
+  set_scan_enable,
+  create_connection,
+  create_connection_cancel,
+  connection_update,
+  disconnect,
+  send,
+  send_list
+};
+/*---------------------------------------------------------------------------*/
+/* The parameter are parsed according to Bluetooth Specification v4 (page 2510)*/
+static void
+parse_connect_request_data(ble_conn_param_t *p, uint8_t *entry)
+{
+  int offset = 12;
+  int i;
+  for(i = 0; i < BLE_ADDR_SIZE; i++) {
+    p->initiator_address[i] = entry[BLE_ADDR_SIZE - 1 - i];
+  }
+  memcpy(&p->access_address, &entry[offset], 4);
+  p->crc_init_0 = entry[offset + 4];
+  p->crc_init_1 = entry[offset + 5];
+  p->crc_init_2 = entry[offset + 6];
+  p->win_size = entry[offset + 7];
+  p->win_offset = (entry[offset + 9] << 8) + entry[offset + 8];
+  p->interval = (entry[offset + 11] << 8) + entry[offset + 10];
+  p->latency = (entry[offset + 13] << 8) + entry[offset + 12];
+  p->timeout = (entry[offset + 15] << 8) + entry[offset + 14];
+  memcpy(&p->channel_map, &entry[offset + 16], 5);
+  p->hop = entry[offset + 21] & 0x1F;
+  p->sca = (entry[offset + 21] >> 5) & 0x07;
+  p->timestamp = (entry[offset + 27] << 24) +
+    (entry[offset + 26] << 16) +
+    (entry[offset + 25] << 8) +
+    entry[offset + 24];
+}
+/*---------------------------------------------------------------------------*/
+static void
+free_finished_rx_buf(void)
+{
+  rfc_dataEntryGeneral_t *entry;
+
+  /* free finished RX entries */
+  entry = (rfc_dataEntryGeneral_t *)current_rx_entry;
+  /* clear the length field */
+  current_rx_entry[8] = 0;
+  /* set status to pending */
+  entry->status = DATA_ENTRY_PENDING;
+  /* set next data queue entry */
+  current_rx_entry = entry->pNextEntry;
+  entry = (rfc_dataEntryGeneral_t *)current_rx_entry;
+}
+/*---------------------------------------------------------------------------*/
+static void
+free_finished_tx_bufs(void)
+{
+  tx_buf_t *buf = list_head(tx_buffers_queued);
+  rfc_dataEntryGeneral_t *e;
+
+  while(buf != NULL) {
+    e = (rfc_dataEntryGeneral_t *)buf->data;
+    if((e != NULL) && (e->status == DATA_ENTRY_FINISHED)) {
+      /* free memory block */
+      memb_free(&tx_buffers, buf);
+
+      /* remove from queued list */
+      list_pop(tx_buffers_queued);
+    }
+    buf = list_item_next(buf);
+  }
+}
+/*---------------------------------------------------------------------------*/
+static void
+append_new_tx_bufs(void)
+{
+  tx_buf_t *buf = list_head(tx_buffers_queued);
+
+  while(buf != NULL) {
+    if(buf->queued == 0) {
+      /* add tx entry to tx queue */
+      if(rf_ble_cmd_add_data_queue_entry(&tx_data_queue, buf->data)
+         != RF_BLE_CMD_OK) {
+        PRINTF("append_new_tx_bufs() could not add buffer to tx data queue\n");
+      }
+      buf->queued = 1;
+    }
+    buf = list_item_next(buf);
+  }
+}
+/*---------------------------------------------------------------------------*/
+static void
+update_data_channel()
+{
+  uint8_t i;
+  uint8_t j;
+  uint8_t remap_index;
+  /* perform the data channel selection according to BLE standard */
+
+  /* calculate unmapped channel*/
+  conn_event.unmapped_channel = (conn_event.unmapped_channel + conn_param.hop)
+    % CONN_EVENT_NUM_DATA_CHANNELS;
+
+  /* map the calculated channel */
+  if(conn_param.channel_map & (1ULL << conn_event.unmapped_channel)) {
+    /* channel is marked as used */
+    conn_event.mapped_channel = conn_event.unmapped_channel;
+  } else {
+    remap_index = conn_event.unmapped_channel % conn_param.num_used_channels;
+    j = 0;
+    for(i = 0; i < CONN_EVENT_NUM_DATA_CHANNELS; i++) {
+      if(conn_param.channel_map & (1ULL << i)) {
+        if(j == remap_index) {
+          conn_event.mapped_channel = i;
+        }
+        j++;
+      }
+    }
+  }
+}
+/*---------------------------------------------------------------------------*/
+static void
+state_advertising(process_event_t ev, process_data_t data,
+                  uint8_t *cmd, uint8_t *param, uint8_t *output)
+{
+  rfc_dataEntryGeneral_t *entry;
+
+  if(ev == rf_core_timer_event) {
+    /* advertising event */
+    rf_ble_cmd_create_adv_params(param, &rx_data_queue, adv_data_len,
+                                 adv_data, scan_resp_data_len, scan_resp_data,
+                                 adv_param.own_addr_type,
+                                 (uint8_t *)BLE_ADDR_LOCATION);
+
+    if(adv_param.channel_map & BLE_ADV_CHANNEL_1_MASK) {
+      rf_ble_cmd_create_adv_cmd(cmd, BLE_ADV_CHANNEL_1, param, output);
+      rf_ble_cmd_send(cmd);
+      rf_ble_cmd_wait(cmd);
+    }
+    if(adv_param.channel_map & BLE_ADV_CHANNEL_2_MASK) {
+      rf_ble_cmd_create_adv_cmd(cmd, BLE_ADV_CHANNEL_2, param, output);
+      rf_ble_cmd_send(cmd);
+      rf_ble_cmd_wait(cmd);
+    }
+    if(adv_param.channel_map & BLE_ADV_CHANNEL_3_MASK) {
+      rf_ble_cmd_create_adv_cmd(cmd, BLE_ADV_CHANNEL_3, param, output);
+      rf_ble_cmd_send(cmd);
+      rf_ble_cmd_wait(cmd);
+    }
+    /* set timer interrupt for next advertising event */
+    adv_event_next = adv_event_next + adv_param.interval;
+    rf_core_start_timer_comp(adv_event_next);
+  } else if(ev == rf_core_data_rx_event) {
+    /* data received */
+    entry = (rfc_dataEntryGeneral_t *)current_rx_entry;
+    if(entry->status != DATA_ENTRY_FINISHED) {
+      return;
+    }
+
+    if((current_rx_entry[9] & 0x0F) == 5) {
+      /* CONN REQ received */
+
+      /* switch to the standby state, until connection data is parsed */
+      state = BLE_CONTROLLER_STATE_STANDBY;
+
+      /* parse connection data*/
+      parse_connect_request_data(&conn_param,
+                                 (uint8_t *)&current_rx_entry[11]);
+
+      /* convert the timing values into rf core ticks */
+      conn_param.win_size = conn_param.win_size * 5000;
+      conn_param.win_offset = conn_param.win_offset * 5000;
+      conn_param.interval = conn_param.interval * 5000;
+      conn_param.timeout = conn_param.timeout * 40000;
+      conn_param.window_widening = CONN_EVENT_WINDOW_WIDENING;
+
+      conn_event.counter = 0;
+      conn_event.unmapped_channel = 0;
+      update_data_channel();
+      first_conn_event_anchor = conn_param.timestamp + conn_param.win_offset;
+
+      if(conn_param.win_offset <= 60000) {
+        /* in this case the first anchor point starts too early,
+         * ignore the first conn event and start with the 2nd */
+        conn_event.counter++;
+        update_data_channel();
+        first_conn_event_anchor += conn_param.interval;
+      }
+      conn_event.start = first_conn_event_anchor;
+
+      rf_ble_cmd_create_slave_params(param, &rx_data_queue, &tx_data_queue,
+                                     conn_param.access_address,
+                                     conn_param.crc_init_0,
+                                     conn_param.crc_init_1,
+                                     conn_param.crc_init_2,
+                                     conn_param.win_size,
+                                     conn_param.window_widening, 1);
+
+      rf_ble_cmd_create_slave_cmd(cmd, conn_event.mapped_channel, param,
+                                  output,
+                                  (conn_event.start - conn_param.window_widening));
+
+      if(rf_ble_cmd_send(cmd) != RF_BLE_CMD_OK) {
+        PRINTF("could not establish connection\n");
+        state = BLE_CONTROLLER_STATE_STANDBY;
+        set_adv_enable(1);
+        return;
+      }
+
+      /* setup timer interrupt for first connection event */
+      conn_event.next_start = first_conn_event_anchor + conn_param.interval;
+
+      state = BLE_CONTROLLER_STATE_CONN_SLAVE;
+
+      /* clear the output buffer, so that the counters are actually correct*/
+      memset(output_buf, 0x00, sizeof(output_buf));
+    }
+    free_finished_rx_buf();
+  }
+}
+/*---------------------------------------------------------------------------*/
+void
+process_ll_ctrl_msg(uint8_t *data)
+{
+  uint8_t resp_len = 0;
+  uint8_t resp_data[26];
+  /* the first 2 bytes in the packet buffer are the header */
+/*    uint8_t *data = packetbuf_dataptr() + 2; */
+  uint8_t op_code = data[0];
+
+  uint64_t channel_map = 0;
+  uint16_t instant;
+  uint16_t i;
+
+  if(op_code == BLE_LL_CHANNEL_MAP_REQ) {
+    memcpy(&channel_map, &data[1], 5);
+    memcpy(&instant, &data[6], 2);
+
+    conn_channel_update.channel_map = channel_map;
+    conn_channel_update.counter = instant;
+    conn_channel_update.num_used_channels = 0;
+
+    for(i = 0; i < CONN_EVENT_NUM_DATA_CHANNELS; i++) {
+      if(channel_map & (1ULL << i)) {
+        conn_channel_update.num_used_channels++;
+      }
+    }
+  } else if(op_code == BLE_LL_FEATURE_REQ) {
+    resp_data[0] = BLE_LL_FEATURE_RSP;
+    memset(&resp_data[1], 0x00, 8);
+    resp_len = 9;
+  } else if(op_code == BLE_LL_VERSION_IND) {
+    resp_data[0] = BLE_LL_VERSION_IND;
+    resp_data[1] = BLE_VERSION_NR;
+    resp_data[2] = (BLE_COMPANY_ID >> 8) & 0xFF;
+    resp_data[3] = BLE_COMPANY_ID & 0xFF;
+    resp_data[4] = (BLE_SUB_VERSION_NR >> 8) & 0xFF;
+    resp_data[5] = BLE_SUB_VERSION_NR & 0xFF;
+    resp_len = 6;
+  } else {
+    PRINTF("parse_ll_ctrl_msg() opcode: 0x%02X received\n", op_code);
+  }
+
+  if(resp_len > 0) {
+    tx_buf_t *tx_buf = prepare_tx_buf();
+    if(tx_buf == NULL) {
+      PRINTF("process_ll_ctrl_msg() could not allocate TX buffer\n");
+      return;
+    }
+
+    prepare_tx_buf_payload(tx_buf, resp_data, resp_len, BLE_DATA_PDU_LLID_CONTROL);
+
+    if(rf_ble_cmd_add_data_queue_entry(&tx_data_queue, tx_buf->data)
+       != RF_BLE_CMD_OK) {
+      PRINTF("process_ll_ctrl_msg() could not add buffer to tx data queue\n");
+      return;
+    }
+  }
+}
+/*---------------------------------------------------------------------------*/
+static void
+process_rx_entry_data_channel(void)
+{
+  uint8_t data_offset = 9;                       /* start index of BLE data */
+  uint8_t data_len;
+  uint8_t rssi;
+  uint8_t frame_type;
+  uint8_t more_data;
+  linkaddr_t sender_addr;
+
+  rfc_dataEntryGeneral_t *entry = (rfc_dataEntryGeneral_t *)current_rx_entry;
+  if(entry->status != DATA_ENTRY_FINISHED) {
+    return;
+  }
+
+  while(entry->status == DATA_ENTRY_FINISHED) {
+    /* the last 6 bytes of the data are status and timestamp bytes */
+    data_len = current_rx_entry[8] - 6 - 2;
+
+    if(data_len > 0) {
+      frame_type = (current_rx_entry[data_offset] & 0x03);
+      more_data = (current_rx_entry[data_offset] & 0x10) >> 4;
+
+      /* process the received data */
+      if(frame_type == BLE_DATA_PDU_LLID_CONTROL) {
+        /* received frame is a LL control frame */
+        /* exclude the header (first 2 bytes) */
+        process_ll_ctrl_msg(&current_rx_entry[data_offset + 2]);
+      } else if(frame_type == BLE_DATA_PDU_LLID_DATA_MESSAGE) {
+        /* message start or complete message */
+        packetbuf_clear();
+        memcpy(packetbuf_dataptr(), &current_rx_entry[data_offset + 2], data_len);
+        packetbuf_set_datalen(data_len);
+        /* set the controller dependent attributes */
+        rssi = current_rx_entry[data_offset + data_len];
+        ble_addr_to_eui64(sender_addr.u8, conn_param.initiator_address);
+        packetbuf_set_attr(PACKETBUF_ATTR_RSSI, rssi);
+        packetbuf_set_addr(PACKETBUF_ADDR_RECEIVER, &linkaddr_node_addr);
+        packetbuf_set_addr(PACKETBUF_ADDR_SENDER, &sender_addr);
+
+        /* notify upper layers, if complete message was received */
+        if(!more_data || (data_len < 27)) {
+          NETSTACK_RDC.input();
+        }
+      } else if(frame_type == BLE_DATA_PDU_LLID_DATA_FRAGMENT) {
+        /* message fragment */
+        memcpy((packetbuf_dataptr() + packetbuf_datalen()),
+               &current_rx_entry[data_offset + 2], data_len);
+        packetbuf_set_datalen(packetbuf_datalen() + data_len);
+
+        /* notify upper layers, if complete message was received */
+        if(!more_data || (data_len < 27)) {
+          NETSTACK_RDC.input();
+        }
+      }
+    }
+    free_finished_rx_buf();
+  }
+}
+/*---------------------------------------------------------------------------*/
+static void
+state_conn_slave(process_event_t ev, process_data_t data,
+                 uint8_t *cmd, uint8_t *param, uint8_t *output)
+{
+  rfc_bleMasterSlaveOutput_t *o = (rfc_bleMasterSlaveOutput_t *)output;
+
+  if(ev == rf_core_command_done_event) {
+
+    free_finished_tx_bufs();
+    append_new_tx_bufs();
+
+    conn_event.last_status = CMD_GET_STATUS(cmd);
+    /* check if the last connection event was executed properly */
+    if(conn_event.last_status != RF_CORE_RADIO_OP_STATUS_BLE_DONE_OK) {
+      PRINTF("command status: 0x%04X; connection event counter: %d\n",
+             CMD_GET_STATUS(cmd), conn_event.counter);
+      PRINTF("command_status_flags: crc_err: %d, ignored: %d, md: %d, ack: %d\n",
+             o->pktStatus.bLastCrcErr, o->pktStatus.bLastIgnored,
+             o->pktStatus.bLastMd, o->pktStatus.bLastAck);
+    }
+
+    /* calculate parameters for upcoming connection event */
+    if(o->pktStatus.bTimeStampValid) {
+      /* get the actual value of the anchor point */
+      conn_event.start = (o->timeStamp + conn_param.interval);
+    } else {
+      /* use the estimated start */
+      conn_event.start = conn_event.next_start;
+    }
+    conn_event.counter++;
+    if(conn_event.counter == conn_channel_update.counter) {
+      /* use the new channel map from this event on */
+      conn_param.channel_map = conn_channel_update.channel_map;
+      conn_param.num_used_channels = conn_channel_update.num_used_channels;
+    }
+    update_data_channel();
+
+    /* create & send slave command for upcoming connection event */
+    rf_ble_cmd_create_slave_params(param, &rx_data_queue, &tx_data_queue,
+                                   conn_param.access_address,
+                                   conn_param.crc_init_0,
+                                   conn_param.crc_init_1,
+                                   conn_param.crc_init_2,
+                                   conn_param.win_size,
+                                   conn_param.window_widening,
+                                   0);
+
+    rf_ble_cmd_create_slave_cmd(cmd, conn_event.mapped_channel, param,
+                                output,
+                                (conn_event.start - conn_param.window_widening));
+
+    if(rf_ble_cmd_send(cmd) != RF_BLE_CMD_OK) {
+      PRINTF("connection error; event counter: %u\n", conn_event.counter);
+    }
+
+    /* calculate next anchor point*/
+    conn_event.next_start = conn_event.start + conn_param.interval;
+  } else if(ev == rf_core_data_rx_event) {
+    process_rx_entry_data_channel();
+  }
+}
+/*---------------------------------------------------------------------------*/
+PROCESS_THREAD(ble_hal_process, ev, data)
+{
+  PROCESS_BEGIN();
+  PRINTF("ble_hal_process started\n");
+
+  while(1) {
+    PROCESS_WAIT_EVENT();
+    switch(state) {
+    case BLE_CONTROLLER_STATE_STANDBY:
+      /* nothing to do here */
+      break;
+    case BLE_CONTROLLER_STATE_ADVERTISING:
+      state_advertising(ev, data, (uint8_t *)cmd_buf,
+                        (uint8_t *)param_buf, (uint8_t *)output_buf);
+      break;
+    case BLE_CONTROLLER_STATE_SCANNING:
+      /* currently not supported */
+      break;
+    case BLE_CONTROLLER_STATE_INITIATING:
+      /* currently not supported */
+      break;
+    case BLE_CONTROLLER_STATE_CONN_MASTER:
+      /* currently not supported */
+      break;
+    case BLE_CONTROLLER_STATE_CONN_SLAVE:
+      state_conn_slave(ev, data, (uint8_t *)cmd_buf,
+                       (uint8_t *)param_buf, (uint8_t *)output_buf);
+      break;
+    }
+  }
+
+  PRINTF("ble_hal_process stopped\n");
+  PROCESS_END();
+}

--- a/cpu/cc26xx-cc13xx/rf-core/ble-hal/ble-hal-cc26xx.h
+++ b/cpu/cc26xx-cc13xx/rf-core/ble-hal/ble-hal-cc26xx.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2016, Michael Spoerk
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Author: Michael Spoerk <mi.spoerk@gmail.com>
+ *
+ */
+/*---------------------------------------------------------------------------*/
+
+#ifndef BLE_HAL_CC26XX_H_
+#define BLE_HAL_CC26XX_H_
+
+#include "ble-hal.h"
+
+extern const struct ble_hal_driver ble_hal;
+
+#endif /* BLE_HAL_CC26XX_H_ */

--- a/cpu/cc26xx-cc13xx/rf-core/ble-hal/rf-ble-cmd.c
+++ b/cpu/cc26xx-cc13xx/rf-core/ble-hal/rf-ble-cmd.c
@@ -1,0 +1,347 @@
+/*
+ * Copyright (c) 2016, Michael Spoerk
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Author: Michael Spoerk <mi.spoerk@gmail.com>
+ *
+ */
+/*---------------------------------------------------------------------------*/
+#include "contiki.h"
+
+#include "rf-core/api/ble_cmd.h"
+#include "rf-core/rf-core.h"
+#include "rf-core/ble-hal/rf-ble-cmd.h"
+
+/*---------------------------------------------------------------------------*/
+#define DEBUG 0
+#if DEBUG
+#include <stdio.h>
+#define PRINTF(...) printf(__VA_ARGS__)
+#else
+#define PRINTF(...)
+#endif
+/*---------------------------------------------------------------------------*/
+typedef struct tx_power_config {
+  uint8_t register_ib;
+  uint8_t register_gc;
+  uint8_t temp_coeff;
+} tx_power_config_t;
+
+/* values for a selection of available TX powers (values from SmartRF Studio) */
+/*static tx_power_config_t tx_power  = {0x30, 0x00, 0x93};    // +5 dBm */
+static tx_power_config_t tx_power = { 0x21, 0x01, 0x31 };    /*  0 dBm */
+/*static tx_power_config_t tx_power  = {0x0E, 0x01, 0x19};    // -9 dBm */
+/*static tx_power_config_t tx_power  = {0x07, 0x03, 0x0C};    //-21 dBm */
+
+/*---------------------------------------------------------------------------*/
+/* BLE overrides */
+static uint32_t ble_overrides[] = {
+  0x00364038, /* Synth: Set RTRIM (POTAILRESTRIM) to 6 */
+  0x000784A3, /* Synth: Set FREF = 3.43 MHz (24 MHz / 7) */
+  0xA47E0583, /* Synth: Set loop bandwidth after lock to 80 kHz (K2) */
+  0xEAE00603, /* Synth: Set loop bandwidth after lock to 80 kHz (K3, LSB) */
+  0x00010623, /* Synth: Set loop bandwidth after lock to 80 kHz (K3, MSB) */
+  0x00456088, /* Adjust AGC reference level */
+  0xFFFFFFFF, /* End of override list */
+};
+/*---------------------------------------------------------------------------*/
+/* GENERAL functions                                                         */
+static void
+print_cmdsta(uint32_t cmdsta)
+{
+  uint8_t val = (uint8_t)(cmdsta & RF_CORE_CMDSTA_RESULT_MASK);
+
+  if(val == RF_CORE_CMDSTA_PENDING) {
+    PRINTF("CMDSTA: PENDING\n");
+  } else if(val == RF_CORE_CMDSTA_DONE) {
+    PRINTF("CMDSTA: DONE\n");
+  } else if(val == RF_CORE_CMDSTA_ILLEGAL_PTR) {
+    PRINTF("CMDSTA: ILLEGAL_PTR\n");
+  } else if(val == RF_CORE_CMDSTA_UNKNOWN_CMD) {
+    PRINTF("CMDSTA: UNKNOWN_CMD\n");
+  } else if(val == RF_CORE_CMDSTA_UNKNOWN_DIR_CMD) {
+    PRINTF("CMDSTA: UNKNOWN_DIR_CMD\n");
+  } else if(val == RF_CORE_CMDSTA_CONTEXT_ERR) {
+    PRINTF("CMDSTA: CONTEXT_ERR\n");
+  } else if(val == RF_CORE_CMDSTA_SCHEDULING_ERR) {
+    PRINTF("CMDSTA: SCHEDULING_ERR\n");
+  } else if(val == RF_CORE_CMDSTA_PAR_ERR) {
+    PRINTF("CMDSTA: PAR_ERR\n");
+  } else if(val == RF_CORE_CMDSTA_QUEUE_ERR) {
+    PRINTF("CMDSTA: QUEUE_ERR\n");
+  } else if(val == RF_CORE_CMDSTA_QUEUE_BUSY) {
+    PRINTF("CMDSTA: QUEUE_BUSY\n");
+  } else {
+    PRINTF("CMDSTA: 0x%08lx\n", cmdsta);
+  }
+}
+/*---------------------------------------------------------------------------*/
+static void
+print_command_status(uint16_t status_field)
+{
+  if(status_field == RF_CORE_RADIO_OP_STATUS_IDLE) {
+    PRINTF("Status: IDLE\n");
+  } else if(status_field == RF_CORE_RADIO_OP_STATUS_PENDING) {
+    PRINTF("Status: PENDING\n");
+  } else if(status_field == RF_CORE_RADIO_OP_STATUS_ACTIVE) {
+    PRINTF("Status: ACTIVE\n");
+  } else if(status_field == RF_CORE_RADIO_OP_STATUS_ERROR_PAST_START) {
+    PRINTF("Status: ERROR_PAST_START\n");
+  } else if(status_field == RF_CORE_RADIO_OP_STATUS_ERROR_START_TRIG) {
+    PRINTF("Status: ERROR_START_TRIG\n");
+  } else if(status_field == RF_CORE_RADIO_OP_STATUS_ERROR_CONDITION) {
+    PRINTF("Status: ERROR_CONDITION\n");
+  } else if(status_field == RF_CORE_RADIO_OP_STATUS_ERROR_PAR) {
+    PRINTF("Status: ERROR_PAR\n");
+  } else if(status_field == RF_CORE_RADIO_OP_STATUS_ERROR_POINTER) {
+    PRINTF("Status: ERROR_POINTER\n");
+  } else if(status_field == RF_CORE_RADIO_OP_STATUS_ERROR_CMDID) {
+    PRINTF("Status: ERROR_CMDID\n");
+  } else if(status_field == RF_CORE_RADIO_OP_STATUS_ERROR_NO_SETUP) {
+    PRINTF("Status: ERROR_NO_SETUP\n");
+  } else if(status_field == RF_CORE_RADIO_OP_STATUS_ERROR_NO_FS) {
+    PRINTF("Status: ERROR_NO_FS\n");
+  } else if(status_field == RF_CORE_RADIO_OP_STATUS_ERROR_SYNTH_PROG) {
+    PRINTF("Status: ERROR_SYNTH_PROG\n");
+  } else if(status_field == RF_CORE_RADIO_OP_STATUS_BLE_DONE_OK) {
+    PRINTF("Status: BLE_DONE_OK\n");
+  } else if(status_field == RF_CORE_RADIO_OP_STATUS_BLE_DONE_RXTIMEOUT) {
+    PRINTF("Status: BLE_DONE_RXTIMEOUT\n");
+  } else if(status_field == RF_CORE_RADIO_OP_STATUS_BLE_DONE_NOSYNC) {
+    PRINTF("Status: BLE_DONE_NOSYNC\n");
+  } else if(status_field == RF_CORE_RADIO_OP_STATUS_BLE_DONE_RXERR) {
+    PRINTF("Status: BLE_DONE_RXERR\n");
+  } else if(status_field == RF_CORE_RADIO_OP_STATUS_BLE_DONE_CONNECT) {
+    PRINTF("Status: BLE_DONE_CONNECT\n");
+  } else if(status_field == RF_CORE_RADIO_OP_STATUS_BLE_DONE_MAXNACK) {
+    PRINTF("Status: BLE_DONE_MAXNACK\n");
+  } else if(status_field == RF_CORE_RADIO_OP_STATUS_BLE_DONE_ENDED) {
+    PRINTF("Status: BLE_DONE_ENDED\n");
+  } else if(status_field == RF_CORE_RADIO_OP_STATUS_BLE_DONE_ABORT) {
+    PRINTF("Status: BLE_DONE_ABORT\n");
+  } else if(status_field == RF_CORE_RADIO_OP_STATUS_BLE_DONE_STOPPED) {
+    PRINTF("Status: BLE_DONE_STOPPED\n");
+  } else if(status_field == RF_CORE_RADIO_OP_STATUS_BLE_ERROR_PAR) {
+    PRINTF("Status: BLE_ERROR_PAR\n");
+  } else if(status_field == RF_CORE_RADIO_OP_STATUS_BLE_ERROR_RXBUF) {
+    PRINTF("Status: BLE_ERROR_RXBUF\n");
+  } else if(status_field == RF_CORE_RADIO_OP_STATUS_BLE_ERROR_NO_SETUP) {
+    PRINTF("Status: BLE_ERROR_NO_SETUP\n");
+  } else if(status_field == RF_CORE_RADIO_OP_STATUS_BLE_ERROR_NO_FS) {
+    PRINTF("Status: BLE_ERROR_NO_FS\n");
+  } else if(status_field == RF_CORE_RADIO_OP_STATUS_BLE_ERROR_SYNTH_PROG) {
+    PRINTF("Status: BLE_ERROR_SYNTH_PROT\n");
+  } else if(status_field == RF_CORE_RADIO_OP_STATUS_BLE_ERROR_RXOVF) {
+    PRINTF("Status: BLE_ERROR_RXOVF\n");
+  } else if(status_field == RF_CORE_RADIO_OP_STATUS_BLE_ERROR_TXUNF) {
+    PRINTF("Status: BLE_ERROR_TXUNF\n");
+  } else {
+    PRINTF("cmd->status: 0x%04X\n", status_field);
+  }
+}
+/*---------------------------------------------------------------------------*/
+unsigned short
+rf_ble_cmd_send(uint8_t *command)
+{
+  uint32_t cmdsta;
+  rfc_radioOp_t *cmd = (rfc_radioOp_t *)command;
+
+  if(rf_core_send_cmd((uint32_t)cmd, &cmdsta) != RF_CORE_CMD_OK) {
+    PRINTF("rf_ble_cmd_send() could not send cmd\n");
+    print_cmdsta(cmdsta);
+    print_command_status(cmd->status);
+    return RF_BLE_CMD_ERROR;
+  }
+  return RF_BLE_CMD_OK;
+}
+/*---------------------------------------------------------------------------*/
+unsigned short
+rf_ble_cmd_wait(uint8_t *command)
+{
+  rfc_radioOp_t *cmd = (rfc_radioOp_t *)command;
+  if(rf_core_wait_cmd_done((void *)cmd) != RF_CORE_CMD_OK) {
+    PRINTF("rf_ble_cmd_wait() coudn not wait\n");
+    print_command_status(cmd->status);
+    return RF_BLE_CMD_ERROR;
+  }
+  return RF_BLE_CMD_OK;
+}
+/*---------------------------------------------------------------------------*/
+unsigned short
+rf_ble_cmd_setup_ble_mode(void)
+{
+  rfc_CMD_RADIO_SETUP_t cmd;
+
+  /* Create radio setup command */
+  rf_core_init_radio_op((rfc_radioOp_t *)&cmd, sizeof(cmd), CMD_RADIO_SETUP);
+
+  cmd.txPower.IB = tx_power.register_ib;
+  cmd.txPower.GC = tx_power.register_gc;
+  cmd.txPower.tempCoeff = tx_power.temp_coeff;
+  cmd.pRegOverride = ble_overrides;
+  cmd.mode = 0;
+
+  /* Send Radio setup to RF Core */
+  if(rf_ble_cmd_send((uint8_t *)&cmd) != RF_BLE_CMD_OK) {
+    return RF_BLE_CMD_ERROR;
+  }
+
+  /* Wait until radio setup is done */
+  return rf_ble_cmd_wait((uint8_t *)&cmd);
+}
+/*---------------------------------------------------------------------------*/
+/* ADVERTISING functions                                                     */
+void
+rf_ble_cmd_create_adv_cmd(uint8_t *command, uint8_t channel,
+                          uint8_t *param, uint8_t *output)
+{
+  rfc_CMD_BLE_ADV_t *c = (rfc_CMD_BLE_ADV_t *)command;
+
+  memset(c, 0x00, sizeof(rfc_CMD_BLE_ADV_t));
+  c->commandNo = CMD_BLE_ADV;
+  c->condition.rule = COND_NEVER;
+  c->whitening.bOverride = 0;
+  c->channel = channel;
+  c->pParams = (rfc_bleAdvPar_t *)param;
+  c->startTrigger.triggerType = TRIG_NOW;
+  c->pOutput = (rfc_bleAdvOutput_t *)output;
+}
+/*---------------------------------------------------------------------------*/
+void
+rf_ble_cmd_create_adv_params(uint8_t *param, dataQueue_t *rx_queue,
+                             uint8_t adv_data_len, uint8_t *adv_data,
+                             uint8_t scan_resp_data_len, uint8_t *scan_resp_data,
+                             ble_addr_type_t own_addr_type, uint8_t *own_addr)
+{
+  rfc_bleAdvPar_t *p = (rfc_bleAdvPar_t *)param;
+
+  memset(p, 0x00, sizeof(rfc_bleAdvPar_t));
+
+  p->pRxQ = rx_queue;
+  p->rxConfig.bAutoFlushIgnored = 1;
+  p->rxConfig.bAutoFlushCrcErr = 0;
+  p->rxConfig.bAutoFlushEmpty = 1;
+  p->rxConfig.bIncludeLenByte = 1;
+  p->rxConfig.bIncludeCrc = 0;
+  p->rxConfig.bAppendRssi = 1;
+  p->rxConfig.bAppendStatus = 1;
+  p->rxConfig.bAppendTimestamp = 1;
+  p->advConfig.advFilterPolicy = 0;
+  p->advConfig.bStrictLenFilter = 0;
+  p->advConfig.deviceAddrType = own_addr_type;
+  p->pDeviceAddress = (uint16_t *)own_addr;
+  p->advLen = adv_data_len;
+  p->scanRspLen = scan_resp_data_len;
+  p->pAdvData = adv_data;
+  p->pScanRspData = scan_resp_data;
+  p->endTrigger.triggerType = TRIG_NEVER;
+}
+/*---------------------------------------------------------------------------*/
+/* CONNECTION slave functions                                                */
+/*---------------------------------------------------------------------------*/
+void
+rf_ble_cmd_create_slave_cmd(uint8_t *cmd, uint8_t channel, uint8_t *params,
+                            uint8_t *output, uint32_t start_time)
+{
+  rfc_CMD_BLE_SLAVE_t *c = (rfc_CMD_BLE_SLAVE_t *)cmd;
+
+  memset(c, 0x00, sizeof(rfc_CMD_BLE_SLAVE_t));
+
+  c->commandNo = CMD_BLE_SLAVE;
+  c->condition.rule = COND_NEVER;
+  c->whitening.bOverride = 0;
+  c->channel = channel;
+  c->pParams = (rfc_bleSlavePar_t *)params;
+  c->startTrigger.triggerType = TRIG_ABSTIME;
+  c->startTrigger.pastTrig = 1;
+  c->startTime = start_time;
+  c->pOutput = (rfc_bleMasterSlaveOutput_t *)output;
+}
+/*---------------------------------------------------------------------------*/
+void
+rf_ble_cmd_create_slave_params(uint8_t *params, dataQueue_t *rx_queue,
+                               dataQueue_t *tx_queue, uint32_t access_address,
+                               uint8_t crc_init_0, uint8_t crc_init_1,
+                               uint8_t crc_init_2, uint32_t win_size,
+                               uint32_t window_widening, uint8_t first_packet)
+{
+  rfc_bleSlavePar_t *p = (rfc_bleSlavePar_t *)params;
+
+  p->pRxQ = rx_queue;
+  p->pTxQ = tx_queue;
+  p->rxConfig.bAutoFlushIgnored = 1;
+  p->rxConfig.bAutoFlushCrcErr = 1;
+  p->rxConfig.bAutoFlushEmpty = 1;
+  p->rxConfig.bIncludeLenByte = 1;
+  p->rxConfig.bIncludeCrc = 0;
+  p->rxConfig.bAppendRssi = 1;
+  p->rxConfig.bAppendStatus = 1;
+  p->rxConfig.bAppendTimestamp = 1;
+
+  if(first_packet) {
+    /* set parameters for first packet according to TI Technical Reference Manual */
+    p->seqStat.lastRxSn = 1;
+    p->seqStat.lastTxSn = 1;
+    p->seqStat.nextTxSn = 0;
+    p->seqStat.bFirstPkt = 1;
+    p->seqStat.bAutoEmpty = 0;
+    p->seqStat.bLlCtrlTx = 0;
+    p->seqStat.bLlCtrlAckRx = 0;
+    p->seqStat.bLlCtrlAckPending = 0;
+  }
+
+  p->maxNack = 0;
+  p->maxPkt = 0;
+  p->accessAddress = access_address;
+  p->crcInit0 = crc_init_0;
+  p->crcInit1 = crc_init_1;
+  p->crcInit2 = crc_init_2;
+  p->timeoutTrigger.triggerType = TRIG_REL_START;
+  p->timeoutTime = (uint32_t)(win_size + 2 * window_widening);
+  p->endTrigger.triggerType = TRIG_NEVER;
+}
+/*---------------------------------------------------------------------------*/
+/* DATA queue functions                                                      */
+/*---------------------------------------------------------------------------*/
+unsigned short
+rf_ble_cmd_add_data_queue_entry(dataQueue_t *q, uint8_t *e)
+{
+  uint32_t cmdsta;
+
+  rfc_CMD_ADD_DATA_ENTRY_t cmd;
+  cmd.commandNo = CMD_ADD_DATA_ENTRY;
+  cmd.pQueue = q;
+  cmd.pEntry = e;
+
+  if(rf_core_send_cmd((uint32_t)&cmd, &cmdsta) != RF_CORE_CMD_OK) {
+    PRINTF("rf_ble_cmd_add_data_queue_entry: ");
+    print_cmdsta(cmdsta);
+    return RF_BLE_CMD_ERROR;
+  }
+  return RF_BLE_CMD_OK;
+}

--- a/cpu/cc26xx-cc13xx/rf-core/ble-hal/rf-ble-cmd.h
+++ b/cpu/cc26xx-cc13xx/rf-core/ble-hal/rf-ble-cmd.h
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2016, Michael Spoerk
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Author: Michael Spoerk <mi.spoerk@gmail.com>
+ *
+ */
+/*---------------------------------------------------------------------------*/
+
+#ifndef RF_BLE_CMD_H_
+#define RF_BLE_CMD_H_
+
+#include "ble-hal.h"
+#include "rf-core/api/common_cmd.h"
+#include "ble-addr.h"
+
+#define RF_BLE_CMD_OK    1
+#define RF_BLE_CMD_ERROR 0
+
+unsigned short rf_ble_cmd_send(uint8_t *cmd);
+
+unsigned short rf_ble_cmd_wait(uint8_t *cmd);
+
+unsigned short rf_ble_cmd_setup_ble_mode(void);
+
+void rf_ble_cmd_create_adv_cmd(uint8_t *command, uint8_t channel,
+                               uint8_t *param, uint8_t *output);
+
+void rf_ble_cmd_create_adv_params(uint8_t *param, dataQueue_t *rx_queue,
+                                  uint8_t adv_data_len, uint8_t *adv_data,
+                                  uint8_t scan_resp_data_len, uint8_t *scan_resp_data,
+                                  ble_addr_type_t own_addr_type, uint8_t *own_addr);
+
+void rf_ble_cmd_create_slave_cmd(uint8_t *cmd, uint8_t channel, uint8_t *params,
+                                 uint8_t *output, uint32_t start_time);
+
+void rf_ble_cmd_create_slave_params(uint8_t *params, dataQueue_t *rx_queue,
+                                    dataQueue_t *tx_queue, uint32_t access_address,
+                                    uint8_t crc_init_0, uint8_t crc_init_1,
+                                    uint8_t crc_init_2, uint32_t win_size,
+                                    uint32_t window_widening, uint8_t first_packet);
+
+unsigned short rf_ble_cmd_add_data_queue_entry(dataQueue_t *q, uint8_t *e);
+
+#endif /* RF_BLE_CMD_H_ */

--- a/cpu/cc26xx-cc13xx/rf-core/ble-mode.c
+++ b/cpu/cc26xx-cc13xx/rf-core/ble-mode.c
@@ -1,0 +1,203 @@
+/*
+ * Copyright (c) 2016, Michael Spoerk
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Author: Michael Spoerk <mi.spoerk@gmail.com>
+ *
+ */
+/*---------------------------------------------------------------------------*/
+
+#include <ble-hal.h>
+#include <rf-core/ble-hal/ble-hal-cc26xx.h>
+#include "contiki.h"
+#include "dev/radio.h"
+
+#include <string.h>
+#include <stdio.h>
+
+/*---------------------------------------------------------------------------*/
+#define DEBUG 0
+#if DEBUG
+#define PRINTF(...) printf(__VA_ARGS__)
+#else
+#define PRINTF(...)
+#endif
+/*---------------------------------------------------------------------------*/
+static uint16_t adv_interval;
+static ble_adv_type_t adv_type;
+static ble_addr_type_t adv_own_addr_type;
+static uint8_t adv_channel_map;
+static uint16_t buffer_size = 0;
+/*---------------------------------------------------------------------------*/
+static int
+init(void)
+{
+  int result = ble_hal.reset();
+  return result == BLE_RESULT_OK;
+}
+/*---------------------------------------------------------------------------*/
+static int
+send(const void *payload, unsigned short payload_len)
+{
+  uint8_t res;
+  res = ble_hal.send((void *)payload, payload_len);
+  PRINTF("ble-mode send() %d bytes\n", payload_len);
+  if(res == BLE_RESULT_OK) {
+    return RADIO_TX_OK;
+  } else {
+    PRINTF("ble-mode send() error: %d\n", res);
+    return RADIO_TX_ERR;
+  }
+}
+/*---------------------------------------------------------------------------*/
+static int
+on(void)
+{
+  return 1;
+}
+/*---------------------------------------------------------------------------*/
+static int
+off(void)
+{
+  ble_hal.disconnect(0, 0);
+  return 1;
+}
+/*---------------------------------------------------------------------------*/
+static radio_result_t
+get_value(radio_param_t param, radio_value_t *value)
+{
+  unsigned int temp;
+
+  if(!value) {
+    return RADIO_RESULT_INVALID_VALUE;
+  }
+
+  switch(param) {
+  case RADIO_CONST_CHANNEL_MIN:
+    *value = BLE_DATA_CHANNEL_MIN;
+    return RADIO_RESULT_OK;
+  case RADIO_CONST_CHANNEL_MAX:
+    *value = BLE_DATA_CHANNEL_MAX;
+    return RADIO_RESULT_OK;
+  case RADIO_CONST_BLE_BUFFER_SIZE:
+    if(buffer_size == 0) {
+      ble_hal.read_buffer_size((unsigned int *)&buffer_size, &temp);
+    }
+    memcpy(value, &buffer_size, 2);
+    return RADIO_RESULT_OK;
+  case RADIO_CONST_BLE_BUFFER_AMOUNT:
+    ble_hal.read_buffer_size(&temp, (unsigned int *)value);
+    return RADIO_RESULT_OK;
+  default:
+    return RADIO_RESULT_NOT_SUPPORTED;
+  }
+}
+/*---------------------------------------------------------------------------*/
+static radio_result_t
+set_value(radio_param_t param, radio_value_t value)
+{
+  switch(param) {
+  case RADIO_PARAM_BLE_ADV_INTERVAL:
+    if((value > BLE_ADV_INTERVAL_MAX) || (value < BLE_ADV_INTERVAL_MIN)) {
+      return RADIO_RESULT_INVALID_VALUE;
+    }
+    adv_interval = (uint16_t)value;
+    return RADIO_RESULT_OK;
+  case RADIO_PARAM_BLE_ADV_TYPE:
+    adv_type = value;
+    return RADIO_RESULT_OK;
+  case RADIO_PARAM_BLE_ADV_OWN_ADDR_TYPE:
+    adv_own_addr_type = value;
+    return RADIO_RESULT_OK;
+  case RADIO_PARAM_BLE_ADV_CHANNEL_MAP:
+    adv_channel_map = value;
+    return RADIO_RESULT_OK;
+  case RADIO_PARAM_BLE_ADV_ENABLE:
+    if(value) {
+      /* set the advertisement parameter before enabling */
+      ble_hal.set_adv_param(adv_interval, adv_type,
+                            adv_own_addr_type, adv_channel_map);
+    }
+    ble_hal.set_adv_enable(value);
+    return RADIO_RESULT_OK;
+  default:
+    return RADIO_RESULT_NOT_SUPPORTED;
+  }
+}
+/*---------------------------------------------------------------------------*/
+static radio_result_t
+get_object(radio_param_t param, void *dest, size_t size)
+{
+  switch(param) {
+  case RADIO_CONST_BLE_BD_ADDR:
+    if(size != BLE_ADDR_SIZE || !dest) {
+      return RADIO_RESULT_INVALID_VALUE;
+    }
+    ble_hal.read_bd_addr(dest);
+    return RADIO_RESULT_OK;
+  }
+  return RADIO_RESULT_NOT_SUPPORTED;
+}
+/*---------------------------------------------------------------------------*/
+static radio_result_t
+set_object(radio_param_t param, const void *src, size_t size)
+{
+  switch(param) {
+  case RADIO_PARAM_BLE_ADV_PAYLOAD:
+    if(size <= 0 || size >= BLE_ADV_DATA_LEN || !src) {
+      return RADIO_RESULT_INVALID_VALUE;
+    }
+    ble_hal.set_adv_data((unsigned short)size, (char *)src);
+    return RADIO_RESULT_OK;
+  case RADIO_PARAM_BLE_ADV_SCAN_RESPONSE:
+    if(size <= 0 || size >= BLE_SCAN_RESP_DATA_LEN || !src) {
+      return RADIO_RESULT_INVALID_VALUE;
+    }
+    ble_hal.set_scan_resp_data((unsigned short)size, (char *)src);
+    return RADIO_RESULT_OK;
+  }
+  return RADIO_RESULT_NOT_SUPPORTED;
+}
+/*---------------------------------------------------------------------------*/
+const struct radio_driver ble_mode_driver = {
+  init,
+  NULL,
+  NULL,
+  send,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  on,
+  off,
+  get_value,
+  set_value,
+  get_object,
+  set_object,
+};
+/*---------------------------------------------------------------------------*/

--- a/cpu/cc26xx-cc13xx/rf-core/rf-core.c
+++ b/cpu/cc26xx-cc13xx/rf-core/rf-core.c
@@ -82,20 +82,24 @@
 /*---------------------------------------------------------------------------*/
 /* RF interrupts */
 #define RX_FRAME_IRQ IRQ_RX_ENTRY_DONE
+#define COMMAND_IRQ  IRQ_COMMAND_DONE
 #define ERROR_IRQ    IRQ_INTERNAL_ERROR
 #define RX_NOK_IRQ   IRQ_RX_NOK
 
 /* Those IRQs are enabled all the time */
 #if RF_CORE_DEBUG_CRC
-#define ENABLED_IRQS (RX_FRAME_IRQ | ERROR_IRQ | RX_NOK_IRQ)
+#define ENABLED_IRQS (RX_FRAME_IRQ | ERROR_IRQ | RX_NOK_IRQ | COMMAND_IRQ)
 #else
-#define ENABLED_IRQS (RX_FRAME_IRQ | ERROR_IRQ)
+#define ENABLED_IRQS (RX_FRAME_IRQ | ERROR_IRQ | IRQ_COMMAND_DONE)
 #endif
 
 #define ENABLED_IRQS_POLL_MODE (ENABLED_IRQS & ~(RX_FRAME_IRQ | ERROR_IRQ))
 
 #define cc26xx_rf_cpe0_isr RFCCPE0IntHandler
 #define cc26xx_rf_cpe1_isr RFCCPE1IntHandler
+#define cc26xx_rf_hw_isr   RFCHardwareIntHandler
+/*---------------------------------------------------------------------------*/
+#define TIMESTAMP_LOCATION 0x40043004
 /*---------------------------------------------------------------------------*/
 typedef ChipType_t chip_type_t;
 /*---------------------------------------------------------------------------*/
@@ -110,6 +114,10 @@ int32_t rat_offset = 0;
 static bool rat_offset_known = false;
 /*---------------------------------------------------------------------------*/
 PROCESS(rf_core_process, "CC13xx / CC26xx RF driver");
+/*---------------------------------------------------------------------------*/
+process_event_t rf_core_data_rx_event;
+process_event_t rf_core_command_done_event;
+process_event_t rf_core_timer_event;
 /*---------------------------------------------------------------------------*/
 #define RF_CORE_CLOCKS_MASK (RFC_PWR_PWMCLKEN_RFC_M | RFC_PWR_PWMCLKEN_CPE_M \
                              | RFC_PWR_PWMCLKEN_CPERAM_M)
@@ -240,22 +248,27 @@ rf_core_power_up()
 
   ti_lib_int_pend_clear(INT_RFC_CPE_0);
   ti_lib_int_pend_clear(INT_RFC_CPE_1);
+  ti_lib_int_pend_clear(INT_RFC_HW_COMB);
   ti_lib_int_disable(INT_RFC_CPE_0);
   ti_lib_int_disable(INT_RFC_CPE_1);
+  ti_lib_int_disable(INT_RFC_HW_COMB);
 
   /* Enable RF Core power domain */
   ti_lib_prcm_power_domain_on(PRCM_DOMAIN_RFCORE);
   while(ti_lib_prcm_power_domain_status(PRCM_DOMAIN_RFCORE)
-        != PRCM_DOMAIN_POWER_ON);
+        != PRCM_DOMAIN_POWER_ON) ;
 
   ti_lib_prcm_domain_enable(PRCM_DOMAIN_RFCORE);
   ti_lib_prcm_load_set();
-  while(!ti_lib_prcm_load_get());
+  while(!ti_lib_prcm_load_get()) ;
 
   HWREG(RFC_DBELL_NONBUF_BASE + RFC_DBELL_O_RFCPEIFG) = 0x0;
   HWREG(RFC_DBELL_NONBUF_BASE + RFC_DBELL_O_RFCPEIEN) = 0x0;
+  HWREG(RFC_DBELL_NONBUF_BASE + RFC_DBELL_O_RFHWIFG) = 0x0;
+  HWREG(RFC_DBELL_NONBUF_BASE + RFC_DBELL_O_RFHWIEN) = 0x0;
   ti_lib_int_enable(INT_RFC_CPE_0);
   ti_lib_int_enable(INT_RFC_CPE_1);
+  ti_lib_int_enable(INT_RFC_HW_COMB);
 
   if(!interrupts_disabled) {
     ti_lib_int_master_enable();
@@ -320,7 +333,7 @@ rf_core_stop_rat(void)
   ret = rf_core_wait_cmd_done(&cmd_stop);
   if(ret != RF_CORE_CMD_OK) {
     PRINTF("rf_core_cmd_ok: SYNC_STOP_RAT wait, CMDSTA=0x%08lx, status=0x%04x\n",
-        cmd_status, cmd_stop.status);
+           cmd_status, cmd_stop.status);
     return ret;
   }
 
@@ -339,10 +352,13 @@ rf_core_power_down()
   bool interrupts_disabled = ti_lib_int_master_disable();
   ti_lib_int_disable(INT_RFC_CPE_0);
   ti_lib_int_disable(INT_RFC_CPE_1);
+  ti_lib_int_disable(INT_RFC_HW_COMB);
 
   if(rf_core_is_accessible()) {
     HWREG(RFC_DBELL_NONBUF_BASE + RFC_DBELL_O_RFCPEIFG) = 0x0;
     HWREG(RFC_DBELL_NONBUF_BASE + RFC_DBELL_O_RFCPEIEN) = 0x0;
+    HWREG(RFC_DBELL_NONBUF_BASE + RFC_DBELL_O_RFHWIFG) = 0x0;
+    HWREG(RFC_DBELL_NONBUF_BASE + RFC_DBELL_O_RFHWIEN) = 0x0;
 
     /* need to send FS_POWERDOWN or analog components will use power */
     fs_powerdown();
@@ -353,17 +369,19 @@ rf_core_power_down()
   /* Shut down the RFCORE clock domain in the MCU VD */
   ti_lib_prcm_domain_disable(PRCM_DOMAIN_RFCORE);
   ti_lib_prcm_load_set();
-  while(!ti_lib_prcm_load_get());
+  while(!ti_lib_prcm_load_get()) ;
 
   /* Turn off RFCORE PD */
   ti_lib_prcm_power_domain_off(PRCM_DOMAIN_RFCORE);
   while(ti_lib_prcm_power_domain_status(PRCM_DOMAIN_RFCORE)
-        != PRCM_DOMAIN_POWER_OFF);
+        != PRCM_DOMAIN_POWER_OFF) ;
 
   ti_lib_int_pend_clear(INT_RFC_CPE_0);
   ti_lib_int_pend_clear(INT_RFC_CPE_1);
+  ti_lib_int_pend_clear(INT_RFC_HW_COMB);
   ti_lib_int_enable(INT_RFC_CPE_0);
   ti_lib_int_enable(INT_RFC_CPE_1);
+  ti_lib_int_enable(INT_RFC_HW_COMB);
   if(!interrupts_disabled) {
     ti_lib_int_master_enable();
   }
@@ -414,6 +432,31 @@ rf_core_boot()
   return RF_CORE_CMD_OK;
 }
 /*---------------------------------------------------------------------------*/
+uint32_t
+rf_core_read_current_rf_ticks(void)
+{
+  uint32_t ticks;
+  memcpy(&ticks, (uint8_t *)TIMESTAMP_LOCATION, sizeof(uint32_t));
+  return ticks;
+}
+/*---------------------------------------------------------------------------*/
+uint8_t
+rf_core_start_timer_comp(uint32_t time)
+{
+  uint32_t cmd_status;
+  rfc_CMD_SET_RAT_CMP_t cmd;
+
+  rf_core_init_radio_op((rfc_radioOp_t *)&cmd, sizeof(cmd), CMD_SET_RAT_CMP);
+  cmd.ratCh = RF_CORE_TIMER_INTERRUPT;
+  cmd.compareTime = (ratmr_t)time;
+
+  if(rf_core_send_cmd((uint32_t)&cmd, &cmd_status) != RF_CORE_CMD_OK) {
+    PRINTF("rf_core_start_timer_comp: CMDSTA=0x%08lx\n", cmd_status);
+    return RF_CORE_CMD_ERROR;
+  }
+  return RF_CORE_CMD_OK;
+}
+/*---------------------------------------------------------------------------*/
 uint8_t
 rf_core_restart_rat(void)
 {
@@ -458,14 +501,22 @@ rf_core_setup_interrupts(bool poll_mode)
   /* Clear interrupt flags, active low clear(?) */
   HWREG(RFC_DBELL_NONBUF_BASE + RFC_DBELL_O_RFCPEIFG) = 0x0;
 
+  /* Set timer channel 7 of rf core as HW interrupt */
+  HWREG(RFC_DBELL_NONBUF_BASE + RFC_DBELL_O_RFHWIEN) = RFC_DBELL_RFHWIFG_RATCH7;
+
   ti_lib_int_pend_clear(INT_RFC_CPE_0);
   ti_lib_int_pend_clear(INT_RFC_CPE_1);
+  ti_lib_int_pend_clear(INT_RFC_HW_COMB);
   ti_lib_int_enable(INT_RFC_CPE_0);
   ti_lib_int_enable(INT_RFC_CPE_1);
+  ti_lib_int_enable(INT_RFC_HW_COMB);
 
   if(!interrupts_disabled) {
     ti_lib_int_master_enable();
   }
+  rf_core_data_rx_event = process_alloc_event();
+  rf_core_command_done_event = process_alloc_event();
+  rf_core_timer_event = process_alloc_event();
 }
 /*---------------------------------------------------------------------------*/
 void
@@ -535,7 +586,7 @@ PROCESS_THREAD(rf_core_process, ev, data)
   PROCESS_BEGIN();
 
   while(1) {
-    PROCESS_YIELD_UNTIL(ev == PROCESS_EVENT_POLL);
+    PROCESS_YIELD_UNTIL(ev == rf_core_data_rx_event);
     do {
       watchdog_periodic();
       packetbuf_clear();
@@ -595,7 +646,12 @@ cc26xx_rf_cpe0_isr(void)
   if(HWREG(RFC_DBELL_NONBUF_BASE + RFC_DBELL_O_RFCPEIFG) & RX_FRAME_IRQ) {
     /* Clear the RX_ENTRY_DONE interrupt flag */
     HWREG(RFC_DBELL_NONBUF_BASE + RFC_DBELL_O_RFCPEIFG) = 0xFF7FFFFF;
-    process_poll(&rf_core_process);
+    process_post(PROCESS_BROADCAST, rf_core_data_rx_event, NULL);
+  }
+
+  if(HWREG(RFC_DBELL_NONBUF_BASE + RFC_DBELL_O_RFCPEIFG) & COMMAND_IRQ) {
+    HWREG(RFC_DBELL_NONBUF_BASE + RFC_DBELL_O_RFCPEIFG) = 0xFFFFFFFE;
+    process_post(PROCESS_BROADCAST, rf_core_command_done_event, NULL);
   }
 
   if(RF_CORE_DEBUG_CRC) {
@@ -614,6 +670,22 @@ cc26xx_rf_cpe0_isr(void)
 
   ti_lib_int_master_enable();
 
+  ENERGEST_OFF(ENERGEST_TYPE_IRQ);
+}
+/*---------------------------------------------------------------------------*/
+void
+cc26xx_rf_hw_isr(void)
+{
+  ENERGEST_ON(ENERGEST_TYPE_IRQ);
+  ti_lib_int_master_disable();
+
+  if(HWREG(RFC_DBELL_NONBUF_BASE + RFC_DBELL_O_RFHWIFG) & RFC_DBELL_RFHWIFG_RATCH7) {
+    /* Clear the RAT channel 7 interrupt flag */
+    HWREG(RFC_DBELL_NONBUF_BASE + RFC_DBELL_O_RFHWIFG) = 0xFFF7FFFF;
+    process_post(PROCESS_BROADCAST, rf_core_timer_event, NULL);
+  }
+
+  ti_lib_int_master_enable();
   ENERGEST_OFF(ENERGEST_TYPE_IRQ);
 }
 /*---------------------------------------------------------------------------*/

--- a/cpu/cc26xx-cc13xx/rf-core/rf-core.h
+++ b/cpu/cc26xx-cc13xx/rf-core/rf-core.h
@@ -228,11 +228,27 @@ typedef struct rf_core_primary_mode_s {
 #define RF_CORE_COMMAND_PROTOCOL_IEEE                    0x2000
 #define RF_CORE_COMMAND_PROTOCOL_PROP                    0x3000
 /*---------------------------------------------------------------------------*/
+#define RF_CORE_EVENT_RX                                 0x1000
+#define RF_CORE_EVENT_RX_CONN_REQUEST                    0x1001
+/*---------------------------------------------------------------------------*/
+/* The ticks per second of the rf core timer                                 */
+#define RF_CORE_TIMER_SECOND                            4000000
+/* The channel number of the rf core hardware timer                          */
+#define RF_CORE_TIMER_INTERRUPT                               7
+/*---------------------------------------------------------------------------*/
+
 /* Radio timer register */
 #define RATCNT  0x00000004
 /*---------------------------------------------------------------------------*/
 /* Make the main driver process visible to mode drivers */
 PROCESS_NAME(rf_core_process);
+/*---------------------------------------------------------------------------*/
+/* Event triggered, when a finished rx entry is available                    */
+extern process_event_t rf_core_data_rx_event;
+/* Event triggered, when rf_core timer interrupt was received                */
+extern process_event_t rf_core_command_done_event;
+/* Event triggered, when rf_core timer interrupt was received                */
+extern process_event_t rf_core_timer_event;
 /*---------------------------------------------------------------------------*/
 /**
  * \brief Check whether the RF core is accessible
@@ -330,6 +346,25 @@ uint8_t rf_core_stop_rat(void);
  * To achieve good timing accuracy, it should be called periodically.
  */
 uint8_t rf_core_restart_rat(void);
+
+/**
+ * \brief Reads the current rf ticks.
+ * \return current ticks of the rf core
+ */
+uint32_t rf_core_read_current_rf_ticks(void);
+
+/**
+ * \brief Start compare mode of RAT channel
+ * \param time the time when the HW interrupt should occure
+ * (in rf_core timer ticks)
+ * \return RF_CORE_CMD_OK or RF_CORE_CMD_ERROR
+ *
+ * This function starts the RAT channel (RF_CORE_TIMER_INTERRUPT) in
+ * compare mode. If the current timer value is greater or equal to
+ * the time parameter, a HW interrupt is raised.
+ * The HW interrupt fires the rf_core_timer_event.
+ */
+uint8_t rf_core_start_timer_comp(uint32_t time);
 
 /**
  * \brief Boot the RF Core

--- a/examples/cc26xx/ble-udp-demo/Makefile
+++ b/examples/cc26xx/ble-udp-demo/Makefile
@@ -1,0 +1,9 @@
+DEFINES+=PROJECT_CONF_H=\"project-conf.h\"
+CONTIKI_PROJECT = ble-udp-demo
+all: $(CONTIKI_PROJECT)
+
+CONTIKI_WITH_RPL = 0
+CONTIKI_WITH_IPV6 = 1
+
+CONTIKI = ../../..
+include $(CONTIKI)/Makefile.include

--- a/examples/cc26xx/ble-udp-demo/README.md
+++ b/examples/cc26xx/ble-udp-demo/README.md
@@ -1,0 +1,18 @@
+# CC26xx IPv6 over BLE - UDP client
+
+This example demonstrates a UDP client using IPv6 over BLE.
+The node operates as a UDP client connected via IPv6 over BLE to a border router.
+
+After booting the node starts to send ICMPv6 echo requests to an UDP server
+(IPv6: aaaa::1) and waits for a valid ICMPv6 echo response from the server.
+
+When an echo response was received, the node periodically sends UDP messages 
+to the UDP server and prints every UDP message received from the server.
+
+## Requirements
+
+To run this example you will need:
+
+* A IPv6 over BLE border router.
+  See [nRF5 IoT SDK] (http://developer.nordicsemi.com/nRF5_IoT_SDK/doc/0.9.0/html/a00092.html)
+  for instructions on how to setup a border router on a Raspberry Pi.

--- a/examples/cc26xx/ble-udp-demo/ble-udp-demo.c
+++ b/examples/cc26xx/ble-udp-demo/ble-udp-demo.c
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2016, Michael Spoerk
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Author: Michael Spoerk <mi.spoerk@gmail.com>
+ *
+ */
+/*---------------------------------------------------------------------------*/
+#include "contiki.h"
+#include "contiki-net.h"
+#include "net/ip/uiplib.h"
+#include "net/ipv6/uip-icmp6.h"
+#include "dev/leds.h"
+
+#include <stdio.h>
+/*---------------------------------------------------------------------------*/
+#define CLIENT_PORT     61617
+#define SERVER_ADDR     "aaaa::1"
+//#define SERVER_ADDR     "fe80::21a:7dff:feda:7114"
+#define SERVER_PORT     61616
+
+#define ECHO_INTERVAL   (1 * CLOCK_SECOND)
+#define SEND_INTERVAL   (1 * CLOCK_SECOND)
+
+#define TEST_PAYLOAD    "IPv6 over BLE message from TI SensorTag"
+/*---------------------------------------------------------------------------*/
+static struct etimer timer;
+
+static struct uip_icmp6_echo_reply_notification echo_notification;
+static unsigned short echo_received = 0;
+
+static uip_ipaddr_t server_addr;
+static struct uip_udp_conn *conn;
+
+static char send_buf[80];
+/*---------------------------------------------------------------------------*/
+PROCESS(ble_udp_demo_process, "BLE UDP demo process");
+AUTOSTART_PROCESSES(&ble_udp_demo_process);
+/*---------------------------------------------------------------------------*/
+void
+echo_reply_handler(uip_ipaddr_t *source, uint8_t ttl,
+                   uint8_t *data, uint16_t datalen)
+{
+  printf("echo response received\n");
+  echo_received = 1;
+}
+/*---------------------------------------------------------------------------*/
+static void
+tcpip_handler(void)
+{
+  char *str;
+  unsigned int data_len;
+  if(uip_newdata()) {
+    str = uip_appdata;
+    data_len = uip_datalen();
+    str[data_len] = '\0';
+
+    printf("udp data (len: %d) received: %s\n", data_len, str);
+  }
+}
+/*---------------------------------------------------------------------------*/
+static void
+timeout_handler(void)
+{
+    unsigned short msg_len = strlen(TEST_PAYLOAD);
+    sprintf(send_buf, TEST_PAYLOAD);
+    printf("sending %d bytes of UDP payload\n", msg_len);
+    uip_udp_packet_send(conn, send_buf, msg_len);
+}
+/*---------------------------------------------------------------------------*/
+PROCESS_THREAD(ble_udp_demo_process, ev, data)
+{
+  PROCESS_BEGIN();
+  printf("BLE UDP demo process started\n");
+  leds_on(LEDS_GREEN);
+
+  uiplib_ipaddrconv(SERVER_ADDR, &server_addr);
+  uip_icmp6_echo_reply_callback_add(&echo_notification, echo_reply_handler);
+
+  /* wait for an echo response from the server */
+  do {
+      leds_on(LEDS_RED);
+      uip_icmp6_send(&server_addr, ICMP6_ECHO_REQUEST, 0, 20);
+      etimer_set(&timer, ECHO_INTERVAL);
+      leds_off(LEDS_RED);
+      PROCESS_WAIT_EVENT_UNTIL(etimer_expired(&timer));
+  } while(!echo_received);
+
+  /* creating the UDP connection */
+  conn = udp_new(&server_addr, UIP_HTONS(SERVER_PORT), NULL);
+  udp_bind(conn, UIP_HTONS(CLIENT_PORT));
+  printf("UDP connection created\n");
+
+  etimer_set(&timer, SEND_INTERVAL);
+  while(1) {
+      PROCESS_YIELD();
+      if((ev == PROCESS_EVENT_TIMER) && (data == &timer)) {
+          timeout_handler();
+                etimer_set(&timer, SEND_INTERVAL);
+      }
+      else if(ev == tcpip_event) {
+          tcpip_handler();
+      }
+  }
+
+  PROCESS_END();
+}
+/*---------------------------------------------------------------------------*/
+

--- a/examples/cc26xx/ble-udp-demo/ble-udp-demo.c
+++ b/examples/cc26xx/ble-udp-demo/ble-udp-demo.c
@@ -41,7 +41,7 @@
 /*---------------------------------------------------------------------------*/
 #define CLIENT_PORT     61617
 #define SERVER_ADDR     "aaaa::1"
-//#define SERVER_ADDR     "fe80::21a:7dff:feda:7114"
+/*#define SERVER_ADDR     "fe80::21a:7dff:feda:7114" */
 #define SERVER_PORT     61616
 
 #define ECHO_INTERVAL   (1 * CLOCK_SECOND)
@@ -87,10 +87,10 @@ tcpip_handler(void)
 static void
 timeout_handler(void)
 {
-    unsigned short msg_len = strlen(TEST_PAYLOAD);
-    sprintf(send_buf, TEST_PAYLOAD);
-    printf("sending %d bytes of UDP payload\n", msg_len);
-    uip_udp_packet_send(conn, send_buf, msg_len);
+  unsigned short msg_len = strlen(TEST_PAYLOAD);
+  sprintf(send_buf, TEST_PAYLOAD);
+  printf("sending %d bytes of UDP payload\n", msg_len);
+  uip_udp_packet_send(conn, send_buf, msg_len);
 }
 /*---------------------------------------------------------------------------*/
 PROCESS_THREAD(ble_udp_demo_process, ev, data)
@@ -104,11 +104,11 @@ PROCESS_THREAD(ble_udp_demo_process, ev, data)
 
   /* wait for an echo response from the server */
   do {
-      leds_on(LEDS_RED);
-      uip_icmp6_send(&server_addr, ICMP6_ECHO_REQUEST, 0, 20);
-      etimer_set(&timer, ECHO_INTERVAL);
-      leds_off(LEDS_RED);
-      PROCESS_WAIT_EVENT_UNTIL(etimer_expired(&timer));
+    leds_on(LEDS_RED);
+    uip_icmp6_send(&server_addr, ICMP6_ECHO_REQUEST, 0, 20);
+    etimer_set(&timer, ECHO_INTERVAL);
+    leds_off(LEDS_RED);
+    PROCESS_WAIT_EVENT_UNTIL(etimer_expired(&timer));
   } while(!echo_received);
 
   /* creating the UDP connection */
@@ -118,14 +118,13 @@ PROCESS_THREAD(ble_udp_demo_process, ev, data)
 
   etimer_set(&timer, SEND_INTERVAL);
   while(1) {
-      PROCESS_YIELD();
-      if((ev == PROCESS_EVENT_TIMER) && (data == &timer)) {
-          timeout_handler();
-                etimer_set(&timer, SEND_INTERVAL);
-      }
-      else if(ev == tcpip_event) {
-          tcpip_handler();
-      }
+    PROCESS_YIELD();
+    if((ev == PROCESS_EVENT_TIMER) && (data == &timer)) {
+      timeout_handler();
+      etimer_set(&timer, SEND_INTERVAL);
+    } else if(ev == tcpip_event) {
+      tcpip_handler();
+    }
   }
 
   PROCESS_END();

--- a/examples/cc26xx/ble-udp-demo/project-conf.h
+++ b/examples/cc26xx/ble-udp-demo/project-conf.h
@@ -63,7 +63,7 @@
 #define SICSLOWPAN_CONF_FRAG                    0
 #define SICSLOWPAN_FRAMER_HDRLEN                0
 
-///* network layer settings */
+/* network layer settings */
 #define UIP_CONF_ROUTER                         0
 #define UIP_CONF_ND6_SEND_NA                    1
 #define UIP_CONF_IP_FORWARD                     0

--- a/examples/cc26xx/ble-udp-demo/project-conf.h
+++ b/examples/cc26xx/ble-udp-demo/project-conf.h
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2016, Michael Spoerk
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Author: Michael Spoerk <mi.spoerk@gmail.com>
+ *
+ */
+/*---------------------------------------------------------------------------*/
+#ifndef PROJECT_CONF_H_
+#define PROJECT_CONF_H_
+/*---------------------------------------------------------------------------*/
+/* Disable button shutdown functionality */
+#define BUTTON_SENSOR_CONF_ENABLE_SHUTDOWN    0
+/*---------------------------------------------------------------------------*/
+/* Change to match your configuration */
+#define BOARD_CONF_DEBUGGER_DEVPACK           1
+
+#define STARTUP_CONF_VERBOSE 1
+/*---------------------------------------------------------------------------*/
+/* network stack settings */
+#define PACKETBUF_CONF_SIZE                  1280
+#define QUEUEBUF_CONF_NUM                       1
+#define UIP_CONF_BUFFER_SIZE                 1280
+
+/* radio settings */
+#define NETSTACK_CONF_RADIO             ble_mode_driver
+
+/* RDC settings */
+#define NETSTACK_CONF_RDC               nullrdc_noframer_driver
+
+/* MAC settings */
+#define NETSTACK_CONF_MAC               ble_mac_driver
+
+/* 6LoWPAN settings */
+#define SICSLOWPAN_CONF_MAC_MAX_PAYLOAD      1280
+#define SICSLOWPAN_CONF_COMPRESSION          SICSLOWPAN_COMPRESSION_HC06
+#define SICSLOWPAN_CONF_COMPRESSION_THRESHOLD   0   /* always use compression */
+#define SICSLOWPAN_CONF_FRAG                    0
+#define SICSLOWPAN_FRAMER_HDRLEN                0
+
+///* network layer settings */
+#define UIP_CONF_ROUTER                         0
+#define UIP_CONF_ND6_SEND_NA                    1
+#define UIP_CONF_IP_FORWARD                     0
+/*---------------------------------------------------------------------------*/
+#endif /* PROJECT_CONF_H_ */
+/*---------------------------------------------------------------------------*/

--- a/platform/srf06-cc26xx/contiki-conf.h
+++ b/platform/srf06-cc26xx/contiki-conf.h
@@ -119,7 +119,9 @@
 #define CONTIKIMAC_CONF_AFTER_ACK_DETECTECT_WAIT_TIME (RTIMER_SECOND / 1000)
 #define CONTIKIMAC_CONF_INTER_PACKET_INTERVAL     (RTIMER_SECOND / 240)
 #else
+#ifndef NETSTACK_CONF_RADIO
 #define NETSTACK_CONF_RADIO        ieee_mode_driver
+#endif
 
 #ifndef RF_CORE_CONF_CHANNEL
 #define RF_CORE_CONF_CHANNEL                     25
@@ -132,9 +134,18 @@
 #define NETSTACK_RADIO_MAX_PAYLOAD_LEN        125
 
 /* 6LoWPAN */
+#ifndef SICSLOWPAN_CONF_COMPRESSION
 #define SICSLOWPAN_CONF_COMPRESSION          SICSLOWPAN_COMPRESSION_HC06
+#endif
+
+#ifndef SICSLOWPAN_CONF_COMPRESSION_THRESHOLD
 #define SICSLOWPAN_CONF_COMPRESSION_THRESHOLD  63
+#endif
+
+#ifndef SICSLOWPAN_CONF_FRAG
 #define SICSLOWPAN_CONF_FRAG                    1
+#endif
+
 #define SICSLOWPAN_CONF_MAXAGE                  8
 /** @} */
 /*---------------------------------------------------------------------------*/

--- a/platform/srf06-cc26xx/contiki-main.c
+++ b/platform/srf06-cc26xx/contiki-main.c
@@ -51,6 +51,7 @@
 #include "dev/watchdog.h"
 #include "dev/oscillators.h"
 #include "ieee-addr.h"
+#include "ble-addr.h"
 #include "vims.h"
 #include "dev/cc26xx-uart.h"
 #include "dev/soc-rtc.h"
@@ -97,10 +98,17 @@ fade(unsigned char l)
 static void
 set_rf_params(void)
 {
-  uint16_t short_addr;
   uint8_t ext_addr[8];
-  radio_value_t val = 0;
 
+#if NETSTACK_CONF_RADIO == ble_mode_driver
+  ble_eui64_addr_cpy_to(ext_addr);
+
+  /* Populate linkaddr_node_addr. Maintain endianness */
+  memcpy(&linkaddr_node_addr, &ext_addr[8 - LINKADDR_SIZE], LINKADDR_SIZE);
+  NETSTACK_RADIO.set_object(RADIO_PARAM_64BIT_ADDR, ext_addr, 8);
+#else
+  uint16_t short_addr;
+  radio_value_t val = 0;
   ieee_addr_cpy_to(ext_addr, 8);
 
   short_addr = ext_addr[7];
@@ -117,6 +125,10 @@ set_rf_params(void)
   NETSTACK_RADIO.get_value(RADIO_PARAM_CHANNEL, &val);
   printf(" RF: Channel %d\n", val);
 
+  /* also set the global node id */
+  node_id = short_addr;
+#endif
+
 #if STARTUP_CONF_VERBOSE
   {
     int i;
@@ -126,11 +138,8 @@ set_rf_params(void)
     }
     printf("%02x\n", linkaddr_node_addr.u8[i]);
   }
-#endif
-
-  /* also set the global node id */
-  node_id = short_addr;
   printf(" Node ID: %d\n", node_id);
+#endif
 }
 /*---------------------------------------------------------------------------*/
 /**


### PR DESCRIPTION
This pull request adds IPv6 over BLE support according to the [RFC 7886](https://tools.ietf.org/html/rfc7668) standard for the Texas Instruments SensorTag CC2650.

This PR adds a BLE implementation of the radio layer for the SensorTag CC2650.
A hardware-independent MAC layer implementation for IPv6 over BLE that implements packet fragmentation/reassembly is also included.

