### PR TITLE
Removed artifacts of former uip_appdata handling.

### DIFF
--- a/core/dev/slip.c
+++ b/core/dev/slip.c
@@ -107,9 +107,6 @@ slip_send(void)
 
   ptr = &uip_buf[UIP_LLH_LEN];
   for(i = 0; i < uip_len; ++i) {
-    if(i == UIP_TCPIP_HLEN) {
-      ptr = (uint8_t *)uip_appdata;
-    }
     c = *ptr++;
     if(c == SLIP_END) {
       slip_arch_writeb(SLIP_ESC);
@@ -161,6 +158,7 @@ rxbuf_init(void)
 static uint16_t
 slip_poll_handler(uint8_t *outbuf, uint16_t blen)
 {
+#ifdef SLIP_CONF_MICROSOFT_CHAT
   /* This is a hack and won't work across buffer edge! */
   if(rxbuf[begin] == 'C') {
     int i;
@@ -177,6 +175,8 @@ slip_poll_handler(uint8_t *outbuf, uint16_t blen)
       return 0;
     }
   }
+#endif /* SLIP_CONF_MICROSOFT_CHAT */
+
 #ifdef SLIP_CONF_ANSWER_MAC_REQUEST
   else if(rxbuf[begin] == '?') { 
     /* Used by tapslip6 to request mac for auto configure */

--- a/core/net/ip/slipdev.c
+++ b/core/net/ip/slipdev.c
@@ -102,9 +102,6 @@ slipdev_send(void)
 
   ptr = &uip_buf[UIP_LLH_LEN];
   for(i = 0; i < uip_len; ++i) {
-    if(i == UIP_TCPIP_HLEN) {
-      ptr = (uint8_t *)uip_appdata;
-    }
     c = *ptr++;
     switch(c) {
     case SLIP_END:

--- a/core/net/ip/uip.h
+++ b/core/net/ip/uip.h
@@ -490,26 +490,8 @@ void uip_reass_over(void);
  *
  * The uip_aligned_buf array is used to hold incoming and outgoing
  * packets. The device driver should place incoming data into this
- * buffer. When sending data, the device driver should read the link
- * level headers and the TCP/IP headers from this buffer. The size of
- * the link level headers is configured by the UIP_LLH_LEN define.
- *
- * \note The application data need not be placed in this buffer, so
- * the device driver must read it from the place pointed to by the
- * uip_appdata pointer as illustrated by the following example:
- \code
- void
- devicedriver_send(void)
- {
- hwsend(&uip_buf[0], UIP_LLH_LEN);
- if(uip_len <= UIP_LLH_LEN + UIP_TCPIP_HLEN) {
- hwsend(&uip_buf[UIP_LLH_LEN], uip_len - UIP_LLH_LEN);
- } else {
- hwsend(&uip_buf[UIP_LLH_LEN], UIP_TCPIP_HLEN);
- hwsend(uip_appdata, uip_len - UIP_TCPIP_HLEN - UIP_LLH_LEN);
- }
- }
- \endcode
+ * buffer. When sending data, the device driver should read the
+ * outgoing data from this buffer.
 */
 
 typedef union {

--- a/core/net/ip/uip_arch.h
+++ b/core/net/ip/uip_arch.h
@@ -120,10 +120,6 @@ uint16_t uip_ipchksum(void);
  * The TCP checksum is the Internet checksum of data contents of the
  * TCP segment, and a pseudo-header as defined in RFC793.
  *
- * \note The uip_appdata pointer that points to the packet data may
- * point anywhere in memory, so it is not possible to simply calculate
- * the Internet checksum of the contents of the uip_buf buffer.
- *
  * \return The TCP checksum of the TCP segment in uip_buf and pointed
  * to by uip_appdata.
  */

--- a/platform/jn516x/lib/slip.c
+++ b/platform/jn516x/lib/slip.c
@@ -200,9 +200,6 @@ slip_send(void)
 
   ptr = &uip_buf[UIP_LLH_LEN];
   for(i = 0; i < uip_len; ++i) {
-    if(i == UIP_TCPIP_HLEN) {
-      ptr = (uint8_t *)uip_appdata;
-    }
     c = *ptr++;
     slip_write_char(c);
   }

--- a/tools/sky/uip6-bridge/dev/slip.c
+++ b/tools/sky/uip6-bridge/dev/slip.c
@@ -112,9 +112,6 @@ slip_send(void)
 
   ptr = &uip_buf[UIP_LLH_LEN];
   for(i = 0; i < uip_len; ++i) {
-    if(i == UIP_TCPIP_HLEN) {
-      ptr = (uint8_t *)uip_appdata;
-    }
     c = *ptr++;
     if(c == SLIP_END) {
       slip_arch_writeb(SLIP_ESC);

--- a/tools/stm32w/uip6_bridge/dev/slip.c
+++ b/tools/stm32w/uip6_bridge/dev/slip.c
@@ -127,9 +127,6 @@ slip_send(void)
 
 	ptr = &uip_buf[UIP_LLH_LEN];
 	for(i = 0; i < uip_len; ++i) {
-		if(i == UIP_TCPIP_HLEN) {
-			ptr = (uint8_t *)uip_appdata;
-		}
 		c = *ptr++;
 		if(c == SLIP_END) {
 			slip_arch_writeb(SLIP_ESC);


### PR DESCRIPTION
Adam Dunkels writes on 2/5/2017 on the Contiki mailing list:
[...] the original idea was that the application could just point the uip_appdata pointer to wherever the data was, but we then changed it so that the data actually had to be copied into the uip_aligned_buf buffer. So, yes, the network device driver should only need to read from this buffer. [...]

This change removes comments on the possibility of uip_appdata pointing somewhere outside the uip_aligned_buf. And it removes code in the SLIP drivers not necessary anymore.

Additionally it makes code in a SLIP driver optional that takes care of the Microsoft-specific CLIENT / SERVER / CLIENTSERVER chat.