### PR TITLE
Remove definitions of outdated RPL_CONF_OF

### DIFF
--- a/examples/er-rest-example/project-conf.h
+++ b/examples/er-rest-example/project-conf.h
@@ -96,12 +96,9 @@
 #undef COAP_PROXY_OPTION_PROCESSING
 #define COAP_PROXY_OPTION_PROCESSING   0
 
-/* Turn of DAO ACK to make code smaller */
+/* Turn off DAO ACK to make code smaller */
 #undef RPL_CONF_WITH_DAO_ACK
 #define RPL_CONF_WITH_DAO_ACK          0
-
-#undef RPL_CONF_OF
-#define RPL_CONF_OF                    rpl_of0
 
 /* Enable client-side support for COAP observe */
 #define COAP_OBSERVE_CLIENT 1

--- a/platform/cc2530dk/contiki-conf.h
+++ b/platform/cc2530dk/contiki-conf.h
@@ -220,10 +220,6 @@
 #define UIP_CONF_IP_FORWARD                  0
 #define RPL_CONF_STATS                       0
 
-#ifndef RPL_CONF_OF
-#define RPL_CONF_OF rpl_mrhof
-#endif
-
 #define UIP_CONF_ND6_REACHABLE_TIME     600000
 #define UIP_CONF_ND6_RETRANS_TIMER       10000
 

--- a/platform/cc2538dk/contiki-conf.h
+++ b/platform/cc2538dk/contiki-conf.h
@@ -424,10 +424,6 @@ typedef uint32_t rtimer_clock_t;
 #define UIP_CONF_IP_FORWARD                  0
 #define RPL_CONF_STATS                       0
 
-#ifndef RPL_CONF_OF
-#define RPL_CONF_OF rpl_mrhof
-#endif
-
 #define UIP_CONF_ND6_REACHABLE_TIME     600000
 #define UIP_CONF_ND6_RETRANS_TIMER       10000
 

--- a/platform/openmote-cc2538/contiki-conf.h
+++ b/platform/openmote-cc2538/contiki-conf.h
@@ -476,10 +476,6 @@ typedef uint32_t rtimer_clock_t;
 #define UIP_CONF_IP_FORWARD                  0
 #define RPL_CONF_STATS                       0
 
-#ifndef RPL_CONF_OF
-#define RPL_CONF_OF rpl_mrhof
-#endif
-
 #define UIP_CONF_ND6_REACHABLE_TIME     600000
 #define UIP_CONF_ND6_RETRANS_TIMER       10000
 

--- a/platform/srf06-cc26xx/contiki-conf.h
+++ b/platform/srf06-cc26xx/contiki-conf.h
@@ -221,10 +221,6 @@
 #define UIP_CONF_IP_FORWARD                  0
 #define RPL_CONF_STATS                       0
 
-#ifndef RPL_CONF_OF
-#define RPL_CONF_OF rpl_mrhof
-#endif
-
 #define UIP_CONF_ND6_REACHABLE_TIME     600000
 #define UIP_CONF_ND6_RETRANS_TIMER       10000
 

--- a/platform/zoul/contiki-conf.h
+++ b/platform/zoul/contiki-conf.h
@@ -493,10 +493,6 @@ typedef uint32_t rtimer_clock_t;
 #define UIP_CONF_IP_FORWARD                  0
 #define RPL_CONF_STATS                       0
 
-#ifndef RPL_CONF_OF
-#define RPL_CONF_OF rpl_mrhof
-#endif
-
 #define UIP_CONF_ND6_REACHABLE_TIME     600000
 #define UIP_CONF_ND6_RETRANS_TIMER       10000
 


### PR DESCRIPTION
The way to configure the RPL Objective Function to be used has changed and now uses the definitions of  `RPL_CONF_SUPPORTED_OFS` and `RPL_CONF_OF_OCP`. Previously, to change the objective function `RPL_CONF_OF` was used. This definition is not used anymore.

This PR removes the outdated definitions of `RPL_CONF_OF` from several platforms and the `er-rest-example`. Note that this should not affect the platforms because MRHOF is by default the objective function of RPL.

For more information see the appearance of `RPL_CONF_OF`in the code:
https://github.com/contiki-os/contiki/search?utf8=✓&q=RPL_CONF_OF

And also the discussion in issue [#1955](https://github.com/contiki-os/contiki/issues/1955).