### PR TITLE
TSCH: POC of a bug in tsch_queue_flush_nbr_queue()

### DIFF
--- a/core/net/mac/tsch/tsch-queue.c
+++ b/core/net/mac/tsch/tsch-queue.c
@@ -202,6 +202,7 @@ tsch_queue_flush_nbr_queue(struct tsch_neighbor *n)
       /* Free packet queuebuf */
       tsch_queue_free_packet(p);
     }
+    PRINTF("TSCH-queue: packet is deleted packet=%p\n", p);
   }
 }
 /*---------------------------------------------------------------------------*/
@@ -253,6 +254,8 @@ tsch_queue_add_packet(const linkaddr_t *addr, mac_callback_t sent, void *ptr)
             /* Add to ringbuf (actual add committed through atomic operation) */
             n->tx_array[put_index] = p;
             ringbufindex_put(&n->tx_ringbuf);
+            PRINTF("TSCH-queue: packet is added put_index=%u, packet=%p\n",
+                   put_index, p);
             return p;
           } else {
             memb_free(&packet_memb, p);
@@ -288,6 +291,7 @@ tsch_queue_remove_packet_from_queue(struct tsch_neighbor *n)
       /* Get and remove packet from ringbuf (remove committed through an atomic operation */
       int16_t get_index = ringbufindex_get(&n->tx_ringbuf);
       if(get_index != -1) {
+        PRINTF("TSCH-queue: packet is removed, get_index=%u\n", get_index);
         return n->tx_array[get_index];
       } else {
         return NULL;

--- a/regression-tests/27-tsch/01-cooja-flush-nbr-queue.csc
+++ b/regression-tests/27-tsch/01-cooja-flush-nbr-queue.csc
@@ -1,0 +1,147 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<simconf>
+  <project EXPORT="discard">[APPS_DIR]/mrm</project>
+  <project EXPORT="discard">[APPS_DIR]/mspsim</project>
+  <project EXPORT="discard">[APPS_DIR]/avrora</project>
+  <project EXPORT="discard">[APPS_DIR]/serial_socket</project>
+  <project EXPORT="discard">[APPS_DIR]/collect-view</project>
+  <project EXPORT="discard">[APPS_DIR]/powertracker</project>
+  <simulation>
+    <title>My simulation</title>
+    <randomseed>123456</randomseed>
+    <motedelay_us>1000000</motedelay_us>
+    <radiomedium>
+      org.contikios.cooja.radiomediums.UDGM
+      <transmitting_range>50.0</transmitting_range>
+      <interference_range>100.0</interference_range>
+      <success_ratio_tx>1.0</success_ratio_tx>
+      <success_ratio_rx>1.0</success_ratio_rx>
+    </radiomedium>
+    <events>
+      <logoutput>40000</logoutput>
+    </events>
+    <motetype>
+      org.contikios.cooja.contikimote.ContikiMoteType
+      <identifier>mtype476</identifier>
+      <description>Cooja Mote Type #1</description>
+      <source>[CONTIKI_DIR]/regression-tests/27-tsch/code/test-flush-nbr-queue.c</source>
+      <commands>make test-flush-nbr-queue.cooja TARGET=cooja</commands>
+      <moteinterface>org.contikios.cooja.interfaces.Position</moteinterface>
+      <moteinterface>org.contikios.cooja.interfaces.Battery</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiVib</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiMoteID</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiRS232</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiBeeper</moteinterface>
+      <moteinterface>org.contikios.cooja.interfaces.RimeAddress</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiIPAddress</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiRadio</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiButton</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiPIR</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiClock</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiLED</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiCFS</moteinterface>
+      <moteinterface>org.contikios.cooja.contikimote.interfaces.ContikiEEPROM</moteinterface>
+      <moteinterface>org.contikios.cooja.interfaces.Mote2MoteRelations</moteinterface>
+      <moteinterface>org.contikios.cooja.interfaces.MoteAttributes</moteinterface>
+      <symbols>false</symbols>
+    </motetype>
+    <mote>
+      <interface_config>
+        org.contikios.cooja.interfaces.Position
+        <x>38.79981729133275</x>
+        <y>97.05367953429746</y>
+        <z>0.0</z>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.contikimote.interfaces.ContikiMoteID
+        <id>1</id>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.contikimote.interfaces.ContikiRadio
+        <bitrate>250.0</bitrate>
+      </interface_config>
+      <interface_config>
+        org.contikios.cooja.contikimote.interfaces.ContikiEEPROM
+        <eeprom>AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==</eeprom>
+      </interface_config>
+      <motetype_identifier>mtype476</motetype_identifier>
+    </mote>
+  </simulation>
+  <plugin>
+    org.contikios.cooja.plugins.SimControl
+    <width>280</width>
+    <z>4</z>
+    <height>160</height>
+    <location_x>400</location_x>
+    <location_y>0</location_y>
+  </plugin>
+  <plugin>
+    org.contikios.cooja.plugins.Visualizer
+    <plugin_config>
+      <moterelations>true</moterelations>
+      <skin>org.contikios.cooja.plugins.skins.IDVisualizerSkin</skin>
+      <skin>org.contikios.cooja.plugins.skins.GridVisualizerSkin</skin>
+      <skin>org.contikios.cooja.plugins.skins.TrafficVisualizerSkin</skin>
+      <skin>org.contikios.cooja.plugins.skins.UDGMVisualizerSkin</skin>
+      <viewport>0.9090909090909091 0.0 0.0 0.9090909090909091 158.72743882606113 84.76938224154777</viewport>
+    </plugin_config>
+    <width>400</width>
+    <z>3</z>
+    <height>400</height>
+    <location_x>1</location_x>
+    <location_y>1</location_y>
+  </plugin>
+  <plugin>
+    org.contikios.cooja.plugins.LogListener
+    <plugin_config>
+      <filter />
+      <formatted_time />
+      <coloring />
+    </plugin_config>
+    <width>1320</width>
+    <z>2</z>
+    <height>240</height>
+    <location_x>400</location_x>
+    <location_y>160</location_y>
+  </plugin>
+  <plugin>
+    org.contikios.cooja.plugins.TimeLine
+    <plugin_config>
+      <mote>0</mote>
+      <showRadioRXTX />
+      <showRadioHW />
+      <showLEDs />
+      <zoomfactor>500.0</zoomfactor>
+    </plugin_config>
+    <width>1720</width>
+    <z>1</z>
+    <height>166</height>
+    <location_x>0</location_x>
+    <location_y>957</location_y>
+  </plugin>
+  <plugin>
+    org.contikios.cooja.plugins.Notes
+    <plugin_config>
+      <notes>Enter notes here</notes>
+      <decorations>true</decorations>
+    </plugin_config>
+    <width>1040</width>
+    <z>0</z>
+    <height>160</height>
+    <location_x>680</location_x>
+    <location_y>0</location_y>
+  </plugin>
+  <plugin>
+    org.contikios.cooja.plugins.ScriptRunner
+    <plugin_config>
+      <scriptfile>[CONTIKI_DIR]/regression-tests/27-tsch/js/unit-test.js</scriptfile>
+      <active>true</active>
+    </plugin_config>
+    <width>495</width>
+    <z>0</z>
+    <height>525</height>
+    <location_x>663</location_x>
+    <location_y>105</location_y>
+  </plugin>
+</simconf>
+

--- a/regression-tests/27-tsch/Makefile
+++ b/regression-tests/27-tsch/Makefile
@@ -1,0 +1,1 @@
+include ../Makefile.simulation-test

--- a/regression-tests/27-tsch/code/Makefile
+++ b/regression-tests/27-tsch/code/Makefile
@@ -1,0 +1,11 @@
+all: 
+
+CFLAGS  += -D PROJECT_CONF_H=\"project-conf.h\"
+APPS    += unit-test
+MODULES += core/net/mac/tsch core/net/mac/tsch/sixtop
+
+PROJECT_SOURCEFILES += common.c
+
+CONTIKI = ../../..
+CONTIKI_WITH_IPV6 = 1
+include $(CONTIKI)/Makefile.include

--- a/regression-tests/27-tsch/code/common.c
+++ b/regression-tests/27-tsch/code/common.c
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2017, Yasuyuki Tanaka
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdio.h>
+#include <string.h>
+
+#include "unit-test.h"
+#include "common.h"
+
+#include "lib/simEnvChange.h"
+#include "sys/cooja_mt.h"
+
+void
+test_print_report(const unit_test_t *utp)
+{
+  printf("=check-me= ");
+  if(utp->result == unit_test_failure) {
+    printf("FAILED   - %s: exit at L%u\n", utp->descr, utp->exit_line);
+  } else {
+    printf("SUCCEEDED - %s\n", utp->descr);
+  }
+
+  /* give up the CPU so that the mote can output messages in the serial buffer */
+  simProcessRunValue = 1;
+  cooja_mt_yield();
+}

--- a/regression-tests/27-tsch/code/common.h
+++ b/regression-tests/27-tsch/code/common.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2017, Yasuyuki Tanaka
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef _COMMON_H
+#define _COMMON_H
+
+#include "unit-test.h"
+
+void test_print_report(const unit_test_t *utp);
+
+#endif /* !_COMMON_H */

--- a/regression-tests/27-tsch/code/project-conf.h
+++ b/regression-tests/27-tsch/code/project-conf.h
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2017, Yasuyuki Tanaka
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef _PROJECT_CONF_H_
+#define _PROJECT_CONF_H_
+
+#define UNIT_TEST_PRINT_FUNCTION test_print_report
+
+/* Set the minimum value of QUEUEBUF_CONF_NUM for the flush_nbr_queue test */
+#undef QUEUEBUF_CONF_NUM
+#define QUEUEBUF_CONF_NUM   1
+
+#undef TSCH_LOG_CONF_LEVEL
+#define TSCH_LOG_CONF_LEVEL 2
+
+#undef TSCH_CONF_AUTOSTART
+#define TSCH_CONF_AUTOSTART 1
+
+#undef NETSTACK_CONF_MAC
+#define NETSTACK_CONF_MAC        tschmac_driver
+
+#undef NETSTACK_CONF_RDC
+#define NETSTACK_CONF_RDC        nordc_driver
+
+#undef NETSTACK_CONF_FRAMER
+#define NETSTACK_CONF_FRAMER     framer_802154
+
+#undef FRAME802154_CONF_VERSION
+#define FRAME802154_CONF_VERSION FRAME802154_IEEE802154E_2012
+
+#if CONTIKI_TARGET_COOJA
+#define COOJA_CONF_SIMULATE_TURNAROUND 0
+#endif /* CONTIKI_TARGET_COOJA */
+
+#endif /* __PROJECT_CONF_H__ */

--- a/regression-tests/27-tsch/code/test-flush-nbr-queue.c
+++ b/regression-tests/27-tsch/code/test-flush-nbr-queue.c
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2017, Yasuyuki Tanaka
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdio.h>
+
+#include "contiki.h"
+#include "contiki-net.h"
+#include "contiki-lib.h"
+#include "lib/assert.h"
+
+#include "net/linkaddr.h"
+#include "net/mac/tsch/tsch.h"
+#include "net/mac/tsch/tsch-queue.h"
+
+#include "unit-test.h"
+#include "common.h"
+
+PROCESS(test_process, "tsch_queue_flush_nbr_queue() test");
+AUTOSTART_PROCESSES(&test_process);
+
+static linkaddr_t test_nbr_addr = {{ 0x01 }};
+#define TEST_PEER_ADDR &test_nbr_addr
+
+UNIT_TEST_REGISTER(test,
+                   "flush_nbr_queue() should delete all the packet in the queue");
+UNIT_TEST(test)
+{
+  struct tsch_packet *packet;
+  struct tsch_neighbor *nbr;
+
+  UNIT_TEST_BEGIN();
+
+  packet = tsch_queue_add_packet(TEST_PEER_ADDR, NULL, NULL);
+  UNIT_TEST_ASSERT(packet != NULL);
+
+  nbr = tsch_queue_get_nbr(TEST_PEER_ADDR);
+  UNIT_TEST_ASSERT(nbr != NULL);
+
+  /*
+   * QUEUEBUF_CONF_NUM is set with 1; so another addition should fail due to
+   * lack of memory.
+   */
+  packet = tsch_queue_add_packet(TEST_PEER_ADDR, NULL, NULL);
+  UNIT_TEST_ASSERT(packet == NULL);
+
+  /* tsch_queue_flush_nbr_queue() is called inside of tsch_queue_reset(). */
+  tsch_queue_reset();
+
+  /* After flushing the nbr queue, we should be able to add a new packet */
+  packet = tsch_queue_add_packet(TEST_PEER_ADDR, NULL, NULL);
+  UNIT_TEST_ASSERT(packet != NULL);
+
+  UNIT_TEST_END();
+}
+
+PROCESS_THREAD(test_process, ev, data)
+{
+  static struct etimer et;
+
+  PROCESS_BEGIN();
+
+  tsch_set_coordinator(1);
+
+  etimer_set(&et, CLOCK_SECOND);
+  while(tsch_is_associated == 0) {
+    PROCESS_YIELD_UNTIL(etimer_expired(&et));
+    etimer_reset(&et);
+  }
+
+  printf("Run unit-test\n");
+  printf("---\n");
+
+  UNIT_TEST_RUN(test);
+
+  printf("=check-me= DONE\n");
+  PROCESS_END();
+}

--- a/regression-tests/27-tsch/js/unit-test.js
+++ b/regression-tests/27-tsch/js/unit-test.js
@@ -1,0 +1,27 @@
+TIMEOUT(10000, log.testFailed());
+
+var failed = false;
+var done = 0;
+
+while(done < sim.getMotes().length) {
+    YIELD();
+
+    log.log(time + " " + "node-" + id + " "+ msg + "\n");
+    
+    if(msg.contains("=check-me=") == false) {
+        continue;
+    }
+
+    if(msg.contains("FAILED")) {
+        failed = true;
+    }
+
+    if(msg.contains("DONE")) {
+        done++;
+    }
+}
+if(failed) {
+    log.testFailed();
+}
+log.testOK();
+


### PR DESCRIPTION
This PR doesn't fix anything; just demonstrates a bug in `tsch_queue_flush_nbr_queue()`, which could be related to discussions in Issue/https://github.com/contiki-os/contiki/issues/1766 and Issue/https://github.com/contiki-os/contiki/issues/2105. 

The test introduced by this PR does the following: Please note `QUEUEBUF_CONF_NUM` is set with 1.

1. add one packet by `tsch_queue_add_packet(); should succeed
2. add one more packet by `tsch_queue_add_packet(); should fail because of lack of memory
3. call `tsch_queue_reset()` to invoke `tsch_queue_flush_nbr_queue()`
4. add one packet by `tsch_queue_add_packet(); should succeed

You can find the test code in `regression-tests/27-tsch/code/test-flush-nbr-queue.c`.

Here is the result on the tip of the master branch:
```shell
$ make 01-cooja-flush-nbr-queue.testlog
Running test 01-cooja-flush-nbr-queue with random Seed 1: ..................................Message:  CC        ../../../core/net/mac/nullmac.c
Message:  CC        ../../../core/net/mac/nullrdc-noframer.c
(snip)
../Makefile.simulation-test:60: recipe for target '01-cooja-flush-nbr-queue.testlog' failed
make: *** [01-cooja-flush-nbr-queue.testlog] Error 1
$ tail 01-cooja-flush-nbr-queue.1.faillog
1549000 node-1 TSCH-queue: packet is added put_index=1, packet=0x7fe588680620
1549000 node-1 TSCH-queue:! add packet failed: 0 0x7fe588680800 2 (nil) (nil)
1549000 node-1 TSCH-queue: packet is removed, get_index=0
1549000 node-1 TSCH-queue: packet is deleted packet=(nil)
1549000 node-1 TSCH-queue:! add packet failed: 0 0x7fe588680800 2 (nil) (nil)
1549000 node-1 =check-me= FAILED   - flush_nbr_queue() should delete all the packet in the queue: exit at L79
1550000 node-1 =check-me= DONE
TEST FAILED
Test ended at simulation time: 2093020
 FAIL ಠ_ಠ
```

The root cause of the bug seems to exist in `ringbufferindex`, that can be resolved by PR/https://github.com/contiki-os/contiki/pull/2046.  With the changes from PR/https://github.com/contiki-os/contiki/pull/2046, the test passes.
```shell
$ make 01-cooja-flush-nbr-queue.testlog
Running test 01-cooja-flush-nbr-queue with random Seed 1: .............................. OK
$ tail 01-cooja-flush-nbr-queue.testlog
1549000 node-1 TSCH-queue: packet is added put_index=0, packet=0x7fe1fcf6d620
1549000 node-1 TSCH-queue:! add packet failed: 0 0x7fe1fcf6d800 1 (nil) (nil)
1549000 node-1 TSCH-queue: packet is removed, get_index=0
1549000 node-1 TSCH-queue:! flushing packet
1549000 node-1 TSCH-queue: packet is deleted packet=0x7fe1fcf6d620
1549000 node-1 TSCH-queue: packet is added put_index=1, packet=0x7fe1fcf6d620
1549000 node-1 =check-me= SUCCEEDED - flush_nbr_queue() should delete all the packet in the queue
1550000 node-1 =check-me= DONE
TEST OK
Test ended at simulation time: 2161020
```

Because of the bug in `ringbufferindex`, some problem could arise if an index returned by `ringbufferindex_get()` is used meaningfully. In this case, `tsch_queue_remove_packet_from_queue()`, that is called by `tsch_queue_flush_nbr_queue()`, returns the pointer of a `tsch_packet` which is retrieved by such an index. The `tsch_packet` is NOT what is expected to be removed or freed. 

```C
 286 struct tsch_packet *
 287 tsch_queue_remove_packet_from_queue(struct tsch_neighbor *n)
 288 {
 289   if(!tsch_is_locked()) {
 290     if(n != NULL) {
 291       /* Get and remove packet from ringbuf (remove committed through an atomic operation */
 292       int16_t get_index = ringbufindex_get(&n->tx_ringbuf);
 293       if(get_index != -1) {
 294         PRINTF("TSCH-queue: packet is removed, get_index=%u\n", get_index);
 295         return n->tx_array[get_index];
```

`tsch_queue_flush_nbr_queue()` frees the memory pointed by `p` returned from `tsch_queue_remove_packet_from_queue()`. Again, `p` does NOT point to the memory that we want to free. When `p` is `NULL`, `tsch_queue_free_packet(p)` is not called. This leads to memory leak.
```C
 191 static void
 192 tsch_queue_flush_nbr_queue(struct tsch_neighbor *n)
 193 {
 194   while(!tsch_queue_is_empty(n)) {
 195     struct tsch_packet *p = tsch_queue_remove_packet_from_queue(n);
 196     if(p != NULL) {
 197       /* Set return status for packet_sent callback */
 198       p->ret = MAC_TX_ERR;
 199       PRINTF("TSCH-queue:! flushing packet\n");
 200       /* Call packet_sent callback */
 201       mac_call_sent_callback(p->sent, p->ptr, p->ret, p->transmissions);
 202       /* Free packet queuebuf */
 203       tsch_queue_free_packet(p);
 204     }
```