### PR TITLE
Resolve  "unmatched single quote" error in Travis CI failed tests

### DIFF
--- a/tools/cooja/java/org/contikios/cooja/contikimote/ContikiMoteType.java
+++ b/tools/cooja/java/org/contikios/cooja/contikimote/ContikiMoteType.java
@@ -401,7 +401,7 @@ public class ContikiMoteType implements MoteType {
     }
 
     // Allocate core communicator class
-    logger.info("Creating core communicator between Java class " + javaClassName + " and Contiki library '" + getContikiFirmwareFile().getPath() + "");
+    logger.info("Creating core communicator between Java class " + javaClassName + " and Contiki library '" + getContikiFirmwareFile().getPath() + "'");
     myCoreComm = CoreComm.createCoreComm(this.javaClassName, getContikiFirmwareFile());
 
     /* Parse addresses using map file


### PR DESCRIPTION
In some failed tests, e.g. [this one](https://travis-ci.org/contiki-os/contiki/jobs/181329851), the "unmatched single quote" error by xargs is found:
```
==== Files used for simulation (sha1sum) ====
xargs: unmatched single quote; by default quotes are special to xargs unless you use the -0 option
FAIL ಠ_ಠ
```

This error is caused by a missing single quotation mark at the end of the file path of a Cooja image in `Cooja.log`. Here is an example:
```
[17:43:16 - main] [ContikiMoteType.java:404] [INFO] - (snip) code/obj_cooja/mtype483.cooja
```

This PR adds the missing single quotation mark as shown below:
```
[17:49:16 - main] [ContikiMoteType.java:404] [INFO] - (snip) code/obj_cooja/mtype740.cooja'
```