### PR TITLE
CC26xx/CC13xx: Support uni-directional UART

### DIFF
--- a/cpu/cc26xx-cc13xx/dev/cc26xx-uart.c
+++ b/cpu/cc26xx-cc13xx/dev/cc26xx-uart.c
@@ -65,10 +65,20 @@
 static int (*input_handler)(unsigned char c);
 /*---------------------------------------------------------------------------*/
 static bool
-usable(void)
+usable_rx(void)
 {
   if(BOARD_IOID_UART_RX == IOID_UNUSED ||
-     BOARD_IOID_UART_TX == IOID_UNUSED ||
+     CC26XX_UART_CONF_ENABLE == 0) {
+    return false;
+  }
+
+  return true;
+}
+/*---------------------------------------------------------------------------*/
+static bool
+usable_tx(void)
+{
+  if(BOARD_IOID_UART_TX == IOID_UNUSED ||
      CC26XX_UART_CONF_ENABLE == 0) {
     return false;
   }
@@ -271,7 +281,7 @@ cc26xx_uart_init()
   bool interrupts_disabled;
 
   /* Return early if disabled by user conf or if ports are misconfigured */
-  if(usable() == false) {
+  if(!usable_rx() && !usable_tx()) {
     return;
   }
 
@@ -299,7 +309,7 @@ void
 cc26xx_uart_write_byte(uint8_t c)
 {
   /* Return early if disabled by user conf or if ports are misconfigured */
-  if(usable() == false) {
+  if(usable_tx() == false) {
     return;
   }
 
@@ -316,7 +326,7 @@ cc26xx_uart_set_input(int (*input)(unsigned char c))
   input_handler = input;
 
   /* Return early if disabled by user conf or if ports are misconfigured */
-  if(usable() == false) {
+  if(usable_rx() == false) {
     return;
   }
 
@@ -348,7 +358,7 @@ uint8_t
 cc26xx_uart_busy(void)
 {
   /* Return early if disabled by user conf or if ports are misconfigured */
-  if(usable() == false) {
+  if(usable_tx() == false) {
     return UART_IDLE;
   }
 


### PR DESCRIPTION
This PR removes the requirement for both UART TX and RX to be set, thus adding support for boards which only have one or the other.