### PR TITLE
CC26xx IEEE mode driver fixes and robustness improvements

### DIFF
--- a/cpu/cc26xx-cc13xx/rf-core/rf-core.c
+++ b/cpu/cc26xx-cc13xx/rf-core/rf-core.c
@@ -419,8 +419,7 @@ rf_core_restart_rat(void)
 {
   if(rf_core_stop_rat() != RF_CORE_CMD_OK) {
     PRINTF("rf_core_restart_rat: rf_core_stop_rat() failed\n");
-
-    return RF_CORE_CMD_ERROR;
+    /* Don't bail out here, still try to start it */
   }
 
   if(rf_core_start_rat() != RF_CORE_CMD_OK) {


### PR DESCRIPTION
This patch add a fix for the radio driver that limits the time it spends in busywaiting operations. At the moment it can lock up in case turning off the radio Rx mode fails, leading to a reboot of the system.

The patch also makes the radio timer (RAT) handling more robust.

This code was developed as part of the SPHERE project (http://irc-sphere.ac.uk/)