### PR TITLE
Added boundary checks when parsing CoAP packets.

### DIFF
--- a/apps/er-coap/er-coap.c
+++ b/apps/er-coap/er-coap.c
@@ -529,7 +529,20 @@ coap_parse_message(void *packet, uint8_t *data, uint16_t data_len)
       ++current_option;
     }
 
+    if(current_option + option_length > data + data_len) {
+      /* Malformed CoAP - out of bounds */
+      PRINTF("BAD REQUEST: options outside data packet: %u > %u\n",
+             (unsigned)(current_option + option_length - data), data_len);
+      return BAD_REQUEST_4_00;
+    }
+
     option_number += option_delta;
+
+    if(option_number > COAP_OPTION_SIZE1) {
+      /* Malformed CoAP - out of bounds */
+      PRINTF("BAD REQUEST: option number too large: %u\n", option_number);
+      return BAD_REQUEST_4_00;
+    }
 
     PRINTF("OPTION %u (delta %u, len %zu): ", option_number, option_delta,
            option_length);


### PR DESCRIPTION
This should address the issues reported in #2238, #2239 and #2240. Thanks to Stephan Zeisberg for reporting the issues and for the excellent test cases.