### PR TITLE
Override HTTP host/path lenght and updated http-socket example

### DIFF
--- a/core/net/http-socket/http-socket.c
+++ b/core/net/http-socket/http-socket.c
@@ -35,8 +35,6 @@
 #include <ctype.h>
 #include <stdio.h>
 
-#define MAX_PATHLEN 80
-#define MAX_HOSTLEN 40
 PROCESS(http_socket_process, "HTTP socket process");
 LIST(socketlist);
 

--- a/core/net/http-socket/http-socket.h
+++ b/core/net/http-socket/http-socket.h
@@ -33,6 +33,18 @@
 
 #include "tcp-socket.h"
 
+#ifdef MAX_HTTP_SOCKET_CONF_PATHLEN
+#define MAX_PATHLEN MAX_HTTP_SOCKET_CONF_PATHLEN
+#else
+#define MAX_PATHLEN 80
+#endif
+
+#ifdef MAX_HTTP_SOCKET_CONF_HOSTLEN
+#define MAX_HOSTLEN MAX_HTTP_SOCKET_CONF_HOSTLEN
+#else
+#define MAX_HOSTLEN 40
+#endif
+
 struct http_socket;
 
 typedef enum {


### PR DESCRIPTION
This PR allows to override the maximum host and path lenght used by the http-socket library, and adds reconnections attempts to the http-socket example.