### PR TITLE
Enable llsec on Z1 nodes

### DIFF
--- a/platform/z1/Makefile.z1
+++ b/platform/z1/Makefile.z1
@@ -11,5 +11,5 @@ endif
 
 MODULES += core/net \
            core/net/mac core/net/mac/contikimac \
-           core/net/llsec \
+           core/net/llsec core/net/llsec/noncoresec \
            dev/cc2420

--- a/platform/z1/contiki-conf.h
+++ b/platform/z1/contiki-conf.h
@@ -241,4 +241,8 @@
 
 #define BOARD_STRING        "Zolertia Z1 platform"
 
+#ifndef AES_128_CONF
+#define AES_128_CONF cc2420_aes_128_driver
+#endif /* AES_128_CONF */
+
 #endif /* CONTIKI_CONF_H */

--- a/platform/z1/contiki-z1-main.c
+++ b/platform/z1/contiki-z1-main.c
@@ -318,10 +318,11 @@ main(int argc, char **argv)
 
   NETSTACK_RDC.init();
   NETSTACK_MAC.init();
+  NETSTACK_LLSEC.init();
   NETSTACK_NETWORK.init();
 
-  printf("%s %s, channel check rate %lu Hz, radio channel %u\n",
-         NETSTACK_MAC.name, NETSTACK_RDC.name,
+  printf("%s %s %s, channel check rate %lu Hz, radio channel %u\n",
+         NETSTACK_LLSEC.name, NETSTACK_MAC.name, NETSTACK_RDC.name,
          CLOCK_SECOND / (NETSTACK_RDC.channel_check_interval() == 0 ? 1 :
                          NETSTACK_RDC.channel_check_interval()),
          CC2420_CONF_CHANNEL);
@@ -359,10 +360,11 @@ main(int argc, char **argv)
 
   NETSTACK_RDC.init();
   NETSTACK_MAC.init();
+  NETSTACK_LLSEC.init();
   NETSTACK_NETWORK.init();
 
-  printf("%s %s, channel check rate %lu Hz, radio channel %u\n",
-         NETSTACK_MAC.name, NETSTACK_RDC.name,
+  printf("%s %s %s, channel check rate %lu Hz, radio channel %u\n",
+         NETSTACK_LLSEC.name, NETSTACK_MAC.name, NETSTACK_RDC.name,
          CLOCK_SECOND / (NETSTACK_RDC.channel_check_interval() == 0 ? 1 :
                          NETSTACK_RDC.channel_check_interval()),
          CC2420_CONF_CHANNEL);


### PR DESCRIPTION
This PR add the required includes and commands to use link layer security (llsec) with Zolertia Z1 nodes (copied from Sky platform).