### PR TITLE
Step 3 of "Cooja mote configuration wizard" now passing in Instant Contiki (Issue #1991)

### DIFF
--- a/tools/cooja/config/external_tools.config
+++ b/tools/cooja/config/external_tools.config
@@ -41,10 +41,10 @@ COMMAND_VAR_SEC_DATA = [DdGg]
 COMMAND_VAR_SEC_BSS = [Bb]
 COMMAND_VAR_SEC_COMMON = [C]
 COMMAND_VAR_SEC_READONLY = [Rr]
-COMMAND_DATA_START = ^.data[ \t]d[ \t]([0-9A-Fa-f]*)[ \t]*$
-COMMAND_DATA_END = ^_edata[ \t]A[ \t]([0-9A-Fa-f]*)[ \t]*$
-COMMAND_BSS_START = ^__bss_start[ \t]A[ \t]([0-9A-Fa-f]*)[ \t]*$
-COMMAND_BSS_END = ^_end[ \t]A[ \t]([0-9A-Fa-f]*)[ \t]*$
+COMMAND_DATA_START = ^\.data[ \t]d[ \t]([0-9A-Fa-f]*)[ \t]*$
+COMMAND_DATA_END = ^_edata[ \t]D[ \t]([0-9A-Fa-f]*)[ \t]*$
+COMMAND_BSS_START = ^__bss_start[ \t]B[ \t]([0-9A-Fa-f]*)[ \t]*$
+COMMAND_BSS_END = ^_end[ \t]B[ \t]([0-9A-Fa-f]*)[ \t]*$
 COMMAND_READONLY_START = ^.rodata[ \t]r[ \t]([0-9A-Fa-f]*)[ \t]*$
 COMMAND_READONLY_END = ^.eh_frame_hdr[ \t]r[ \t]([0-9A-Fa-f]*)[ \t]*$
 

--- a/tools/cooja/examples/jni_test/mac_users/nmandsize
+++ b/tools/cooja/examples/jni_test/mac_users/nmandsize
@@ -4,8 +4,8 @@ S="$(size -x -m -l $1)"
 
 parse() (
     echo "$S" |
-	awk '/^Segment/ {s=$2} s=="__DATA:" && $2=="'$1'" \
-		{printf "%s %s 0x%x\n",$5,$3,$3+$5}' |
+	awk --non-decimal-data '/^Segment/ {s=$2} s=="__DATA:" && $2=="'$1'" \
+		{printf "%s %s 0x%x\n",$5,$3,($3+$5)}' |
 	(read start size end; 
 	 echo "$2 START: $start";
 	 echo "$2 SIZE: $size";

--- a/tools/cooja/java/org/contikios/cooja/contikimote/ContikiMoteType.java
+++ b/tools/cooja/java/org/contikios/cooja/contikimote/ContikiMoteType.java
@@ -525,6 +525,7 @@ public class ContikiMoteType implements MoteType {
     private final String[] mapFileData;
     protected int startAddr;
     protected int size;
+    protected Map<String, Symbol> variables;
 
     public SectionParser(String[] mapFileData) {
       this.mapFileData = mapFileData;
@@ -540,6 +541,10 @@ public class ContikiMoteType implements MoteType {
 
     public int getSize() {
       return size;
+    }
+
+    public Map<String, Symbol> getVariables(){
+      return variables;
     }
 
     protected abstract void parseStartAddr();
@@ -568,7 +573,7 @@ public class ContikiMoteType implements MoteType {
         return null;
       }
 
-      Map<String, Symbol> variables = parseSymbols(offset);
+      variables = parseSymbols(offset);
 
       logger.info(String.format("Parsed section at 0x%x ( %d == 0x%x bytes)",
                                 getStartAddr() + offset,

--- a/tools/cooja/java/org/contikios/cooja/dialogs/ConfigurationWizard.java
+++ b/tools/cooja/java/org/contikios/cooja/dialogs/ConfigurationWizard.java
@@ -49,6 +49,7 @@ import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
 import java.io.PrintStream;
 import java.lang.reflect.Constructor;
+import java.util.Map;
 import java.util.HashMap;
 
 import javax.swing.Box;
@@ -144,7 +145,7 @@ public class ConfigurationWizard extends JDialog {
   private static File cLibraryFile;
   private static String javaLibraryName;
   private static CoreComm javaLibrary;
-  private static HashMap<String, Symbol> addresses;
+  private static Map<String, Symbol> addresses;
   private static int relDataSectionAddr;
   private static int dataSectionSize;
   private static int relBssSectionAddr;
@@ -850,7 +851,6 @@ public class ConfigurationWizard extends JDialog {
     }
 
     testOutput.addMessage("### Parsing command output for addresses");
-    addresses = new HashMap<String, Symbol>();
 //    boolean parseOK = ContikiMoteType.parseCommandData(commandData, addresses);
 //    if (!parseOK) {
 //      testOutput.addMessage("### Error: Failed parsing command output", MessageList.ERROR);
@@ -861,20 +861,22 @@ public class ConfigurationWizard extends JDialog {
     SectionParser dataSecParser = new ContikiMoteType.CommandSectionParser(
             commandData,
             Cooja.getExternalToolsSetting("COMMAND_DATA_START"),
-            Cooja.getExternalToolsSetting("COMMAND_DATA_SIZE"),
+            Cooja.getExternalToolsSetting("COMMAND_DATA_END"),
             Cooja.getExternalToolsSetting("COMMAND_VAR_SEC_DATA"));
     SectionParser bssSecParser = new ContikiMoteType.CommandSectionParser(
             commandData,
             Cooja.getExternalToolsSetting("COMMAND_BSS_START"),
-            Cooja.getExternalToolsSetting("COMMAND_BSS_SIZE"),
+            Cooja.getExternalToolsSetting("COMMAND_BSS_END"),
             Cooja.getExternalToolsSetting("COMMAND_VAR_SEC_BSS"));
 
     dataSecParser.parse(0);
     bssSecParser.parse(0);
     relDataSectionAddr = dataSecParser.getStartAddr();
     dataSectionSize = dataSecParser.getSize();
+    addresses = dataSecParser.getVariables();
     relBssSectionAddr = bssSecParser.getStartAddr();
     bssSectionSize = bssSecParser.getSize();
+    addresses.putAll(bssSecParser.getVariables());
     testOutput.addMessage("Data section address: 0x" + Integer.toHexString(relDataSectionAddr));
     testOutput.addMessage("Data section size: 0x" + Integer.toHexString(dataSectionSize));
     testOutput.addMessage("BSS section address: 0x" + Integer.toHexString(relBssSectionAddr));


### PR DESCRIPTION
Altered regex expressions in external_tools.config to fit the output of the `nm -aP $(LIBFILE)` command.

Also added a method to get variables out of SectionParser to easily retrieve variables from the parsed document: the code to parse the variables was in the parser class, but this information was not being retrieved by the configuration wizard. Also some configuration strings were wrong.

Did not do the Map, from what I could see the generated map file does not have the information of a variable size in one line for variables in the data section. Is it required to get the current line holding the variable's address and name and the address in the next line to get the size? I did not do it as it seems to be working as is using the nm command.

I also fixed the nmandsize script in tools/cooja/examples/jni_test/mac_users since it was an easy fix. The awk command was missing the `--non-decimal-data` argument in order to sum hexadecimal values.

As for the memory replacement test, it is not being completed successfully: it freezes in `memory.setMemorySegment(relDataSectionAddr, initialDataSection);`. The problems seems to be that the test is missing the memory segment creation part: `addMemorySegment` is never called in the test if I am not mistaken.

Cheers,

Afonso