### PR TITLE
Don't force RPL MOP configuration in contiki-default-conf.h

### DIFF
--- a/core/contiki-default-conf.h
+++ b/core/contiki-default-conf.h
@@ -148,13 +148,6 @@
 #endif /* NBR_TABLE_FIND_REMOVABLE */
 #endif /* UIP_CONF_IPV6_RPL */
 
-/* RPL_CONF_MOP specifies the RPL mode of operation that will be
- * advertised by the RPL root. Possible values: RPL_MOP_NO_DOWNWARD_ROUTES,
- * RPL_MOP_NON_STORING, RPL_MOP_STORING_NO_MULTICAST, RPL_MOP_STORING_MULTICAST */
-#ifndef RPL_CONF_MOP
-#define RPL_CONF_MOP RPL_MOP_STORING_NO_MULTICAST
-#endif /* RPL_CONF_MOP */
-
 /* UIP_CONF_MAX_ROUTES specifies the maximum number of routes that each
    node will be able to handle. */
 #ifndef UIP_CONF_MAX_ROUTES


### PR DESCRIPTION
We are trying to set the default MOP in two places:

* `rpl-private.h`: Considers multicast engine selection and correctly allows MOP to be set to 3 when required.
* `contiki-default-conf.h` is not only redundant but also fails to handle situations where RPL multicast is required.

When selecting a multicast engine that requires RPL to be in MOP 3, compilation fails with the error shown in #2143.

This pull simply removes RPL MOP-related configuration from `contiki-default-conf.h` and allows user-provided configuration to take care of things, with `rpl-private.h` setting correct defaults if required.

Fixes #2143 