### PR TITLE
TSCH: re-enable TSCH regression tests

### DIFF
--- a/apps/orchestra/orchestra-rule-unicast-per-neighbor-rpl-storing.c
+++ b/apps/orchestra/orchestra-rule-unicast-per-neighbor-rpl-storing.c
@@ -45,6 +45,14 @@
 #include "net/ipv6/uip-ds6-route.h"
 #include "net/packetbuf.h"
 #include "net/rpl/rpl-conf.h"
+#include "net/rpl/rpl-private.h"
+
+/*
+ * The body of this rule should be compiled only when "nbr_routes" is available,
+ * otherwise a link error causes build failure. "nbr_routes" is compiled if
+ * UIP_CONF_MAX_ROUTES != 0. See uip-ds6-route.c.
+ */
+#if UIP_CONF_MAX_ROUTES != 0
 
 #if ORCHESTRA_UNICAST_SENDER_BASED && ORCHESTRA_COLLISION_FREE_HASH
 #define UNICAST_SLOT_SHARED_FLAG    ((ORCHESTRA_UNICAST_PERIOD < (ORCHESTRA_MAX_HASH + 1)) ? LINK_OPTION_SHARED : 0)
@@ -211,3 +219,5 @@ struct orchestra_rule unicast_per_neighbor_rpl_storing = {
   child_added,
   child_removed,
 };
+
+#endif /* UIP_MAX_ROUTES */

