### PR TITLE
Trivial Updates on tsch-security.[ch]

### DIFF
--- a/core/net/mac/tsch/tsch-security.c
+++ b/core/net/mac/tsch/tsch-security.c
@@ -73,7 +73,7 @@ static aes_key keys[] = {
 /*---------------------------------------------------------------------------*/
 static void
 tsch_security_init_nonce(uint8_t *nonce,
-    const linkaddr_t *sender, struct asn_t *asn)
+                         const linkaddr_t *sender, struct asn_t *asn)
 {
   memcpy(nonce, sender, 8);
   nonce[8] = asn->ms1b;
@@ -120,8 +120,9 @@ tsch_security_check_level(const frame802154_t *frame)
       required_key_index = TSCH_SECURITY_KEY_INDEX_OTHER;
       break;
   }
-  return frame->aux_hdr.security_control.security_level == required_security_level
-         && frame->aux_hdr.key_index == required_key_index;
+  return ((frame->aux_hdr.security_control.security_level ==
+           required_security_level) &&
+          frame->aux_hdr.key_index == required_key_index);
 }
 /*---------------------------------------------------------------------------*/
 int
@@ -136,7 +137,7 @@ tsch_security_mic_len(const frame802154_t *frame)
 /*---------------------------------------------------------------------------*/
 int
 tsch_security_secure_frame(uint8_t *hdr, uint8_t *outbuf,
-    int hdrlen, int datalen, struct asn_t *asn)
+                           int hdrlen, int datalen, struct asn_t *asn)
 {
   frame802154_t frame;
   uint8_t key_index = 0;
@@ -190,17 +191,16 @@ tsch_security_secure_frame(uint8_t *hdr, uint8_t *outbuf,
   CCM_STAR.set_key(keys[key_index - 1]);
 
   CCM_STAR.aead(nonce,
-      outbuf + a_len, m_len,
-      outbuf, a_len,
-      outbuf + hdrlen + datalen, mic_len, 1
-  );
+                outbuf + a_len, m_len,
+                outbuf, a_len,
+                outbuf + hdrlen + datalen, mic_len, 1);
 
   return mic_len;
 }
 /*---------------------------------------------------------------------------*/
 int
 tsch_security_parse_frame(const uint8_t *hdr, int hdrlen, int datalen,
-    const frame802154_t *frame, const linkaddr_t *sender, struct asn_t *asn)
+                          const frame802154_t *frame, const linkaddr_t *sender, struct asn_t *asn)
 {
   uint8_t generated_mic[16];
   uint8_t key_index = 0;
@@ -248,10 +248,9 @@ tsch_security_parse_frame(const uint8_t *hdr, int hdrlen, int datalen,
   CCM_STAR.set_key(keys[key_index - 1]);
 
   CCM_STAR.aead(nonce,
-       (uint8_t *)hdr + a_len, m_len,
-       (uint8_t *)hdr, a_len,
-       generated_mic, mic_len, 0
-       );
+                (uint8_t *)hdr + a_len, m_len,
+                (uint8_t *)hdr, a_len,
+                generated_mic, mic_len, 0);
 
   if(mic_len > 0 && memcmp(generated_mic, hdr + hdrlen + datalen, mic_len) != 0) {
     return 0;

--- a/core/net/mac/tsch/tsch-security.c
+++ b/core/net/mac/tsch/tsch-security.c
@@ -125,7 +125,7 @@ tsch_security_check_level(const frame802154_t *frame)
           frame->aux_hdr.key_index == required_key_index);
 }
 /*---------------------------------------------------------------------------*/
-int
+unsigned int
 tsch_security_mic_len(const frame802154_t *frame)
 {
   if(frame != NULL && frame->fcf.security_enabled) {
@@ -135,7 +135,7 @@ tsch_security_mic_len(const frame802154_t *frame)
   }
 }
 /*---------------------------------------------------------------------------*/
