### PR TITLE
Correct SPI pins

### DIFF
--- a/platform/srf06-cc26xx/sensortag/cc2650/board.h
+++ b/platform/srf06-cc26xx/sensortag/cc2650/board.h
@@ -137,8 +137,12 @@
  * Those values are not meant to be modified by the user
  * @{
  */
+#define BOARD_IOID_SPI_SCK        IOID_17
 #define BOARD_IOID_SPI_MOSI       IOID_19
 #define BOARD_IOID_SPI_MISO       IOID_18
+#define BOARD_SPI_SCK             (1 << BOARD_IOID_SPI_SCK)
+#define BOARD_SPI_MOSI            (1 << BOARD_IOID_SPI_MOSI)
+#define BOARD_SPI_MISO            (1 << BOARD_IOID_SPI_MISO)
 /** @} */
 /*---------------------------------------------------------------------------*/
 /**


### PR DESCRIPTION
I make some changes to SPI pin definition for Sensortag so it will be similar to launchpad. I successfully use this to connect ENC28J60 module and run 6lbr (eth-module and external flash works).