### PR TITLE
Bugfix on source address setting in framer_802154.create()

### DIFF
--- a/core/net/mac/contikimac/contikimac.c
+++ b/core/net/mac/contikimac/contikimac.c
@@ -873,6 +873,10 @@ qsend_list(mac_callback_t sent, void *ptr, struct rdc_buf_list *buf_list)
       if(next != NULL) {
         packetbuf_set_attr(PACKETBUF_ATTR_PENDING, 1);
       }
+#if !NETSTACK_CONF_BRIDGE_MODE
+      /* If NETSTACK_CONF_BRIDGE_MODE is set, assume PACKETBUF_ADDR_SENDER is already set. */
+      packetbuf_set_addr(PACKETBUF_ADDR_SENDER, &linkaddr_node_addr);
+#endif
       packetbuf_set_attr(PACKETBUF_ATTR_MAC_ACK, 1);
       if(NETSTACK_FRAMER.create() < 0) {
         PRINTF("contikimac: framer failed\n");

--- a/core/net/mac/framer-802154.c
+++ b/core/net/mac/framer-802154.c
@@ -173,7 +173,8 @@ create_frame(int type, int do_create)
    * Set up the source address using only the long address mode for
    * phase 1.
    */
-  linkaddr_copy((linkaddr_t *)&params.src_addr, &linkaddr_node_addr);
+  linkaddr_copy((linkaddr_t *)&params.src_addr,
+                packetbuf_addr(PACKETBUF_ADDR_SENDER));
 
   params.payload = packetbuf_dataptr();
   params.payload_len = packetbuf_datalen();

--- a/core/net/mac/tsch/tsch.c
+++ b/core/net/mac/tsch/tsch.c
@@ -910,6 +910,15 @@ send_packet(mac_callback_t sent, void *ptr)
 
   packet_count_before = tsch_queue_packet_count(addr);
 
+#if !NETSTACK_CONF_BRIDGE_MODE
+  /*
+   * In the Contiki stack, the source address of a frame is set at the RDC
+   * layer. Since TSCH doesn't use any RDC protocol and bypasses the layer to
+   * transmit a frame, it should set the source address by itself.
+   */
+  packetbuf_set_addr(PACKETBUF_ADDR_SENDER, &linkaddr_node_addr);
+#endif
+
   if((hdr_len = NETSTACK_FRAMER.create()) < 0) {
     PRINTF("TSCH:! can't send packet due to framer error\n");
     ret = MAC_TX_ERR;


### PR DESCRIPTION
Here is an excerpt from the code of  `create_frame()` in `framer-802154.c`:
```C
 172   /*
 173    * Set up the source address using only the long address mode for
 174    * phase 1.
 175    */
 176   linkaddr_copy((linkaddr_t *)&params.src_addr, &linkaddr_node_addr);
 177
 178   params.payload = packetbuf_dataptr();
 179   params.payload_len = packetbuf_datalen();
 180   hdr_len = frame802154_hdrlen(&params);
 181   if(!do_create) {
 182     /* Only calculate header length */
 183     return hdr_len;
 184   } else if(packetbuf_hdralloc(hdr_len)) {
 185     frame802154_create(&params, packetbuf_hdrptr());
```
It always sets `linkaddr_node_addr` to the source address of a newly creating frame at Line 176. It should take the address of `PACKETBUF_ADDR_SENDER` into account.

\<obsolete\>
As far as I know, there are two protocols which depend on this bug: `ContikiMAC` and `TSCH`. They are supposed to set an address to `PACKET_ADDR_SENDER` by themselves to specify what address should be used as the source address of their frame.
\</obsolete\>

We have six RDC protocols in the code base: 
```shell
$ find core -name \*.c | xargs grep rdc_driver | grep const
core/net/mac/sicslowmac/sicslowmac.c:const struct rdc_driver sicslowmac_driver = {
core/net/mac/nullrdc.c:const struct rdc_driver nullrdc_driver = {
core/net/mac/cxmac/cxmac.c:const struct rdc_driver cxmac_driver =
core/net/mac/nullrdc-noframer.c:const struct rdc_driver nullrdc_noframer_driver = {
core/net/mac/nordc.c:const struct rdc_driver nordc_driver = {
core/net/mac/contikimac/contikimac.c:const struct rdc_driver contikimac_driver = {
```

Only `contikimac` gets affected by this bugfix. The following table shows whether each RDC protocol sets `PACKETBUF_ADDR_SENDER` in its APIs for transmission ( ✔️ ) or not ( ✖️ ).

|Protocol|`send()`|`send_list()`|Note|
| --- | --- | --- | --- |
|sicslowmac| ✔️  | ✔️   |`send_packet()` takes care for both cases at [L148](https://github.com/contiki-os/contiki/blob/9ef28c7eae7a5b6220bc2be767524d4141846303/core/net/mac/sicslowmac/sicslowmac.c#L148) |
|nullrdc| ✔️ | ✔️ | `send_one_packet()` takes care for both cases at [L119](https://github.com/contiki-os/contiki/blob/9ef28c7eae7a5b6220bc2be767524d4141846303/core/net/mac/nullrdc.c#L119). However, it doesn't have a `!NETSTACK_CONF_BRIDGE_MODE` guard.|
|cxmac| ✔️ | ✔️ | `send_packet()` takes care for both cases at [L431](https://github.com/contiki-os/contiki/blob/9ef28c7eae7a5b6220bc2be767524d4141846303/core/net/mac/cxmac/cxmac.c#L431)|
|nullrdc-noframer| N/A | N/A | This doesn't create any MAC frame by itself.|
|nordc| N/A | N/A | This doesn't create any MAC frame by itself. |
|contikimac| ✔️ | ✖️ | `send_packet()` takes care for the `send()`, `qsend_packet()`, case. The `send_list()`, `qsend_list()`, case is handled by this PR|


`nullrdc-noframer` and `nordc` doesn't create a MAC frame by themselves. Instead, an upper layer protocol should set `PACKETBUF_ADDR_SENDER` if it's depends on `NETSTACK_FRAMER.create()`.

An upper protocol using `nullrdc_driver` could be affected by this PR. But, in the code base, only `nullmac` is used with `nullrdc_driver`. Regarding this particular case, we don't have to anything for it.

Contiki TSCH assumes  it has `nordc` as a RDC protocol. This case is handled by this PR.