### PR TITLE
remove callee-super-interworking from econotag build

### DIFF
--- a/cpu/mc1322x/Makefile.include
+++ b/cpu/mc1322x/Makefile.include
@@ -41,7 +41,8 @@ CFLAGS_MISC  ?= -pipe
 CFLAGS := $(CFLAGS_PLAT) $(CFLAGS_WARN) $(CFLAGS_OPT) $(CFLAGS_DEBUG) $(CFLAGS_MISC) $(CFLAGS)
 
 # Thumb flags, used for building most objects
-CFLAGS_THUMB ?= -mthumb -mcallee-super-interworking
+#CFLAGS_THUMB ?= -mthumb -mcallee-super-interworking
+CFLAGS_THUMB ?= -mthumb
 
 # Linker flags
 LINKERSCRIPT ?= $(MC1322X)/mc1322x.lds

--- a/cpu/mc1322x/Makefile.mc1322x
+++ b/cpu/mc1322x/Makefile.mc1322x
@@ -46,7 +46,8 @@ LINKERSCRIPT = $(OBJECTDIR)/mc1322x.lds
 STARTUP=$(OBJECTDIR)/start.o
 
 ARCH_FLAGS= -mcpu=arm7tdmi-s -mthumb-interwork -march=armv4t -mtune=arm7tdmi-s -DCONFIG_ARM -D__ARM__ #-Wcast-align
-THUMB_FLAGS= -mthumb -mcallee-super-interworking
+#THUMB_FLAGS= -mthumb -mcallee-super-interworking
+THUMB_FLAGS= -mthumb
 ARM_FLAGS= -marm
 
 CFLAGSNO = -I. -I$(CONTIKI)/core -I$(CONTIKI_CPU) -I$(CONTIKI_CPU)/loader \


### PR DESCRIPTION
After two years away from econotag builds, I resumed only to find that new options do not work with currently available crop of compilers.  Perhaps we need to switch on some gcc version here.
    gcc-arm-none-eabi                                                                                         4.8.4-1+11-1 

removing this option seems to let things compile. I will test it later today.  I assume it changes the register model in some way that is faster, but incompatible with official ARM ABI.