### PR TITLE
RPL: move a debug message for RPL_LEAF_ONLY to a correct place

### DIFF
--- a/core/net/rpl/rpl-icmp6.c
+++ b/core/net/rpl/rpl-icmp6.c
@@ -218,16 +218,15 @@ dis_input(void)
   for(instance = &instance_table[0], end = instance + RPL_MAX_INSTANCES;
       instance < end; ++instance) {
     if(instance->used == 1) {
-#if RPL_LEAF_ONLY
-      if(!uip_is_addr_mcast(&UIP_IP_BUF->destipaddr)) {
-	PRINTF("RPL: LEAF ONLY Multicast DIS will NOT reset DIO timer\n");
-#else /* !RPL_LEAF_ONLY */
       if(uip_is_addr_mcast(&UIP_IP_BUF->destipaddr)) {
+#if RPL_LEAF_ONLY
+        PRINTF("RPL: LEAF ONLY Multicast DIS will NOT reset DIO timer\n");
+#else /* !RPL_LEAF_ONLY */
         PRINTF("RPL: Multicast DIS => reset DIO timer\n");
         rpl_reset_dio_timer(instance);
-      } else {
 #endif /* !RPL_LEAF_ONLY */
-	/* Check if this neighbor should be added according to the policy. */
+      } else {
+        /* Check if this neighbor should be added according to the policy. */
         if(rpl_icmp6_update_nbr_table(&UIP_IP_BUF->srcipaddr,
                                       NBR_TABLE_REASON_RPL_DIS, NULL) == NULL) {
           PRINTF("RPL: Out of Memory, not sending unicast DIO, DIS from ");


### PR DESCRIPTION
A debug message output for `RPL_LEAF_ONLY` seems to have been added at a wrong place in `rpl-icmp6.c` by PR https://github.com/contiki-os/contiki/pull/142. Here is the relevant part. While L223 is within the case where the destination is a unicast address, the debug message is talking about "Multicast DIS." 

```C
    221 #if RPL_LEAF_ONLY
    222       if(!uip_is_addr_mcast(&UIP_IP_BUF->destipaddr)) {
    223         PRINTF("RPL: LEAF ONLY Multicast DIS will NOT reset DIO timer\n");
    224 #else /* !RPL_LEAF_ONLY */
    225       if(uip_is_addr_mcast(&UIP_IP_BUF->destipaddr)) {
    226         PRINTF("RPL: Multicast DIS => reset DIO timer\n");
    227         rpl_reset_dio_timer(instance);
    228       } else {
    229 #endif /* !RPL_LEAF_ONLY */
```

The following is my proposal. 

```C
    221       if(uip_is_addr_mcast(&UIP_IP_BUF->destipaddr)) {
    222 #if RPL_LEAF_ONLY
    223         PRINTF("RPL: LEAF ONLY Multicast DIS will NOT reset DIO timer\n");
    224 #else /* !RPL_LEAF_ONLY */
    225         PRINTF("RPL: Multicast DIS => reset DIO timer\n");
    226         rpl_reset_dio_timer(instance);
    227 #endif /* !RPL_LEAF_ONLY */
    228       } else {
```