### PR TITLE
Native monotonic timer

### DIFF
--- a/platform/native/Makefile.native
+++ b/platform/native/Makefile.native
@@ -42,4 +42,8 @@ CURSES_LIBS ?= -lncurses
 
 TARGET_LIBFILES += $(CURSES_LIBS)
 
+ifeq ($(HOST_OS),Linux)
+TARGET_LIBFILES += -lrt
+endif
+
 MODULES+=core/net core/net/mac core/ctk core/net/llsec core/net/ip64-addr/

--- a/platform/native/clock.c
+++ b/platform/native/clock.c
@@ -40,6 +40,9 @@
 #include "sys/clock.h"
 #include <time.h>
 #include <sys/time.h>
+#if defined(__MACH__)
+#include <mach/mach_time.h>
+#endif
 
 /*---------------------------------------------------------------------------*/
 clock_time_t
@@ -50,6 +53,13 @@ clock_time(void)
 
   clock_gettime(CLOCK_MONOTONIC, &ts);
   return ts.tv_sec * 1000 + ts.tv_nsec / 1000000;
+#elif defined(__MACH__)
+  static mach_timebase_info_data_t info = {0,0};
+  if(info.denom == 0) {
+    mach_timebase_info(&info);
+  }
+  uint64_t elapsednano = mach_absolute_time() * (info.numer / info.denom);
+  return elapsednano / 1000000;
 #else
   struct timeval tv;
 
@@ -68,6 +78,13 @@ clock_seconds(void)
   clock_gettime(CLOCK_MONOTONIC, &ts);
 
   return ts.tv_sec;
+#elif defined(__MACH__)
+  static mach_timebase_info_data_t info = {0,0};
+  if(info.denom == 0) {
+    mach_timebase_info(&info);
+  }
+  uint64_t elapsednano = mach_absolute_time() * (info.numer / info.denom);
+  return elapsednano / 1000000000;
 #else
   struct timeval tv;
 

--- a/platform/native/clock.c
+++ b/platform/native/clock.c
@@ -45,21 +45,36 @@
 clock_time_t
 clock_time(void)
 {
+#ifdef __linux
+  struct timespec ts;
+
+  clock_gettime(CLOCK_MONOTONIC, &ts);
+  return ts.tv_sec * 1000 + ts.tv_nsec / 1000000;
+#else
   struct timeval tv;
 
   gettimeofday(&tv, NULL);
 
   return tv.tv_sec * 1000 + tv.tv_usec / 1000;
+#endif
 }
 /*---------------------------------------------------------------------------*/
 unsigned long
 clock_seconds(void)
 {
+#ifdef __linux
+  struct timespec ts;
+
+  clock_gettime(CLOCK_MONOTONIC, &ts);
+
+  return ts.tv_sec;
+#else
   struct timeval tv;
 
   gettimeofday(&tv, NULL);
 
   return tv.tv_sec;
+#endif
 }
 /*---------------------------------------------------------------------------*/
 void


### PR DESCRIPTION
Currently on native platform we use gettimeofday() to create the time of all the timers, however gettimeofday() is not an absolute monotonic time source. When the system clock is updated (either because of drift, DST or user configuration) the time returned is shifted. This breaks completely the Contiki timer, resulting in timers already expired before even starting or times scheduled billions of seconds later in time...

With this PR, I switched to clock_gettime(CLOCK_MONOTONIC) on linux and mach_absolute_time() on MacOS-X. These two functions are guaranteed to always return a monotonic time, independent of any clock change on the platform.