### PR TITLE
Revert to static Ethernet driver for the ATARI.

### DIFF
--- a/cpu/6502/README.md
+++ b/cpu/6502/README.md
@@ -40,9 +40,9 @@ high-level configuration macros may be set:
     - Default: 2
     - Purpose: Set the maximum number of concurrent TCP connections.
 
-- ETHERNET
+- STATIC_DRIVER
     - Default: N/A
-    - Purpose: Link Ethernet driver statically instead of loading it dynamically
+    - Purpose: Link device driver statically instead of loading it dynamically
       using the network configuration file.
 
 - WITH_LOGGING

--- a/cpu/6502/lib/config.c
+++ b/cpu/6502/lib/config.c
@@ -90,15 +90,15 @@ config_read(char *filename)
   log_message("Def. Router: ",  ipaddrtoa(&config.draddr, uip_buf));
   log_message("DNS Server:  ",  ipaddrtoa(&config.resolvaddr, uip_buf));
 
-#ifndef ETHERNET
+#ifndef STATIC_DRIVER
   log_message("Eth. Driver: ",  config.ethernetcfg.name);
-#else /* !ETHERNET */
+#else /* !STATIC_DRIVER */
   #define _stringize(arg) #arg
   #define  stringize(arg) _stringize(arg)
   log_message("Eth. Driver: ",  stringize(ETHERNET));
   #undef  _stringize
   #undef   stringize
-#endif /* !ETHERNET */
+#endif /* !STATIC_DRIVER */
   log_message("Driver Port: $", utoa(config.ethernetcfg.addr, uip_buf, 16));
 
   uip_sethostaddr(&config.hostaddr);

--- a/cpu/6502/net/ethernet.c
+++ b/cpu/6502/net/ethernet.c
@@ -63,7 +63,7 @@ ethernet_init(struct ethernet_config *config)
 {
   static const char signature[4] = {0x65, 0x74, 0x68, 0x01};
 
-#ifndef ETHERNET
+#ifndef STATIC_DRIVER
 
   struct mod_ctrl module_control = {cfs_read};
   uint8_t byte;
@@ -91,13 +91,13 @@ ethernet_init(struct ethernet_config *config)
     }
   }
 
-#else /* !ETHERNET */
+#else /* !STATIC_DRIVER */
 
-  extern void ETHERNET;
+  extern void STATIC_DRIVER;
 
-  module = &ETHERNET;
+  module = &STATIC_DRIVER;
 
-#endif /* !ETHERNET */
+#endif /* !STATIC_DRIVER */
 
   module->buffer = uip_buf;
   module->buffer_size = UIP_BUFSIZE;
@@ -126,8 +126,8 @@ ethernet_exit(void)
 {
   module->exit();
 
-#ifndef ETHERNET
+#ifndef STATIC_DRIVER
   mod_free(module);
-#endif /* !ETHERNET */
+#endif /* !STATIC_DRIVER */
 }
 /*---------------------------------------------------------------------------*/

--- a/platform/atarixl/Makefile.atarixl
+++ b/platform/atarixl/Makefile.atarixl
@@ -31,6 +31,8 @@
 # Author: Oliver Schmidt <ol.sc@web.de>
 #
 
+DEFINES += STATIC_DRIVER=cs8900a
+
 CONTIKI_CPU = $(CONTIKI)/cpu/6502
 include $(CONTIKI_CPU)/Makefile.6502
 
@@ -53,7 +55,6 @@ disk: all
 	cp $(CONTIKI)/tools/$(TARGET)/dos25/dup.sys atr/dup.sys
 	cp $(CONTIKI_PROJECT).$(TARGET)             atr/autorun.sys
 	cp $(CONTIKI)/tools/$(TARGET)/sample.cfg    atr/contiki.cfg
-	cp cs8900a.eth                              atr/cs8900a.eth
 ifeq ($(findstring WITH_MOUSE,$(DEFINES)),WITH_MOUSE)
 	cp $(CC65_TARGET_DIR)/drv/mou/atrxst.mou    atr/contiki.mou
 endif

--- a/tools/6502/Makefile
+++ b/tools/6502/Makefile
@@ -189,7 +189,6 @@ contiki-atari-1.atr: atarixl-makes
 	cp ../../examples/webbrowser/webbrowser.atarixl atr/webbrows.com
 	cp ../../examples/wget/wget.atarixl             atr/wget.com
 	cp ../atarixl/default.cfg                       atr/contiki.cfg
-	cp ../../cpu/6502/ethconfig/cs8900a.eth         atr/cs8900a.eth
 	cp $(CC65)/atarixl/drv/mou/atrxst.mou           atr/contiki.mou
 	cp $(CC65)/atarixl/drv/mou/atrxami.mou          atr/ami.mou
 	cp $(CC65)/atarixl/drv/mou/atrxjoy.mou          atr/joy.mou
@@ -205,7 +204,6 @@ contiki-atari-2.atr: atarixl-makes
 	cp ../../cpu/6502/ipconfig/ipconfig.atarixl atr/ipconfig.com
 	cp ../../examples/irc/irc-client.atarixl    atr/irc.com
 	cp ../atarixl/default.cfg                   atr/contiki.cfg
-	cp ../../cpu/6502/ethconfig/cs8900a.eth     atr/cs8900a.eth
 	cp $(CC65)/atarixl/drv/mou/atrxst.mou       atr/contiki.mou
 	cp $(CC65)/atarixl/drv/mou/atrxami.mou      atr/ami.mou
 	cp $(CC65)/atarixl/drv/mou/atrxjoy.mou      atr/joy.mou
@@ -222,7 +220,6 @@ contiki-atari-3.atr: atarixl-makes
 	cp ../../examples/webserver/webserver-example.atarixl atr/webserv.com
 	cp ../../examples/telnet-server/telnet-server.atarixl atr/telnetd.com
 	cp ../atarixl/default.cfg                             atr/contiki.cfg
-	cp ../../cpu/6502/ethconfig/cs8900a.eth               atr/cs8900a.eth
 	cp $(CC65)/atarixl/drv/mou/atrxst.mou                 atr/contiki.mou
 	cp $(CC65)/atarixl/drv/mou/atrxami.mou                atr/ami.mou
 	cp $(CC65)/atarixl/drv/mou/atrxjoy.mou                atr/joy.mou
@@ -246,7 +243,6 @@ contiki-atari.atr: atarixl-makes
 	cp ../../examples/webserver/webserver-example.atarixl atr/webserv.com
 	cp ../../examples/telnet-server/telnet-server.atarixl atr/telnetd.com
 	cp ../atarixl/default.cfg                             atr/contiki.cfg
-	cp ../../cpu/6502/ethconfig/cs8900a.eth               atr/cs8900a.eth
 	cp $(CC65)/atarixl/drv/mou/atrxst.mou                 atr/contiki.mou
 	cp $(CC65)/atarixl/drv/mou/atrxami.mou                atr/ami.mou
 	cp $(CC65)/atarixl/drv/mou/atrxjoy.mou                atr/joy.mou


### PR DESCRIPTION
After all there's no momentum for a W5100-based Ethernet solution on the ATARI. So I revert to static linkage of the CS8900A driver as this improves program load times.