### PR TITLE
added support for 6-bytes link-layer address

### DIFF
--- a/core/net/linkaddr.c
+++ b/core/net/linkaddr.c
@@ -54,7 +54,7 @@ const linkaddr_t linkaddr_null = { { 0, 0, 0, 0, 0, 0, 0, 0 } };
 #endif /*LINKADDR_SIZE == 8*/
 #if LINKADDR_SIZE == 6
 const linkaddr_t linkaddr_null = { { 0, 0, 0, 0, 0, 0 } };
-#endif /*LINKADDR_SIZE == 8*/
+#endif /*LINKADDR_SIZE == 6*/
 #endif /*LINKADDR_SIZE == 2*/
 
 

--- a/core/net/linkaddr.c
+++ b/core/net/linkaddr.c
@@ -52,6 +52,9 @@ const linkaddr_t linkaddr_null = { { 0, 0 } };
 #if LINKADDR_SIZE == 8
 const linkaddr_t linkaddr_null = { { 0, 0, 0, 0, 0, 0, 0, 0 } };
 #endif /*LINKADDR_SIZE == 8*/
+#if LINKADDR_SIZE == 6
+const linkaddr_t linkaddr_null = { { 0, 0, 0, 0, 0, 0 } };
+#endif /*LINKADDR_SIZE == 8*/
 #endif /*LINKADDR_SIZE == 2*/
 
 

--- a/platform/minimal-net/contiki-conf.h
+++ b/platform/minimal-net/contiki-conf.h
@@ -64,7 +64,6 @@ typedef  int32_t s32_t;
 
 typedef unsigned short uip_stats_t;
 
-
 #if NETSTACK_CONF_WITH_IPV6
 /* The Windows build uses wpcap to connect to a host interface. It finds the interface by scanning for
  * an address, which can be specified here and overridden with the command line.
@@ -148,6 +147,7 @@ typedef unsigned short uip_stats_t;
 #endif
 
 #define UIP_CONF_LLH_LEN              14
+#define LINKADDR_CONF_SIZE             6
 #define UIP_CONF_MAX_LISTENPORTS      40
 #define UIP_CONF_MAX_CONNECTIONS      40
 #define UIP_CONF_BYTE_ORDER           UIP_LITTLE_ENDIAN


### PR DESCRIPTION
This PR adds the ability for the nbr table to use 6-bytes link-layer address. Should improve things for cases where Ethernet is used instead of 802.15.4 (8 or 2 bytes). Also fixed config for minimal-net to use the 6-bytes address as it make use of a TAP (ethernet) to hook into the IP-stack of the host.