### PR TITLE
er-coap: Fix style and add missing `addr` argument

### DIFF
--- a/apps/er-coap/er-coap-engine.c
+++ b/apps/er-coap/er-coap-engine.c
@@ -256,12 +256,12 @@ coap_receive(void)
         transaction = NULL;
 
 #if COAP_OBSERVE_CLIENT
-	/* if observe notification */
+        /* if observe notification */
         if((message->type == COAP_TYPE_CON || message->type == COAP_TYPE_NON)
-              && IS_OPTION(message, COAP_OPTION_OBSERVE)) {
+           && IS_OPTION(message, COAP_OPTION_OBSERVE)) {
           PRINTF("Observe [%u]\n", message->observe);
           coap_handle_notification(&UIP_IP_BUF->srcipaddr, UIP_UDP_BUF->srcport,
-              message);
+                                   message);
         }
 #endif /* COAP_OBSERVE_CLIENT */
       } /* request or response */

--- a/apps/er-coap/er-coap-observe-client.h
+++ b/apps/er-coap/er-coap-observe-client.h
@@ -107,7 +107,7 @@ int coap_obs_remove_observee_by_token(uip_ipaddr_t *addr, uint16_t port,
 int coap_obs_remove_observee_by_url(uip_ipaddr_t *addr, uint16_t port,
                                     const char *url);
 
-void coap_handle_notification(uip_ipaddr_t *, uint16_t port,
+void coap_handle_notification(uip_ipaddr_t *addr, uint16_t port,
                               coap_packet_t *notification);
 
 coap_observee_t *coap_obs_request_registration(uip_ipaddr_t *addr,

--- a/apps/er-coap/er-coap-observe.c
+++ b/apps/er-coap/er-coap-observe.c
@@ -266,7 +266,7 @@ coap_observe_handler(resource_t *resource, void *request, void *response)
 {
   coap_packet_t *const coap_req = (coap_packet_t *)request;
   coap_packet_t *const coap_res = (coap_packet_t *)response;
-  coap_observer_t * obs;
+  coap_observer_t *obs;
 
   if(coap_req->code == COAP_GET && coap_res->code < 128) { /* GET request and response without error code */
     if(IS_OPTION(coap_req, COAP_OPTION_OBSERVE)) {
@@ -274,7 +274,7 @@ coap_observe_handler(resource_t *resource, void *request, void *response)
         obs = add_observer(&UIP_IP_BUF->srcipaddr, UIP_UDP_BUF->srcport,
                            coap_req->token, coap_req->token_len,
                            coap_req->uri_path, coap_req->uri_path_len);
-       if(obs) {
+        if(obs) {
           coap_set_header_observe(coap_res, (obs->obs_counter)++);
           /*
            * Following payload is for demonstration purposes only.

--- a/apps/er-coap/er-coap.c
+++ b/apps/er-coap/er-coap.c
@@ -178,7 +178,7 @@ coap_serialize_array_option(unsigned int number, unsigned int current_number,
   size_t i = 0;
 
   PRINTF("ARRAY type %u, len %zu, full [%.*s]\n", number, length,
-	 (int)length, array);
+         (int)length, array);
 
   if(split_char != '\0') {
     int j;
@@ -602,7 +602,7 @@ coap_parse_message(void *packet, uint8_t *data, uint16_t data_len)
       coap_pkt->uri_host = (char *)current_option;
       coap_pkt->uri_host_len = option_length;
       PRINTF("Uri-Host [%.*s]\n", (int)coap_pkt->uri_host_len,
-	     coap_pkt->uri_host);
+             coap_pkt->uri_host);
       break;
     case COAP_OPTION_URI_PORT:
       coap_pkt->uri_port = coap_parse_int_option(current_option,

--- a/apps/er-coap/er-coap.h
+++ b/apps/er-coap/er-coap.h
@@ -61,8 +61,8 @@
                                         (REST_MAX_CHUNK_SIZE < 128 ? 64 : \
                                          (REST_MAX_CHUNK_SIZE < 256 ? 128 : \
                                           (REST_MAX_CHUNK_SIZE < 512 ? 256 : \
-                                          (REST_MAX_CHUNK_SIZE < 1024 ? 512 : \
-                                          (REST_MAX_CHUNK_SIZE < 2048 ? 1024 : 2048)))))))
+                                           (REST_MAX_CHUNK_SIZE < 1024 ? 512 : \
+                                            (REST_MAX_CHUNK_SIZE < 2048 ? 1024 : 2048)))))))
 #endif /* COAP_MAX_BLOCK_SIZE */
 
 /* direct access into the buffer */
@@ -135,7 +135,7 @@ typedef struct {
 /* option format serialization */
 #define COAP_SERIALIZE_INT_OPTION(number, field, text) \
   if(IS_OPTION(coap_pkt, number)) { \
-    PRINTF(text " [%u]\n", (unsigned int)coap_pkt->field);		\
+    PRINTF(text " [%u]\n", (unsigned int)coap_pkt->field); \
     option += coap_serialize_int_option(number, current_number, option, coap_pkt->field); \
     current_number = number; \
   }
@@ -167,7 +167,7 @@ typedef struct {
     uint32_t block = coap_pkt->field##_num << 4; \
     if(coap_pkt->field##_more) { block |= 0x8; } \
     block |= 0xF & coap_log_2(coap_pkt->field##_size / 16); \
-    PRINTF(text " encoded: 0x%lX\n", (unsigned long)block);		\
+    PRINTF(text " encoded: 0x%lX\n", (unsigned long)block); \
     option += coap_serialize_int_option(number, current_number, option, block); \
     current_number = number; \
   }


### PR DESCRIPTION
Er-coap style cleanup (`uncrustify-fix-style.sh`).

I wanted to clean up the style before contributing new code (https://github.com/contiki-os/contiki/pull/1995).

I also added a missing attribute name in the header.