### PR TITLE
fixed so that Cooja can run in quick mode when having UI

### DIFF
--- a/tools/cooja/apps/mspsim/src/org/contikios/cooja/mspmote/AbstractMspMoteType.java
+++ b/tools/cooja/apps/mspsim/src/org/contikios/cooja/mspmote/AbstractMspMoteType.java
@@ -81,7 +81,7 @@ public abstract class AbstractMspMoteType extends MspMoteType {
         }
 
         /* If visualized, show compile dialog and let user configure */
-        if (visAvailable) {
+        if (visAvailable && !simulation.isQuickSetup()) {
 
             /* Create unique identifier */
             if (getIdentifier() == null) {

--- a/tools/cooja/apps/mspsim/src/org/contikios/cooja/mspmote/CC430MoteType.java
+++ b/tools/cooja/apps/mspsim/src/org/contikios/cooja/mspmote/CC430MoteType.java
@@ -78,7 +78,7 @@ public class CC430MoteType extends MspMoteType {
   throws MoteTypeCreationException {
 
     /* If visualized, show compile dialog and let user configure */
-    if (visAvailable) {
+    if (visAvailable && !simulation.isQuickSetup()) {
 
       /* Create unique identifier */
       if (getIdentifier() == null) {

--- a/tools/cooja/apps/mspsim/src/org/contikios/cooja/mspmote/ESBMoteType.java
+++ b/tools/cooja/apps/mspsim/src/org/contikios/cooja/mspmote/ESBMoteType.java
@@ -114,7 +114,7 @@ public class ESBMoteType extends MspMoteType {
     }
 
     /* If visualized, show compile dialog and let user configure */
-    if (visAvailable) {
+    if (visAvailable && !simulation.isQuickSetup()) {
 
       /* Create unique identifier */
       if (getIdentifier() == null) {

--- a/tools/cooja/apps/mspsim/src/org/contikios/cooja/mspmote/Eth1120MoteType.java
+++ b/tools/cooja/apps/mspsim/src/org/contikios/cooja/mspmote/Eth1120MoteType.java
@@ -36,7 +36,7 @@ public class Eth1120MoteType extends Exp5438MoteType {
   throws MoteTypeCreationException {
 
     /* If visualized, show compile dialog and let user configure */
-    if (visAvailable) {
+    if (visAvailable && !simulation.isQuickSetup()) {
 
       /* Create unique identifier */
       if (getIdentifier() == null) {

--- a/tools/cooja/apps/mspsim/src/org/contikios/cooja/mspmote/Exp1101MoteType.java
+++ b/tools/cooja/apps/mspsim/src/org/contikios/cooja/mspmote/Exp1101MoteType.java
@@ -36,7 +36,7 @@ public class Exp1101MoteType extends Exp5438MoteType {
   throws MoteTypeCreationException {
 
     /* If visualized, show compile dialog and let user configure */
-    if (visAvailable) {
+    if (visAvailable && !simulation.isQuickSetup()) {
 
       /* Create unique identifier */
       if (getIdentifier() == null) {

--- a/tools/cooja/apps/mspsim/src/org/contikios/cooja/mspmote/Exp1120MoteType.java
+++ b/tools/cooja/apps/mspsim/src/org/contikios/cooja/mspmote/Exp1120MoteType.java
@@ -37,7 +37,7 @@ public class Exp1120MoteType extends Exp5438MoteType {
   throws MoteTypeCreationException {
 
     /* If visualized, show compile dialog and let user configure */
-    if (visAvailable) {
+    if (visAvailable && !simulation.isQuickSetup()) {
 
       /* Create unique identifier */
       if (getIdentifier() == null) {

--- a/tools/cooja/apps/mspsim/src/org/contikios/cooja/mspmote/Exp2420MoteType.java
+++ b/tools/cooja/apps/mspsim/src/org/contikios/cooja/mspmote/Exp2420MoteType.java
@@ -37,7 +37,7 @@ public class Exp2420MoteType extends Exp5438MoteType {
   throws MoteTypeCreationException {
 
     /* If visualized, show compile dialog and let user configure */
-    if (visAvailable) {
+    if (visAvailable && !simulation.isQuickSetup()) {
 
       /* Create unique identifier */
       if (getIdentifier() == null) {

--- a/tools/cooja/apps/mspsim/src/org/contikios/cooja/mspmote/Exp5438MoteType.java
+++ b/tools/cooja/apps/mspsim/src/org/contikios/cooja/mspmote/Exp5438MoteType.java
@@ -78,7 +78,7 @@ public class Exp5438MoteType extends MspMoteType {
   throws MoteTypeCreationException {
 
     /* If visualized, show compile dialog and let user configure */
-    if (visAvailable) {
+    if (visAvailable && !simulation.isQuickSetup()) {
 
       /* Create unique identifier */
       if (getIdentifier() == null) {

--- a/tools/cooja/apps/mspsim/src/org/contikios/cooja/mspmote/SkyMoteType.java
+++ b/tools/cooja/apps/mspsim/src/org/contikios/cooja/mspmote/SkyMoteType.java
@@ -98,7 +98,7 @@ public class SkyMoteType extends MspMoteType {
     }
 
     /* If visualized, show compile dialog and let user configure */
-    if (visAvailable) {
+    if (visAvailable && !simulation.isQuickSetup()) {
 
       /* Create unique identifier */
       if (getIdentifier() == null) {

--- a/tools/cooja/apps/mspsim/src/org/contikios/cooja/mspmote/Trxeb1120MoteType.java
+++ b/tools/cooja/apps/mspsim/src/org/contikios/cooja/mspmote/Trxeb1120MoteType.java
@@ -36,7 +36,7 @@ public class Trxeb1120MoteType extends Exp5438MoteType {
   throws MoteTypeCreationException {
 
     /* If visualized, show compile dialog and let user configure */
-    if (visAvailable) {
+    if (visAvailable && !simulation.isQuickSetup()) {
 
       /* Create unique identifier */
       if (getIdentifier() == null) {

--- a/tools/cooja/apps/mspsim/src/org/contikios/cooja/mspmote/Trxeb2520MoteType.java
+++ b/tools/cooja/apps/mspsim/src/org/contikios/cooja/mspmote/Trxeb2520MoteType.java
@@ -36,7 +36,7 @@ public class Trxeb2520MoteType extends Exp5438MoteType {
   throws MoteTypeCreationException {
 
     /* If visualized, show compile dialog and let user configure */
-    if (visAvailable) {
+    if (visAvailable && !simulation.isQuickSetup()) {
 
       /* Create unique identifier */
       if (getIdentifier() == null) {

--- a/tools/cooja/apps/mspsim/src/org/contikios/cooja/mspmote/TyndallMoteType.java
+++ b/tools/cooja/apps/mspsim/src/org/contikios/cooja/mspmote/TyndallMoteType.java
@@ -77,7 +77,7 @@ public class TyndallMoteType extends MspMoteType {
   throws MoteTypeCreationException {
 
     /* If visualized, show compile dialog and let user configure */
-    if (visAvailable) {
+    if (visAvailable && !simulation.isQuickSetup()) {
 
       /* Create unique identifier */
       if (getIdentifier() == null) {

--- a/tools/cooja/java/org/contikios/cooja/Cooja.java
+++ b/tools/cooja/java/org/contikios/cooja/Cooja.java
@@ -3378,7 +3378,7 @@ public class Cooja extends Observable {
       }
 
       /* Verify extension directories */
-      boolean projectsOk = verifyProjects(root.getChildren(), isVisualized());
+      boolean projectsOk = verifyProjects(root.getChildren());
 
       /* GENERATE UNIQUE MOTE TYPE IDENTIFIERS */
       root.detach();
@@ -3429,7 +3429,7 @@ public class Cooja extends Observable {
           newSim = new Simulation(this);
           System.gc();
           
-          boolean createdOK = newSim.setConfigXML(config, isVisualized(), manualRandomSeed);
+          boolean createdOK = newSim.setConfigXML(config, isVisualized(), quick, manualRandomSeed);
           if (!createdOK) {
             logger.info("Simulation not loaded");
             return null;
@@ -3438,7 +3438,7 @@ public class Cooja extends Observable {
       }
 
       // Restart plugins from config
-      setPluginsConfigXML(root.getChildren(), newSim, isVisualized());
+      setPluginsConfigXML(root.getChildren(), newSim, isVisualized(), quick);
 
     } catch (JDOMException e) {
       throw (SimulationCreationException) new SimulationCreationException(
@@ -3600,7 +3600,7 @@ public class Cooja extends Observable {
     return config;
   }
 
-  public boolean verifyProjects(Collection<Element> configXML, boolean visAvailable) {
+  public boolean verifyProjects(Collection<Element> configXML) {
     boolean allOk = true;
 
     /* Match current extensions against extensions in simulation config */
@@ -3642,8 +3642,8 @@ public class Cooja extends Observable {
    * @return True if all plugins started, false otherwise
    */
   public boolean setPluginsConfigXML(Collection<Element> configXML,
-      Simulation simulation, boolean visAvailable) {
-
+      Simulation simulation, boolean visAvailable, boolean quick) {
+      
     for (final Element pluginElement : configXML.toArray(new Element[0])) {
       if (pluginElement.getName().equals("plugin")) {
 

--- a/tools/cooja/java/org/contikios/cooja/Simulation.java
+++ b/tools/cooja/java/org/contikios/cooja/Simulation.java
@@ -544,6 +544,17 @@ public class Simulation extends Observable implements Runnable {
     return config;
   }
 
+  
+  /* indicator to components setting up that they need to respect the fast setup mode */
+  private boolean quick = false;
+  public boolean isQuickSetup() {
+      return quick;
+  }
+  
+  public void setQuickSetup(boolean q) {
+      quick = q;
+  }
+  
   /**
    * Sets the current simulation config depending on the given configuration.
    *
@@ -554,8 +565,9 @@ public class Simulation extends Observable implements Runnable {
    * @throws Exception If configuration could not be loaded
    */
   public boolean setConfigXML(Collection<Element> configXML,
-      boolean visAvailable, Long manualRandomSeed) throws Exception {
+      boolean visAvailable, boolean quick, Long manualRandomSeed) throws Exception {
 
+      setQuickSetup(quick);
     // Parse elements
     for (Element element : configXML) {
 
@@ -623,7 +635,7 @@ public class Simulation extends Observable implements Runnable {
 
         // Show configure simulation dialog
         boolean createdOK = false;
-        if (visAvailable) {
+        if (visAvailable && !quick) {
           createdOK = CreateSimDialog.showDialog(Cooja.getTopParentContainer(), this);
         } else {
           createdOK = true;
@@ -657,7 +669,7 @@ public class Simulation extends Observable implements Runnable {
         }
 
         /* Try to recreate simulation using a different mote type */
-        if (visAvailable) {
+        if (visAvailable && !quick) {
           String[] availableMoteTypes = getCooja().getProjectConfig().getStringArrayValue("org.contikios.cooja.Cooja.MOTETYPES");
           String newClass = (String) JOptionPane.showInputDialog(
               Cooja.getTopParentContainer(),


### PR DESCRIPTION
The fix for travis (#1987) made the regular UI mode a bit boring to use since the "quick" mode did not work anymore so that everybody need to click 10 times to start the simulation. This fix re-enabled quick mode when using UI again and make using Cooja. Now any component that is configured at startup should respect `simulator.isQuickSetup()` if it supports quick mode.