### PR TITLE
fix a macro related to multicast, which are not user configuration

### DIFF
--- a/core/net/ipv6/multicast/uip-mcast6.h
+++ b/core/net/ipv6/multicast/uip-mcast6.h
@@ -162,7 +162,7 @@ struct uip_mcast6_driver {
 #define UIP_MCAST6             smrf_driver
 
 #elif UIP_MCAST6_ENGINE == UIP_MCAST6_ENGINE_ESMRF
-#define RPL_CONF_MULTICAST     1
+#define RPL_WITH_MULTICAST     1
 #define UIP_MCAST6             esmrf_driver
 
 #else


### PR DESCRIPTION
fix a macro related to multicast, which are not user configuration
- RPL_CONF_MULTICAST      -> RPL_WITH_MULTICAST