### PR TITLE
fix make deps generation on windows

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -208,12 +208,22 @@ endif
 
 ### See http://make.paulandlesley.org/autodep.html#advanced
 
+ifeq ([${WINDIR}],[])
 define FINALIZE_DEPENDENCY
 cp $(@:.o=.d) $(@:.o=.$$$$); \
-sed -e 's/#.*//' -e 's/^[^:]*: *//' -e 's/ *\\$$//' \
+sed -e 's/#.*//' -e 's/^[^:].*: *//' -e 's/ *\\$$//' \
     -e '/^$$/ d' -e 's/$$/ :/' < $(@:.o=.$$$$) >> $(@:.o=.d); \
 rm -f $(@:.o=.$$$$)
 endef
+else
+###  windows pathes can contain ':' char, so just allow it
+define FINALIZE_DEPENDENCY
+cp $(@:.o=.d) $(@:.o=.$$$$); \
+sed -e 's/#.*//' -e 's/^.*: *//' -e 's/ *\\$$//' \
+    -e '/^$$/ d' -e 's/$$/ :/' < $(@:.o=.$$$$) >> $(@:.o=.d); \
+rm -f $(@:.o=.$$$$)
+endef
+endif
 
 clean:
 	-rm -f *~ *core core *.srec \


### PR DESCRIPTION
fixed FINALIZE_DEPENDENCY to work with windows pathes. need to build on cygwin.

*just suggest that dep item starts with single path until ": " delimiter. this rule helps
accept windows path starts with drive letter "x:"