### PR TITLE
Introduce packetbuf_remaininglen()

### DIFF
--- a/core/net/packetbuf.c
+++ b/core/net/packetbuf.c
@@ -196,7 +196,7 @@ packetbuf_attr_clear(void)
 /*---------------------------------------------------------------------------*/
 void
 packetbuf_attr_copyto(struct packetbuf_attr *attrs,
-		    struct packetbuf_addr *addrs)
+                      struct packetbuf_addr *addrs)
 {
   memcpy(attrs, packetbuf_attrs, sizeof(packetbuf_attrs));
   memcpy(addrs, packetbuf_addrs, sizeof(packetbuf_addrs));
@@ -204,7 +204,7 @@ packetbuf_attr_copyto(struct packetbuf_attr *attrs,
 /*---------------------------------------------------------------------------*/
 void
 packetbuf_attr_copyfrom(struct packetbuf_attr *attrs,
-		      struct packetbuf_addr *addrs)
+                        struct packetbuf_addr *addrs)
 {
   memcpy(packetbuf_attrs, attrs, sizeof(packetbuf_attrs));
   memcpy(packetbuf_addrs, addrs, sizeof(packetbuf_addrs));

--- a/core/net/packetbuf.c
+++ b/core/net/packetbuf.c
@@ -184,6 +184,12 @@ packetbuf_totlen(void)
   return packetbuf_hdrlen() + packetbuf_datalen();
 }
 /*---------------------------------------------------------------------------*/
+uint16_t
+packetbuf_remaininglen(void)
+{
+  return PACKETBUF_SIZE - packetbuf_totlen();
+}
+/*---------------------------------------------------------------------------*/
 void
 packetbuf_attr_clear(void)
 {

--- a/core/net/packetbuf.h
+++ b/core/net/packetbuf.h
@@ -124,6 +124,13 @@ uint16_t packetbuf_datalen(void);
 uint16_t packetbuf_totlen(void);
 
 /**
+ * \brief      Get the total length of the remaining space in the packetbuf
+ * \return     Length of the remaining space in the packetbuf
+ *
+ */
+uint16_t packetbuf_remaininglen(void);
+
+/**
  * \brief      Set the length of the data in the packetbuf
  * \param len  The length of the data
  */

--- a/core/net/packetbuf.h
+++ b/core/net/packetbuf.h
@@ -241,7 +241,7 @@ enum {
   PACKETBUF_ATTR_TSCH_SLOTFRAME,
   PACKETBUF_ATTR_TSCH_TIMESLOT,
 #endif /* TSCH_WITH_LINK_SELECTOR */
-  
+
   /* Scope 1 attributes: used between two neighbors only. */
 #if PACKETBUF_WITH_PACKET_TYPE
   PACKETBUF_ATTR_PACKET_TYPE,
@@ -267,7 +267,7 @@ enum {
   PACKETBUF_ATTR_KEY_INDEX,
   PACKETBUF_ATTR_KEY_SOURCE_BYTES_0_1,
 #endif /* LLSEC802154_USES_EXPLICIT_KEYS */
-  
+
   /* Scope 2 attributes: used between end-to-end nodes. */
 #if NETSTACK_CONF_WITH_RIME
   PACKETBUF_ATTR_HOPS,
@@ -343,9 +343,9 @@ int               packetbuf_holds_broadcast(void);
 void              packetbuf_attr_clear(void);
 
 void              packetbuf_attr_copyto(struct packetbuf_attr *attrs,
-				      struct packetbuf_addr *addrs);
+                                        struct packetbuf_addr *addrs);
 void              packetbuf_attr_copyfrom(struct packetbuf_attr *attrs,
-					struct packetbuf_addr *addrs);
+                                          struct packetbuf_addr *addrs);
 
 #define PACKETBUF_ATTRIBUTES(...) { __VA_ARGS__ PACKETBUF_ATTR_LAST }
 #define PACKETBUF_ATTR_LAST { PACKETBUF_ATTR_NONE, 0 }


### PR DESCRIPTION
As far as I know, we don't have any API to get the length of remaining data space in `packetbuf`. `packetbuf_remaininglen()` provides this.