### PR TITLE
JN516x: Add support for hardware MAC

### DIFF
--- a/core/net/mac/frame802154.c
+++ b/core/net/mac/frame802154.c
@@ -183,7 +183,7 @@ frame802154_has_panid(frame802154_fcf_t *fcf, int *has_src_pan_id, int *has_dest
   } else {
     /* No PAN ID in ACK */
     if(fcf->frame_type != FRAME802154_ACKFRAME) {
-      if(!fcf->panid_compression && fcf->src_addr_mode & 3) {
+      if(!fcf->panid_compression && (fcf->src_addr_mode & 3)) {
         /* If compressed, don't include source PAN ID */
         src_pan_id = 1;
       }
@@ -304,7 +304,7 @@ field_len(frame802154_t *p, field_length_t *flen)
    * up to the caller. */
   if(p->fcf.frame_version < FRAME802154_IEEE802154E_2012) {
     /* Set PAN ID compression bit if src pan id matches dest pan id. */
-    if(p->fcf.dest_addr_mode & 3 && p->fcf.src_addr_mode & 3 &&
+    if((p->fcf.dest_addr_mode & 3) && (p->fcf.src_addr_mode & 3) &&
        p->src_pid == p->dest_pid) {
       p->fcf.panid_compression = 1;
     } else {
@@ -362,6 +362,20 @@ frame802154_hdrlen(frame802154_t *p)
   return 2 + flen.seqno_len + flen.dest_pid_len + flen.dest_addr_len +
          flen.src_pid_len + flen.src_addr_len + flen.aux_sec_len;
 }
+void
+frame802154_create_fcf(frame802154_fcf_t *fcf, uint8_t *buf)
+{
+  buf[0] = (fcf->frame_type & 7) |
+    ((fcf->security_enabled & 1) << 3) |
+    ((fcf->frame_pending & 1) << 4) |
+    ((fcf->ack_required & 1) << 5) |
+    ((fcf->panid_compression & 1) << 6);
+  buf[1] = ((fcf->sequence_number_suppression & 1)) |
+    ((fcf->ie_list_present & 1)) << 1 |
+    ((fcf->dest_addr_mode & 3) << 2) |
+    ((fcf->frame_version & 3) << 4) |
+    ((fcf->src_addr_mode & 3) << 6);
+}
 /*----------------------------------------------------------------------------*/
 /**
  *   \brief Creates a frame for transmission over the air.  This function is
@@ -388,17 +402,7 @@ frame802154_create(frame802154_t *p, uint8_t *buf)
 
   /* OK, now we have field lengths.  Time to actually construct */
   /* the outgoing frame, and store it in buf */
-  buf[0] = (p->fcf.frame_type & 7) |
-    ((p->fcf.security_enabled & 1) << 3) |
-    ((p->fcf.frame_pending & 1) << 4) |
-    ((p->fcf.ack_required & 1) << 5) |
-    ((p->fcf.panid_compression & 1) << 6);
-  buf[1] = ((p->fcf.sequence_number_suppression & 1)) |
-    ((p->fcf.ie_list_present & 1)) << 1 |
-    ((p->fcf.dest_addr_mode & 3) << 2) |
-    ((p->fcf.frame_version & 3) << 4) |
-    ((p->fcf.src_addr_mode & 3) << 6);
-
+  frame802154_create_fcf(&p->fcf, buf);
   pos = 2;
 
   /* Sequence number */
@@ -460,6 +464,28 @@ frame802154_create(frame802154_t *p, uint8_t *buf)
 
   return (int)pos;
 }
+
+void
+frame802154_parse_fcf(uint8_t *data, frame802154_fcf_t *pfcf)
+{
+  frame802154_fcf_t fcf;
+
+  /* decode the FCF */
+  fcf.frame_type = data[0] & 7;
+  fcf.security_enabled = (data[0] >> 3) & 1;
+  fcf.frame_pending = (data[0] >> 4) & 1;
+  fcf.ack_required = (data[0] >> 5) & 1;
+  fcf.panid_compression = (data[0] >> 6) & 1;
+
+  fcf.sequence_number_suppression = data[1] & 1;
+  fcf.ie_list_present = (data[1] >> 1) & 1;
+  fcf.dest_addr_mode = (data[1] >> 2) & 3;
+  fcf.frame_version = (data[1] >> 4) & 3;
+  fcf.src_addr_mode = (data[1] >> 6) & 3;
+
+  /* copy fcf */
+  memcpy(pfcf, &fcf, sizeof(frame802154_fcf_t));
+}
 /*----------------------------------------------------------------------------*/
 /**
  *   \brief Parses an input frame.  Scans the input frame to find each
@@ -489,19 +515,7 @@ frame802154_parse(uint8_t *data, int len, frame802154_t *pf)
   p = data;
 
   /* decode the FCF */
-  fcf.frame_type = p[0] & 7;
-  fcf.security_enabled = (p[0] >> 3) & 1;
-  fcf.frame_pending = (p[0] >> 4) & 1;
-  fcf.ack_required = (p[0] >> 5) & 1;
-  fcf.panid_compression = (p[0] >> 6) & 1;
-
-  fcf.sequence_number_suppression = p[1] & 1;
-  fcf.ie_list_present = (p[1] >> 1) & 1;
-  fcf.dest_addr_mode = (p[1] >> 2) & 3;
-  fcf.frame_version = (p[1] >> 4) & 3;
-  fcf.src_addr_mode = (p[1] >> 6) & 3;
-
-  /* copy fcf and seqNum */
+  frame802154_parse_fcf(p, &fcf);
   memcpy(&pf->fcf, &fcf, sizeof(frame802154_fcf_t));
   p += 2;                             /* Skip first two bytes */
 

--- a/core/net/mac/frame802154.h
+++ b/core/net/mac/frame802154.h
@@ -207,8 +207,10 @@ typedef struct {
 /* Prototypes */
 
 int frame802154_hdrlen(frame802154_t *p);
+void frame802154_create_fcf(frame802154_fcf_t *fcf, uint8_t *buf);
 int frame802154_create(frame802154_t *p, uint8_t *buf);
 int frame802154_parse(uint8_t *data, int length, frame802154_t *pf);
+void frame802154_parse_fcf(uint8_t *data, frame802154_fcf_t *pfcf);
 
 /* Get current PAN ID */
 uint16_t frame802154_get_pan_id(void);

--- a/platform/jn516x/contiki-conf.h
+++ b/platform/jn516x/contiki-conf.h
@@ -112,6 +112,16 @@
 /* Configure NullRDC for when it is selected */
 #define NULLRDC_CONF_802154_AUTOACK_HW  1
 
+/* Configure ContikiMAC for when it's selected */
+#define CONTIKIMAC_CONF_WITH_CONTIKIMAC_HEADER  0
+#define CONTIKIMAC_CONF_WITH_PHASE_OPTIMIZATION 0
+#define WITH_FAST_SLEEP                         1
+
+#ifndef NETSTACK_CONF_RDC_CHANNEL_CHECK_RATE
+#define NETSTACK_CONF_RDC_CHANNEL_CHECK_RATE    8
+#endif
+#define RDC_CONF_HARDWARE_ACK        1
+
 #define UIP_CONF_LL_802154              1
 #define UIP_CONF_LLH_LEN                0
 


### PR DESCRIPTION
The PR allows the micromac driver of the JN516x platform to use the hardware MAC layer engine provided by NXP.

At first I wanted to have a JN516 framer to create a specific frame for micromac, however there are so many pieces of code that assume that the content of a packetbuf is a real 802.15.4 frame, that the complexity of the change were skyrocketing... Instead, the driver receives the 802.15.4 frame from the RDC layer and dissect it to create the JN516 specific frame and send it to the micromac driver. Similarly, when a frame is received from the microbic layer, the driver recreates a full 802.15.4 frame.

This driver has been tested with NullRDC and ContikiMAC, but without LLSEC, this would require additional changes to support the security header.

By default the hardware mac layer is still disabled, it can be activated using  MICROMAC_CONF_RADIO_MAC macro. However, the default configuration in contiki-conf.h of JN516x reference csma_driver and nullrdc_driver which requires the hardware MAC to be enabled, so in the future either the contiki-conf.h should be modified to activate it by default and modify the TSCH examples to disable it explicitly or make TSCH the default MAC layer for JN516x :)