### PR TITLE
Bugfix in ringbufindex

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -163,3 +163,4 @@ env:
   - BUILD_TYPE='llsec' MAKE_TARGETS='cooja'
   - BUILD_TYPE='compile-avr' BUILD_CATEGORY='compile' BUILD_ARCH='avr-rss2'
   - BUILD_TYPE='ieee802154'
+  - BUILD_TYPE='tsch'

--- a/core/lib/ringbufindex.c
+++ b/core/lib/ringbufindex.c
@@ -83,7 +83,7 @@ ringbufindex_peek_put(const struct ringbufindex *r)
   if(((r->put_ptr - r->get_ptr) & r->mask) == r->mask) {
     return -1;
   }
-  return (r->put_ptr + 1) & r->mask;
+  return r->put_ptr;
 }
 /* Remove the first element and return its index */
 int
@@ -118,7 +118,7 @@ ringbufindex_peek_get(const struct ringbufindex *r)
      first one. If there are no bytes left, we return -1.
    */
   if(((r->put_ptr - r->get_ptr) & r->mask) > 0) {
-    return (r->get_ptr + 1) & r->mask;
+    return r->get_ptr;
   } else {
     return -1;
   }

--- a/core/lib/ringbufindex.h
+++ b/core/lib/ringbufindex.h
@@ -58,7 +58,7 @@ int ringbufindex_peek_put(const struct ringbufindex *r);
 /* Remove the first element and return its index */
 int ringbufindex_get(struct ringbufindex *r);
 /* Return the index of the first element
- * (which will be removed if calling ringbufindex_peek) */
+ * (which will be removed if calling ringbufindex_get) */
 int ringbufindex_peek_get(const struct ringbufindex *r);
 /* Return the ring buffer size */
 int ringbufindex_size(const struct ringbufindex *r);

--- a/core/lib/ringbufindex.h
+++ b/core/lib/ringbufindex.h
@@ -48,25 +48,72 @@ struct ringbufindex {
   uint8_t put_ptr, get_ptr;
 };
 
-/* Initialize a ring buffer. The size must be a power of two */
+/**
+ * \brief Initialize a ring buffer. The size must be a power of two
+ * \param r Pointer to ringbufindex
+ * \param size Size of ring buffer
+ */
 void ringbufindex_init(struct ringbufindex *r, uint8_t size);
-/* Put one element to the ring buffer */
+
+/**
+ * \brief Put one element to the ring buffer
+ * \param r Pointer to ringbufindex
+ * \retval 0 Failure; the ring buffer is full
+ * \retval 1 Success; an element is added
+ */
 int ringbufindex_put(struct ringbufindex *r);
-/* Check if there is space to put an element.
- * Return the index where the next element is to be added */
+
+/**
+ * \brief Check if there is space to put an element.
+ * \param r Pinter to ringbufindex
+ * \retval >= 0 The index where the next element is to be added.
+ * \retval -1 Failure; the ring buffer is full
+ */
 int ringbufindex_peek_put(const struct ringbufindex *r);
-/* Remove the first element and return its index */
+
+/**
+ * \brief Remove the first element and return its index
+ * \param r Pinter to ringbufindex
+ * \retval >= 0 The index of the first element
+ * \retval -1 No element in the ring buffer
+ */
 int ringbufindex_get(struct ringbufindex *r);
-/* Return the index of the first element
- * (which will be removed if calling ringbufindex_get) */
+
+/**
+ * \brief Return the index of the first element which will be removed if calling
+ *        ringbufindex_get.
+ * \param r Pinter to ringbufindex
+ * \retval >= 0 The index of the first element
+ * \retval -1 No element in the ring buffer
+ */
 int ringbufindex_peek_get(const struct ringbufindex *r);
-/* Return the ring buffer size */
+
+/**
+ * \brief Return the ring buffer size
+ * \param r Pinter to ringbufindex
+ * \return The size of the ring buffer
+ */
 int ringbufindex_size(const struct ringbufindex *r);
-/* Return the number of elements currently in the ring buffer */
+
+/**
+ * \brief Return the number of elements currently in the ring buffer.
+ * \param r Pinter to ringbufindex
+ * \return The number of elements in the ring buffer
+ */
 int ringbufindex_elements(const struct ringbufindex *r);
