### PR TITLE
Fix to rtimer

### DIFF
--- a/core/sys/rtimer.c
+++ b/core/sys/rtimer.c
@@ -68,23 +68,18 @@ rtimer_set(struct rtimer *rtimer, rtimer_clock_t time,
 	   rtimer_clock_t duration,
 	   rtimer_callback_t func, void *ptr)
 {
-  int first = 0;
-
   PRINTF("rtimer_set time %d\n", time);
 
-  if(next_rtimer == NULL) {
-    first = 1;
+  if(next_rtimer) {
+    return RTIMER_ERR_ALREADY_SCHEDULED;
   }
 
   rtimer->func = func;
   rtimer->ptr = ptr;
-
   rtimer->time = time;
   next_rtimer = rtimer;
+  rtimer_arch_schedule(time);
 
-  if(first == 1) {
-    rtimer_arch_schedule(time);
-  }
   return RTIMER_OK;
 }
 /*---------------------------------------------------------------------------*/
@@ -92,16 +87,12 @@ void
 rtimer_run_next(void)
 {
   struct rtimer *t;
-  if(next_rtimer == NULL) {
+
+  if(!(t = next_rtimer)) {
     return;
   }
-  t = next_rtimer;
   next_rtimer = NULL;
   t->func(t, t->ptr);
-  if(next_rtimer != NULL) {
-    rtimer_arch_schedule(next_rtimer->time);
-  }
-  return;
 }
 /*---------------------------------------------------------------------------*/
 


### PR DESCRIPTION
I noticed that `rtimer_arch_schedule` gets called twice if `rtimer_set` is called from within the rtimer ISR, which is often the case. This PR fixes this issue.