### PR TITLE
Explicitly specify light sensor model in example

### DIFF
--- a/examples/zolertia/zoul/project-conf.h
+++ b/examples/zolertia/zoul/project-conf.h
@@ -50,6 +50,9 @@
 #define MOTION_SENSOR_PIN        5
 #define MOTION_SENSOR_VECTOR     GPIO_A_IRQn
 
+/* Specify the digital light sensor model to use: TSL2561 (default) or TSL2563 */
+#define TSL256X_CONF_REF         TSL2561_SENSOR_REF
+
 /* Use the following I2C address for the BME280 sensor (from MikroElektronika) */
 #define BME280_CONF_ADDR         0x76
 


### PR DESCRIPTION
Minor documentation: explicitly specify the light sensor model in the example, so users know how to switch between the TSL2536 and TSL2561