### PR TITLE
Add basic support for static routes

### DIFF
--- a/core/net/ipv6/uip-ds6-route.h
+++ b/core/net/ipv6/uip-ds6-route.h
@@ -88,6 +88,12 @@ void uip_ds6_notification_rm(struct uip_ds6_notification *n);
 #define UIP_DS6_ROUTE_NB 4
 #endif /* UIP_CONF_MAX_ROUTES */
 
+#ifndef UIP_CONF_DS6_STATIC_ROUTES
+#define UIP_DS6_STATIC_ROUTES 0
+#else
+#define UIP_DS6_STATIC_ROUTES UIP_CONF_DS6_STATIC_ROUTES
+#endif
+
 /** \brief define some additional RPL related route state and
  *  neighbor callback for RPL - if not a DS6_ROUTE_STATE is already set */
 #ifndef UIP_DS6_ROUTE_STATE_TYPE
@@ -154,6 +160,9 @@ typedef struct uip_ds6_route {
      uses. */
   struct uip_ds6_route_neighbor_routes *neighbor_routes;
   uip_ipaddr_t ipaddr;
+#if UIP_DS6_STATIC_ROUTES
+  uip_ipaddr_t nexthop;
+#endif
 #ifdef UIP_DS6_ROUTE_STATE_TYPE
   UIP_DS6_ROUTE_STATE_TYPE state;
 #endif
@@ -191,6 +200,8 @@ void uip_ds6_defrt_periodic(void);
 /** @{ */
 uip_ds6_route_t *uip_ds6_route_lookup(uip_ipaddr_t *destipaddr);
 uip_ds6_route_t *uip_ds6_route_add(uip_ipaddr_t *ipaddr, uint8_t length,
+                                   uip_ipaddr_t *next_hop);
+uip_ds6_route_t *uip_ds6_route_add_static(uip_ipaddr_t *ipaddr, uint8_t length,
                                    uip_ipaddr_t *next_hop);
 void uip_ds6_route_rm(uip_ds6_route_t *route);
 void uip_ds6_route_rm_by_nexthop(uip_ipaddr_t *nexthop);


### PR DESCRIPTION
This PR add support for static routes. The difference between static routes and current routes in Contiki is that the static routes do not depend on an entry in the neighbor table or their link layer address resolution.
Static routes can therefore be created at any time, even if the configured next hop is not reachable yet, and will not be deleted if the neighbor table is full or if the next hop is temporarily unreachable.
Static routes will be needed to support Route Information Option (RIO) in Router Advertisement messages (which is part of an upcoming PR).

For this implementation, instead of creating a complete new set of configuration data, I kept the route object and used the content of the neighborroutes field to distinguish between static routes and dynamic routes. If the field is set to NULL, it means that the route entry is a static one.