### PR TITLE
Validate MQTT broker IP and escape quotes when displaying

### DIFF
--- a/examples/cc26xx/cc26xx-web-demo/mqtt-client.c
+++ b/examples/cc26xx/cc26xx-web-demo/mqtt-client.c
@@ -64,6 +64,9 @@
  */
 static const char *broker_ip = "0064:ff9b:0000:0000:0000:0000:b8ac:7cbd";
 /*---------------------------------------------------------------------------*/
+#define ADDRESS_CONVERSION_OK       1
+#define ADDRESS_CONVERSION_ERROR    0
+/*---------------------------------------------------------------------------*/
 /*
  * A timeout used when waiting for something to happen (e.g. to connect or to
  * disconnect)
@@ -356,7 +359,14 @@ ip_addr_post_handler(char *key, int key_len, char *val, int val_len)
     return HTTPD_SIMPLE_POST_HANDLER_UNKNOWN;
   }
 
-  if(val_len > MQTT_CLIENT_CONFIG_IP_ADDR_STR_LEN) {
+  /*
+   * uiplib_ip6addrconv will immediately start writing into the supplied buffer
+   * even if it subsequently fails. Thus, pass an intermediate buffer
+   */
+  uip_ip6addr_t tmp_addr;
+
+  if(val_len > MQTT_CLIENT_CONFIG_IP_ADDR_STR_LEN
+          || uiplib_ip6addrconv(val, &tmp_addr) != ADDRESS_CONVERSION_OK) {
     /* Ours but bad value */
     rv = HTTPD_SIMPLE_POST_HANDLER_ERROR;
   } else {


### PR DESCRIPTION
This commit implements address validation for the broker address in the MQTT configuration page of the CC26XX web demo example. Additionally, the Type ID, Org ID, Auth Token, Command Type and Event Type ID fields have quotes escaped (" -> &quot;) to prevent XSS/broken page issues when displaying user-sourced input in HTML input fields.