### PR TITLE
native-border-router: fix for disappearing timer 'uip_ds6_timer_perio…

### DIFF
--- a/examples/ipv6/native-border-router/border-router.c
+++ b/examples/ipv6/native-border-router/border-router.c
@@ -247,8 +247,10 @@ border_router_set_mac(const uint8_t *data)
 
   /* is this ok - should instead remove all addresses and
      add them back again - a bit messy... ?*/
+  PROCESS_CONTEXT_BEGIN(&tcpip_process);
   uip_ds6_init();
   rpl_init();
+  PROCESS_CONTEXT_END(&tcpip_process);
 
   mac_set = 1;
 }


### PR DESCRIPTION
…dic'

When UIP_ND6_SEND_NS is enabled, I've noticed that unreachable
neighbours still remains in REACHABLE state even if lifetime
(nbr->reachable) expired.

During network init 'tcpip_process' is scheduling
'uip_ds6_timer_periodic' is to tick every 100ms and make necessary
expiration.

When MAC address is received from slip-radio (from 'etimer_process'
context), network is "reinitialized" and timer 'uip_ds6_timer_periodic'
is set again with wrong process.