### PR TITLE
Fix Bug in MQTT App: Refused Connections should not be pursued.

### DIFF
--- a/apps/mqtt/mqtt.c
+++ b/apps/mqtt/mqtt.c
@@ -751,6 +751,8 @@ handle_connack(struct mqtt_connection *conn)
     call_event(conn,
                MQTT_EVENT_CONNECTION_REFUSED_ERROR,
                &conn->in_packet.payload[1]);
+    abort_connection(conn);
+    return;
   }
 
   conn->out_packet.qos_state = MQTT_QOS_STATE_GOT_ACK;


### PR DESCRIPTION
If the MQTT connection is acked by the broker with an error, like when the given client ID is not accepted by the server, the MQTT app recognizes that error, sends a corresponding event to the app user process, but then continues to use the connection as if the connection had been acked without an error, including sending another event to the app user process.