### PR TITLE
Use RPL_DAG_LIFETIME when computing dag lifetime

### DIFF
--- a/core/net/rpl/rpl-dag.c
+++ b/core/net/rpl/rpl-dag.c
@@ -1542,7 +1542,7 @@ rpl_process_dio(uip_ipaddr_t *from, rpl_dio_t *dio)
   }
 
   /* The DIO comes from a valid DAG, we can refresh its lifetime */
-  dag->lifetime = (1UL << (instance->dio_intmin + instance->dio_intdoubl)) / 1000;
+  dag->lifetime = (1UL << (instance->dio_intmin + instance->dio_intdoubl)) * RPL_DAG_LIFETIME / 1000;
   PRINTF("Set dag ");
   PRINT6ADDR(&dag->dag_id);
   PRINTF(" lifetime to %ld\n", dag->lifetime);

--- a/regression-tests/12-rpl/10-rpl-multi-dodag.csc
+++ b/regression-tests/12-rpl/10-rpl-multi-dodag.csc
@@ -286,14 +286,14 @@
 GENERATE_MSG(0000000, "add-sink-2");&#xD;
 GENERATE_MSG(0000000, "remove-sink-3");&#xD;
 &#xD;
-GENERATE_MSG(2000000, "remove-sink-1");&#xD;
-GENERATE_MSG(4000000, "remove-sink-2");&#xD;
-GENERATE_MSG(4000000, "add-sink-3");&#xD;
+GENERATE_MSG(6000000, "remove-sink-1");&#xD;
+GENERATE_MSG(12000000, "remove-sink-2");&#xD;
+GENERATE_MSG(12000000, "add-sink-3");&#xD;
 &#xD;
 lostMsgs = 0;&#xD;
 newDagOk = 0;&#xD;
 &#xD;
-TIMEOUT(6000000, if(newDagOk == 2) { log.testOK(); } );&#xD;
+TIMEOUT(18000000, if(newDagOk == 2) { log.testOK(); } );&#xD;
 &#xD;
 lastMsg = -1;&#xD;
 newSink = 0;&#xD;

--- a/regression-tests/23-rpl-non-storing/10-rpl-multi-dodag.csc
+++ b/regression-tests/23-rpl-non-storing/10-rpl-multi-dodag.csc
@@ -286,14 +286,14 @@
 GENERATE_MSG(0000000, "add-sink-2");&#xD;
 GENERATE_MSG(0000000, "remove-sink-3");&#xD;
 &#xD;
-GENERATE_MSG(2000000, "remove-sink-1");&#xD;
-GENERATE_MSG(4000000, "remove-sink-2");&#xD;
-GENERATE_MSG(4000000, "add-sink-3");&#xD;
+GENERATE_MSG(6000000, "remove-sink-1");&#xD;
+GENERATE_MSG(12000000, "remove-sink-2");&#xD;
+GENERATE_MSG(12000000, "add-sink-3");&#xD;
 &#xD;
 lostMsgs = 0;&#xD;
 newDagOk = 0;&#xD;
 &#xD;
-TIMEOUT(6000000, if(newDagOk == 2) { log.testOK(); } );&#xD;
+TIMEOUT(18000000, if(newDagOk == 2) { log.testOK(); } );&#xD;
 &#xD;
 lastMsg = -1;&#xD;
 newSink = 0;&#xD;


### PR DESCRIPTION
When updating the dag lifetime, the multiplication constant RPL_DAG_LIFETIME must be used (or it has no use at all :) )