### PR TITLE
Keep CoAP 'observe' option length <= 3 bytes

### DIFF
--- a/apps/er-coap/er-coap-observe.c
+++ b/apps/er-coap/er-coap-observe.c
@@ -249,6 +249,8 @@ coap_notify_observers_sub(resource_t *resource, const char *subpath)
 
         if(notification->code < BAD_REQUEST_4_00) {
           coap_set_header_observe(notification, (obs->obs_counter)++);
+          /* mask out to keep the CoAP observe option length <= 3 bytes */
+          obs->obs_counter &= 0xffffff;
         }
         coap_set_token(notification, obs->token, obs->token_len);
 
@@ -276,6 +278,8 @@ coap_observe_handler(resource_t *resource, void *request, void *response)
                            coap_req->uri_path, coap_req->uri_path_len);
         if(obs) {
           coap_set_header_observe(coap_res, (obs->obs_counter)++);
+          /* mask out to keep the CoAP observe option length <= 3 bytes */
+          obs->obs_counter &= 0xffffff;
           /*
            * Following payload is for demonstration purposes only.
            * A subscription should return the same representation as a normal GET.


### PR DESCRIPTION
Currently Contiki generates Observe notifications with the observe counter going up to 4 bytes. Yet RFC 7641(https://tools.ietf.org/html/rfc7641) clearly shows that the Observe option may have length from 0 to 3 bytes.

This causes problems for out application because with 4 byte observe option some packets will get too large to be sent over the air.