### PR TITLE
Adding sensniff support for Atmel via avr-rss2 platform

### DIFF
--- a/examples/sensniff/README.md
+++ b/examples/sensniff/README.md
@@ -49,6 +49,7 @@ The following radios have been tested:
 * CC2538
 * CC2530/CC2531
 * CC1200
+* RF233
 
 Once you have the radio sorted out, you also need to configure character I/O.
 The firmware captures wireless frames and streams them over a serial line to

--- a/examples/sensniff/avr-rss2/avr-rss2-io.h
+++ b/examples/sensniff/avr-rss2/avr-rss2-io.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2016, George Oikonomou - http://www.spd.gr
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+/*---------------------------------------------------------------------------*/
+#ifndef AVR_RSS2_IO_H_
+#define AVR_RSS2_IO_H_
+/*---------------------------------------------------------------------------*/
+#include "contiki-conf.h"
+#include "dev/rs232.h"
+
+#define sensniff_io_byte_out(b)  rs232_send(0, b)
+#define sensniff_io_flush()
+#define sensniff_io_set_input(b) rs232_set_input(RS232_PORT_0, b)
+/*---------------------------------------------------------------------------*/
+#endif /* AVR_RSS2_IO_H_ */
+/*---------------------------------------------------------------------------*/

--- a/examples/sensniff/avr-rss2/target-conf.h
+++ b/examples/sensniff/avr-rss2/target-conf.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2016, George Oikonomou - http://www.spd.gr
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+/*---------------------------------------------------------------------------*/
+#ifndef TARGET_CONF_H_
+#define TARGET_CONF_H_
+/*---------------------------------------------------------------------------*/
+#define SENSNIFF_IO_DRIVER_H "avr-rss2/avr-rss2-io.h"
+#define RS232_BAUDRATE USART_BAUD_500000
+/*---------------------------------------------------------------------------*/
+#endif /* TARGET_CONF_H_ */
+/*---------------------------------------------------------------------------*/

--- a/platform/avr-rss2/README.md
+++ b/platform/avr-rss2/README.md
@@ -108,6 +108,7 @@ Tested applications and examples
 * `rime`
 * `ipv6/multicast`
 * `examples/powertrace`
+* `examples/sensniff` use 500kBAUD
 * `example-shell`
 
 Note that the shell example needs file `symbols.c` to be added to project also seems like


### PR DESCRIPTION
Title says it. Gives a very useful app with wireshark. Use 500 kbaud (default) or 1 Mbaud which goes well with the UART XTAL at 16Mhz. Tested on AtMega256RFR2.