### PR TITLE
Fixed COOJA to avoid using UI based message list when not using UI.

### DIFF
--- a/tools/cooja/apps/avrora/src/org/contikios/cooja/avrmote/MicaZMoteType.java
+++ b/tools/cooja/apps/avrora/src/org/contikios/cooja/avrmote/MicaZMoteType.java
@@ -63,8 +63,6 @@ import org.contikios.cooja.avrmote.interfaces.MicaZLED;
 import org.contikios.cooja.avrmote.interfaces.MicaZRadio;
 import org.contikios.cooja.dialogs.CompileContiki;
 import org.contikios.cooja.dialogs.MessageList;
-import org.contikios.cooja.dialogs.MessageListText;
-import org.contikios.cooja.dialogs.MessageListUI;
 import org.contikios.cooja.dialogs.MessageContainer;
 import org.contikios.cooja.interfaces.Mote2MoteRelations;
 import org.contikios.cooja.interfaces.MoteAttributes;
@@ -366,7 +364,7 @@ public class MicaZMoteType implements MoteType {
       throw new MoteTypeCreationException("No identifier");
     }
 
-    final MessageList compilationOutput = visAvailable ? new MessageListUI() : new MessageListText();
+    final MessageList compilationOutput = MessageContainer.createMessageList(visAvailable);
 
     if (getCompileCommands() != null) {
       /* Handle multiple compilation commands one by one */

--- a/tools/cooja/apps/mspsim/src/org/contikios/cooja/mspmote/AbstractMspMoteType.java
+++ b/tools/cooja/apps/mspsim/src/org/contikios/cooja/mspmote/AbstractMspMoteType.java
@@ -118,7 +118,7 @@ public abstract class AbstractMspMoteType extends MspMoteType {
             throw new MoteTypeCreationException("No identifier");
         }
 
-        final MessageList compilationOutput = visAvailable ? new MessageListUI() : new MessageListText();
+        final MessageList compilationOutput = MessageContainer.createMessageList(visAvailable);
 
         if (getCompileCommands() != null) {
             /* Handle multiple compilation commands one by one */

--- a/tools/cooja/apps/mspsim/src/org/contikios/cooja/mspmote/CC430MoteType.java
+++ b/tools/cooja/apps/mspsim/src/org/contikios/cooja/mspmote/CC430MoteType.java
@@ -115,7 +115,7 @@ public class CC430MoteType extends MspMoteType {
       throw new MoteTypeCreationException("No identifier");
     }
 
-    final MessageList compilationOutput = visAvailable ? new MessageListUI() : new MessageListText();
+    final MessageList compilationOutput = MessageContainer.createMessageList(visAvailable);
 
     if (getCompileCommands() != null) {
       /* Handle multiple compilation commands one by one */

--- a/tools/cooja/apps/mspsim/src/org/contikios/cooja/mspmote/ESBMoteType.java
+++ b/tools/cooja/apps/mspsim/src/org/contikios/cooja/mspmote/ESBMoteType.java
@@ -151,7 +151,7 @@ public class ESBMoteType extends MspMoteType {
       throw new MoteTypeCreationException("No identifier");
     }
 
-    final MessageList compilationOutput = visAvailable ? new MessageListUI() : new MessageListText();
+    final MessageList compilationOutput = MessageContainer.createMessageList(visAvailable);
 
     if (getCompileCommands() != null) {
       /* Handle multiple compilation commands one by one */

--- a/tools/cooja/apps/mspsim/src/org/contikios/cooja/mspmote/Eth1120MoteType.java
+++ b/tools/cooja/apps/mspsim/src/org/contikios/cooja/mspmote/Eth1120MoteType.java
@@ -73,7 +73,7 @@ public class Eth1120MoteType extends Exp5438MoteType {
       throw new MoteTypeCreationException("No identifier");
     }
 
-    final MessageList compilationOutput = visAvailable ? new MessageListUI() : new MessageListText();
+    final MessageList compilationOutput = MessageContainer.createMessageList(visAvailable);
 
     if (getCompileCommands() != null) {
       /* Handle multiple compilation commands one by one */

--- a/tools/cooja/apps/mspsim/src/org/contikios/cooja/mspmote/Exp1101MoteType.java
+++ b/tools/cooja/apps/mspsim/src/org/contikios/cooja/mspmote/Exp1101MoteType.java
@@ -73,7 +73,7 @@ public class Exp1101MoteType extends Exp5438MoteType {
       throw new MoteTypeCreationException("No identifier");
     }
 
-    final MessageList compilationOutput = visAvailable ? new MessageListUI() : new MessageListText();
+    final MessageList compilationOutput = MessageContainer.createMessageList(visAvailable);
 
     if (getCompileCommands() != null) {
       /* Handle multiple compilation commands one by one */

--- a/tools/cooja/apps/mspsim/src/org/contikios/cooja/mspmote/Exp1120MoteType.java
+++ b/tools/cooja/apps/mspsim/src/org/contikios/cooja/mspmote/Exp1120MoteType.java
@@ -74,7 +74,7 @@ public class Exp1120MoteType extends Exp5438MoteType {
       throw new MoteTypeCreationException("No identifier");
     }
 
-    final MessageList compilationOutput = visAvailable ? new MessageListUI() : new MessageListText();
+    final MessageList compilationOutput = MessageContainer.createMessageList(visAvailable);
 
     if (getCompileCommands() != null) {
       /* Handle multiple compilation commands one by one */

--- a/tools/cooja/apps/mspsim/src/org/contikios/cooja/mspmote/Exp2420MoteType.java
+++ b/tools/cooja/apps/mspsim/src/org/contikios/cooja/mspmote/Exp2420MoteType.java
@@ -74,7 +74,7 @@ public class Exp2420MoteType extends Exp5438MoteType {
       throw new MoteTypeCreationException("No identifier");
     }
 
-    final MessageList compilationOutput = visAvailable ? new MessageListUI() : new MessageListText();
+    final MessageList compilationOutput = MessageContainer.createMessageList(visAvailable);
 
     if (getCompileCommands() != null) {
       /* Handle multiple compilation commands one by one */

--- a/tools/cooja/apps/mspsim/src/org/contikios/cooja/mspmote/Exp5438MoteType.java
+++ b/tools/cooja/apps/mspsim/src/org/contikios/cooja/mspmote/Exp5438MoteType.java
@@ -115,7 +115,7 @@ public class Exp5438MoteType extends MspMoteType {
       throw new MoteTypeCreationException("No identifier");
     }
 
-    final MessageList compilationOutput = visAvailable ? new MessageListUI() : new MessageListText();
+    final MessageList compilationOutput = MessageContainer.createMessageList(visAvailable);
 
     if (getCompileCommands() != null) {
       /* Handle multiple compilation commands one by one */

--- a/tools/cooja/apps/mspsim/src/org/contikios/cooja/mspmote/SkyMoteType.java
+++ b/tools/cooja/apps/mspsim/src/org/contikios/cooja/mspmote/SkyMoteType.java
@@ -51,8 +51,6 @@ import org.contikios.cooja.MoteType;
 import org.contikios.cooja.Simulation;
 import org.contikios.cooja.dialogs.CompileContiki;
 import org.contikios.cooja.dialogs.MessageList;
-import org.contikios.cooja.dialogs.MessageListText;
-import org.contikios.cooja.dialogs.MessageListUI;
 import org.contikios.cooja.dialogs.MessageContainer;
 import org.contikios.cooja.interfaces.IPAddress;
 import org.contikios.cooja.interfaces.Mote2MoteRelations;
@@ -137,7 +135,7 @@ public class SkyMoteType extends MspMoteType {
       throw new MoteTypeCreationException("No identifier");
     }
 
-    final MessageList compilationOutput = visAvailable ? new MessageListUI() : new MessageListText();
+    final MessageList compilationOutput = MessageContainer.createMessageList(visAvailable);
 
     if (getCompileCommands() != null) {
       /* Handle multiple compilation commands one by one */

--- a/tools/cooja/apps/mspsim/src/org/contikios/cooja/mspmote/Trxeb1120MoteType.java
+++ b/tools/cooja/apps/mspsim/src/org/contikios/cooja/mspmote/Trxeb1120MoteType.java
@@ -73,7 +73,7 @@ public class Trxeb1120MoteType extends Exp5438MoteType {
       throw new MoteTypeCreationException("No identifier");
     }
 
-    final MessageList compilationOutput = visAvailable ? new MessageListUI() : new MessageListText();
+    final MessageList compilationOutput = MessageContainer.createMessageList(visAvailable);
 
     if (getCompileCommands() != null) {
       /* Handle multiple compilation commands one by one */

--- a/tools/cooja/apps/mspsim/src/org/contikios/cooja/mspmote/Trxeb2520MoteType.java
+++ b/tools/cooja/apps/mspsim/src/org/contikios/cooja/mspmote/Trxeb2520MoteType.java
@@ -73,7 +73,7 @@ public class Trxeb2520MoteType extends Exp5438MoteType {
       throw new MoteTypeCreationException("No identifier");
     }
 
-    final MessageList compilationOutput = visAvailable ? new MessageListUI() : new MessageListText();
+    final MessageList compilationOutput = MessageContainer.createMessageList(visAvailable);
 
     if (getCompileCommands() != null) {
       /* Handle multiple compilation commands one by one */

--- a/tools/cooja/apps/mspsim/src/org/contikios/cooja/mspmote/TyndallMoteType.java
+++ b/tools/cooja/apps/mspsim/src/org/contikios/cooja/mspmote/TyndallMoteType.java
@@ -114,7 +114,7 @@ public class TyndallMoteType extends MspMoteType {
       throw new MoteTypeCreationException("No identifier");
     }
 
-    final MessageList compilationOutput = visAvailable ? new MessageListUI() : new MessageListText();
+    final MessageList compilationOutput = MessageContainer.createMessageList(visAvailable);
 
     if (getCompileCommands() != null) {
       /* Handle multiple compilation commands one by one */

--- a/tools/cooja/java/org/contikios/cooja/Cooja.java
+++ b/tools/cooja/java/org/contikios/cooja/Cooja.java
@@ -3378,7 +3378,7 @@ public class Cooja extends Observable {
       }
 
       /* Verify extension directories */
-      boolean projectsOk = verifyProjects(root.getChildren(), !quick);
+      boolean projectsOk = verifyProjects(root.getChildren(), isVisualized());
 
       /* GENERATE UNIQUE MOTE TYPE IDENTIFIERS */
       root.detach();
@@ -3428,7 +3428,8 @@ public class Cooja extends Observable {
           Collection<Element> config = ((Element) element).getChildren();
           newSim = new Simulation(this);
           System.gc();
-          boolean createdOK = newSim.setConfigXML(config, !quick, manualRandomSeed);
+          
+          boolean createdOK = newSim.setConfigXML(config, isVisualized(), manualRandomSeed);
           if (!createdOK) {
             logger.info("Simulation not loaded");
             return null;
@@ -3437,7 +3438,7 @@ public class Cooja extends Observable {
       }
 
       // Restart plugins from config
-      setPluginsConfigXML(root.getChildren(), newSim, !quick);
+      setPluginsConfigXML(root.getChildren(), newSim, isVisualized());
 
     } catch (JDOMException e) {
       throw (SimulationCreationException) new SimulationCreationException(

--- a/tools/cooja/java/org/contikios/cooja/CoreComm.java
+++ b/tools/cooja/java/org/contikios/cooja/CoreComm.java
@@ -35,8 +35,9 @@ import java.util.Vector;
 
 import org.contikios.cooja.MoteType.MoteTypeCreationException;
 import org.contikios.cooja.contikimote.ContikiMoteType;
+import org.contikios.cooja.dialogs.MessageContainer;
 import org.contikios.cooja.dialogs.MessageList;
-import org.contikios.cooja.dialogs.MessageListUI;
+
 
 /**
  * The purpose of corecomm's is communicating with a compiled Contiki system
@@ -204,9 +205,10 @@ public abstract class CoreComm {
    */
   public static void compileSourceFile(String className)
       throws MoteTypeCreationException {
-    MessageListUI compilationOutput = new MessageListUI();
+      /* Try to create a message list with support for GUI - will give not UI if headless */
+    MessageList compilationOutput = MessageContainer.createMessageList(true);
     OutputStream compilationStandardStream = compilationOutput
-        .getInputStream(MessageListUI.NORMAL);
+        .getInputStream(MessageList.NORMAL);
     OutputStream compilationErrorStream = compilationOutput
         .getInputStream(MessageList.ERROR);
 

--- a/tools/cooja/java/org/contikios/cooja/contikimote/ContikiMoteType.java
+++ b/tools/cooja/java/org/contikios/cooja/contikimote/ContikiMoteType.java
@@ -66,7 +66,7 @@ import org.contikios.cooja.mote.memory.SectionMoteMemory;
 import org.contikios.cooja.Simulation;
 import org.contikios.cooja.dialogs.CompileContiki;
 import org.contikios.cooja.dialogs.ContikiMoteCompileDialog;
-import org.contikios.cooja.dialogs.MessageListUI;
+import org.contikios.cooja.dialogs.MessageList;
 import org.contikios.cooja.dialogs.MessageContainer;
 import org.contikios.cooja.mote.memory.ArrayMemory;
 import org.contikios.cooja.mote.memory.MemoryInterface;
@@ -317,7 +317,7 @@ public class ContikiMoteType implements MoteType {
       if (getCompileCommands() == null) {
         throw new MoteTypeCreationException("No compile commands specified");
       }
-      final MessageListUI compilationOutput = new MessageListUI();
+      final MessageList compilationOutput = MessageContainer.createMessageList(visAvailable);
       String[] arr = getCompileCommands().split("\n");
       for (String cmd : arr) {
         if (cmd.trim().isEmpty()) {

--- a/tools/cooja/java/org/contikios/cooja/dialogs/CompileContiki.java
+++ b/tools/cooja/java/org/contikios/cooja/dialogs/CompileContiki.java
@@ -127,7 +127,7 @@ public class CompileContiki {
   	/* TODO Fix me */
     final MessageList messageDialog;
   	if (compilationOutput == null) {
-  		messageDialog = new MessageListUI();
+            messageDialog = MessageContainer.createMessageList(true);
   	} else {
   		messageDialog = compilationOutput;
   	}
@@ -138,8 +138,8 @@ public class CompileContiki {
       	cmd += c + " ";
       }
       logger.info("> " + cmd);
-      messageDialog.addMessage("", MessageListUI.NORMAL);
-      messageDialog.addMessage("> " + cmd, MessageListUI.NORMAL);
+      messageDialog.addMessage("", MessageList.NORMAL);
+      messageDialog.addMessage("> " + cmd, MessageList.NORMAL);
     }
 
     final Process compileProcess;
@@ -170,7 +170,7 @@ public class CompileContiki {
             String readLine;
             while ((readLine = processNormal.readLine()) != null) {
               if (messageDialog != null) {
-                messageDialog.addMessage(readLine, MessageListUI.NORMAL);
+                messageDialog.addMessage(readLine, MessageList.NORMAL);
               }
             }
           } catch (IOException e) {
@@ -203,7 +203,7 @@ public class CompileContiki {
             compileProcess.waitFor();
           } catch (Exception e) {
             messageDialog.addMessage(e.getMessage(), MessageList.ERROR);
-            syncException.setCompilationOutput(new MessageListUI());
+            syncException.setCompilationOutput(MessageContainer.createMessageList(true));
             syncException.fillInStackTrace();
             return;
           }
@@ -214,7 +214,7 @@ public class CompileContiki {
             if (onFailure != null) {
               onFailure.actionPerformed(null);
             }
-            syncException.setCompilationOutput(new MessageListUI());
+            syncException.setCompilationOutput(MessageContainer.createMessageList(true));
             syncException.fillInStackTrace();
             return;
           }
@@ -232,13 +232,13 @@ public class CompileContiki {
             if (onFailure != null) {
               onFailure.actionPerformed(null);
             }
-            syncException.setCompilationOutput(new MessageListUI());
+            syncException.setCompilationOutput(MessageContainer.createMessageList(true));
             syncException.fillInStackTrace();
             return;
           }
 
-          messageDialog.addMessage("", MessageListUI.NORMAL);
-          messageDialog.addMessage("Compilation succeded", MessageListUI.NORMAL);
+          messageDialog.addMessage("", MessageList.NORMAL);
+          messageDialog.addMessage("Compilation succeded", MessageList.NORMAL);
           if (onSuccess != null) {
             onSuccess.actionPerformed(null);
           }

--- a/tools/cooja/java/org/contikios/cooja/dialogs/MessageContainer.java
+++ b/tools/cooja/java/org/contikios/cooja/dialogs/MessageContainer.java
@@ -1,4 +1,7 @@
 package org.contikios.cooja.dialogs;
+import java.awt.GraphicsEnvironment;
+
+import org.contikios.cooja.Cooja;
 
 public class MessageContainer {
 
@@ -13,5 +16,16 @@ public class MessageContainer {
     @Override
     public String toString() {
         return message;
+    }
+    
+    /* This will select UI based or not UI based depending on withUI in combination with
+     * headless info.
+     */
+    public static MessageList createMessageList(boolean withUI) {
+        if (withUI && !GraphicsEnvironment.isHeadless() && Cooja.isVisualized()) {
+            return new MessageListUI();
+        } else {
+            return new MessageListText();
+        }
     }
 }

--- a/tools/cooja/java/org/contikios/cooja/dialogs/MessageList.java
+++ b/tools/cooja/java/org/contikios/cooja/dialogs/MessageList.java
@@ -1,5 +1,7 @@
 package org.contikios.cooja.dialogs;
 
+import java.io.OutputStream;
+
 public interface MessageList {
 
     public static final int NORMAL = 0;
@@ -13,5 +15,7 @@ public interface MessageList {
     public void clearMessages();
 
     public void addMessage(String string);
+
+    public OutputStream getInputStream(int type);
 
 }

--- a/tools/cooja/java/org/contikios/cooja/dialogs/MessageListText.java
+++ b/tools/cooja/java/org/contikios/cooja/dialogs/MessageListText.java
@@ -1,7 +1,12 @@
 package org.contikios.cooja.dialogs;
 
+import java.io.OutputStream;
+
 public class MessageListText implements MessageList {
 
+    public MessageListText() {
+    }
+    
     @Override
     public void addMessage(String string, int type) {
         System.out.println("Message:" + string);
@@ -24,4 +29,12 @@ public class MessageListText implements MessageList {
         addMessage(string, MessageList.NORMAL);
     }
 
+    @Override
+    public OutputStream getInputStream(int type) {
+        // TODO Auto-generated method stub
+        return System.out;
+    }
+
+    
+    
 }

--- a/tools/cooja/java/org/contikios/cooja/dialogs/MessageListUI.java
+++ b/tools/cooja/java/org/contikios/cooja/dialogs/MessageListUI.java
@@ -33,6 +33,7 @@ package org.contikios.cooja.dialogs;
 import java.awt.Color;
 import java.awt.Component;
 import java.awt.Dimension;
+import java.awt.GraphicsEnvironment;
 import java.awt.Toolkit;
 import java.awt.datatransfer.Clipboard;
 import java.awt.datatransfer.StringSelection;
@@ -81,6 +82,9 @@ public class MessageListUI extends JList implements MessageList {
   private int max = -1;
   
   public MessageListUI() {
+    if (GraphicsEnvironment.isHeadless()) {
+        throw new RuntimeException("Can not use UI version of message list in Headless mode");
+    }
     super.setModel(new MessageModel());
     setCellRenderer(new MessageRenderer());
     setSelectionMode(ListSelectionModel.SINGLE_SELECTION);


### PR DESCRIPTION
This hopefully fixes a few of the last parts of the COOJA code that still made use of the MessageList with UI that sometimes cause strange class cast exceptions when running in travis. Fixing the parts of the code that cause the problems that is mentioned in PR #1986.
