### PR TITLE
Fixing Avr-Zigbit Makefile not compiling.

### DIFF
--- a/platform/avr-zigbit/Makefile.avr-zigbit
+++ b/platform/avr-zigbit/Makefile.avr-zigbit
@@ -7,7 +7,7 @@ CONTIKI_TARGET_MAIN = ${CONTIKI_CORE}.o
 CONTIKI_TARGET_SOURCEFILES +=	rs232.c cfs-eeprom.c eeprom.c random.c mmem.c \
 				contiki-avr-zigbit-main.c \
 				sicslowmac.c linkaddr.c queuebuf.c nullmac.c packetbuf.c \
-				frame802154.c framer-802154.c framer.c nullsec.c nbr-table.c
+				frame802154.c framer-802154.c nullsec.c nbr-table.c
 
 CONTIKIAVR = $(CONTIKI)/cpu/avr
 CONTIKIBOARD = .
@@ -18,3 +18,4 @@ MCU = atmega1281
 
 include $(CONTIKIAVR)/Makefile.avr
 include $(CONTIKIAVR)/radio/Makefile.radio
+MODULES += core/net


### PR DESCRIPTION
I just tried to compile this platform for my Zigbit mote (AT86RF230) here in a hello-world example, but it didn't work.
I reviewed this makefile and found that the request to compile "frame.c" was not necessary and bring up a missing error:
"make: *** No rule to make target `obj_avr-zigbit/frame.o', needed by `contiki-avr-zigbit.a'.  Stop."
Frame.c is already inserted in radio's makefile.

Another problem was the undefined reference created by the missing module "core/net":
"contiki-avr-zigbit.a(sicslowpan.o): In function `input':"
"contiki/examples/hello-world/../../core/net/ipv6/sicslowpan.c:1521: undefined reference to `link_stats_input_callback'"

Both solved now. Hope it helps someone else.