### PR TITLE
Make RPL route lifetime RFC compliant

### DIFF
--- a/core/net/rpl/rpl-private.h
+++ b/core/net/rpl/rpl-private.h
@@ -145,8 +145,14 @@
 /* Special value indicating immediate removal. */
 #define RPL_ZERO_LIFETIME               0
 
+/* Special value indicating infinite lifetime. */
+#define RPL_INFINITE_LIFETIME           0xFF
+
+#define RPL_ROUTE_INFINITE_LIFETIME           0xFFFFFFFF
+
 #define RPL_LIFETIME(instance, lifetime) \
-          ((unsigned long)(instance)->lifetime_unit * (lifetime))
+          (((lifetime) == RPL_INFINITE_LIFETIME) ? RPL_ROUTE_INFINITE_LIFETIME : (unsigned long)(instance)->lifetime_unit * (lifetime))
+
 
 #ifndef RPL_CONF_MIN_HOPRANKINC
 /* RFC6550 defines the default MIN_HOPRANKINC as 256.

--- a/core/net/rpl/rpl-timers.c
+++ b/core/net/rpl/rpl-timers.c
@@ -238,7 +238,7 @@ set_dao_lifetime_timer(rpl_instance_t *instance)
 
   /* Set up another DAO within half the expiration time, if such a
      time has been configured */
-  if(instance->lifetime_unit != 0xffff && instance->default_lifetime != 0xff) {
+  if(instance->default_lifetime != RPL_INFINITE_LIFETIME) {
     clock_time_t expiration_time;
     expiration_time = (clock_time_t)instance->default_lifetime *
       (clock_time_t)instance->lifetime_unit *

--- a/core/net/rpl/rpl.c
+++ b/core/net/rpl/rpl.c
@@ -122,7 +122,7 @@ rpl_purge_routes(void)
   r = uip_ds6_route_head();
 
   while(r != NULL) {
-    if(r->state.lifetime >= 1) {
+    if(r->state.lifetime >= 1 && r->state.lifetime != RPL_ROUTE_INFINITE_LIFETIME) {
       /*
        * If a route is at lifetime == 1, set it to 0, scheduling it for
        * immediate removal below. This achieves the same as the original code,


### PR DESCRIPTION
RPL RFC states that if the path lifetime in a DAO transit option is set to 0xFF, it means that the path lifetime is infinite. On the other hand, a lifetime unit of 0xFFFF has not peculiar meaning.

<pre>
   Path Lifetime: 8-bit unsigned integer.  The length of time in
         Lifetime Units (obtained from the Configuration option) that
         the prefix is valid for route determination.  The period starts
         when a new Path Sequence is seen.  A value of all one bits
         (0xFF) represents infinity.
</pre>

