### PR TITLE
Check broker IP conversion. Adjust state machine accordingly

### DIFF
--- a/apps/mqtt/mqtt.c
+++ b/apps/mqtt/mqtt.c
@@ -1333,7 +1333,9 @@ mqtt_connect(struct mqtt_connection *conn, char *host, uint16_t port,
   conn->connect_vhdr_flags |= MQTT_VHDR_CLEAN_SESSION_FLAG;
 
   /* convert the string IPv6 address to a numeric IPv6 address */
-  uiplib_ip6addrconv(host, &ip6addr);
+  if(uiplib_ip6addrconv(host, &ip6addr) == 0) {
+    return MQTT_STATUS_ERROR;
+  }
 
   uip_ipaddr_copy(&(conn->server_ip), ipaddr);
 


### PR DESCRIPTION
The result of converting the IP address of the broker wasn't checked. As a result, if an invalid IP address was entered, the pointer was left uninitialised and the IPv6 address used for connecting was some random data. The function now returns an error. Before connect_to_broker is called, mqtt_register is executed, which memsets conn to 0, making its state 0 (MQTT_CONN_STATE_ERROR). In order to recover from this error state, the extra check was added in the MQTT_CLIENT_STATE_NEWCONFIG state.

This was discovered by @jackmcbride using [CodeSonar](https://www.grammatech.com/products/codesonar).