### PR TITLE
update httpd_cgi to enable the compilation of webserver-ipv6 example

### DIFF
--- a/apps/webserver/httpd-cgi.c
+++ b/apps/webserver/httpd-cgi.c
@@ -252,7 +252,7 @@ extern uip_ds6_netif_t uip_ds6_if;
 static unsigned short
 make_addresses(void *p)
 {
-uint8_t i,j=0;
+uint8_t j=0;
 uint16_t numprinted;
   numprinted = httpd_snprintf((char *)uip_appdata, uip_mss(),httpd_cgi_addrh);
   for (i=0; i<UIP_DS6_ADDR_NB;i++) {
@@ -280,7 +280,7 @@ PT_THREAD(addresses(struct httpd_state *s, char *ptr))
 static unsigned short
 make_neighbors(void *p)
 {
-uint8_t i,j=0;
+uint8_t j=0;
 uint16_t numprinted;
   numprinted = httpd_snprintf((char *)uip_appdata, uip_mss(),httpd_cgi_addrh);
   uip_ds6_nbr_t *nbr;
@@ -312,7 +312,7 @@ make_routes(void *p)
   static const char httpd_cgi_rtes1[] HTTPD_STRING_ATTR = "(%u (via ";
   static const char httpd_cgi_rtes2[] HTTPD_STRING_ATTR = ") %lus<br>";
   static const char httpd_cgi_rtes3[] HTTPD_STRING_ATTR = ")<br>";
-  uint8_t i,j=0;
+  uint8_t j=0;
   uint16_t numprinted;
   uip_ds6_route_t *r;
 
@@ -323,7 +323,7 @@ make_routes(void *p)
     j++;
     numprinted += httpd_cgi_sprint_ip6(r->ipaddr, uip_appdata + numprinted);
     numprinted += httpd_snprintf((char *)uip_appdata+numprinted, uip_mss()-numprinted, httpd_cgi_rtes1, r->length);
-    numprinted += httpd_cgi_sprint_ip6(uip_ds6_route_nexthop(r), uip_appdata + numprinted);
+    numprinted += httpd_cgi_sprint_ip6(*(uip_ds6_route_nexthop(r)), uip_appdata + numprinted);
     if(r->state.lifetime < 3600) {
       numprinted += httpd_snprintf((char *)uip_appdata+numprinted, uip_mss()-numprinted, httpd_cgi_rtes2, r->state.lifetime);
     } else {


### PR DESCRIPTION
this simple change fixes the bug reported in #1541.
../../apps/webserver/httpd.h:63:9: note: expected ‘uip_ip6addr_t’ but argument is of type ‘union uip_ipaddr_t *’