### PR TITLE
zoul: default cc2538-bsl baudrate to 460800

### DIFF
--- a/platform/zoul/Makefile.zoul
+++ b/platform/zoul/Makefile.zoul
@@ -18,6 +18,8 @@ endif
 PYTHON = python
 BSL_FLAGS += -e -w -v
 
+BSL_SPEED ?= 460800
+
 # Works in Linux and probably on OSX too (RTCC example)
 CFLAGS += -DDATE="\"`date +"%02u %02d %02m %02y %02H %02M %02S"`\""
 
@@ -98,7 +100,7 @@ define UPLOAD_RULE
 	@BSL_ADDRESS=`$(OBJDUMP) -h $$*.elf | grep -B1 LOAD | \
 	             grep -Ev 'LOAD|\-\-' | awk '{print "0x" $$$$5}' | \
 	             sort -g | head -1`; \
-	$(PYTHON) $(BSL) $(BSL_FLAGS) -a $$$${BSL_ADDRESS} -p $(MOTE) $$<
+	$(PYTHON) $(BSL) $(BSL_FLAGS) -b $(BSL_SPEED) -a $$$${BSL_ADDRESS} -p $(MOTE) $$<
 endef
 
 ### Create an upload rule for every MOTE connected


### PR DESCRIPTION
This PR brings back having the baudrate set at the platform's `Makefile`, instead of defaulting to the maximum value in the `cc2538-bsl` script.  Now the default (and tested) baudrate is `460800`.

After testing several batches of platforms, we found the 3% have timing issues, related probably to the on-board PIC governing the flashing process, thus using the default `500000` yielded in errors, whereas other baudrates are OK:

````
$ make TARGET=zoul BOARD=firefly-reva zoul-demo.upload
  CC        ../../../cpu/cc2538/./ieee-addr.c
  CC        ../../../cpu/cc2538/cc2538.lds
  CC        ../../../cpu/cc2538/./startup-gcc.c
  CC        zoul-demo.c
  LD        zoul-demo.elf
arm-none-eabi-objcopy -O binary --gap-fill 0xff zoul-demo.elf zoul-demo.bin
Flashing /dev/ttyUSB0
Opening port /dev/ttyUSB0, baud 500000
Reading data from zoul-demo.bin
Firmware file: Raw Binary
Connecting to target...
ERROR: Timeout waiting for ACK/NACK after 'Mem Read (0x2A)'
make: *** [zoul-demo./dev/ttyUSB0] Error 1
rm obj_zoul/startup-gcc.o zoul-demo.co
````
Using `460800`:
````
$ make TARGET=zoul BOARD=firefly-reva zoul-demo.upload
  CC        ../../../cpu/cc2538/./ieee-addr.c
  CC        ../../../cpu/cc2538/cc2538.lds
  CC        ../../../cpu/cc2538/./startup-gcc.c
  CC        zoul-demo.c
  LD        zoul-demo.elf
arm-none-eabi-objcopy -O binary --gap-fill 0xff zoul-demo.elf zoul-demo.bin
Flashing /dev/ttyUSB0
Opening port /dev/ttyUSB0, baud 460800
Reading data from zoul-demo.bin
Firmware file: Raw Binary
Connecting to target...
CC2538 PG2.0: 512KB Flash, 32KB SRAM, CCFG at 0x0027FFD4
Primary IEEE Address: 00:12:4B:00:06:0D:67:F1
Erasing 524288 bytes starting at address 0x00200000
    Erase done
Writing 516096 bytes starting at address 0x00202000
Write 8 bytes at 0x0027FFF8F00
    Write done                                
Verifying by comparing CRC32 calculations.
    Verified (match: 0x2492f289)
rm obj_zoul/startup-gcc.o zoul-demo.co
````

Using `460800` is a good trade-off as it is close to the maximum `500000`, and it will work 100% of the times in 100% of boards.