### PR TITLE
add CPU energest measurements that were lacking in this platform

### DIFF
--- a/platform/avr-rss2/contiki-main.c
+++ b/platform/avr-rss2/contiki-main.c
@@ -258,6 +258,8 @@ initialize(void)
 /* rtimers needed for radio cycling */
   rtimer_init();
 
+/* we can initialize the energest arrays here */
+  energest_init();
 /* after the timer intitialisation we start the cpu measurement */
   ENERGEST_ON(ENERGEST_TYPE_CPU);
 
@@ -462,9 +464,6 @@ main(void)
 #if NETSTACK_CONF_WITH_IPV6
   uip_ds6_nbr_t *nbr;
 #endif /* NETSTACK_CONF_WITH_IPV6 */
-
-/* we can initialize the energest here, before the hardware */
-  energest_init();
  
 
   initialize();

--- a/platform/avr-rss2/contiki-main.c
+++ b/platform/avr-rss2/contiki-main.c
@@ -258,6 +258,10 @@ initialize(void)
 /* rtimers needed for radio cycling */
   rtimer_init();
 
+/* after the timer intitialisation we start the cpu measurement */
+  ENERGEST_ON(ENERGEST_TYPE_CPU);
+
+
   /* Initialize process subsystem */
   process_init();
 
@@ -458,6 +462,11 @@ main(void)
 #if NETSTACK_CONF_WITH_IPV6
   uip_ds6_nbr_t *nbr;
 #endif /* NETSTACK_CONF_WITH_IPV6 */
+
+/* we can initialize the energest here, before the hardware */
+  energest_init();
+ 
+
   initialize();
 
   while(1) {


### PR DESCRIPTION
This platform did not have the Energest functions to measure CPU rticks, so they were added.