### PR TITLE
RDNSS and DNSSL do not rely on O Flag

### DIFF
--- a/core/net/ipv6/uip-nd6.c
+++ b/core/net/ipv6/uip-nd6.c
@@ -1028,18 +1028,16 @@ ra_input(void)
       break;
 #if UIP_ND6_RA_RDNSS
     case UIP_ND6_OPT_RDNSS:
-      if(UIP_ND6_RA_BUF->flags_reserved & (UIP_ND6_O_FLAG << 6)) {
-        PRINTF("Processing RDNSS option\n");
-        uint8_t naddr = (UIP_ND6_OPT_RDNSS_BUF->len - 1) / 2;
-        uip_ipaddr_t *ip = (uip_ipaddr_t *)(&UIP_ND6_OPT_RDNSS_BUF->ip);
-        PRINTF("got %d nameservers\n", naddr);
-        while(naddr-- > 0) {
-          PRINTF(" nameserver: ");
-          PRINT6ADDR(ip);
-          PRINTF(" lifetime: %lx\n", uip_ntohl(UIP_ND6_OPT_RDNSS_BUF->lifetime));
-          uip_nameserver_update(ip, uip_ntohl(UIP_ND6_OPT_RDNSS_BUF->lifetime));
-          ip++;
-        }
+      PRINTF("Processing RDNSS option\n");
+      uint8_t naddr = (UIP_ND6_OPT_RDNSS_BUF->len - 1) / 2;
+      uip_ipaddr_t *ip = (uip_ipaddr_t *)(&UIP_ND6_OPT_RDNSS_BUF->ip);
+      PRINTF("got %d nameservers\n", naddr);
+      while(naddr-- > 0) {
+        PRINTF(" nameserver: ");
+        PRINT6ADDR(ip);
+        PRINTF(" lifetime: %lx\n", uip_ntohl(UIP_ND6_OPT_RDNSS_BUF->lifetime));
+        uip_nameserver_update(ip, uip_ntohl(UIP_ND6_OPT_RDNSS_BUF->lifetime));
+        ip++;
       }
       break;
 #endif /* UIP_ND6_RA_RDNSS */

--- a/core/net/ipv6/uip-nd6.h
+++ b/core/net/ipv6/uip-nd6.h
@@ -90,7 +90,7 @@
 #define UIP_ND6_MIN_RA_INTERVAL             UIP_CONF_ND6_MIN_RA_INTERVAL
 #endif
 #define UIP_ND6_M_FLAG                      0
-#define UIP_ND6_O_FLAG                      (UIP_ND6_RA_RDNSS || UIP_ND6_RA_DNSSL)
+#define UIP_ND6_O_FLAG                      0
 #define UIP_ND6_ROUTER_LIFETIME             3 * UIP_ND6_MAX_RA_INTERVAL
 
 #define UIP_ND6_MAX_INITIAL_RA_INTERVAL     16  /*seconds*/


### PR DESCRIPTION
According to NDP RFC, the 'O' flag in Router Advertisement messages indicates that some or all the network configuration is provided by another configuration protocol (usually DHCP). However, in Contiki the meaning of the flag has been inverted for RDNSS and DNSSL options.

This PR fixes this by always setting the 'O' flag to 0, and always processing the incoming RDNSS option.