### PR TITLE
Adding uip_ds6_defrt_list_head()

### DIFF
--- a/core/net/ipv6/uip-ds6-route.c
+++ b/core/net/ipv6/uip-ds6-route.c
@@ -573,6 +573,12 @@ uip_ds6_route_rm_by_nexthop(uip_ipaddr_t *nexthop)
 }
 /*---------------------------------------------------------------------------*/
 uip_ds6_defrt_t *
+uip_ds6_defrt_head(void)
+{
+  return list_head(defaultrouterlist);
+}
+/*---------------------------------------------------------------------------*/
+uip_ds6_defrt_t *
 uip_ds6_defrt_add(uip_ipaddr_t *ipaddr, unsigned long interval)
 {
   uip_ds6_defrt_t *d;

--- a/core/net/ipv6/uip-ds6-route.h
+++ b/core/net/ipv6/uip-ds6-route.h
@@ -177,6 +177,7 @@ typedef struct uip_ds6_defrt {
 
 /** \name Default router list basic routines */
 /** @{ */
+uip_ds6_defrt_t *uip_ds6_defrt_head(void);
 uip_ds6_defrt_t *uip_ds6_defrt_add(uip_ipaddr_t *ipaddr,
                                    unsigned long interval);
 void uip_ds6_defrt_rm(uip_ds6_defrt_t *defrt);


### PR DESCRIPTION
Trivial PR adding the missing uip_ds6_defrt_list_head() function to retrieve the first element of the default router list.