-/* Is the ring buffer full? */
+
+/**
+ * \brief Is the ring buffer full?
+ * \retval 0 Not full
+ * \retval 1 Full
+ */
 int ringbufindex_full(const struct ringbufindex *r);
-/* Is the ring buffer empty? */
+
+/**
+ * \brief Is the ring buffer empty?
+ * \retval 0 Not empty
+ * \retval 1 Empty
+ */
 int ringbufindex_empty(const struct ringbufindex *r);
 
 #endif /* __RINGBUFINDEX_H__ */

--- a/regression-tests/03-base/04-ringbufindex.csc
+++ b/regression-tests/03-base/04-ringbufindex.csc
@@ -1,0 +1,148 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<simconf>
+  <project EXPORT="discard">[APPS_DIR]/mrm</project>
+  <project EXPORT="discard">[APPS_DIR]/mspsim</project>
+  <project EXPORT="discard">[APPS_DIR]/avrora</project>
+  <project EXPORT="discard">[APPS_DIR]/serial_socket</project>
+  <project EXPORT="discard">[APPS_DIR]/collect-view</project>
+  <project EXPORT="discard">[APPS_DIR]/powertracker</project>
+  <project EXPORT="discard">[APPS_DIR]/radiologger-headless</project>
+  <simulation>
+    <title>Test ringbufindex</title>
+    <randomseed>123456</randomseed>
+    <motedelay_us>1000000</motedelay_us>
+    <radiomedium>
+      org.contikios.cooja.radiomediums.UDGM
+      <transmitting_range>50.0</transmitting_range>
+      <interference_range>100.0</interference_range>
+      <success_ratio_tx>1.0</success_ratio_tx>
+      <success_ratio_rx>1.0</success_ratio_rx>
+    </radiomedium>
+    <events>
+      <logoutput>40000</logoutput>
+    </events>
+    <motetype>
+      org.contikios.cooja.contikimote.ContikiMoteType
+      <identifier>mtype297</identifier>
+      <description>ringbufindex testee</description>
+      <source>[CONTIKI_DIR]/regression-tests/03-base/code/test-ringbufindex.c</source>
+      <commands>make test-ringbufindex.cooja TARGET=cooja</commands>
+      <moteinterface>org.contikios.cooja.interfaces.Position</moteinterface>
+      <moteinterface>org.contikios.cooja.interfaces.Battery</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiVib</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiMoteID</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiRS232</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiBeeper</moteinterface>
+      <moteinterface>org.contikios.cooja.interfaces.RimeAddress</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiIPAddress</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiRadio</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiButton</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiPIR</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiClock</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiLED</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiCFS</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiEEPROM</moteinterface>
+      <moteinterface>org.contikios.cooja.interfaces.Mote2MoteRelations</moteinterface>
+      <moteinterface>org.contikios.cooja.interfaces.MoteAttributes</moteinterface>
+      <symbols>false</symbols>
+    </motetype>
+    <mote>
+      <interface_config>
+        org.contikios.cooja.interfaces.Position
+        <x>0.0</x>
+        <y>0.0</y>
+        <z>0.0</z>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.contikimote.interfaces.ContikiMoteID
+        <id>1</id>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.contikimote.interfaces.ContikiRadio
+        <bitrate>250.0</bitrate>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.contikimote.interfaces.ContikiEEPROM
+        <eeprom>AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==</eeprom>
+      </interface_config>
+      <motetype_identifier>mtype297</motetype_identifier>
+    </mote>
+  </simulation>
+  <plugin>
+    org.contikios.cooja.plugins.SimControl
+    <width>280</width>
+    <z>1</z>
+    <height>160</height>
+    <location_x>400</location_x>
+    <location_y>0</location_y>
+  </plugin>
+  <plugin>
+    org.contikios.cooja.plugins.Visualizer
+    <plugin_config>
+      <moterelations>true</moterelations>
+      <skin>org.contikios.cooja.plugins.skins.IDVisualizerSkin</skin>
+      <skin>org.contikios.cooja.plugins.skins.GridVisualizerSkin</skin>
+      <skin>org.contikios.cooja.plugins.skins.TrafficVisualizerSkin</skin>
+      <skin>org.contikios.cooja.plugins.skins.UDGMVisualizerSkin</skin>
+      <viewport>0.9090909090909091 0.0 0.0 0.9090909090909091 194.0 173.0</viewport>
+    </plugin_config>
+    <width>400</width>
+    <z>4</z>
+    <height>400</height>
+    <location_x>1</location_x>
+    <location_y>1</location_y>
+  </plugin>
+  <plugin>
+    org.contikios.cooja.plugins.LogListener
+    <plugin_config>
+      <filter />
+      <formatted_time />
+      <coloring />
+    </plugin_config>
+    <width>1320</width>
+    <z>3</z>
+    <height>240</height>
+    <location_x>400</location_x>
+    <location_y>160</location_y>
+  </plugin>
+  <plugin>
+    org.contikios.cooja.plugins.TimeLine
+    <plugin_config>
+      <mote>0</mote>
+      <showRadioRXTX />
+      <showRadioHW />
+      <showLEDs />
+      <zoomfactor>500.0</zoomfactor>
+    </plugin_config>
+    <width>1720</width>
+    <z>2</z>
+    <height>166</height>
+    <location_x>0</location_x>
+    <location_y>957</location_y>
+  </plugin>
+  <plugin>
+    org.contikios.cooja.plugins.Notes
+    <plugin_config>
+      <notes>Enter notes here</notes>
+      <decorations>true</decorations>
+    </plugin_config>
+    <width>1040</width>
+    <z>5</z>
+    <height>160</height>
+    <location_x>680</location_x>
+    <location_y>0</location_y>
+  </plugin>
+  <plugin>
+    org.contikios.cooja.plugins.ScriptRunner
+    <plugin_config>
+      <scriptfile>[CONTIKI_DIR]/regression-tests/03-base/js/04-ringbufindex.js</scriptfile>
+      <active>true</active>
+    </plugin_config>
+    <width>495</width>
+    <z>0</z>
+    <height>525</height>
+    <location_x>663</location_x>
+    <location_y>105</location_y>
+  </plugin>
+</simconf>
+

