### PR TITLE
make for сс26-13 generates hex only if  srec exist

### DIFF
--- a/cpu/cc26xx-cc13xx/Makefile.cc26xx-cc13xx
+++ b/cpu/cc26xx-cc13xx/Makefile.cc26xx-cc13xx
@@ -6,7 +6,15 @@ OBJCOPY = arm-none-eabi-objcopy
 OBJDUMP = arm-none-eabi-objdump
 NM      = arm-none-eabi-nm
 SIZE    = arm-none-eabi-size
+SREC_TEST = $(shell srec_cat --version > null && echo 1)
+ifeq ([${SREC_TEST}],[1])
 SREC_CAT = srec_cat
+CAN_HEX  = %.hex
+else
+$(waring "install srecord to allow hex image generation")
+SREC_CAT =
+CAN_HEX  =
+endif
 
 CPU_ABS_PATH       = cpu/cc26xx-cc13xx
 TI_XXWARE = $(CONTIKI_CPU)/$(TI_XXWARE_PATH)
@@ -33,6 +41,7 @@ CFLAGS += -mcpu=cortex-m3 -mthumb -mlittle-endian
 CFLAGS += -ffunction-sections -fdata-sections
 CFLAGS += -fshort-enums -fomit-frame-pointer -fno-strict-aliasing
 CFLAGS += -Wall -std=c99
+CFLAGS += -g3
 
 LDFLAGS += -mcpu=cortex-m3 -mthumb -mlittle-endian -nostartfiles
 LDFLAGS += -T $(LDSCRIPT)
@@ -128,7 +137,7 @@ CUSTOM_RULE_LINK=1
 
 ### We don't really need the .hex and .bin for the .$(TARGET) but let's make
 ### sure they get built
-%.$(TARGET): %.elf %.hex %.bin
+%.$(TARGET): %.elf $(CAN_HEX) %.bin
 	cp $< $@
 
 # a target that gives a user-friendly memory profile, taking into account the RAM


### PR DESCRIPTION
hex generate only if srec_cat exist. this patch helps avoid make errors if srecord absent.

*when build on windows host, there are hard to achieve srecord. and now this is not a problem - elf images, and binaries are enough. So, with this patch hex generation just ignored, and make - success