### PR TITLE
Attempt to resolve Travis failure by "java.lang.ClassCastException"

### DIFF
--- a/tools/cooja/java/org/contikios/cooja/CoreComm.java
+++ b/tools/cooja/java/org/contikios/cooja/CoreComm.java
@@ -327,11 +327,11 @@ public abstract class CoreComm {
 
     compileSourceFile(className);
 
-    Class newCoreCommClass = loadClassFile(className);
+    Class<?> newCoreCommClass = loadClassFile(className);
 
     try {
-      Constructor constr = newCoreCommClass
-          .getConstructor(new Class[] { File.class });
+      Constructor<?> constr = newCoreCommClass
+          .getConstructor(new Class<?>[] { File.class });
       CoreComm newCoreComm = (CoreComm) constr
           .newInstance(new Object[] { libFile });
 


### PR DESCRIPTION
# Issue
Travis failures by `java.lang.ClassCastException` have been experienced randomly. [This](https://travis-ci.org/contiki-os/contiki/jobs/181329851) is a Travis job which failed with the exception. Here is an excerpt of the log.
```shell
Contiki library '/home/travis/build/contiki-os/contiki/regression-tests/12-rpl/code/obj_cooja/mtype280.cooja
FATAL [main] (Cooja.java:1337) - Exception when loading simulation: 
org.contikios.cooja.Cooja$SimulationCreationException: Unknown error: javax.swing.plaf.BorderUIResource cannot be cast to java.lang.Boolean
(snip)
	at org.contikios.cooja.dialogs.MessageListUI.<init>(MessageListUI.java:85)
	at org.contikios.cooja.CoreComm.compileSourceFile(CoreComm.java:207)
	at org.contikios.cooja.CoreComm.createCoreComm(CoreComm.java:328)
	at org.contikios.cooja.contikimote.ContikiMoteType.doInit(ContikiMoteType.java:405)
	at org.contikios.cooja.contikimote.ContikiMoteType.configureAndInit(ContikiMoteType.java:366)
	at org.contikios.cooja.contikimote.ContikiMoteType.setConfigXML(ContikiMoteType.java:1333)
	at org.contikios.cooja.Simulation.setConfigXML(Simulation.java:691)
	at org.contikios.cooja.Cooja.loadSimulationConfig(Cooja.java:3431)
	... 3 more
```
# What the Internet told me
I found [a post](http://stackoverflow.com/questions/12613293/classcastexception-javax-swing-plaf-fontuiresource-cannot-be-cast-to-javax-swin
) about a similar situation on Stack Overflow. The best answer says the issue could be caused by improper handling of the Swing threading. Further googling gave me other helpful articles listed below. The point is, any operation on a Swing object should be done in Event Dispatcher Thread. 

- http://bugs.java.com/view_bug.do?bug_id=6785663
- http://stackoverflow.com/questions/26834078/how-to-initialize-gui-objects-in-a-thread-safe-manner-in-java-swing
- https://docs.oracle.com/javase/tutorial/uiswing/concurrency/initial.html
- http://javarevisited.blogspot.ch/2011/09/invokeandwait-invokelater-swing-example.html

# Possible Cause and Proposed Change
At line 207 of `tools/cooja/java/org/contikios/cooja/CoreComm.java`, an instance of `MessageListUI`, a sub class of a Swing component, is created in the current thread. This might be wrong according to the web articles.

```JAVA
 197   /**
 198    * Compiles Java class.
 199    *
 200    * @param className
 201    *          Java class name (without extension)
 202    * @throws MoteTypeCreationException
 203    *           If Java class compilation error occurs
 204    */
 205   public static void compileSourceFile(String className)
 206       throws MoteTypeCreationException {
 207     MessageListUI compilationOutput = new MessageListUI();
 208     OutputStream compilationStandardStream = compilationOutput
 209         .getInputStream(MessageListUI.NORMAL);
 210     OutputStream compilationErrorStream = compilationOutput
 211         .getInputStream(MessageList.ERROR);
```

Since operations on the `MessageListUI` instance other than instantiation are also done in `compileSourceFile()` method, I changed the code to make the whole contents of the original `compileSourceFile()` done in Event Dispatcher Thread (EDT).

According to [the latest Travis job on my account](https://travis-ci.org/yatch/contiki/builds/182916634), my change doesn't break anything in Contiki/Cooja at least...

# Need Help :-)
Honestly, I'm not sure the change I made could resolve the issue. I have little knowledge and experience on Java... But, I want it resolved; failures by the exception are annoying... Please some Java programmers help me (>_<)