### PR TITLE
Various updates for NAT64

### DIFF
--- a/core/net/ip/ip64-addr.c
+++ b/core/net/ip/ip64-addr.c
@@ -35,6 +35,10 @@
 #include <string.h>
 
 #define printf(...)
+
+static uip_ip6addr_t ip64_prefix = {{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff, 0, 0, 0, 0}};
+static uint8_t ip64_prefix_len = 96;
+
 /*---------------------------------------------------------------------------*/
 void
 ip64_addr_copy4(uip_ip4addr_t *dest, const uip_ip4addr_t *src)
@@ -56,20 +60,7 @@ ip64_addr_4to6(const uip_ip4addr_t *ipv4addr,
      addresses. It returns 0 if it failed to convert the address and
      non-zero if it could successfully convert the address. */
 
-  /* The IPv4 address is encoded as an IPv6-encoded IPv4 address in
-     the ::ffff:0000/24 prefix.*/
-  ipv6addr->u8[0] = 0;
-  ipv6addr->u8[1] = 0;
-  ipv6addr->u8[2] = 0;
-  ipv6addr->u8[3] = 0;
-  ipv6addr->u8[4] = 0;
-  ipv6addr->u8[5] = 0;
-  ipv6addr->u8[6] = 0;
-  ipv6addr->u8[7] = 0;
-  ipv6addr->u8[8] = 0;
-  ipv6addr->u8[9] = 0;
-  ipv6addr->u8[10] = 0xff;
-  ipv6addr->u8[11] = 0xff;
+  uip_ipaddr_copy(ipv6addr, &ip64_prefix);
   ipv6addr->u8[12] = ipv4addr->u8[0];
   ipv6addr->u8[13] = ipv4addr->u8[1];
   ipv6addr->u8[14] = ipv4addr->u8[2];
@@ -90,21 +81,7 @@ ip64_addr_6to4(const uip_ip6addr_t *ipv6addr,
      returns 0 if it failed to convert the address and non-zero if it
      could successfully convert the address. */
 
-  /* If the IPv6 address is an IPv6-encoded
-     IPv4 address (i.e. in the ::ffff:0/8 prefix), we simply use the
-     IPv4 addresses directly. */
-  if(ipv6addr->u8[0] == 0 &&
-     ipv6addr->u8[1] == 0 &&
-     ipv6addr->u8[2] == 0 &&
-     ipv6addr->u8[3] == 0 &&
-     ipv6addr->u8[4] == 0 &&
-     ipv6addr->u8[5] == 0 &&
-     ipv6addr->u8[6] == 0 &&
-     ipv6addr->u8[7] == 0 &&
-     ipv6addr->u8[8] == 0 &&
-     ipv6addr->u8[9] == 0 &&
-     ipv6addr->u8[10] == 0xff &&
-     ipv6addr->u8[11] == 0xff) {
+  if(ip64_addr_is_ip64(ipv6addr)) {
     ipv4addr->u8[0] = ipv6addr->u8[12];
     ipv4addr->u8[1] = ipv6addr->u8[13];
     ipv4addr->u8[2] = ipv6addr->u8[14];
@@ -119,5 +96,18 @@ ip64_addr_6to4(const uip_ip6addr_t *ipv6addr,
   }
   /* We could not convert the IPv6 address, so we return 0. */
   return 0;
+}
+/*---------------------------------------------------------------------------*/
+int
+ip64_addr_is_ip64(const uip_ip6addr_t *ipv6addr)
+{
+  return uip_ipaddr_prefixcmp(ipv6addr, &ip64_prefix, ip64_prefix_len);
+}
+/*---------------------------------------------------------------------------*/
+void
+ip64_addr_set_prefix(const uip_ip6addr_t *prefix, uint8_t prefix_len)
+{
+  uip_ipaddr_copy(&ip64_prefix, prefix);
+  ip64_prefix_len = prefix_len;
 }
 /*---------------------------------------------------------------------------*/

--- a/core/net/ip/ip64-addr.h
+++ b/core/net/ip/ip64-addr.h
@@ -58,6 +58,9 @@ int ip64_addr_6to4(const uip_ip6addr_t *ipv6addr,
 int ip64_addr_4to6(const uip_ip4addr_t *ipv4addr,
 		   uip_ip6addr_t *ipv6addr);
 
+int ip64_addr_is_ip64(const uip_ip6addr_t *ipv6addr);
+
+void ip64_addr_set_prefix(const uip_ip6addr_t *prefix, uint8_t prefix_len);
 
 #endif /* IP64_ADDR_H */
 

--- a/core/net/ip64/ip64-dhcpc.c
+++ b/core/net/ip64/ip64-dhcpc.c
@@ -163,7 +163,6 @@ create_msg(CC_REGISTER_ARG struct dhcp_msg *m)
   memset(&m->chaddr[s.mac_len], 0, sizeof(m->chaddr) - s.mac_len);
 
   memset(m->sname, 0, sizeof(m->sname));
-  strcpy((char *)m->sname, "Thingsquare");
   memset(m->file, 0, sizeof(m->file));
 
 

--- a/core/net/ip64/ip64-ipv4-dhcp.c
+++ b/core/net/ip64/ip64-ipv4-dhcp.c
@@ -39,6 +39,9 @@
 
 #include <stdio.h>
 
+#define DEBUG DEBUG_NONE
+#include "net/ip/uip-debug.h"
+
 PROCESS(ip64_ipv4_dhcp_process, "IPv4 DHCP");
 
 uip_ipaddr_t uip_hostaddr; /* Needed because it is referenced by dhcpc.c */
@@ -48,7 +51,7 @@ uip_ipaddr_t uip_hostaddr; /* Needed because it is referenced by dhcpc.c */
 void
 ip64_ipv4_dhcp_init(void)
 {
-  printf("Starting DHCPv4\n");
+  printf("IP64: Starting DHCPv4\n");
   process_start(&ip64_ipv4_dhcp_process, NULL);
 }
 /*---------------------------------------------------------------------------*/
@@ -58,10 +61,10 @@ PROCESS_THREAD(ip64_ipv4_dhcp_process, ev, data)
 
   ip64_dhcpc_init(&ip64_eth_addr, sizeof(ip64_eth_addr));
 
-  printf("Inited\n");
+  PRINTF("IP64: Inited\n");
 
   ip64_dhcpc_request();
-  printf("Requested\n");
+  PRINTF("IP64: Requested\n");
   while(1) {
     PROCESS_WAIT_EVENT();
 
@@ -78,7 +81,7 @@ void
 ip64_dhcpc_configured(const struct ip64_dhcpc_state *s)
 {
   uip_ip6addr_t ip6dnsaddr;
-  printf("DHCP Configured with %d.%d.%d.%d\n",
+  PRINTF("IP64: DHCP Configured with %d.%d.%d.%d\n",
 	 s->ipaddr.u8[0], s->ipaddr.u8[1],
 	 s->ipaddr.u8[2], s->ipaddr.u8[3]);
 

--- a/core/net/ip64/ip64-ipv4-dhcp.c
+++ b/core/net/ip64/ip64-ipv4-dhcp.c
@@ -88,8 +88,15 @@ ip64_dhcpc_configured(const struct ip64_dhcpc_state *s)
   ip64_set_hostaddr((uip_ip4addr_t *)&s->ipaddr);
   ip64_set_netmask((uip_ip4addr_t *)&s->netmask);
   ip64_set_draddr((uip_ip4addr_t *)&s->default_router);
-  ip64_addr_4to6((uip_ip4addr_t *)&s->dnsaddr, &ip6dnsaddr);
-  //  mdns_conf(&ip6dnsaddr);
+  if(!uip_ip4addr_cmp((uip_ip4addr_t *)&s->dnsaddr, &uip_all_zeroes_addr)) {
+    /* Note: Currently we assume only one DNS server */
+    uip_ipaddr_t * dns = uip_nameserver_get(0);
+    /* Only update DNS entry if it is empty or already IPv4 */
+    if(uip_is_addr_unspecified(dns) || ip64_addr_is_ip64(dns)) {
+      ip64_addr_4to6((uip_ip4addr_t *)&s->dnsaddr, &ip6dnsaddr);
+      uip_nameserver_update(&ip6dnsaddr, uip_ntohs(s->lease_time[0])*65536ul + uip_ntohs(s->lease_time[1]));
+    }
+  }
 }
 /*---------------------------------------------------------------------------*/
 void


### PR DESCRIPTION
This PR contains various small updated for the NAT64 modules :

* Support for runtime configuration of the NAT64 prefix used, but default it's still the ::FFFF:/96 prefix
* Removal of the servername in the outgoing DHCP request
* Replace printf() with PRINTF() macros
* Update of the nameserver using the information received in the DHCP reply (Note that the update is only done if no server is already configured or if it was already configured by NAT64) 