### PR TITLE
Fixed checking of the cc1200 GPIO0 pin status.

### DIFF
--- a/platform/zoul/dev/cc1200-zoul-arch.c
+++ b/platform/zoul/dev/cc1200-zoul-arch.c
@@ -241,7 +241,7 @@ cc1200_arch_gpio2_disable_irq(void)
 int
 cc1200_arch_gpio0_read_pin(void)
 {
-  return GPIO_READ_PIN(CC1200_GDO0_PORT_BASE, CC1200_GDO0_PIN_MASK);
+  return (GPIO_READ_PIN(CC1200_GDO0_PORT_BASE, CC1200_GDO0_PIN_MASK) ? 1 : 0);
 }
 /*---------------------------------------------------------------------------*/
 int


### PR DESCRIPTION
Driver of cc1200 was mistakenly comparing gpio0 pin high status with 1. When the pin is high you should compare it with the pin number.