### PR TITLE
TSCH bugfix: reset keep-alive timeout when switching time source

### DIFF
--- a/core/net/mac/tsch/tsch-queue.c
+++ b/core/net/mac/tsch/tsch-queue.c
@@ -163,6 +163,13 @@ tsch_queue_update_time_source(const linkaddr_t *new_addr)
         /* Update time source */
         if(new_time_src != NULL) {
           new_time_src->is_time_source = 1;
+          /* (Re)set keep-alive timeout */
+          tsch_set_ka_timeout(TSCH_KEEPALIVE_TIMEOUT);
+          /* Start sending keepalives */
+          tsch_schedule_keepalive();
+        } else {
+          /* Stop sending keepalives */
+          tsch_set_ka_timeout(0);
         }
 
         if(old_time_src != NULL) {


### PR DESCRIPTION
The bug was created when adding adaptive sync traffic with https://github.com/contiki-os/contiki/pull/1741