### PR TITLE
Fix several uninitialized variables

### DIFF
--- a/core/net/mac/frame802154.c
+++ b/core/net/mac/frame802154.c
@@ -205,7 +205,7 @@ frame802154_has_panid(frame802154_fcf_t *fcf, int *has_src_pan_id, int *has_dest
 int
 frame802154_check_dest_panid(frame802154_t *frame)
 {
-  int has_dest_panid;
+  int has_dest_panid = 0;
 
   if(frame == NULL) {
     return 0;

--- a/core/net/rpl/rpl-icmp6.c
+++ b/core/net/rpl/rpl-icmp6.c
@@ -652,6 +652,7 @@ dao_input_storing(void)
 
   prefixlen = 0;
   parent = NULL;
+  memset(&prefix, 0, sizeof(prefix));
 
   uip_ipaddr_copy(&dao_sender_addr, &UIP_IP_BUF->srcipaddr);
 

--- a/cpu/cc26xx-cc13xx/rf-core/ieee-mode.c
+++ b/cpu/cc26xx-cc13xx/rf-core/ieee-mode.c
@@ -1587,7 +1587,7 @@ get_object(radio_param_t param, void *dest, size_t size)
 static radio_result_t
 set_object(radio_param_t param, const void *src, size_t size)
 {
-  radio_result_t rv;
+  radio_result_t rv = RADIO_RESULT_OK;
   int i;
   uint8_t *dst;
   rfc_CMD_IEEE_RX_t *cmd = (rfc_CMD_IEEE_RX_t *)cmd_ieee_rx_buf;


### PR DESCRIPTION
This fixes several potentially unitinitialized variables found by codesonar.