### PR TITLE
RPL: fix a bug accessing an uninitialized pointer

### DIFF
--- a/core/net/rpl/rpl-icmp6.c
+++ b/core/net/rpl/rpl-icmp6.c
@@ -79,7 +79,7 @@ static void dao_input(void);
 static void dao_ack_input(void);
 
 static void dao_output_target_seq(rpl_parent_t *parent, uip_ipaddr_t *prefix,
-				  uint8_t lifetime, uint8_t seq_no);
+                                  uint8_t lifetime, uint8_t seq_no);
 
 /* some debug callbacks useful when debugging RPL networks */
 #ifdef RPL_DEBUG_DIO_INPUT
@@ -158,8 +158,8 @@ get_global_addr(uip_ipaddr_t *addr)
 static uint32_t
 get32(uint8_t *buffer, int pos)
 {
-  return (uint32_t)buffer[pos] << 24 | (uint32_t)buffer[pos + 1] << 16 |
-         (uint32_t)buffer[pos + 2] << 8 | buffer[pos + 3];
+  return ((uint32_t)buffer[pos] << 24 | (uint32_t)buffer[pos + 1] << 16 |
+          (uint32_t)buffer[pos + 2] << 8 | buffer[pos + 3]);
 }
 /*---------------------------------------------------------------------------*/
 static void
@@ -202,7 +202,7 @@ rpl_icmp6_update_nbr_table(uip_ipaddr_t *from, nbr_table_reason_t reason, void *
   }
 
   return nbr;
- }
+}
 /*---------------------------------------------------------------------------*/
 static void
 dis_input(void)
@@ -238,7 +238,7 @@ dis_input(void)
           PRINTF("RPL: Unicast DIS, reply to sender\n");
           dio_output(instance, &UIP_IP_BUF->srcipaddr);
         }
-	/* } */
+        /* } */
       }
     }
   }