--- a/regression-tests/03-base/code/Makefile
+++ b/regression-tests/03-base/code/Makefile
@@ -1,0 +1,8 @@
+all: test-ringbufindex
+
+CFLAGS  += -D PROJECT_CONF_H=\"project-conf.h\"
+APPS    += unit-test
+
+CONTIKI = ../../..
+CONTIKI_WITH_IPV6 = 1
+include $(CONTIKI)/Makefile.include

--- a/regression-tests/03-base/code/project-conf.h
+++ b/regression-tests/03-base/code/project-conf.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2017, Yasuyuki Tanaka
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef _PROJECT_CONF_H_
+#define _PROJECT_CONF_H_
+
+#define UNIT_TEST_PRINT_FUNCTION test_print_report
+
+#endif /* !_PROJECT_CONF_H_ */

--- a/regression-tests/03-base/code/test-ringbufindex.c
+++ b/regression-tests/03-base/code/test-ringbufindex.c
@@ -1,0 +1,366 @@
+/*
+ * Copyright (c) 2017, Yasuyuki Tanaka
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdio.h>
+
+#include "contiki.h"
+#include "unit-test.h"
+
+#include "lib/ringbufindex.h"
+
+PROCESS(test_process, "ringbuf-index.c test");
+AUTOSTART_PROCESSES(&test_process);
+
+static struct ringbufindex ri;
+static const uint8_t ri_size = 2;
+
+static void
+test_print_report(const unit_test_t *utp)
+{
+  printf("=check-me= ");
+  if(utp->result == unit_test_failure) {
+    printf("FAILED   - %s: exit at L%u\n", utp->descr, utp->exit_line);
+  } else {
+    printf("SUCCEEDED - %s\n", utp->descr);
+  }
+}
+
+UNIT_TEST_REGISTER(test_ringbufindex_init, "Init");
+UNIT_TEST(test_ringbufindex_init)
+{
+  UNIT_TEST_BEGIN();
+
+  ringbufindex_init(&ri, ri_size);
+
+  UNIT_TEST_ASSERT(ri.mask == ri_size - 1 &&
+                   ri.put_ptr == 0 &&
+                   ri.get_ptr == 0);
+
+  UNIT_TEST_END();
+}
+
+UNIT_TEST_REGISTER(test_ringbufindex_put, "Put");
+UNIT_TEST(test_ringbufindex_put)
+{
+  int ret;
+
+  UNIT_TEST_BEGIN();
+
+  ringbufindex_init(&ri, ri_size);
+
+  /* Put the first item */
+  ret = ringbufindex_put(&ri);
+  UNIT_TEST_ASSERT(ret == 1 && ri.put_ptr == 1 && ri.get_ptr == 0);
+
+  /*
+   * This one must fail because the ringbuf is full. The ringbuf can have one
+   * item (size - 1) at most.
+   */
+  ret = ringbufindex_put(&ri);
+  UNIT_TEST_ASSERT(ret == 0 && ri.put_ptr == 1 && ri.get_ptr == 0);
+
+  UNIT_TEST_END();
+}
+
+UNIT_TEST_REGISTER(test_ringbufindex_peek_put, "PeekPut");
+UNIT_TEST(test_ringbufindex_peek_put)
+{
+  int ret;
+
+  UNIT_TEST_BEGIN();
+
+  ringbufindex_init(&ri, ri_size);
+
+  /* Get index for the first item */
+  ret = ringbufindex_peek_put(&ri);
+  UNIT_TEST_ASSERT(ret == 0 && ri.put_ptr == 0 && ri.get_ptr == 0);
+
+  /* Put the first item */
+  ret = ringbufindex_put(&ri);
+  UNIT_TEST_ASSERT(ret == 1 && ri.put_ptr == 1 && ri.get_ptr == 0);
+
+  /* Get index for the second item; should be -1 because it's full */
+  ret = ringbufindex_peek_put(&ri);
+  UNIT_TEST_ASSERT(ret == -1 && ri.put_ptr == 1 && ri.get_ptr == 0);
+
+  UNIT_TEST_END();
+}
+
+UNIT_TEST_REGISTER(test_ringbufindex_get, "Get");
+UNIT_TEST(test_ringbufindex_get)
+{
+  int ret;
+
+  UNIT_TEST_BEGIN();
+
+  ringbufindex_init(&ri, ri_size);
+
+  /* Get the first item; it's been not put yet. */
+  ret = ringbufindex_get(&ri);
+  UNIT_TEST_ASSERT(ret == -1 && ri.put_ptr == 0 && ri.get_ptr == 0);
+
+  /* Put the first item */
+  ret = ringbufindex_put(&ri);
+  UNIT_TEST_ASSERT(ret == 1 && ri.put_ptr == 1 && ri.get_ptr == 0);
+
+  /* Get the first item */
+  ret = ringbufindex_get(&ri);
+  UNIT_TEST_ASSERT(ret == 0 && ri.put_ptr == 1 && ri.get_ptr == 1);
+
+  /* Put the second item */
+  ret = ringbufindex_put(&ri);
+  UNIT_TEST_ASSERT(ret == 1 && ri.put_ptr == 0 && ri.get_ptr == 1);
+
+  /* Get the second item */
+  ret = ringbufindex_get(&ri);
+  UNIT_TEST_ASSERT(ret == 1 && ri.put_ptr == 0 && ri.get_ptr == 0);
+
+  UNIT_TEST_END();
+}
+
+UNIT_TEST_REGISTER(test_ringbufindex_peek_get, "PeekGet");
+UNIT_TEST(test_ringbufindex_peek_get)
+{
+  int ret;
+
+  UNIT_TEST_BEGIN();
+
+  ringbufindex_init(&ri, ri_size);
+
+  /* Get the index of the first item; it's been not put yet. */
+  ret = ringbufindex_peek_get(&ri);
+  UNIT_TEST_ASSERT(ret == -1 && ri.put_ptr == 0 && ri.get_ptr == 0);
+
+  /* Put the first item */
+  ret = ringbufindex_put(&ri);
+  UNIT_TEST_ASSERT(ret == 1 && ri.put_ptr == 1 && ri.get_ptr == 0);
+
+  /* Get the index of the first item */
+  ret = ringbufindex_peek_get(&ri);
+  UNIT_TEST_ASSERT(ret == 0 && ri.put_ptr == 1 && ri.get_ptr == 0);
+
+  /* Get and remove the first item */
+  ret = ringbufindex_get(&ri);
+  UNIT_TEST_ASSERT(ret == 0 && ri.put_ptr == 1 && ri.get_ptr == 1);
+
+  /* Put the second item */
+  ret = ringbufindex_put(&ri);
+  UNIT_TEST_ASSERT(ret == 1 && ri.put_ptr == 0 && ri.get_ptr == 1);
+
+  /* Get the index of the second item */
+  ret = ringbufindex_peek_get(&ri);
+  UNIT_TEST_ASSERT(ret == 1 && ri.put_ptr == 0 && ri.get_ptr == 1);
+
+  /* Get and remove the second item */
+  ret = ringbufindex_get(&ri);
+  UNIT_TEST_ASSERT(ret == 1 && ri.put_ptr == 0 && ri.get_ptr == 0);
+
+  UNIT_TEST_END();
+}
+
+UNIT_TEST_REGISTER(test_ringbufindex_size, "Size");
+UNIT_TEST(test_ringbufindex_size)
+{
+  int ret;
+
+  UNIT_TEST_BEGIN();
+
+  ringbufindex_init(&ri, ri_size);
+
+  ret = ringbufindex_size(&ri);
+  UNIT_TEST_ASSERT(ret == ri_size);
+
+  UNIT_TEST_END();
+}
+
+UNIT_TEST_REGISTER(test_ringbufindex_elements, "Elements");
+UNIT_TEST(test_ringbufindex_elements)
+{
+  int ret;
+
+  UNIT_TEST_BEGIN();
+
+  ringbufindex_init(&ri, ri_size);
+
+  /* Nothing in ringbuf */
+  ret = ringbufindex_elements(&ri);
+  UNIT_TEST_ASSERT(ret == 0 && ri.put_ptr == 0 && ri.get_ptr == 0);
+
+  /* Put the first item */
+  ret = ringbufindex_put(&ri);
+  UNIT_TEST_ASSERT(ret == 1 && ri.put_ptr == 1 && ri.get_ptr == 0);
+
+  /* One item in ringbuf */
+  ret = ringbufindex_elements(&ri);
+  UNIT_TEST_ASSERT(ret == 1 && ri.put_ptr == 1 && ri.get_ptr == 0);
+
+  /* Get the first item */
+  ret = ringbufindex_get(&ri);
+  UNIT_TEST_ASSERT(ret == 0 && ri.put_ptr == 1 && ri.get_ptr == 1);
+
+  /* Nothing in ringbuf */
+  ret = ringbufindex_elements(&ri);
+  UNIT_TEST_ASSERT(ret == 0 && ri.put_ptr == 1 && ri.get_ptr == 1);
+
+  /* Put the second item */
+  ret = ringbufindex_put(&ri);
+  UNIT_TEST_ASSERT(ret == 1 && ri.put_ptr == 0 && ri.get_ptr == 1);
+
+  /* One item in ringbuf */
+  ret = ringbufindex_elements(&ri);
+  UNIT_TEST_ASSERT(ret == 1 && ri.put_ptr == 0 && ri.get_ptr == 1);
+
+  /* Get the second item */
+  ret = ringbufindex_get(&ri);
+  UNIT_TEST_ASSERT(ret == 1 && ri.put_ptr == 0 && ri.get_ptr == 0);
+
+  /* Nothing in ringbuf */
+  ret = ringbufindex_elements(&ri);
+  UNIT_TEST_ASSERT(ret == 0 && ri.put_ptr == 0 && ri.get_ptr == 0);
+
+  UNIT_TEST_END();
+}
+
+UNIT_TEST_REGISTER(test_ringbufindex_full, "Full");
+UNIT_TEST(test_ringbufindex_full)
+{
+  int ret;
+
+  UNIT_TEST_BEGIN();
+
+  ringbufindex_init(&ri, ri_size);
+
+  /* Nothing in ringbuf; not full */
+  ret = ringbufindex_full(&ri);
+  UNIT_TEST_ASSERT(ret == 0 && ri.put_ptr == 0 && ri.get_ptr == 0);
+
+  /* Put the first item */
+  ret = ringbufindex_put(&ri);
+  UNIT_TEST_ASSERT(ret == 1 && ri.put_ptr == 1 && ri.get_ptr == 0);
+
+  /* One item in ringbuf; full */
+  ret = ringbufindex_full(&ri);
+  UNIT_TEST_ASSERT(ret == 1 && ri.put_ptr == 1 && ri.get_ptr == 0);
+
+  /* Get the first item */
+  ret = ringbufindex_get(&ri);
+  UNIT_TEST_ASSERT(ret == 0 && ri.put_ptr == 1 && ri.get_ptr == 1);
+
+  /* Nothing in ringbuf; not full */
+  ret = ringbufindex_full(&ri);
+  UNIT_TEST_ASSERT(ret == 0 && ri.put_ptr == 1 && ri.get_ptr == 1);
+
+  /* Put the second item */
+  ret = ringbufindex_put(&ri);
+  UNIT_TEST_ASSERT(ret == 1 && ri.put_ptr == 0 && ri.get_ptr == 1);
+
+  /* One item in ringbuf; full */
+  ret = ringbufindex_full(&ri);
+  UNIT_TEST_ASSERT(ret == 1 && ri.put_ptr == 0 && ri.get_ptr == 1);
+
+  /* Get the second item */
+  ret = ringbufindex_get(&ri);
+  UNIT_TEST_ASSERT(ret == 1 && ri.put_ptr == 0 && ri.get_ptr == 0);
+
+  /* Nothing in ringbuf; not full */
+  ret = ringbufindex_full(&ri);
+  UNIT_TEST_ASSERT(ret == 0 && ri.put_ptr == 0 && ri.get_ptr == 0);
+
+  UNIT_TEST_END();
+}
+
+UNIT_TEST_REGISTER(test_ringbufindex_empty, "Empty");
+UNIT_TEST(test_ringbufindex_empty)
+{
+  int ret;
+
+  UNIT_TEST_BEGIN();
+
+  ringbufindex_init(&ri, ri_size);
+
+  /* Nothing in ringbuf; empty */
+  ret = ringbufindex_empty(&ri);
+  UNIT_TEST_ASSERT(ret == 1 && ri.put_ptr == 0 && ri.get_ptr == 0);
+
+  /* Put the first item */
+  ret = ringbufindex_put(&ri);
+  UNIT_TEST_ASSERT(ret == 1 && ri.put_ptr == 1 && ri.get_ptr == 0);
+
+  /* One item in ringbuf; not empty */
+  ret = ringbufindex_empty(&ri);
+  UNIT_TEST_ASSERT(ret == 0 && ri.put_ptr == 1 && ri.get_ptr == 0);
+
+  /* Get the first item */
+  ret = ringbufindex_get(&ri);
+  UNIT_TEST_ASSERT(ret == 0 && ri.put_ptr == 1 && ri.get_ptr == 1);
+
+  /* Nothing in ringbuf; empty */
+  ret = ringbufindex_empty(&ri);
+  UNIT_TEST_ASSERT(ret == 1 && ri.put_ptr == 1 && ri.get_ptr == 1);
+
+  /* Put the second item */
+  ret = ringbufindex_put(&ri);
+  UNIT_TEST_ASSERT(ret == 1 && ri.put_ptr == 0 && ri.get_ptr == 1);
+
+  /* One item in ringbuf; not empty */
+  ret = ringbufindex_empty(&ri);
+  UNIT_TEST_ASSERT(ret == 0 && ri.put_ptr == 0 && ri.get_ptr == 1);
+
+  /* Get the second item */
+  ret = ringbufindex_get(&ri);
+  UNIT_TEST_ASSERT(ret == 1 && ri.put_ptr == 0 && ri.get_ptr == 0);
+
+  /* Nothing in ringbuf; empty */
+  ret = ringbufindex_empty(&ri);
+  UNIT_TEST_ASSERT(ret == 1 && ri.put_ptr == 0 && ri.get_ptr == 0);
+
+  UNIT_TEST_END();
+}
+
+PROCESS_THREAD(test_process, ev, data)
+{
+  PROCESS_BEGIN();
+  printf("Run unit-test\n");
+  printf("---\n");
+
+  UNIT_TEST_RUN(test_ringbufindex_init);
+  UNIT_TEST_RUN(test_ringbufindex_put);
+  UNIT_TEST_RUN(test_ringbufindex_peek_put);
+  UNIT_TEST_RUN(test_ringbufindex_get);
+  UNIT_TEST_RUN(test_ringbufindex_peek_get);
+  UNIT_TEST_RUN(test_ringbufindex_size);
+  UNIT_TEST_RUN(test_ringbufindex_elements);
+  UNIT_TEST_RUN(test_ringbufindex_full);
+  UNIT_TEST_RUN(test_ringbufindex_empty);
+
+  printf("=check-me= DONE\n");
+  PROCESS_END();
+}

