### PR TITLE
Update doc/code-style.c

### DIFF
--- a/doc/code-style.c
+++ b/doc/code-style.c
@@ -7,15 +7,13 @@
  * belong to the same module. Typically, the \defgroup is placed in
  * the .h file and \addtogroup in the .c file.
  *
- * The Contiki source code contains a GNU Indent script that can
- * automatically format a C code file to match the Contiki code
- * style. The Indent configuration is in contiki/tools/indent.pro and
- * a small helper script is in contiki/tools/contiki-indent. Note that
- * this is not a silver bullet - for example, the script does not add
- * separators between functions, nor does it format comments
- * correctly. The script should be treated as an aid in formatting
- * code: first run the formatter on the source code, then manually
- * edit the file.
+ * The Contiki source code contains an Uncrustify configuration file,
+ * uncrustify.cfg, under tools/code-style and small helper scripts are
+ * provided at the same place. Note that this is not a silver bullet -
+ * for example, the script does not add separators between functions,
+ * nor does it format comments correctly. The script should be treated
+ * as an aid in formatting code: first run the formatter on the source
+ * code, then manually edit the file.
  *
  * @{
  */
@@ -74,22 +72,22 @@ static int flag;
  *             between the name and the first parenthesis), followed
  *             by a single curly bracket on its own line.
  */
-void
-code_style_example_function(void)
+int
+code_style_example_function(char c)
 {
   /*
    * Local variables should always be declared at the start of the
    * function.
    */
   int i;                   /* Use short variable names for loop
-			      counters. */
+                              counters. */
 
   /*
    * There should be no space between keywords and the first
    * parenthesis. There should be spaces around binary operators, no
    * spaces between a unary operator and its operand.
    *
-   * Curly brackets following for(), if(), do, and case() statements
+   * Curly brackets following for(), if(), do, and switch() statements
    * should follow the statement on the same line.
    */
   for(i = 0; i < 10; ++i) {
@@ -100,12 +98,25 @@ code_style_example_function(void)
      * are less error prone.
      */
     if(i == c) {
-      return c;           /* No parentesis around return values. */
+      return 1;           /* No parentesis around return values. */
     } else {              /* The else keyword is placed inbetween
-			     curly brackers, always on its own line. */
+                             curly brackers, always on its own line. */
       c++;
     }
   }
+
+  /*
+   * Indent "case" statement and "default" label by two spaces in "switch"
+   * statement.
+   */
+  switch(c) {
+    case 19:
+      return 1;
+    default:
+      break;
+  }
+
+  return 0;
 }
 /*---------------------------------------------------------------------------*/
 /*


### PR DESCRIPTION
Here are changes:
- mention Uncrustify (`tools/code-style/uncrustify.cfg`) instead of GNU Indent : reflect https://github.com/contiki-os/contiki/commit/cbdd7f2f09c3b8a7807fedc06e449c28fe17b7cc
- add a missing argument of code_style_example_function(): `\param c` in doxygen comment
- make the function return 0 or 1 as per doxygen comment: `\return`, `\retval 0`, and `\retval 1` in doxygen comment
- replace tab with spaces
- correct case() to switch() in a comment: I guess it's typo...
- add an indentation example for switch statement: it's missing, but important