@@ -355,103 +355,103 @@ dio_input(void)
     PRINTF("RPL: DIO option %u, length: %u\n", subopt_type, len - 2);
 
     switch(subopt_type) {
-    case RPL_OPTION_DAG_METRIC_CONTAINER:
-      if(len < 6) {
-        PRINTF("RPL: Invalid DAG MC, len = %d\n", len);
-	RPL_STAT(rpl_stats.malformed_msgs++);
-        goto discard;
-      }
-      dio.mc.type = buffer[i + 2];
-      dio.mc.flags = buffer[i + 3] << 1;
-      dio.mc.flags |= buffer[i + 4] >> 7;
-      dio.mc.aggr = (buffer[i + 4] >> 4) & 0x3;
-      dio.mc.prec = buffer[i + 4] & 0xf;
-      dio.mc.length = buffer[i + 5];
+      case RPL_OPTION_DAG_METRIC_CONTAINER:
+        if(len < 6) {
+          PRINTF("RPL: Invalid DAG MC, len = %d\n", len);
+          RPL_STAT(rpl_stats.malformed_msgs++);
+          goto discard;
+        }
+        dio.mc.type = buffer[i + 2];
+        dio.mc.flags = buffer[i + 3] << 1;
+        dio.mc.flags |= buffer[i + 4] >> 7;
+        dio.mc.aggr = (buffer[i + 4] >> 4) & 0x3;
+        dio.mc.prec = buffer[i + 4] & 0xf;
+        dio.mc.length = buffer[i + 5];
 
-      if(dio.mc.type == RPL_DAG_MC_NONE) {
-        /* No metric container: do nothing */
-      } else if(dio.mc.type == RPL_DAG_MC_ETX) {
-        dio.mc.obj.etx = get16(buffer, i + 6);
+        if(dio.mc.type == RPL_DAG_MC_NONE) {
+          /* No metric container: do nothing */
+        } else if(dio.mc.type == RPL_DAG_MC_ETX) {
+          dio.mc.obj.etx = get16(buffer, i + 6);
 
-        PRINTF("RPL: DAG MC: type %u, flags %u, aggr %u, prec %u, length %u, ETX %u\n",
-	       (unsigned)dio.mc.type,
-	       (unsigned)dio.mc.flags,
-	       (unsigned)dio.mc.aggr,
-	       (unsigned)dio.mc.prec,
-	       (unsigned)dio.mc.length,
-	       (unsigned)dio.mc.obj.etx);
-      } else if(dio.mc.type == RPL_DAG_MC_ENERGY) {
-        dio.mc.obj.energy.flags = buffer[i + 6];
-        dio.mc.obj.energy.energy_est = buffer[i + 7];
-      } else {
-       PRINTF("RPL: Unhandled DAG MC type: %u\n", (unsigned)dio.mc.type);
-       goto discard;
-      }
-      break;
-    case RPL_OPTION_ROUTE_INFO:
-      if(len < 9) {
-        PRINTF("RPL: Invalid destination prefix option, len = %d\n", len);
-	RPL_STAT(rpl_stats.malformed_msgs++);
-        goto discard;
-      }
+          PRINTF("RPL: DAG MC: type %u, flags %u, aggr %u, prec %u, length %u, ETX %u\n",
+                 (unsigned)dio.mc.type,
+                 (unsigned)dio.mc.flags,
+                 (unsigned)dio.mc.aggr,
+                 (unsigned)dio.mc.prec,
+                 (unsigned)dio.mc.length,
+                 (unsigned)dio.mc.obj.etx);
+        } else if(dio.mc.type == RPL_DAG_MC_ENERGY) {
+          dio.mc.obj.energy.flags = buffer[i + 6];
+          dio.mc.obj.energy.energy_est = buffer[i + 7];
+        } else {
+          PRINTF("RPL: Unhandled DAG MC type: %u\n", (unsigned)dio.mc.type);
+          goto discard;
+        }
+        break;
+      case RPL_OPTION_ROUTE_INFO:
+        if(len < 9) {
+          PRINTF("RPL: Invalid destination prefix option, len = %d\n", len);
+          RPL_STAT(rpl_stats.malformed_msgs++);
+          goto discard;
+        }
 
-      /* The flags field includes the preference value. */
-      dio.destination_prefix.length = buffer[i + 2];
-      dio.destination_prefix.flags = buffer[i + 3];
-      dio.destination_prefix.lifetime = get32(buffer, i + 4);
+        /* The flags field includes the preference value. */
+        dio.destination_prefix.length = buffer[i + 2];
+        dio.destination_prefix.flags = buffer[i + 3];
+        dio.destination_prefix.lifetime = get32(buffer, i + 4);
 
-      if(((dio.destination_prefix.length + 7) / 8) + 8 <= len &&
-         dio.destination_prefix.length <= 128) {
-        PRINTF("RPL: Copying destination prefix\n");
-        memcpy(&dio.destination_prefix.prefix, &buffer[i + 8],
-               (dio.destination_prefix.length + 7) / 8);
-      } else {
-        PRINTF("RPL: Invalid route info option, len = %d\n", len);
-	RPL_STAT(rpl_stats.malformed_msgs++);
-        goto discard;
-      }
+        if(((dio.destination_prefix.length + 7) / 8) + 8 <= len &&
+           dio.destination_prefix.length <= 128) {
+          PRINTF("RPL: Copying destination prefix\n");
+          memcpy(&dio.destination_prefix.prefix, &buffer[i + 8],
+                 (dio.destination_prefix.length + 7) / 8);
+        } else {
+          PRINTF("RPL: Invalid route info option, len = %d\n", len);
+          RPL_STAT(rpl_stats.malformed_msgs++);
+          goto discard;
+        }
 
-      break;
-    case RPL_OPTION_DAG_CONF:
-      if(len != 16) {
-        PRINTF("RPL: Invalid DAG configuration option, len = %d\n", len);
-	RPL_STAT(rpl_stats.malformed_msgs++);
-        goto discard;
-      }
+        break;
+      case RPL_OPTION_DAG_CONF:
+        if(len != 16) {
+          PRINTF("RPL: Invalid DAG configuration option, len = %d\n", len);
+          RPL_STAT(rpl_stats.malformed_msgs++);
+          goto discard;
+        }
 
-      /* Path control field not yet implemented - at i + 2 */
-      dio.dag_intdoubl = buffer[i + 3];
-      dio.dag_intmin = buffer[i + 4];
-      dio.dag_redund = buffer[i + 5];
-      dio.dag_max_rankinc = get16(buffer, i + 6);
-      dio.dag_min_hoprankinc = get16(buffer, i + 8);
-      dio.ocp = get16(buffer, i + 10);
-      /* buffer + 12 is reserved */
-      dio.default_lifetime = buffer[i + 13];
-      dio.lifetime_unit = get16(buffer, i + 14);
-      PRINTF("RPL: DAG conf:dbl=%d, min=%d red=%d maxinc=%d mininc=%d ocp=%d d_l=%u l_u=%u\n",
-             dio.dag_intdoubl, dio.dag_intmin, dio.dag_redund,
-             dio.dag_max_rankinc, dio.dag_min_hoprankinc, dio.ocp,
-             dio.default_lifetime, dio.lifetime_unit);
-      break;
-    case RPL_OPTION_PREFIX_INFO:
-      if(len != 32) {
-        PRINTF("RPL: Invalid DAG prefix info, len != 32\n");
-	RPL_STAT(rpl_stats.malformed_msgs++);
-        goto discard;
-      }
-      dio.prefix_info.length = buffer[i + 2];
-      dio.prefix_info.flags = buffer[i + 3];
-      /* valid lifetime is ingnored for now - at i + 4 */
-      /* preferred lifetime stored in lifetime */
-      dio.prefix_info.lifetime = get32(buffer, i + 8);
-      /* 32-bit reserved at i + 12 */
-      PRINTF("RPL: Copying prefix information\n");
-      memcpy(&dio.prefix_info.prefix, &buffer[i + 16], 16);
-      break;
-    default:
-      PRINTF("RPL: Unsupported suboption type in DIO: %u\n",
-	(unsigned)subopt_type);
+        /* Path control field not yet implemented - at i + 2 */
+        dio.dag_intdoubl = buffer[i + 3];
+        dio.dag_intmin = buffer[i + 4];
+        dio.dag_redund = buffer[i + 5];
+        dio.dag_max_rankinc = get16(buffer, i + 6);
+        dio.dag_min_hoprankinc = get16(buffer, i + 8);
+        dio.ocp = get16(buffer, i + 10);
+        /* buffer + 12 is reserved */
+        dio.default_lifetime = buffer[i + 13];
+        dio.lifetime_unit = get16(buffer, i + 14);
+        PRINTF("RPL: DAG conf:dbl=%d, min=%d red=%d maxinc=%d mininc=%d ocp=%d d_l=%u l_u=%u\n",
+               dio.dag_intdoubl, dio.dag_intmin, dio.dag_redund,
+               dio.dag_max_rankinc, dio.dag_min_hoprankinc, dio.ocp,
+               dio.default_lifetime, dio.lifetime_unit);
+        break;
+      case RPL_OPTION_PREFIX_INFO:
+        if(len != 32) {
+          PRINTF("RPL: Invalid DAG prefix info, len != 32\n");
+          RPL_STAT(rpl_stats.malformed_msgs++);
+          goto discard;
+        }
+        dio.prefix_info.length = buffer[i + 2];
+        dio.prefix_info.flags = buffer[i + 3];
+        /* valid lifetime is ingnored for now - at i + 4 */
+        /* preferred lifetime stored in lifetime */
+        dio.prefix_info.lifetime = get32(buffer, i + 8);
+        /* 32-bit reserved at i + 12 */
+        PRINTF("RPL: Copying prefix information\n");
+        memcpy(&dio.prefix_info.prefix, &buffer[i + 16], 16);
+        break;
+      default:
+        PRINTF("RPL: Unsupported suboption type in DIO: %u\n",
+               (unsigned)subopt_type);
     }
   }
 
