### PR TITLE
Fix potentially unterminated strings

### DIFF
--- a/core/net/ip/resolv.c
+++ b/core/net/ip/resolv.c
@@ -1094,7 +1094,7 @@ resolv_set_hostname(const char *hostname)
   /* Add the .local suffix if it isn't already there */
   if(strlen(resolv_hostname) < 7 ||
      strcasecmp(resolv_hostname + strlen(resolv_hostname) - 6, ".local") != 0) {
-    strncat(resolv_hostname, ".local", RESOLV_CONF_MAX_DOMAIN_NAME_SIZE);
+    strncat(resolv_hostname, ".local", RESOLV_CONF_MAX_DOMAIN_NAME_SIZE - strlen(resolv_hostname));
   }
 
   PRINTF("resolver: hostname changed to \"%s\"\n", resolv_hostname);
@@ -1248,8 +1248,8 @@ remove_trailing_dots(const char *name) {
   static char dns_name_without_dots[RESOLV_CONF_MAX_DOMAIN_NAME_SIZE + 1];
   size_t len = strlen(name);
 
-  if(name[len - 1] == '.') {
-    strncpy(dns_name_without_dots, name, sizeof(dns_name_without_dots));
+  if(len && name[len - 1] == '.') {
+    strncpy(dns_name_without_dots, name, RESOLV_CONF_MAX_DOMAIN_NAME_SIZE);
     while(len && (dns_name_without_dots[len - 1] == '.')) {
       dns_name_without_dots[--len] = 0;
     }
@@ -1309,7 +1309,7 @@ resolv_query(const char *name)
 
   memset(nameptr, 0, sizeof(*nameptr));
 
-  strncpy(nameptr->name, name, sizeof(nameptr->name));
+  strncpy(nameptr->name, name, sizeof(nameptr->name) - 1);
   nameptr->state = STATE_NEW;
   nameptr->seqno = seqno;
   ++seqno;
@@ -1479,7 +1479,7 @@ resolv_found(char *name, uip_ipaddr_t * ipaddr)
       }
 
       /* Re-add the .local suffix */
-      strncat(resolv_hostname, ".local", RESOLV_CONF_MAX_DOMAIN_NAME_SIZE);
+      strncat(resolv_hostname, ".local", RESOLV_CONF_MAX_DOMAIN_NAME_SIZE - strlen(resolv_hostname));
 
       start_name_collision_check(CLOCK_SECOND * 5);
     } else if(mdns_state == MDNS_STATE_READY) {

--- a/core/net/ipv6/websocket.c
+++ b/core/net/ipv6/websocket.c
@@ -547,8 +547,8 @@ websocket_open(struct websocket *s, const char *url,
 	       websocket_callback c)
 {
   int ret;
-  char host[MAX_HOSTLEN];
-  char path[MAX_PATHLEN];
+  char host[MAX_HOSTLEN + 1] = {0};
+  char path[MAX_PATHLEN + 1] = {0};
   uint16_t port;
   uip_ipaddr_t addr;
 


### PR DESCRIPTION
This fixes some potential issues with strings being copied using strncpy, which causes char arrays that are used as strings later on to be non-terminated.

I have also changed the typecasts in the tolower function calls to unsigned char.

Fixes #2185