### PR TITLE
Zero out httpd_state before deallocating

### DIFF
--- a/examples/cc26xx/cc26xx-web-demo/httpd-simple.c
+++ b/examples/cc26xx/cc26xx-web-demo/httpd-simple.c
@@ -1268,9 +1268,7 @@ appcall(void *state)
 
   if(uip_closed() || uip_aborted() || uip_timedout()) {
     if(s != NULL) {
-      s->script = NULL;
-      s->blen = 0;
-      s->tmp_buf_len = 0;
+      memset(s, 0, sizeof(struct httpd_state));
       memb_free(&conns, s);
     }
   } else if(uip_connected()) {
@@ -1291,7 +1289,7 @@ appcall(void *state)
     if(uip_poll()) {
       if(timer_expired(&s->timer)) {
         uip_abort();
-        s->script = NULL;
+        memset(s, 0, sizeof(struct httpd_state));
         memb_free(&conns, s);
       }
     } else {


### PR DESCRIPTION
When a connection is aborted by the HTTP server while it's still being processed it is possible to hit a null pointer dereference issue by jumping back to a protothread (outputpt) after its httpd_state has been freed. This can be triggered by sending a POST to any form in the CC26xx web demo server using Firefox.
This patch prevents that by zeroing out httpd_state structs before freeing them, thus also clearing the httpd_state->outputpt field.
Tested using Firefox 55.0a1 on a CC2650 LaunchPad.