@@ -461,7 +461,7 @@ dio_input(void)
 
   rpl_process_dio(&from, &dio);
 
- discard:
+discard:
   uip_clear_buf();
 }
 /*---------------------------------------------------------------------------*/
@@ -546,7 +546,7 @@ dio_output(rpl_instance_t *instance, uip_ipaddr_t *uc_addr)
       buffer[pos++] = instance->mc.obj.energy.energy_est;
     } else {
       PRINTF("RPL: Unable to send DIO because of unhandled DAG MC type %u\n",
-	(unsigned)instance->mc.type);
+             (unsigned)instance->mc.type);
       return;
     }
   }
@@ -600,7 +600,7 @@ dio_output(rpl_instance_t *instance, uip_ipaddr_t *uc_addr)
   }
 #endif /* DEBUG_PRINT */
   PRINTF("RPL: Sending unicast-DIO with rank %u to ",
-      (unsigned)dag->rank);
+         (unsigned)dag->rank);
   PRINT6ADDR(uc_addr);
   PRINTF("\n");
   uip_icmp6_send(uc_addr, ICMP6_RPL, RPL_CODE_DIO, pos);
@@ -608,12 +608,12 @@ dio_output(rpl_instance_t *instance, uip_ipaddr_t *uc_addr)
   /* Unicast requests get unicast replies! */
   if(uc_addr == NULL) {
     PRINTF("RPL: Sending a multicast-DIO with rank %u\n",
-        (unsigned)instance->current_dag->rank);
+           (unsigned)instance->current_dag->rank);
     uip_create_linklocal_rplnodes_mcast(&addr);
     uip_icmp6_send(&addr, ICMP6_RPL, RPL_CODE_DIO, pos);
   } else {
     PRINTF("RPL: Sending unicast-DIO with rank %u to ",
-        (unsigned)instance->current_dag->rank);
+           (unsigned)instance->current_dag->rank);
     PRINT6ADDR(uc_addr);
     PRINTF("\n");
     uip_icmp6_send(uc_addr, ICMP6_RPL, RPL_CODE_DIO, pos);