--- a/regression-tests/03-base/js/04-ringbufindex.js
+++ b/regression-tests/03-base/js/04-ringbufindex.js
@@ -1,0 +1,26 @@
+TIMEOUT(10000, log.testFailed());
+
+var failed = false;
+
+while(true) {
+    YIELD();
+
+    log.log(time + " " + "node-" + id + " "+ msg + "\n");
+    
+    if(msg.contains("=check-me=") == false) {
+        continue;
+    }
+
+    if(msg.contains("FAILED")) {
+        failed = true;
+    }
+
+    if(msg.contains("DONE")) {
+        break;
+    }
+}
+if(failed) {
+    log.testFailed();
+}
+log.testOK();
+


### PR DESCRIPTION
There are two bugs in `ringbufindex`. They are similar.

While `ringbufindex_peek_put()` is supposed to return the index of the next element to be added, it returns the next index of the adding element. `ringbufindex_peek_get()` returns the next index of the first element.

Travis got green on my account. However, `19-z1-rpl-tsch.csc.flaky` failed, that is one of non-regression tests of TSCH. Since this one fails even on the tip of the master branch, I would say, this PR doesn't cause the failure...

A regression test for `ringbufindex` has been introduced under `regression-tests/03-base` as `04-ringbufindex`. Without the fixes, two of them fails.

