### PR TITLE
travis: workaround for the Java issue on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
+# Workaround for the issue found in the stable image promoted on Dec 1, 2016.
+# See https://github.com/travis-ci/travis-ci/issues/6928#issuecomment-264227708
+group: deprecated
+
 notifications:
   email: false
 language: c #NOTE: this will set CC=gcc which might cause trouble


### PR DESCRIPTION
The Travis test has been failing since 1st of December. https://travis-ci.org/contiki-os/contiki/builds

I found the warning and error in a Travis Job log shown below, that appeared in failed tests:
```
(snip)
    [javac] warning: [options] bootstrap class path not set in conjunction with -source 1.7
    [javac] 1 warning
(snip)
Running test 01-cooja-http-socket-50 with random Seed 1: Exception in thread "main" java.lang.UnsupportedClassVersionError: org/contikios/cooja/Cooja : Unsupported major.minor version 52.0
```

I assume this issue is related to https://github.com/travis-ci/travis-ci/issues/6928. This PR applies [the workaround](https://github.com/travis-ci/travis-ci/issues/6928#issuecomment-264227708) to make Travis green.

Related Issues:
https://github.com/contiki-os/contiki/issues/1965
https://github.com/travis-ci/travis-ci/issues/6928