### PR TITLE
cc26xx-web-demo: "fix warning: implicit declaration of function 'strncasecmp'"

### DIFF
--- a/examples/cc26xx/cc26xx-web-demo/cc26xx-web-demo.c
+++ b/examples/cc26xx/cc26xx-web-demo/cc26xx-web-demo.c
@@ -55,6 +55,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <strings.h>
 
 #include "ti-lib.h"
 /*---------------------------------------------------------------------------*/

--- a/examples/cc26xx/cc26xx-web-demo/net-uart.c
+++ b/examples/cc26xx/cc26xx-web-demo/net-uart.c
@@ -71,6 +71,7 @@
 
 #include <stdint.h>
 #include <string.h>
+#include <strings.h>
 #include <stdio.h>
 #include <stdlib.h>
 /*---------------------------------------------------------------------------*/


### PR DESCRIPTION
this fixes two warnings adding #include <strings.h> to two more files for the examples to compile cleanly with gcc-arm-none-eabi-5_4-2016q3