### PR TITLE
Bugfix on regression-tests/04-rime/07-sky-collect.csc

### DIFF
--- a/examples/rime/example-collect.c
+++ b/examples/rime/example-collect.c
@@ -58,10 +58,10 @@ static void
 recv(const linkaddr_t *originator, uint8_t seqno, uint8_t hops)
 {
   printf("Sink got message from %d.%d, seqno %d, hops %d: len %d '%s'\n",
-	 originator->u8[0], originator->u8[1],
-	 seqno, hops,
-	 packetbuf_datalen(),
-	 (char *)packetbuf_dataptr());
+         originator->u8[0], originator->u8[1],
+         seqno, hops,
+         packetbuf_datalen(),
+         (char *)packetbuf_dataptr());
 }
 /*---------------------------------------------------------------------------*/
 static const struct collect_callbacks callbacks = { recv };
@@ -70,15 +70,15 @@ PROCESS_THREAD(example_collect_process, ev, data)
 {
   static struct etimer periodic;
   static struct etimer et;
-  
+
   PROCESS_BEGIN();
 
   collect_open(&tc, 130, COLLECT_ROUTER, &callbacks);
 
   if(linkaddr_node_addr.u8[0] == 1 &&
      linkaddr_node_addr.u8[1] == 0) {
-	printf("I am sink\n");
-	collect_set_sink(&tc, 1);
+    printf("I am sink\n");
+    collect_set_sink(&tc, 1);
   }
 
   /* Allow some time for the network to settle. */
@@ -88,22 +88,19 @@ PROCESS_THREAD(example_collect_process, ev, data)
   while(1) {
 
     /* Send a packet every 30 seconds. */
-    if(etimer_expired(&periodic)) {
-      etimer_set(&periodic, CLOCK_SECOND * 30);
-      etimer_set(&et, random_rand() % (CLOCK_SECOND * 30));
-    }
+    etimer_set(&periodic, CLOCK_SECOND * 30);
+    etimer_set(&et, random_rand() % (CLOCK_SECOND * 30));
 
-    PROCESS_WAIT_EVENT();
+    PROCESS_WAIT_UNTIL(etimer_expired(&et));
 
-
-    if(etimer_expired(&et)) {
+    {
       static linkaddr_t oldparent;
       const linkaddr_t *parent;
 
       printf("Sending\n");
       packetbuf_clear();
       packetbuf_set_datalen(sprintf(packetbuf_dataptr(),
-				  "%s", "Hello") + 1);
+                                    "%s", "Hello") + 1);
       collect_send(&tc, 15);
 
       parent = collect_parent(&tc);
@@ -118,6 +115,7 @@ PROCESS_THREAD(example_collect_process, ev, data)
       }
     }
 
+    PROCESS_WAIT_UNTIL(etimer_expired(&periodic));
   }
 
   PROCESS_END();

--- a/regression-tests/04-rime/07-sky-collect.csc
+++ b/regression-tests/04-rime/07-sky-collect.csc
@@ -362,7 +362,7 @@ make example-collect.sky TARGET=sky</commands>
   <plugin>
     org.contikios.cooja.plugins.ScriptRunner
     <plugin_config>
-      <script>TIMEOUT(600000);
+      <script>TIMEOUT(450000);
 
 num_nodes = mote.getSimulation().getMotesCount();
 
@@ -408,6 +408,8 @@ while(true) {
             dups = received[source].substr(seqno, 1);
             if(dups == "_") {
                 dups = 1;
+            } else if (dups == "") {
+                continue;
             } else if(dups &lt; 9) {
                 dups++;
             }


### PR DESCRIPTION
Mainly two fixes:
- `04-rime/07-sky-collect.csc`: while a received `seqno` is supposed to be less than 10 in the test script, it doesn't handle a case where  `seqno` is larger than or equal to 10.
- `example-collect.c`: a node sends messages more frequently than expected, every 30 seconds.

Other changes are trivial: indentation fix and shortening time to wait in case of test failure.