### PR TITLE
'Step instruction' button in 'Instructions' tab of 'Msp Code Watcher'

### DIFF
--- a/tools/cooja/apps/mspsim/src/org/contikios/cooja/mspmote/plugins/MspCodeWatcher.java
+++ b/tools/cooja/apps/mspsim/src/org/contikios/cooja/mspmote/plugins/MspCodeWatcher.java
@@ -224,7 +224,12 @@ public class MspCodeWatcher extends VisPlugin implements MotePlugin {
     for (Component c: assCodeUI.getComponents()) {
       c.setBackground(Color.WHITE);
     }
-    mainPane.addTab("Instructions", null, assCodeUI, null);
+    Box assCodeControl = Box.createHorizontalBox();
+    assCodeControl.add(new JButton(stepAction));
+    JPanel assCodePanel = new JPanel(new BorderLayout());
+    assCodePanel.add(BorderLayout.CENTER, assCodeUI);
+    assCodePanel.add(BorderLayout.SOUTH, assCodeControl);
+    mainPane.addTab("Instructions", null, assCodePanel, null);
 
     breakpointsUI = new BreakpointsUI(mspMote, this);
     mainPane.addTab("Breakpoints", null, breakpointsUI, "Right-click source code to add"); /* BREAKPOINTS */


### PR DESCRIPTION
This is a small but helpful enhancement of Cooja. When debugging with the "Msp Code Watcher", stepping through instructions was only possible in the "Source code" tab but not in the "Instructions" tab. This commit adds this feature.