@@ -636,8 +636,8 @@ dao_input_storing(void)
   uint8_t flags;
   uint8_t subopt_type;
   /*
-  uint8_t pathcontrol;
-  uint8_t pathsequence;
+    uint8_t pathcontrol;
+    uint8_t pathsequence;
   */
   uip_ipaddr_t prefix;
   uip_ds6_route_t *rep;
@@ -683,11 +683,11 @@ dao_input_storing(void)
   }
 
   learned_from = uip_is_addr_mcast(&dao_sender_addr) ?
-                 RPL_ROUTE_FROM_MULTICAST_DAO : RPL_ROUTE_FROM_UNICAST_DAO;
+    RPL_ROUTE_FROM_MULTICAST_DAO : RPL_ROUTE_FROM_UNICAST_DAO;
 
   /* Destination Advertisement Object */
   PRINTF("RPL: Received a (%s) DAO with sequence number %u from ",
-      learned_from == RPL_ROUTE_FROM_UNICAST_DAO? "unicast": "multicast", sequence);
+         learned_from == RPL_ROUTE_FROM_UNICAST_DAO? "unicast": "multicast", sequence);
   PRINT6ADDR(&dao_sender_addr);
   PRINTF("\n");
 
@@ -699,7 +699,7 @@ dao_input_storing(void)
     if(parent != NULL &&
        DAG_RANK(parent->rank, instance) < DAG_RANK(dag->rank, instance)) {
       PRINTF("RPL: Loop detected when receiving a unicast DAO from a node with a lower rank! (%u < %u)\n",
-          DAG_RANK(parent->rank, instance), DAG_RANK(dag->rank, instance));
+             DAG_RANK(parent->rank, instance), DAG_RANK(dag->rank, instance));
       parent->rank = INFINITE_RANK;
       parent->flags |= RPL_PARENT_FLAG_UPDATED;
       return;
@@ -725,24 +725,24 @@ dao_input_storing(void)
     }
 
     switch(subopt_type) {
-    case RPL_OPTION_TARGET:
-      /* Handle the target option. */
-      prefixlen = buffer[i + 3];
-      memset(&prefix, 0, sizeof(prefix));
-      memcpy(&prefix, buffer + i + 4, (prefixlen + 7) / CHAR_BIT);
-      break;
-    case RPL_OPTION_TRANSIT:
-      /* The path sequence and control are ignored. */
-      /*      pathcontrol = buffer[i + 3];
-              pathsequence = buffer[i + 4];*/
-      lifetime = buffer[i + 5];
-      /* The parent address is also ignored. */
-      break;
+      case RPL_OPTION_TARGET:
+        /* Handle the target option. */
+        prefixlen = buffer[i + 3];
+        memset(&prefix, 0, sizeof(prefix));
+        memcpy(&prefix, buffer + i + 4, (prefixlen + 7) / CHAR_BIT);
+        break;
+      case RPL_OPTION_TRANSIT:
+        /* The path sequence and control are ignored. */
+        /*      pathcontrol = buffer[i + 3];
+                pathsequence = buffer[i + 4];*/
+        lifetime = buffer[i + 5];
+        /* The parent address is also ignored. */
+        break;
     }
   }
 
   PRINTF("RPL: DAO lifetime: %u, prefix length: %u prefix: ",
-          (unsigned)lifetime, (unsigned)prefixlen);
+         (unsigned)lifetime, (unsigned)prefixlen);
   PRINT6ADDR(&prefix);
   PRINTF("\n");
 
@@ -781,7 +781,7 @@ dao_input_storing(void)
         out_seq = prepare_for_dao_fwd(sequence, rep);
 
         PRINTF("RPL: Forwarding No-path DAO to parent - out_seq:%d",
-	       out_seq);
+               out_seq);
         PRINT6ADDR(rpl_get_parent_ipaddr(dag->preferred_parent));
         PRINTF("\n");
 
@@ -813,8 +813,8 @@ dao_input_storing(void)
     if(flags & RPL_DAO_K_FLAG) {
       /* signal the failure to add the node */
       dao_ack_output(instance, &dao_sender_addr, sequence,
-		     is_root ? RPL_DAO_ACK_UNABLE_TO_ADD_ROUTE_AT_ROOT :
-		     RPL_DAO_ACK_UNABLE_TO_ACCEPT);
+                     is_root ? RPL_DAO_ACK_UNABLE_TO_ADD_ROUTE_AT_ROOT :
+                     RPL_DAO_ACK_UNABLE_TO_ACCEPT);
     }
     return;
   }
