### PR TITLE
Make the number of Prop Mode RX Buffers easy to configure

### DIFF
--- a/cpu/cc26xx-cc13xx/rf-core/prop-mode.c
+++ b/cpu/cc26xx-cc13xx/rf-core/prop-mode.c
@@ -219,14 +219,23 @@ const output_config_t *tx_power_current = &output_power[1];
 #define PROP_MODE_LO_DIVIDER   0x05
 #endif
 /*---------------------------------------------------------------------------*/
+#ifdef PROP_MODE_CONF_RX_BUF_CNT
+#define PROP_MODE_RX_BUF_CNT PROP_MODE_CONF_RX_BUF_CNT
+#else
+#define PROP_MODE_RX_BUF_CNT 4
+#endif
+/*---------------------------------------------------------------------------*/
 #define DATA_ENTRY_LENSZ_NONE 0
 #define DATA_ENTRY_LENSZ_BYTE 1
 #define DATA_ENTRY_LENSZ_WORD 2 /* 2 bytes */
 
+/*
+ * RX buffers.
+ * PROP_MODE_RX_BUF_CNT buffers of RX_BUF_SIZE bytes each. The start of each
+ * buffer must be 4-byte aligned, therefore RX_BUF_SIZE must divide by 4
+ */
 #define RX_BUF_SIZE 140
-/* Receive buffers: 1 frame in each */
-static uint8_t rx_buf_0[RX_BUF_SIZE] CC_ALIGN(4);
-static uint8_t rx_buf_1[RX_BUF_SIZE] CC_ALIGN(4);
+static uint8_t rx_buf[PROP_MODE_RX_BUF_CNT][RX_BUF_SIZE] CC_ALIGN(4);
 
 /* The RX Data Queue */
 static dataQueue_t rx_data_queue = { 0 };
@@ -431,20 +440,18 @@ static void
 init_rx_buffers(void)
 {
   rfc_dataEntry_t *entry;
+  int i;
 
-  entry = (rfc_dataEntry_t *)rx_buf_0;
-  entry->status = DATA_ENTRY_STATUS_PENDING;
-  entry->config.type = DATA_ENTRY_TYPE_GEN;
-  entry->config.lenSz = DATA_ENTRY_LENSZ_WORD;
-  entry->length = RX_BUF_SIZE - 8;
-  entry->pNextEntry = rx_buf_1;
+  for(i = 0; i < PROP_MODE_RX_BUF_CNT; i++) {
+    entry = (rfc_dataEntry_t *)rx_buf[i];
+    entry->status = DATA_ENTRY_STATUS_PENDING;
+    entry->config.type = DATA_ENTRY_TYPE_GEN;
+    entry->config.lenSz = DATA_ENTRY_LENSZ_WORD;
+    entry->length = RX_BUF_SIZE - 8;
+    entry->pNextEntry = rx_buf[i + 1];
+  }
 
-  entry = (rfc_dataEntry_t *)rx_buf_1;
-  entry->status = DATA_ENTRY_STATUS_PENDING;
-  entry->config.type = DATA_ENTRY_TYPE_GEN;
-  entry->config.lenSz = DATA_ENTRY_LENSZ_WORD;
-  entry->length = RX_BUF_SIZE - 8;
-  entry->pNextEntry = rx_buf_0;
+  ((rfc_dataEntry_t *)rx_buf[PROP_MODE_RX_BUF_CNT - 1])->pNextEntry = rx_buf[0];
 }
 /*---------------------------------------------------------------------------*/
 static int
@@ -593,15 +600,14 @@ init(void)
   rf_core_set_modesel();
 
   /* Initialise RX buffers */
-  memset(rx_buf_0, 0, RX_BUF_SIZE);
-  memset(rx_buf_1, 0, RX_BUF_SIZE);
+  memset(rx_buf, 0, sizeof(rx_buf));
 
   /* Set of RF Core data queue. Circular buffer, no last entry */
-  rx_data_queue.pCurrEntry = rx_buf_0;
+  rx_data_queue.pCurrEntry = rx_buf[0];
   rx_data_queue.pLastEntry = NULL;
 
   /* Initialize current read pointer to first element (used in ISR) */
-  rx_read_entry = rx_buf_0;
+  rx_read_entry = rx_buf[0];
 
   smartrf_settings_cmd_prop_rx_adv.pQueue = &rx_data_queue;
   smartrf_settings_cmd_prop_rx_adv.pOutput = (uint8_t *)&rx_stats;

--- a/platform/srf06-cc26xx/contiki-conf.h
+++ b/platform/srf06-cc26xx/contiki-conf.h
@@ -93,6 +93,11 @@
 #define RF_CORE_CONF_CHANNEL             RF_CHANNEL
 #endif
 
+/* Number of Prop Mode RX buffers */
+#ifndef PROP_MODE_CONF_RX_BUF_CNT
+#define PROP_MODE_CONF_RX_BUF_CNT        4
+#endif
+
 /*
  * Auto-configure Prop-mode radio if we are running on CC13xx, unless the
  * project has specified otherwise. Depending on the final mode, determine a


### PR DESCRIPTION
This pull makes the number of RX buffers for CC13xx prop mode easily configurable via a simple define.

Can be used to fix #1878, possibly also #1933 and #1999.