### PR TITLE
Disable DIO suppression by default

### DIFF
--- a/core/net/rpl/rpl-conf.h
+++ b/core/net/rpl/rpl-conf.h
@@ -197,14 +197,19 @@
 /*
  * DIO redundancy. To learn more about this, see RFC 6206.
  *
- * RFC 6550 suggests a default value of 10. It is unclear what the basis
- * of this suggestion is. Network operators might attain more efficient
- * operation by tuning this parameter for specific deployments.
+ * RFC 6550 suggests a default value of 10. It is unclear what the basis of
+ * this suggestion is. Instead, we disable the suppression mechanism by default.
+ * In Contiki, nodes maintain a single DAO parent. They need to hear a DIO from
+ * this parent to notice DTSN updates. DIO suppression can in result in large
+ * delays (many Trickle periods, in dense networks) in DTSN update. Network
+ * operators might attain more efficient operation by tuning this parameter
+ * for specific deployments.
+ *
  */
 #ifdef RPL_CONF_DIO_REDUNDANCY
 #define RPL_DIO_REDUNDANCY          RPL_CONF_DIO_REDUNDANCY
 #else
-#define RPL_DIO_REDUNDANCY          10
+#define RPL_DIO_REDUNDANCY          0
 #endif
 
 /*


### PR DESCRIPTION
This might be controversial, so discussions are highly welcome here :)

The rationale is that in Contiki, nodes have a single DAO parent, and can only notice DTSN increment from that one particular parent. This means that DTSN increments triggered by the route struggle to propagate. The problem gets more pronounced in denser network.

In large IoT-LAB deployments, such as Grenoble (352 nodes, 6-7 hops diameter), the network even fails to bootstrap in the first place. Disabling redundancy enables quick convergence and swift maintenance. When the signaling traffic gets too heavy, decreasing the Trickle frequency also helps.

Note that this is only the default value; Nodes will adopt whichever value is advertised by the BR, i.e. they will still be able to adapt to networks with specific Trickle-redundancy needs.