@@ -826,8 +826,8 @@ dao_input_storing(void)
     if(flags & RPL_DAO_K_FLAG) {
       /* signal the failure to add the node */
       dao_ack_output(instance, &dao_sender_addr, sequence,
-		     is_root ? RPL_DAO_ACK_UNABLE_TO_ADD_ROUTE_AT_ROOT :
-		     RPL_DAO_ACK_UNABLE_TO_ACCEPT);
+                     is_root ? RPL_DAO_ACK_UNABLE_TO_ADD_ROUTE_AT_ROOT :
+                     RPL_DAO_ACK_UNABLE_TO_ACCEPT);
     }
     return;
   }
@@ -852,7 +852,7 @@ fwd_dao:
        */
       if((!RPL_ROUTE_IS_DAO_PENDING(rep) &&
           rep->state.dao_seqno_in == sequence) ||
-          dag->rank == ROOT_RANK(instance)) {
+         dag->rank == ROOT_RANK(instance)) {
         should_ack = 1;
       }
     }
@@ -948,26 +948,26 @@ dao_input_nonstoring(void)
     }
 
     switch(subopt_type) {
-    case RPL_OPTION_TARGET:
-      /* Handle the target option. */
-      prefixlen = buffer[i + 3];
-      memset(&prefix, 0, sizeof(prefix));
-      memcpy(&prefix, buffer + i + 4, (prefixlen + 7) / CHAR_BIT);
-      break;
-    case RPL_OPTION_TRANSIT:
-      /* The path sequence and control are ignored. */
-      /*      pathcontrol = buffer[i + 3];
-              pathsequence = buffer[i + 4];*/
-      lifetime = buffer[i + 5];
-      if(len >= 20) {
-        memcpy(&dao_parent_addr, buffer + i + 6, 16);
-      }
-      break;
+      case RPL_OPTION_TARGET:
+        /* Handle the target option. */
+        prefixlen = buffer[i + 3];
+        memset(&prefix, 0, sizeof(prefix));
+        memcpy(&prefix, buffer + i + 4, (prefixlen + 7) / CHAR_BIT);
+        break;
+      case RPL_OPTION_TRANSIT:
+        /* The path sequence and control are ignored. */
+        /*      pathcontrol = buffer[i + 3];
+                pathsequence = buffer[i + 4];*/
+        lifetime = buffer[i + 5];
+        if(len >= 20) {
+          memcpy(&dao_parent_addr, buffer + i + 6, 16);
+        }
+        break;
     }
   }
 
   PRINTF("RPL: DAO lifetime: %u, prefix length: %u prefix: ",
-          (unsigned)lifetime, (unsigned)prefixlen);
+         (unsigned)lifetime, (unsigned)prefixlen);
   PRINT6ADDR(&prefix);
   PRINTF(", parent: ");
   PRINT6ADDR(&dao_parent_addr);
@@ -987,7 +987,7 @@ dao_input_nonstoring(void)
     PRINTF("RPL: Sending DAO ACK\n");
     uip_clear_buf();
     dao_ack_output(instance, &dao_sender_addr, sequence,
-        RPL_DAO_ACK_UNCONDITIONAL_ACCEPT);
+                   RPL_DAO_ACK_UNCONDITIONAL_ACCEPT);
   }
 #endif /* RPL_WITH_NON_STORING */
 }
@@ -1017,7 +1017,7 @@ dao_input(void)
     dao_input_nonstoring();
   }
 
- discard:
+discard:
   uip_clear_buf();
 }
 /*---------------------------------------------------------------------------*/
@@ -1059,7 +1059,7 @@ handle_dao_retransmission(void *ptr)
   }
 
   PRINTF("RPL: will retransmit DAO - seq:%d trans:%d\n", instance->my_dao_seqno,
-	 instance->my_dao_transmissions);
+         instance->my_dao_transmissions);
 
   if(get_global_addr(&prefix) == 0) {
     return;
@@ -1068,11 +1068,11 @@ handle_dao_retransmission(void *ptr)
   ctimer_set(&instance->dao_retransmit_timer,
              RPL_DAO_RETRANSMISSION_TIMEOUT / 2 +
              (random_rand() % (RPL_DAO_RETRANSMISSION_TIMEOUT / 2)),
-	     handle_dao_retransmission, parent);
+             handle_dao_retransmission, parent);
 
   instance->my_dao_transmissions++;
   dao_output_target_seq(parent, &prefix,
-			instance->default_lifetime, instance->my_dao_seqno);
+                        instance->default_lifetime, instance->my_dao_seqno);
 }
 #endif /* RPL_WITH_DAO_ACK */
 /*---------------------------------------------------------------------------*/
