### PR TITLE
Don't autoconfigure address on RPL Root

### DIFF
--- a/core/net/rpl/rpl-dag.c
+++ b/core/net/rpl/rpl-dag.c
@@ -522,14 +522,16 @@ rpl_set_prefix(rpl_dag_t *dag, uip_ipaddr_t *prefix, unsigned len)
   dag->prefix_info.length = len;
   dag->prefix_info.flags = UIP_ND6_RA_FLAG_AUTONOMOUS;
   PRINTF("RPL: Prefix set - will announce this in DIOs\n");
-  /* Autoconfigure an address if this node does not already have an address
-     with this prefix. Otherwise, update the prefix */
-  if(last_len == 0) {
-    PRINTF("rpl_set_prefix - prefix NULL\n");
-    check_prefix(NULL, &dag->prefix_info);
-  } else {
-    PRINTF("rpl_set_prefix - prefix NON-NULL\n");
-    check_prefix(&last_prefix, &dag->prefix_info);
+  if(dag->rank != ROOT_RANK(dag->instance)) {
+    /* Autoconfigure an address if this node does not already have an address
+       with this prefix. Otherwise, update the prefix */
+    if(last_len == 0) {
+      PRINTF("rpl_set_prefix - prefix NULL\n");
+      check_prefix(NULL, &dag->prefix_info);
+    } else {
+      PRINTF("rpl_set_prefix - prefix NON-NULL\n");
+      check_prefix(&last_prefix, &dag->prefix_info);
+    }
   }
   return 1;
 }


### PR DESCRIPTION
Currently a DODAG Root with a manually configured address will lose this address when rpl_set_prefix() is called and/or will receive an auto configured address based on the IID and the prefix. 
A Root should always be administratively configured and not rely on self configuration (now I hope not too many examples rely on this behaviour...)