-int
+unsigned int
 tsch_security_secure_frame(uint8_t *hdr, uint8_t *outbuf,
                            int hdrlen, int datalen, struct asn_t *asn)
 {
@@ -198,7 +198,7 @@ tsch_security_secure_frame(uint8_t *hdr, uint8_t *outbuf,
   return mic_len;
 }
 /*---------------------------------------------------------------------------*/
-int
+unsigned int
 tsch_security_parse_frame(const uint8_t *hdr, int hdrlen, int datalen,
                           const frame802154_t *frame, const linkaddr_t *sender, struct asn_t *asn)
 {

--- a/core/net/mac/tsch/tsch-security.h
+++ b/core/net/mac/tsch/tsch-security.h
@@ -118,10 +118,24 @@
 typedef uint8_t aes_key[16];
 
 /********** Functions *********/
-
+/**
+ * \brief Return MIC length
+ * \return The length of MIC (>= 0)
+ */
 int tsch_security_mic_len(const frame802154_t *frame);
+
+/**
+ * \brief Protect a frame with encryption and/or MIC
+ * \return The length of a generated MIC (>= 0)
+ */
 int tsch_security_secure_frame(uint8_t *hdr, uint8_t *outbuf,
     int hdrlen, int datalen, struct asn_t *asn);
+
+/**
+ * \brief Parse and check a frame protected with encryption and/or MIC
+ * \retval 0 On error or security check failure (insecure frame)
+ * \retval 1 On success or no need for security check (good frame)
+ */
 int tsch_security_parse_frame(const uint8_t *hdr, int hdrlen, int datalen,
     const frame802154_t *frame, const linkaddr_t *sender, struct asn_t *asn);
 

--- a/core/net/mac/tsch/tsch-security.h
+++ b/core/net/mac/tsch/tsch-security.h
@@ -129,7 +129,7 @@ int tsch_security_mic_len(const frame802154_t *frame);
  * \return The length of a generated MIC (>= 0)
  */
 int tsch_security_secure_frame(uint8_t *hdr, uint8_t *outbuf,
-    int hdrlen, int datalen, struct asn_t *asn);
+                               int hdrlen, int datalen, struct asn_t *asn);
 
 /**
  * \brief Parse and check a frame protected with encryption and/or MIC
@@ -137,6 +137,7 @@ int tsch_security_secure_frame(uint8_t *hdr, uint8_t *outbuf,
  * \retval 1 On success or no need for security check (good frame)
  */
 int tsch_security_parse_frame(const uint8_t *hdr, int hdrlen, int datalen,
-    const frame802154_t *frame, const linkaddr_t *sender, struct asn_t *asn);
+                              const frame802154_t *frame,
+                              const linkaddr_t *sender, struct asn_t *asn);
 
 #endif /* __TSCH_SECURITY_H__ */

--- a/core/net/mac/tsch/tsch-security.h
+++ b/core/net/mac/tsch/tsch-security.h
@@ -122,22 +122,24 @@ typedef uint8_t aes_key[16];
  * \brief Return MIC length
  * \return The length of MIC (>= 0)
  */
-int tsch_security_mic_len(const frame802154_t *frame);
+unsigned int tsch_security_mic_len(const frame802154_t *frame);
 
 /**
  * \brief Protect a frame with encryption and/or MIC
  * \return The length of a generated MIC (>= 0)
  */
-int tsch_security_secure_frame(uint8_t *hdr, uint8_t *outbuf,
-                               int hdrlen, int datalen, struct asn_t *asn);
+unsigned int tsch_security_secure_frame(uint8_t *hdr, uint8_t *outbuf,
+                                        int hdrlen, int datalen,
+                                        struct asn_t *asn);
 
 /**
  * \brief Parse and check a frame protected with encryption and/or MIC
  * \retval 0 On error or security check failure (insecure frame)
  * \retval 1 On success or no need for security check (good frame)
  */
-int tsch_security_parse_frame(const uint8_t *hdr, int hdrlen, int datalen,
-                              const frame802154_t *frame,
-                              const linkaddr_t *sender, struct asn_t *asn);
+unsigned int tsch_security_parse_frame(const uint8_t *hdr, int hdrlen,
+                                       int datalen, const frame802154_t *frame,
+                                       const linkaddr_t *sender,
+                                       struct asn_t *asn);
 
 #endif /* __TSCH_SECURITY_H__ */


### PR DESCRIPTION
- Add brief explanations for the APIs (`tsch-packet.h`)
- Fix indentation in `tsch-packet.c`
- Change the return type of the APIs from 'int' to 'unsigned int'