@@ -1103,11 +1103,11 @@ dao_output(rpl_parent_t *parent, uint8_t lifetime)
     instance->my_dao_seqno = dao_sequence;
     instance->my_dao_transmissions = 1;
     ctimer_set(&instance->dao_retransmit_timer, RPL_DAO_RETRANSMISSION_TIMEOUT,
- 	       handle_dao_retransmission, parent);
+               handle_dao_retransmission, parent);
   }
 #else
-   /* We know that we have tried to register so now we are assuming
-      that we have a down-link - unless this is a zero lifetime one */
+  /* We know that we have tried to register so now we are assuming
+     that we have a down-link - unless this is a zero lifetime one */
   parent->dag->instance->has_downward_route = lifetime != RPL_ZERO_LIFETIME;
 #endif /* RPL_WITH_DAO_ACK */
 
@@ -1123,7 +1123,7 @@ dao_output_target(rpl_parent_t *parent, uip_ipaddr_t *prefix, uint8_t lifetime)
 /*---------------------------------------------------------------------------*/
 static void
 dao_output_target_seq(rpl_parent_t *parent, uip_ipaddr_t *prefix,
-		      uint8_t lifetime, uint8_t seq_no)
+                      uint8_t lifetime, uint8_t seq_no)
 {
   rpl_dag_t *dag;
   rpl_instance_t *instance;
@@ -1223,7 +1223,7 @@ dao_output_target_seq(rpl_parent_t *parent, uip_ipaddr_t *prefix,
   }
 
   PRINTF("RPL: Sending a %sDAO with sequence number %u, lifetime %u, prefix ",
-      lifetime == RPL_ZERO_LIFETIME ? "No-Path " : "", seq_no, lifetime);
+         lifetime == RPL_ZERO_LIFETIME ? "No-Path " : "", seq_no, lifetime);
 
   PRINT6ADDR(prefix);
   PRINTF(" to ");
@@ -1273,8 +1273,8 @@ dao_ack_input(void)
   }
 
   PRINTF("RPL: Received a DAO %s with sequence number %d (%d) and status %d from ",
-   status < 128 ? "ACK" : "NACK",
-	 sequence, instance->my_dao_seqno, status);
+         status < 128 ? "ACK" : "NACK",
+         sequence, instance->my_dao_seqno, status);
   PRINT6ADDR(&UIP_IP_BUF->srcipaddr);
   PRINTF("\n");
 