```shell
Random seed: 1
549000 node-1 Rime started with address 0.1.0.1.0.1.0.1
549000 node-1 MAC 00:01:00:01:00:01:00:01 sicslowpan/CSMA/nullrdc, channel check rate 1000 Hz
549000 node-1 Tentative link-local IPv6 address fe80:0000:0000:0000:0201:0001:0001:0001
549000 node-1 Tentative global IPv6 address fd00:0000:0000:0000:0201:0001:0001:0001
549000 node-1 Starting 'ringbuf-index.c test'
549000 node-1 =check-me= SUCEEDED - Init
549000 node-1 =check-me= SUCEEDED - Put
549000 node-1 =check-me= FAILED   - PeekPut: exit at L104
549000 node-1 =check-me= SUCEEDED - Get
549000 node-1 =check-me= FAILED   - PeekGet: exit at L168
549000 node-1 =check-me= SUCEEDED - Size
549000 node-1 =check-me= SUCEEDED - Elements
549000 node-1 =check-me= SUCEEDED - Full
549000 node-1 =check-me= SUCEEDED - Empty
TEST FAILED
Test ended at simulation time: 10149000
 FAIL ಠ_ಠ
```

All the tests pass on this branch.
```shell
$ make 04-ringbufindex.testlog
Running test 04-ringbufindex with random Seed 1: ..... OK

$ cat 04-ringbufindex.testlog
Random seed: 1
549000 node-1 Rime started with address 0.1.0.1.0.1.0.1
549000 node-1 MAC 00:01:00:01:00:01:00:01 sicslowpan/CSMA/nullrdc, channel check rate 1000 Hz
549000 node-1 Tentative link-local IPv6 address fe80:0000:0000:0000:0201:0001:0001:0001
549000 node-1 Tentative global IPv6 address fd00:0000:0000:0000:0201:0001:0001:0001
549000 node-1 Starting 'ringbuf-index.c test'
549000 node-1 Run unit-test
549000 node-1 ---
549000 node-1 =check-me= SUCEEDED - Init
549000 node-1 =check-me= SUCEEDED - Put
549000 node-1 =check-me= SUCEEDED - PeekPut
549000 node-1 =check-me= SUCEEDED - Get
549000 node-1 =check-me= SUCEEDED - PeekGet
549000 node-1 =check-me= SUCEEDED - Size
549000 node-1 =check-me= SUCEEDED - Elements
549000 node-1 =check-me= SUCEEDED - Full
549000 node-1 =check-me= SUCEEDED - Empty
549000 node-1 =check-me= DONE
TEST OK
Test ended at simulation time: 549000
```