--- a/examples/ipv6/rpl-tsch/node.c
+++ b/examples/ipv6/rpl-tsch/node.c
@@ -120,17 +120,20 @@ print_network_status(void)
   PRINTF("- Routing links (%u in total):\n", rpl_ns_num_nodes());
   link = rpl_ns_node_head();
   while(link != NULL) {
-    if(link->parent != NULL) {
-      uip_ipaddr_t child_ipaddr;
-      uip_ipaddr_t parent_ipaddr;
-      rpl_ns_get_node_global_addr(&child_ipaddr, link);
-      rpl_ns_get_node_global_addr(&parent_ipaddr, link->parent);
-      PRINTF("-- ");
-      PRINT6ADDR(&child_ipaddr);
+    uip_ipaddr_t child_ipaddr;
+    uip_ipaddr_t parent_ipaddr;
+    rpl_ns_get_node_global_addr(&child_ipaddr, link);
+    rpl_ns_get_node_global_addr(&parent_ipaddr, link->parent);
+    PRINTF("-- ");
+    PRINT6ADDR(&child_ipaddr);
+    if(link->parent == NULL) {
+      memset(&parent_ipaddr, 0, sizeof(parent_ipaddr));
+      PRINTF(" --- DODAG root ");
+    } else {
       PRINTF(" to ");
       PRINT6ADDR(&parent_ipaddr);
-      PRINTF(" (lifetime: %lu seconds)\n", (unsigned long)link->lifetime);
     }
+    PRINTF(" (lifetime: %lu seconds)\n", (unsigned long)link->lifetime);
     link = rpl_ns_node_next(link);
   }
 #endif

--- a/regression-tests/11-ipv6/19-cooja-rpl-tsch.csc
+++ b/regression-tests/11-ipv6/19-cooja-rpl-tsch.csc
@@ -274,9 +274,9 @@ make node.cooja TARGET=cooja MAKE_WITH_ORCHESTRA=0 MAKE_WITH_SECURITY=0</command
       <script>TIMEOUT(300000); /* Time out after 5 minutes */&#xD;
 &#xD;
 /* Wait until a node (can only be the DAGRoot) has&#xD;
- * 8 routing entries (i.e. can reach every node) */&#xD;
+ * 9 routing entries including one for the root (i.e. can reach every node) */&#xD;
 log.log("Waiting for routing tables to fill\n");&#xD;
-WAIT_UNTIL(msg.endsWith("Routing links (8 in total):"));&#xD;
+WAIT_UNTIL(msg.endsWith("Routing links (9 in total):"));&#xD;
 log.log("Root routing table ready\n");&#xD;
 &#xD;
 log.testOK(); /* Report test success and quit */</script>

--- a/regression-tests/11-ipv6/19-cooja-rpl-tsch.csc
+++ b/regression-tests/11-ipv6/19-cooja-rpl-tsch.csc
@@ -7,7 +7,7 @@
   <project EXPORT="discard">[APPS_DIR]/collect-view</project>
   <project EXPORT="discard">[APPS_DIR]/powertracker</project>
   <simulation>
-    <title>RPL+TSCH+Security</title>
+    <title>RPL+TSCH</title>
     <randomseed>123456</randomseed>
     <motedelay_us>1000000</motedelay_us>
     <radiomedium>
@@ -21,25 +21,29 @@
       <logoutput>40000</logoutput>
     </events>
     <motetype>
-      org.contikios.cooja.mspmote.Z1MoteType
+      org.contikios.cooja.contikimote.ContikiMoteType
       <identifier>z11</identifier>
-      <description>Z1 Mote Type #z11</description>
+      <description>Cooja Mote Type #z11</description>
       <source EXPORT="discard">[CONTIKI_DIR]/examples/ipv6/rpl-tsch/node.c</source>
-      <commands EXPORT="discard">make TARGET=z1 clean
-make node.z1 TARGET=z1 MAKE_WITH_ORCHESTRA=0 MAKE_WITH_SECURITY=1</commands>
-      <firmware EXPORT="copy">[CONTIKI_DIR]/examples/ipv6/rpl-tsch/node.z1</firmware>
+      <commands EXPORT="discard">make TARGET=cooja clean
+make node.cooja TARGET=cooja MAKE_WITH_ORCHESTRA=0 MAKE_WITH_SECURITY=0</commands>
       <moteinterface>org.contikios.cooja.interfaces.Position</moteinterface>
+      <moteinterface>org.contikios.cooja.interfaces.Battery</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiVib</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiMoteID</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiRS232</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiBeeper</moteinterface>
       <moteinterface>org.contikios.cooja.interfaces.RimeAddress</moteinterface>
-      <moteinterface>org.contikios.cooja.interfaces.IPAddress</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiIPAddress</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiRadio</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiButton</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiPIR</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiClock</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiLED</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiCFS</moteinterface>
       <moteinterface>org.contikios.cooja.interfaces.Mote2MoteRelations</moteinterface>
       <moteinterface>org.contikios.cooja.interfaces.MoteAttributes</moteinterface>
-      <moteinterface>org.contikios.cooja.mspmote.interfaces.MspClock</moteinterface>
-      <moteinterface>org.contikios.cooja.mspmote.interfaces.MspMoteID</moteinterface>
-      <moteinterface>org.contikios.cooja.mspmote.interfaces.MspButton</moteinterface>
-      <moteinterface>org.contikios.cooja.mspmote.interfaces.Msp802154Radio</moteinterface>
-      <moteinterface>org.contikios.cooja.mspmote.interfaces.MspDefaultSerial</moteinterface>
-      <moteinterface>org.contikios.cooja.mspmote.interfaces.MspLED</moteinterface>
-      <moteinterface>org.contikios.cooja.mspmote.interfaces.MspDebugOutput</moteinterface>
+      <symbols>false</symbols>
     </motetype>
     <mote>
       <breakpoints />
@@ -50,12 +54,12 @@ make node.z1 TARGET=z1 MAKE_WITH_ORCHESTRA=0 MAKE_WITH_SECURITY=1</commands>
         <z>0.0</z>
       </interface_config>
       <interface_config>
-        org.contikios.cooja.mspmote.interfaces.MspClock
-        <deviation>1.0</deviation>
+        org.contikios.cooja.contikimote.interfaces.ContikiMoteID
+        <id>1</id>
       </interface_config>
       <interface_config>
-        org.contikios.cooja.mspmote.interfaces.MspMoteID
-        <id>1</id>
+        org.contikios.cooja.contikimote.interfaces.ContikiRadio
+        <bitrate>250.0</bitrate>
       </interface_config>
       <motetype_identifier>z11</motetype_identifier>
     </mote>
@@ -68,12 +72,12 @@ make node.z1 TARGET=z1 MAKE_WITH_ORCHESTRA=0 MAKE_WITH_SECURITY=1</commands>
         <z>0.0</z>
       </interface_config>
       <interface_config>
-        org.contikios.cooja.mspmote.interfaces.MspClock
-        <deviation>1.0</deviation>
+        org.contikios.cooja.contikimote.interfaces.ContikiMoteID
+        <id>2</id>
       </interface_config>
       <interface_config>
-        org.contikios.cooja.mspmote.interfaces.MspMoteID
-        <id>2</id>
+        org.contikios.cooja.contikimote.interfaces.ContikiRadio
+        <bitrate>250.0</bitrate>
       </interface_config>
       <motetype_identifier>z11</motetype_identifier>
     </mote>
@@ -86,12 +90,12 @@ make node.z1 TARGET=z1 MAKE_WITH_ORCHESTRA=0 MAKE_WITH_SECURITY=1</commands>
         <z>0.0</z>
       </interface_config>
       <interface_config>
-        org.contikios.cooja.mspmote.interfaces.MspClock
-        <deviation>1.0</deviation>
+        org.contikios.cooja.contikimote.interfaces.ContikiMoteID
+        <id>3</id>
       </interface_config>
       <interface_config>
-        org.contikios.cooja.mspmote.interfaces.MspMoteID
-        <id>3</id>
+        org.contikios.cooja.contikimote.interfaces.ContikiRadio
+        <bitrate>250.0</bitrate>
       </interface_config>
       <motetype_identifier>z11</motetype_identifier>
     </mote>
@@ -104,12 +108,12 @@ make node.z1 TARGET=z1 MAKE_WITH_ORCHESTRA=0 MAKE_WITH_SECURITY=1</commands>
         <z>0.0</z>
       </interface_config>
       <interface_config>
-        org.contikios.cooja.mspmote.interfaces.MspClock
-        <deviation>1.0</deviation>
+        org.contikios.cooja.contikimote.interfaces.ContikiMoteID
+        <id>4</id>
       </interface_config>
       <interface_config>
-        org.contikios.cooja.mspmote.interfaces.MspMoteID
-        <id>4</id>
+        org.contikios.cooja.contikimote.interfaces.ContikiRadio
+        <bitrate>250.0</bitrate>
       </interface_config>
       <motetype_identifier>z11</motetype_identifier>
     </mote>
@@ -122,12 +126,12 @@ make node.z1 TARGET=z1 MAKE_WITH_ORCHESTRA=0 MAKE_WITH_SECURITY=1</commands>
         <z>0.0</z>
       </interface_config>
       <interface_config>
-        org.contikios.cooja.mspmote.interfaces.MspClock
-        <deviation>1.0</deviation>
+        org.contikios.cooja.contikimote.interfaces.ContikiMoteID
+        <id>5</id>
       </interface_config>
       <interface_config>
-        org.contikios.cooja.mspmote.interfaces.MspMoteID
-        <id>5</id>
+        org.contikios.cooja.contikimote.interfaces.ContikiRadio
+        <bitrate>250.0</bitrate>
       </interface_config>
       <motetype_identifier>z11</motetype_identifier>
     </mote>
@@ -140,12 +144,12 @@ make node.z1 TARGET=z1 MAKE_WITH_ORCHESTRA=0 MAKE_WITH_SECURITY=1</commands>
         <z>0.0</z>
       </interface_config>
       <interface_config>
-        org.contikios.cooja.mspmote.interfaces.MspClock
-        <deviation>1.0</deviation>
+        org.contikios.cooja.contikimote.interfaces.ContikiMoteID
+        <id>6</id>
       </interface_config>
       <interface_config>
-        org.contikios.cooja.mspmote.interfaces.MspMoteID
-        <id>6</id>
+        org.contikios.cooja.contikimote.interfaces.ContikiRadio
+        <bitrate>250.0</bitrate>
       </interface_config>
       <motetype_identifier>z11</motetype_identifier>
     </mote>
@@ -158,12 +162,12 @@ make node.z1 TARGET=z1 MAKE_WITH_ORCHESTRA=0 MAKE_WITH_SECURITY=1</commands>
         <z>0.0</z>
       </interface_config>
       <interface_config>
-        org.contikios.cooja.mspmote.interfaces.MspClock
-        <deviation>1.0</deviation>
+        org.contikios.cooja.contikimote.interfaces.ContikiMoteID
+        <id>7</id>
       </interface_config>
       <interface_config>
-        org.contikios.cooja.mspmote.interfaces.MspMoteID
-        <id>7</id>
+        org.contikios.cooja.contikimote.interfaces.ContikiRadio
+        <bitrate>250.0</bitrate>
       </interface_config>
       <motetype_identifier>z11</motetype_identifier>
     </mote>
@@ -176,12 +180,12 @@ make node.z1 TARGET=z1 MAKE_WITH_ORCHESTRA=0 MAKE_WITH_SECURITY=1</commands>
         <z>0.0</z>
       </interface_config>
       <interface_config>
-        org.contikios.cooja.mspmote.interfaces.MspClock
-        <deviation>1.0</deviation>
+        org.contikios.cooja.contikimote.interfaces.ContikiMoteID
+        <id>8</id>
       </interface_config>
       <interface_config>
-        org.contikios.cooja.mspmote.interfaces.MspMoteID
-        <id>8</id>
+        org.contikios.cooja.contikimote.interfaces.ContikiRadio
+        <bitrate>250.0</bitrate>
       </interface_config>
       <motetype_identifier>z11</motetype_identifier>
     </mote>
@@ -194,12 +198,12 @@ make node.z1 TARGET=z1 MAKE_WITH_ORCHESTRA=0 MAKE_WITH_SECURITY=1</commands>
         <z>0.0</z>
       </interface_config>
       <interface_config>
-        org.contikios.cooja.mspmote.interfaces.MspClock
-        <deviation>1.0</deviation>
+        org.contikios.cooja.contikimote.interfaces.ContikiMoteID
+        <id>9</id>
       </interface_config>
       <interface_config>
-        org.contikios.cooja.mspmote.interfaces.MspMoteID
-        <id>9</id>
+        org.contikios.cooja.contikimote.interfaces.ContikiRadio
+        <bitrate>250.0</bitrate>
       </interface_config>
       <motetype_identifier>z11</motetype_identifier>
     </mote>
@@ -268,8 +272,6 @@ make node.z1 TARGET=z1 MAKE_WITH_ORCHESTRA=0 MAKE_WITH_SECURITY=1</commands>
     org.contikios.cooja.plugins.ScriptRunner
     <plugin_config>
       <script>TIMEOUT(300000); /* Time out after 5 minutes */&#xD;
-&#xD;
-log.log("Waiting for association with security\n");&#xD;
 &#xD;
 /* Wait until a node (can only be the DAGRoot) has&#xD;
  * 8 routing entries (i.e. can reach every node) */&#xD;

--- a/regression-tests/11-ipv6/20-cooja-rpl-tsch-orchestra.csc
+++ b/regression-tests/11-ipv6/20-cooja-rpl-tsch-orchestra.csc
@@ -281,9 +281,9 @@ WAIT_UNTIL(msg.startsWith("Orchestra:"));&#xD;
 log.log("Orchestra started\n");&#xD;
 &#xD;
 /* Wait until a node (can only be the DAGRoot) has&#xD;
- * 8 routing entries (i.e. can reach every node) */&#xD;
+ * 9 routing entries including one for the root (i.e. can reach every node) */&#xD;
 log.log("Waiting for routing tables to fill\n");&#xD;
-WAIT_UNTIL(msg.endsWith("Routing links (8 in total):"));&#xD;
+WAIT_UNTIL(msg.endsWith("Routing links (9 in total):"));&#xD;
 log.log("Root routing table ready\n");&#xD;
 &#xD;
 log.testOK(); /* Report test success and quit */</script>

--- a/regression-tests/11-ipv6/20-cooja-rpl-tsch-orchestra.csc
+++ b/regression-tests/11-ipv6/20-cooja-rpl-tsch-orchestra.csc
@@ -7,7 +7,7 @@
   <project EXPORT="discard">[APPS_DIR]/collect-view</project>
   <project EXPORT="discard">[APPS_DIR]/powertracker</project>
   <simulation>
-    <title>RPL+TSCH</title>
+    <title>RPL+TSCH+Orchestrsa</title>
     <randomseed>123456</randomseed>
     <motedelay_us>1000000</motedelay_us>
     <radiomedium>
@@ -21,25 +21,31 @@
       <logoutput>40000</logoutput>
     </events>
     <motetype>
-      org.contikios.cooja.mspmote.Z1MoteType
+      org.contikios.cooja.contikimote.ContikiMoteType
       <identifier>z11</identifier>
-      <description>Z1 Mote Type #z11</description>
+      <description>Cooja Mote Type #z11</description>
       <source EXPORT="discard">[CONTIKI_DIR]/examples/ipv6/rpl-tsch/node.c</source>
-      <commands EXPORT="discard">make TARGET=z1 clean
-make node.z1 TARGET=z1 MAKE_WITH_ORCHESTRA=0 MAKE_WITH_SECURITY=0</commands>
-      <firmware EXPORT="copy">[CONTIKI_DIR]/examples/ipv6/rpl-tsch/node.z1</firmware>
+      <commands EXPORT="discard">make TARGET=cooja clean
+make node.cooja TARGET=cooja MAKE_WITH_ORCHESTRA=1 MAKE_WITH_SECURITY=0</commands>
+      <firmware
+          EXPORT="copy">[CONTIKI_DIR]/examples/ipv6/rpl-tsch/node.z1</firmware>
       <moteinterface>org.contikios.cooja.interfaces.Position</moteinterface>
+      <moteinterface>org.contikios.cooja.interfaces.Battery</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiVib</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiMoteID</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiRS232</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiBeeper</moteinterface>
       <moteinterface>org.contikios.cooja.interfaces.RimeAddress</moteinterface>
-      <moteinterface>org.contikios.cooja.interfaces.IPAddress</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiIPAddress</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiRadio</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiButton</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiPIR</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiClock</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiLED</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiCFS</moteinterface>
       <moteinterface>org.contikios.cooja.interfaces.Mote2MoteRelations</moteinterface>
       <moteinterface>org.contikios.cooja.interfaces.MoteAttributes</moteinterface>
-      <moteinterface>org.contikios.cooja.mspmote.interfaces.MspClock</moteinterface>
-      <moteinterface>org.contikios.cooja.mspmote.interfaces.MspMoteID</moteinterface>
-      <moteinterface>org.contikios.cooja.mspmote.interfaces.MspButton</moteinterface>
-      <moteinterface>org.contikios.cooja.mspmote.interfaces.Msp802154Radio</moteinterface>
-      <moteinterface>org.contikios.cooja.mspmote.interfaces.MspDefaultSerial</moteinterface>
-      <moteinterface>org.contikios.cooja.mspmote.interfaces.MspLED</moteinterface>
-      <moteinterface>org.contikios.cooja.mspmote.interfaces.MspDebugOutput</moteinterface>
+      <symbols>false</symbols>
     </motetype>
     <mote>
       <breakpoints />
@@ -50,12 +56,12 @@ make node.z1 TARGET=z1 MAKE_WITH_ORCHESTRA=0 MAKE_WITH_SECURITY=0</commands>
         <z>0.0</z>
       </interface_config>
       <interface_config>
-        org.contikios.cooja.mspmote.interfaces.MspClock
-        <deviation>1.0</deviation>
+        org.contikios.cooja.contikimote.interfaces.ContikiMoteID
+        <id>1</id>
       </interface_config>
       <interface_config>
-        org.contikios.cooja.mspmote.interfaces.MspMoteID
-        <id>1</id>
+        org.contikios.cooja.contikimote.interfaces.ContikiRadio
+        <bitrate>250.0</bitrate>
       </interface_config>
       <motetype_identifier>z11</motetype_identifier>
     </mote>
@@ -68,12 +74,12 @@ make node.z1 TARGET=z1 MAKE_WITH_ORCHESTRA=0 MAKE_WITH_SECURITY=0</commands>
         <z>0.0</z>
       </interface_config>
       <interface_config>
-        org.contikios.cooja.mspmote.interfaces.MspClock
-        <deviation>1.0</deviation>
+        org.contikios.cooja.contikimote.interfaces.ContikiMoteID
+        <id>2</id>
       </interface_config>
       <interface_config>
-        org.contikios.cooja.mspmote.interfaces.MspMoteID
-        <id>2</id>
+        org.contikios.cooja.contikimote.interfaces.ContikiRadio
+        <bitrate>250.0</bitrate>
       </interface_config>
       <motetype_identifier>z11</motetype_identifier>
     </mote>
@@ -86,12 +92,12 @@ make node.z1 TARGET=z1 MAKE_WITH_ORCHESTRA=0 MAKE_WITH_SECURITY=0</commands>
         <z>0.0</z>
       </interface_config>
       <interface_config>
-        org.contikios.cooja.mspmote.interfaces.MspClock
-        <deviation>1.0</deviation>
+        org.contikios.cooja.contikimote.interfaces.ContikiMoteID
+        <id>3</id>
       </interface_config>
       <interface_config>
-        org.contikios.cooja.mspmote.interfaces.MspMoteID
-        <id>3</id>
+        org.contikios.cooja.contikimote.interfaces.ContikiRadio
+        <bitrate>250.0</bitrate>
       </interface_config>
       <motetype_identifier>z11</motetype_identifier>
     </mote>
@@ -104,12 +110,12 @@ make node.z1 TARGET=z1 MAKE_WITH_ORCHESTRA=0 MAKE_WITH_SECURITY=0</commands>
         <z>0.0</z>
       </interface_config>
       <interface_config>
-        org.contikios.cooja.mspmote.interfaces.MspClock
-        <deviation>1.0</deviation>
+        org.contikios.cooja.contikimote.interfaces.ContikiMoteID
+        <id>4</id>
       </interface_config>
       <interface_config>
-        org.contikios.cooja.mspmote.interfaces.MspMoteID
-        <id>4</id>
+        org.contikios.cooja.contikimote.interfaces.ContikiRadio
+        <bitrate>250.0</bitrate>
       </interface_config>
       <motetype_identifier>z11</motetype_identifier>
     </mote>
@@ -122,12 +128,12 @@ make node.z1 TARGET=z1 MAKE_WITH_ORCHESTRA=0 MAKE_WITH_SECURITY=0</commands>
         <z>0.0</z>
       </interface_config>
       <interface_config>
-        org.contikios.cooja.mspmote.interfaces.MspClock
-        <deviation>1.0</deviation>
+        org.contikios.cooja.contikimote.interfaces.ContikiMoteID
+        <id>5</id>
       </interface_config>
       <interface_config>
-        org.contikios.cooja.mspmote.interfaces.MspMoteID
-        <id>5</id>
+        org.contikios.cooja.contikimote.interfaces.ContikiRadio
+        <bitrate>250.0</bitrate>
       </interface_config>
       <motetype_identifier>z11</motetype_identifier>
     </mote>
@@ -140,12 +146,12 @@ make node.z1 TARGET=z1 MAKE_WITH_ORCHESTRA=0 MAKE_WITH_SECURITY=0</commands>
         <z>0.0</z>
       </interface_config>
       <interface_config>
-        org.contikios.cooja.mspmote.interfaces.MspClock
-        <deviation>1.0</deviation>
+        org.contikios.cooja.contikimote.interfaces.ContikiMoteID
+        <id>6</id>
       </interface_config>
       <interface_config>
-        org.contikios.cooja.mspmote.interfaces.MspMoteID
-        <id>6</id>
+        org.contikios.cooja.contikimote.interfaces.ContikiRadio
+        <bitrate>250.0</bitrate>
       </interface_config>
       <motetype_identifier>z11</motetype_identifier>
     </mote>
@@ -158,12 +164,12 @@ make node.z1 TARGET=z1 MAKE_WITH_ORCHESTRA=0 MAKE_WITH_SECURITY=0</commands>
         <z>0.0</z>
       </interface_config>
       <interface_config>
-        org.contikios.cooja.mspmote.interfaces.MspClock
-        <deviation>1.0</deviation>
+        org.contikios.cooja.contikimote.interfaces.ContikiMoteID
+        <id>7</id>
       </interface_config>
       <interface_config>
-        org.contikios.cooja.mspmote.interfaces.MspMoteID
-        <id>7</id>
+        org.contikios.cooja.contikimote.interfaces.ContikiRadio
+        <bitrate>250.0</bitrate>
       </interface_config>
       <motetype_identifier>z11</motetype_identifier>
     </mote>
@@ -176,12 +182,12 @@ make node.z1 TARGET=z1 MAKE_WITH_ORCHESTRA=0 MAKE_WITH_SECURITY=0</commands>
         <z>0.0</z>
       </interface_config>
       <interface_config>
-        org.contikios.cooja.mspmote.interfaces.MspClock
-        <deviation>1.0</deviation>
+        org.contikios.cooja.contikimote.interfaces.ContikiMoteID
+        <id>8</id>
       </interface_config>
       <interface_config>
-        org.contikios.cooja.mspmote.interfaces.MspMoteID
-        <id>8</id>
+        org.contikios.cooja.contikimote.interfaces.ContikiRadio
+        <bitrate>250.0</bitrate>
       </interface_config>
       <motetype_identifier>z11</motetype_identifier>
     </mote>
@@ -194,12 +200,12 @@ make node.z1 TARGET=z1 MAKE_WITH_ORCHESTRA=0 MAKE_WITH_SECURITY=0</commands>
         <z>0.0</z>
       </interface_config>
       <interface_config>
-        org.contikios.cooja.mspmote.interfaces.MspClock
-        <deviation>1.0</deviation>
+        org.contikios.cooja.contikimote.interfaces.ContikiMoteID
+        <id>9</id>
       </interface_config>
       <interface_config>
-        org.contikios.cooja.mspmote.interfaces.MspMoteID
-        <id>9</id>
+        org.contikios.cooja.contikimote.interfaces.ContikiRadio
+        <bitrate>250.0</bitrate>
       </interface_config>
       <motetype_identifier>z11</motetype_identifier>
     </mote>
@@ -268,6 +274,11 @@ make node.z1 TARGET=z1 MAKE_WITH_ORCHESTRA=0 MAKE_WITH_SECURITY=0</commands>
     org.contikios.cooja.plugins.ScriptRunner
     <plugin_config>
       <script>TIMEOUT(300000); /* Time out after 5 minutes */&#xD;
+&#xD;
+log.log("Waiting for Orchestra to start\n");&#xD;
+/* Check that Orchestra is running */&#xD;
+WAIT_UNTIL(msg.startsWith("Orchestra:"));&#xD;
+log.log("Orchestra started\n");&#xD;
 &#xD;
 /* Wait until a node (can only be the DAGRoot) has&#xD;
  * 8 routing entries (i.e. can reach every node) */&#xD;

--- a/regression-tests/11-ipv6/21-cooja-rpl-tsch-security.csc
+++ b/regression-tests/11-ipv6/21-cooja-rpl-tsch-security.csc
@@ -7,7 +7,7 @@
   <project EXPORT="discard">[APPS_DIR]/collect-view</project>
   <project EXPORT="discard">[APPS_DIR]/powertracker</project>
   <simulation>
-    <title>RPL+TSCH+Orchestrsa</title>
+    <title>RPL+TSCH+Security</title>
     <randomseed>123456</randomseed>
     <motedelay_us>1000000</motedelay_us>
     <radiomedium>
@@ -21,25 +21,29 @@
       <logoutput>40000</logoutput>
     </events>
     <motetype>
-      org.contikios.cooja.mspmote.Z1MoteType
+      org.contikios.cooja.contikimote.ContikiMoteType
       <identifier>z11</identifier>
-      <description>Z1 Mote Type #z11</description>
+      <description>Cooja Mote Type #z11</description>
       <source EXPORT="discard">[CONTIKI_DIR]/examples/ipv6/rpl-tsch/node.c</source>
-      <commands EXPORT="discard">make TARGET=z1 clean
-make node.z1 TARGET=z1 MAKE_WITH_ORCHESTRA=1 MAKE_WITH_SECURITY=0</commands>
-      <firmware EXPORT="copy">[CONTIKI_DIR]/examples/ipv6/rpl-tsch/node.z1</firmware>
+      <commands EXPORT="discard">make TARGET=cooja clean
+make node.cooja TARGET=cooja MAKE_WITH_ORCHESTRA=0 MAKE_WITH_SECURITY=1</commands>
       <moteinterface>org.contikios.cooja.interfaces.Position</moteinterface>
+      <moteinterface>org.contikios.cooja.interfaces.Battery</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiVib</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiMoteID</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiRS232</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiBeeper</moteinterface>
       <moteinterface>org.contikios.cooja.interfaces.RimeAddress</moteinterface>
-      <moteinterface>org.contikios.cooja.interfaces.IPAddress</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiIPAddress</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiRadio</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiButton</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiPIR</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiClock</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiLED</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiCFS</moteinterface>
       <moteinterface>org.contikios.cooja.interfaces.Mote2MoteRelations</moteinterface>
       <moteinterface>org.contikios.cooja.interfaces.MoteAttributes</moteinterface>
-      <moteinterface>org.contikios.cooja.mspmote.interfaces.MspClock</moteinterface>
-      <moteinterface>org.contikios.cooja.mspmote.interfaces.MspMoteID</moteinterface>
-      <moteinterface>org.contikios.cooja.mspmote.interfaces.MspButton</moteinterface>
-      <moteinterface>org.contikios.cooja.mspmote.interfaces.Msp802154Radio</moteinterface>
-      <moteinterface>org.contikios.cooja.mspmote.interfaces.MspDefaultSerial</moteinterface>
-      <moteinterface>org.contikios.cooja.mspmote.interfaces.MspLED</moteinterface>
-      <moteinterface>org.contikios.cooja.mspmote.interfaces.MspDebugOutput</moteinterface>
+      <symbols>false</symbols>
     </motetype>
     <mote>
       <breakpoints />
@@ -50,12 +54,12 @@ make node.z1 TARGET=z1 MAKE_WITH_ORCHESTRA=1 MAKE_WITH_SECURITY=0</commands>
         <z>0.0</z>
       </interface_config>
       <interface_config>
-        org.contikios.cooja.mspmote.interfaces.MspClock
-        <deviation>1.0</deviation>
+        org.contikios.cooja.contikimote.interfaces.ContikiMoteID
+        <id>1</id>
       </interface_config>
       <interface_config>
-        org.contikios.cooja.mspmote.interfaces.MspMoteID
-        <id>1</id>
+        org.contikios.cooja.contikimote.interfaces.ContikiRadio
+        <bitrate>250.0</bitrate>
       </interface_config>
       <motetype_identifier>z11</motetype_identifier>
     </mote>
@@ -68,12 +72,12 @@ make node.z1 TARGET=z1 MAKE_WITH_ORCHESTRA=1 MAKE_WITH_SECURITY=0</commands>
         <z>0.0</z>
       </interface_config>
       <interface_config>
-        org.contikios.cooja.mspmote.interfaces.MspClock
-        <deviation>1.0</deviation>
+        org.contikios.cooja.contikimote.interfaces.ContikiMoteID
+        <id>2</id>
       </interface_config>
       <interface_config>
-        org.contikios.cooja.mspmote.interfaces.MspMoteID
-        <id>2</id>
+        org.contikios.cooja.contikimote.interfaces.ContikiRadio
+        <bitrate>250.0</bitrate>
       </interface_config>
       <motetype_identifier>z11</motetype_identifier>
     </mote>
@@ -86,12 +90,12 @@ make node.z1 TARGET=z1 MAKE_WITH_ORCHESTRA=1 MAKE_WITH_SECURITY=0</commands>
         <z>0.0</z>
       </interface_config>
       <interface_config>
-        org.contikios.cooja.mspmote.interfaces.MspClock
-        <deviation>1.0</deviation>
+        org.contikios.cooja.contikimote.interfaces.ContikiMoteID
+        <id>3</id>
       </interface_config>
       <interface_config>
-        org.contikios.cooja.mspmote.interfaces.MspMoteID
-        <id>3</id>
+        org.contikios.cooja.contikimote.interfaces.ContikiRadio
+        <bitrate>250.0</bitrate>
       </interface_config>
       <motetype_identifier>z11</motetype_identifier>
     </mote>
@@ -104,12 +108,12 @@ make node.z1 TARGET=z1 MAKE_WITH_ORCHESTRA=1 MAKE_WITH_SECURITY=0</commands>
         <z>0.0</z>
       </interface_config>
       <interface_config>
-        org.contikios.cooja.mspmote.interfaces.MspClock
-        <deviation>1.0</deviation>
+        org.contikios.cooja.contikimote.interfaces.ContikiMoteID
+        <id>4</id>
       </interface_config>
       <interface_config>
-        org.contikios.cooja.mspmote.interfaces.MspMoteID
-        <id>4</id>
+        org.contikios.cooja.contikimote.interfaces.ContikiRadio
+        <bitrate>250.0</bitrate>
       </interface_config>
       <motetype_identifier>z11</motetype_identifier>
     </mote>
@@ -122,12 +126,12 @@ make node.z1 TARGET=z1 MAKE_WITH_ORCHESTRA=1 MAKE_WITH_SECURITY=0</commands>
         <z>0.0</z>
       </interface_config>
       <interface_config>
-        org.contikios.cooja.mspmote.interfaces.MspClock
-        <deviation>1.0</deviation>
+        org.contikios.cooja.contikimote.interfaces.ContikiMoteID
+        <id>5</id>
       </interface_config>
       <interface_config>
-        org.contikios.cooja.mspmote.interfaces.MspMoteID
-        <id>5</id>
+        org.contikios.cooja.contikimote.interfaces.ContikiRadio
+        <bitrate>250.0</bitrate>
       </interface_config>
       <motetype_identifier>z11</motetype_identifier>
     </mote>
@@ -140,12 +144,12 @@ make node.z1 TARGET=z1 MAKE_WITH_ORCHESTRA=1 MAKE_WITH_SECURITY=0</commands>
         <z>0.0</z>
       </interface_config>
       <interface_config>
-        org.contikios.cooja.mspmote.interfaces.MspClock
-        <deviation>1.0</deviation>
+        org.contikios.cooja.contikimote.interfaces.ContikiMoteID
+        <id>6</id>
       </interface_config>
       <interface_config>
-        org.contikios.cooja.mspmote.interfaces.MspMoteID
-        <id>6</id>
+        org.contikios.cooja.contikimote.interfaces.ContikiRadio
+        <bitrate>250.0</bitrate>
       </interface_config>
       <motetype_identifier>z11</motetype_identifier>
     </mote>
@@ -158,12 +162,12 @@ make node.z1 TARGET=z1 MAKE_WITH_ORCHESTRA=1 MAKE_WITH_SECURITY=0</commands>
         <z>0.0</z>
       </interface_config>
       <interface_config>
-        org.contikios.cooja.mspmote.interfaces.MspClock
-        <deviation>1.0</deviation>
+        org.contikios.cooja.contikimote.interfaces.ContikiMoteID
+        <id>7</id>
       </interface_config>
       <interface_config>
-        org.contikios.cooja.mspmote.interfaces.MspMoteID
-        <id>7</id>
+        org.contikios.cooja.contikimote.interfaces.ContikiRadio
+        <bitrate>250.0</bitrate>
       </interface_config>
       <motetype_identifier>z11</motetype_identifier>
     </mote>
@@ -176,12 +180,12 @@ make node.z1 TARGET=z1 MAKE_WITH_ORCHESTRA=1 MAKE_WITH_SECURITY=0</commands>
         <z>0.0</z>
       </interface_config>
       <interface_config>
-        org.contikios.cooja.mspmote.interfaces.MspClock
-        <deviation>1.0</deviation>
+        org.contikios.cooja.contikimote.interfaces.ContikiMoteID
+        <id>8</id>
       </interface_config>
       <interface_config>
-        org.contikios.cooja.mspmote.interfaces.MspMoteID
-        <id>8</id>
+        org.contikios.cooja.contikimote.interfaces.ContikiRadio
+        <bitrate>250.0</bitrate>
       </interface_config>
       <motetype_identifier>z11</motetype_identifier>
     </mote>
@@ -194,12 +198,12 @@ make node.z1 TARGET=z1 MAKE_WITH_ORCHESTRA=1 MAKE_WITH_SECURITY=0</commands>
         <z>0.0</z>
       </interface_config>
       <interface_config>
-        org.contikios.cooja.mspmote.interfaces.MspClock
-        <deviation>1.0</deviation>
+        org.contikios.cooja.contikimote.interfaces.ContikiMoteID
+        <id>9</id>
       </interface_config>
       <interface_config>
-        org.contikios.cooja.mspmote.interfaces.MspMoteID
-        <id>9</id>
+        org.contikios.cooja.contikimote.interfaces.ContikiRadio
+        <bitrate>250.0</bitrate>
       </interface_config>
       <motetype_identifier>z11</motetype_identifier>
     </mote>
@@ -269,10 +273,7 @@ make node.z1 TARGET=z1 MAKE_WITH_ORCHESTRA=1 MAKE_WITH_SECURITY=0</commands>
     <plugin_config>
       <script>TIMEOUT(300000); /* Time out after 5 minutes */&#xD;
 &#xD;
-log.log("Waiting for Orchestra to start\n");&#xD;
-/* Check that Orchestra is running */&#xD;
-WAIT_UNTIL(msg.startsWith("Orchestra:"));&#xD;
-log.log("Orchestra started\n");&#xD;
+log.log("Waiting for association with security\n");&#xD;
 &#xD;
 /* Wait until a node (can only be the DAGRoot) has&#xD;
  * 8 routing entries (i.e. can reach every node) */&#xD;

--- a/regression-tests/11-ipv6/21-cooja-rpl-tsch-security.csc
+++ b/regression-tests/11-ipv6/21-cooja-rpl-tsch-security.csc
@@ -276,9 +276,9 @@ make node.cooja TARGET=cooja MAKE_WITH_ORCHESTRA=0 MAKE_WITH_SECURITY=1</command
 log.log("Waiting for association with security\n");&#xD;
 &#xD;
 /* Wait until a node (can only be the DAGRoot) has&#xD;
- * 8 routing entries (i.e. can reach every node) */&#xD;
+ * 9 routing entries including one for the root (i.e. can reach every node) */&#xD;
 log.log("Waiting for routing tables to fill\n");&#xD;
-WAIT_UNTIL(msg.endsWith("Routing links (8 in total):"));&#xD;
+WAIT_UNTIL(msg.endsWith("Routing links (9 in total):"));&#xD;
 log.log("Root routing table ready\n");&#xD;
 &#xD;
 log.testOK(); /* Report test success and quit */</script>


### PR DESCRIPTION
The main change is to use `cooja` mote instead of `z1`.

Two other changes:
- `20-rpl-tsch-orchestra.csc` failed because of a link error for `nbr_routes`. This is resolved by adding a `#if` guard in `orchestra-rule-unicast-per-neighbor-rpl-storing.c`. There could be a better solution.
- The test criteria seem incorrect. They are updated by the following.
```diff
-WAIT_UNTIL(msg.endsWith("Routing links (8 in total):"));
+WAIT_UNTIL(msg.endsWith("Routing links (9 in total):"));
```
