### PR TITLE
Fix HDC sensor reading conversion

### DIFF
--- a/platform/srf06-cc26xx/sensortag/hdc-1000-sensor.c
+++ b/platform/srf06-cc26xx/sensortag/hdc-1000-sensor.c
@@ -186,7 +186,7 @@ static void
 convert(float *temp, float *hum)
 {
   /* Convert temperature to degrees C */
-  *temp = ((double)(int16_t)raw_temp / 65536) * 165 - 40;
+  *temp = ((double)raw_temp / 65536) * 165 - 40;
 
   /* Convert relative humidity to a %RH value */
   *hum = ((double)raw_hum / 65536) * 100;


### PR DESCRIPTION
HDC sensor on SensorTag is currently having invalid values when temperature >+42.x degrees Celsius.

The cast to int16_t in this line seems to be at fault:
  `*temp = ((double)(int16_t)raw_temp / 65536) * 165 - 40;`

Casting to signed is just not necessary here, as `raw_temp` can never be negative. `raw_temp` of zero corresponds to -40 degrees Celsius, which is the minimal value the sensor can read according to datasheet.