### PR TITLE
Always use uip_ds6_select_src when sending back an icmp error

### DIFF
--- a/core/net/ipv6/uip-icmp6.c
+++ b/core/net/ipv6/uip-icmp6.c
@@ -239,12 +239,8 @@ uip_icmp6_error_output(uint8_t type, uint8_t code, uint32_t param) {
       return;
     }
   } else {
-#if UIP_CONF_ROUTER
     /* need to pick a source that corresponds to this node */
     uip_ds6_select_src(&UIP_IP_BUF->srcipaddr, &tmp_ipaddr);
-#else
-    uip_ipaddr_copy(&UIP_IP_BUF->srcipaddr, &tmp_ipaddr);
-#endif
   }
 
   UIP_ICMP_BUF->type = type;


### PR DESCRIPTION
If the host is not a router, the source address of ICMP error messages is wrong, it is the address of the originating packet instead of the address of the host.