@@ -1333,7 +1333,7 @@ dao_ack_input(void)
 /*---------------------------------------------------------------------------*/
 void
 dao_ack_output(rpl_instance_t *instance, uip_ipaddr_t *dest, uint8_t sequence,
-	       uint8_t status)
+               uint8_t status)
 {
 #if RPL_WITH_DAO_ACK
   unsigned char *buffer;

--- a/regression-tests/12-rpl/11-rpl-multicast.csc
+++ b/regression-tests/12-rpl/11-rpl-multicast.csc
@@ -1,0 +1,263 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<simconf>
+  <project EXPORT="discard">[APPS_DIR]/mrm</project>
+  <project EXPORT="discard">[APPS_DIR]/mspsim</project>
+  <project EXPORT="discard">[APPS_DIR]/avrora</project>
+  <project EXPORT="discard">[APPS_DIR]/serial_socket</project>
+  <project EXPORT="discard">[APPS_DIR]/collect-view</project>
+  <project EXPORT="discard">[APPS_DIR]/powertracker</project>
+  <project EXPORT="discard">[APPS_DIR]/radiologger-headless</project>
+  <simulation>
+    <title>My simulation</title>
+    <randomseed>123456</randomseed>
+    <motedelay_us>1000000</motedelay_us>
+    <radiomedium>
+      org.contikios.cooja.radiomediums.UDGM
+      <transmitting_range>50.0</transmitting_range>
+      <interference_range>100.0</interference_range>
+      <success_ratio_tx>1.0</success_ratio_tx>
+      <success_ratio_rx>1.0</success_ratio_rx>
+    </radiomedium>
+    <events>
+      <logoutput>40000</logoutput>
+    </events>
+    <motetype>
+      org.contikios.cooja.contikimote.ContikiMoteType
+      <identifier>mtype442</identifier>
+      <description>Cooja Mote Type #1</description>
+      <source>[CONTIKI_DIR]/examples/ipv6/multicast/root.c</source>
+      <commands>make clean TARGET=cooja
+      make DEFINES=RPL_CONF_WITH_DAO_ACK=1,UIP_MCAST6_CONF_ENGINE=UIP_MCAST6_ENGINE_SMRF root.cooja TARGET=cooja</commands>
+      <moteinterface>org.contikios.cooja.interfaces.Position</moteinterface>
+      <moteinterface>org.contikios.cooja.interfaces.Battery</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiVib</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiMoteID</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiRS232</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiBeeper</moteinterface>
+      <moteinterface>org.contikios.cooja.interfaces.RimeAddress</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiIPAddress</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiRadio</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiButton</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiPIR</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiClock</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiLED</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiCFS</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiEEPROM</moteinterface>
+      <moteinterface>org.contikios.cooja.interfaces.Mote2MoteRelations</moteinterface>
+      <moteinterface>org.contikios.cooja.interfaces.MoteAttributes</moteinterface>
+      <symbols>false</symbols>
+    </motetype>
+    <motetype>
+      org.contikios.cooja.contikimote.ContikiMoteType
+      <identifier>mtype774</identifier>
+      <description>Cooja Mote Type #2</description>
+      <source>[CONTIKI_DIR]/examples/ipv6/multicast/sink.c</source>
+      <commands>make clean TARGET=cooja
+      make DEFINES=RPL_CONF_WITH_DAO_ACK=1,UIP_MCAST6_CONF_ENGINE=UIP_MCAST6_ENGINE_SMRF sink.cooja TARGET=cooja</commands>
+      <moteinterface>org.contikios.cooja.interfaces.Position</moteinterface>
+      <moteinterface>org.contikios.cooja.interfaces.Battery</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiVib</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiMoteID</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiRS232</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiBeeper</moteinterface>
+      <moteinterface>org.contikios.cooja.interfaces.RimeAddress</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiIPAddress</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiRadio</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiButton</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiPIR</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiClock</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiLED</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiCFS</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiEEPROM</moteinterface>
+      <moteinterface>org.contikios.cooja.interfaces.Mote2MoteRelations</moteinterface>
+      <moteinterface>org.contikios.cooja.interfaces.MoteAttributes</moteinterface>
+      <symbols>false</symbols>
+    </motetype>
+    <motetype>
+      org.contikios.cooja.contikimote.ContikiMoteType
+      <identifier>mtype224</identifier>
+      <description>Cooja Mote Type #3</description>
+      <source>[CONTIKI_DIR]/examples/ipv6/multicast/intermediate.c</source>
+      <commands>make clean TARGET=cooja
+      make DEFINES=RPL_CONF_WITH_DAO_ACK=1,UIP_MCAST6_CONF_ENGINE=UIP_MCAST6_ENGINE_SMRF intermediate.cooja TARGET=cooja</commands>
+      <moteinterface>org.contikios.cooja.interfaces.Position</moteinterface>
+      <moteinterface>org.contikios.cooja.interfaces.Battery</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiVib</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiMoteID</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiRS232</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiBeeper</moteinterface>
+      <moteinterface>org.contikios.cooja.interfaces.RimeAddress</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiIPAddress</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiRadio</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiButton</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiPIR</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiClock</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiLED</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiCFS</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiEEPROM</moteinterface>
+      <moteinterface>org.contikios.cooja.interfaces.Mote2MoteRelations</moteinterface>
+      <moteinterface>org.contikios.cooja.interfaces.MoteAttributes</moteinterface>
+      <symbols>false</symbols>
+    </motetype>
+    <mote>
+      <interface_config>
+        org.contikios.cooja.interfaces.Position
+        <x>85.56533190308505</x>
+        <y>53.562395364420965</y>
+        <z>0.0</z>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.contikimote.interfaces.ContikiMoteID
+        <id>1</id>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.contikimote.interfaces.ContikiRadio
+        <bitrate>250.0</bitrate>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.contikimote.interfaces.ContikiEEPROM
+        <eeprom>AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==</eeprom>
+      </interface_config>
+      <motetype_identifier>mtype442</motetype_identifier>
+    </mote>
+    <mote>
+      <interface_config>
+        org.contikios.cooja.interfaces.Position
+        <x>43.952924225580446</x>
+        <y>106.6875691603427</y>
+        <z>0.0</z>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.contikimote.interfaces.ContikiMoteID
+        <id>2</id>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.contikimote.interfaces.ContikiRadio
+        <bitrate>250.0</bitrate>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.contikimote.interfaces.ContikiEEPROM
+        <eeprom>AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==</eeprom>
+      </interface_config>
+      <motetype_identifier>mtype774</motetype_identifier>
+    </mote>
+    <mote>
+      <interface_config>
+        org.contikios.cooja.interfaces.Position
+        <x>64.1616459084996</x>
+        <y>81.13076965805963</y>
+        <z>0.0</z>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.contikimote.interfaces.ContikiMoteID
+        <id>3</id>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.contikimote.interfaces.ContikiRadio
+        <bitrate>250.0</bitrate>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.contikimote.interfaces.ContikiEEPROM
+        <eeprom>AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==</eeprom>
+      </interface_config>
+      <motetype_identifier>mtype224</motetype_identifier>
+    </mote>
+  </simulation>
+  <plugin>
+    org.contikios.cooja.plugins.SimControl
+    <width>280</width>
+    <z>2</z>
+    <height>160</height>
+    <location_x>400</location_x>
+    <location_y>0</location_y>
+  </plugin>
+  <plugin>
+    org.contikios.cooja.plugins.Visualizer
+    <plugin_config>
+      <moterelations>true</moterelations>
+      <skin>org.contikios.cooja.plugins.skins.IDVisualizerSkin</skin>
+      <skin>org.contikios.cooja.plugins.skins.GridVisualizerSkin</skin>
+      <skin>org.contikios.cooja.plugins.skins.TrafficVisualizerSkin</skin>
+      <skin>org.contikios.cooja.plugins.skins.UDGMVisualizerSkin</skin>
+      <viewport>3.699424669235615 0.0 0.0 3.699424669235615 -45.57151591938098 -64.4098979798254</viewport>
+    </plugin_config>
+    <width>400</width>
+    <z>1</z>
+    <height>400</height>
+    <location_x>1</location_x>
+    <location_y>1</location_y>
+  </plugin>
+  <plugin>
+    org.contikios.cooja.plugins.LogListener
+    <plugin_config>
+      <filter />
+      <formatted_time />
+      <coloring />
+    </plugin_config>
+    <width>1320</width>
+    <z>6</z>
+    <height>240</height>
+    <location_x>400</location_x>
+    <location_y>160</location_y>
+  </plugin>
+  <plugin>
+    org.contikios.cooja.plugins.TimeLine
+    <plugin_config>
+      <mote>0</mote>
+      <mote>1</mote>
+      <mote>2</mote>
+      <showRadioRXTX />
+      <showRadioHW />
+      <showLEDs />
+      <zoomfactor>500.0</zoomfactor>
+    </plugin_config>
+    <width>1720</width>
+    <z>5</z>
+    <height>166</height>
+    <location_x>0</location_x>
+    <location_y>957</location_y>
+  </plugin>
+  <plugin>
+    org.contikios.cooja.plugins.Notes
+    <plugin_config>
+      <notes>Enter notes here</notes>
+      <decorations>true</decorations>
+    </plugin_config>
+    <width>1040</width>
+    <z>4</z>
+    <height>160</height>
+    <location_x>680</location_x>
+    <location_y>0</location_y>
+  </plugin>
+  <plugin>
+    org.contikios.cooja.plugins.RadioLogger
+    <plugin_config>
+      <split>150</split>
+      <formatted_time />
+      <showdups>false</showdups>
+      <hidenodests>false</hidenodests>
+      <analyzers name="6lowpan-pcap" />
+    </plugin_config>
+    <width>500</width>
+    <z>3</z>
+    <height>300</height>
+    <location_x>710</location_x>
+    <location_y>30</location_y>
+  </plugin>
+  <plugin>
+    org.contikios.cooja.plugins.ScriptRunner
+    <plugin_config>
+      <script>
+        TIMEOUT(3600000, log.testOK());
+        /* If it runs through without crash, this test is regarded as success */
+      </script>
+      <active>true</active>
+    </plugin_config>
+    <width>600</width>
+    <z>0</z>
+    <height>700</height>
+    <location_x>430</location_x>
+    <location_y>30</location_y>
+  </plugin>
+</simconf>
+


### PR DESCRIPTION
This PR aims to resolve https://github.com/contiki-os/contiki/issues/2031.

A new regression test, `11-rpl-multicast.csc`, is introduced under `regression-tests/12-rpl/`.

Without the change, the test fails like this:
```shell
$ cd regression-tests/12-rpl
$ make 11-rpl-multicast.testlog
Running test 11-rpl-multicast with random Seed 1: ............../../regression-tests/simexec.sh: line 70: 83680 Aborted                 (core dumped) java -Xshare:on -j
(snip)
#
# A fatal error has been detected by the Java Runtime Environment:
#
#  SIGSEGV (0xb) at pc=0x00007fb713def1f3, pid=83680, tid=0x00007fb712844700
#
# JRE version: OpenJDK Runtime Environment (8.0_121-b13) (build 1.8.0_121-8u121-b13-0ubuntu1.16.04.2-b13)
# Java VM: OpenJDK 64-Bit Server VM (25.121-b13 mixed mode, sharing linux-amd64 compressed oops)
```

On the tip of the branch, the test succeeds:
```shell
$ cd regression-tests/12-rpl
$ make 11-rpl-multicast.testlog
Running test 11-rpl-multicast with random Seed 1: ................. OK
```