### PR TITLE
enhance cc26 prop-mode rf-core to support tsch

### DIFF
--- a/cpu/cc26xx-cc13xx/Makefile.cc26xx-cc13xx
+++ b/cpu/cc26xx-cc13xx/Makefile.cc26xx-cc13xx
@@ -72,7 +72,7 @@ CONTIKI_CPU_SOURCEFILES += contiki-watchdog.c aux-ctrl.c
 CONTIKI_CPU_SOURCEFILES += putchar.c ieee-addr.c batmon-sensor.c adc-sensor.c
 CONTIKI_CPU_SOURCEFILES += slip-arch.c slip.c cc26xx-uart.c lpm.c
 CONTIKI_CPU_SOURCEFILES += gpio-interrupt.c oscillators.c
-CONTIKI_CPU_SOURCEFILES += rf-core.c rf-ble.c ieee-mode.c
+CONTIKI_CPU_SOURCEFILES += rf-core.c rf-ble.c rf-rat-monitor.c ieee-mode.c
 CONTIKI_CPU_SOURCEFILES += random.c soc-trng.c
 
 DEBUG_IO_SOURCEFILES += dbg-printf.c dbg-snprintf.c dbg-sprintf.c strformat.c

--- a/cpu/cc26xx-cc13xx/rf-core/prop-mode.c
+++ b/cpu/cc26xx-cc13xx/rf-core/prop-mode.c
@@ -475,7 +475,6 @@ int rf_cmd_execute(rfc_radioOp_t *cmd, const char* name )
 static int
 prop_div_radio_setup(void)
 {
-  uint32_t cmd_status;
   rfc_radioOp_t *cmd = (rfc_radioOp_t *)&smartrf_settings_cmd_prop_radio_div_setup;
 
   rf_switch_select_path(RF_SWITCH_PATH_SUBGHZ);
@@ -626,6 +625,19 @@ prop_fs(void)
   rfc_radioOp_t *cmd = (rfc_radioOp_t *)&smartrf_settings_cmd_fs;
   return rf_cmd_execute(cmd, "prop_fs: CMD_FS");
 }
+
+static
+int prop_txpower(void){
+    rfc_CMD_SET_TX_POWER_t cmd_power =
+    {
+      .commandNo    = CMD_SET_TX_POWER,
+      .txPower      = tx_power_current->tx_power,
+    };
+
+    rfc_radioOp_t *cmd = (rfc_radioOp_t *)&cmd_power;
+    return rf_cmd_execute(cmd, "prop_txpower: CMD_SET_TX_POWER");
+}
+
 /*---------------------------------------------------------------------------*/
 static void
 soft_off_prop(void)
@@ -1222,16 +1234,9 @@ set_value(radio_param_t param, radio_value_t value)
       return RADIO_RESULT_INVALID_VALUE;
     }
 
-    soft_off_prop();
-
     set_tx_power(value);
+    return update_prop(&(prop_txpower));
 
-    if(soft_on_prop() != RF_CORE_CMD_OK) {
-      PRINTF("set_value: soft_on_prop() failed\n");
-      rv = RADIO_RESULT_ERROR;
-    }
-
-    return RADIO_RESULT_OK;
   case RADIO_PARAM_RX_MODE:
       if(value & ~(RADIO_RX_MODE_POLL_MODE)) {
         return RADIO_RESULT_INVALID_VALUE;

--- a/cpu/cc26xx-cc13xx/rf-core/rf-core.c
+++ b/cpu/cc26xx-cc13xx/rf-core/rf-core.c
@@ -151,10 +151,10 @@ rf_core_send_cmd(uint32_t cmd, uint32_t *status)
   interrupts_disabled = ti_lib_int_master_disable();
 
   if(!rf_core_is_accessible()) {
-    PRINTF("rf_core_send_cmd: RF was off\n");
     if(!interrupts_disabled) {
       ti_lib_int_master_enable();
     }
+    PRINTF("rf_core_send_cmd: RF was off\n");
     return RF_CORE_CMD_ERROR;
   }
 

--- a/cpu/cc26xx-cc13xx/rf-core/rf-core.h
+++ b/cpu/cc26xx-cc13xx/rf-core/rf-core.h
@@ -113,6 +113,19 @@
 #define RF_CORE_POLL_MODE RF_CORE_CONF_POLL_MODE
 #endif
 /*---------------------------------------------------------------------------*/
+/* RF-Front End RAT resyncing strategy provides mechanisms for RAT sync monitoring
+ *  and resyncing
+ *  \value 0    - resync only on rf-core propety setup
+ *  \value 1    - validate RF-timestamp in window of current operation, and resync if violate
+ * */
+#define RF_CORE_RAT_SYNC_PROP      0
+#define RF_CORE_RAT_SYNC_AGRESSIVE 1
+#ifdef RF_CORE_CONF_RAT_SYNC_STYLE
+#define PROP_MODE_RAT_SYNC_STYLE    RF_CORE_CONF_RAT_SYNC_STYLE
+#else
+#define PROP_MODE_RAT_SYNC_STYLE    RF_CORE_RAT_SYNC_PROP
+#endif
+/*---------------------------------------------------------------------------*/
 #define RF_CORE_CMD_ERROR                     0
 #define RF_CORE_CMD_OK                        1
 /*---------------------------------------------------------------------------*/

--- a/cpu/cc26xx-cc13xx/rf-core/rf-core.h
+++ b/cpu/cc26xx-cc13xx/rf-core/rf-core.h
@@ -103,6 +103,16 @@
 #define RF_CORE_PROP_BIAS_MODE RF_CORE_BIAS_MODE_EXTERNAL
 #endif
 /*---------------------------------------------------------------------------*/
+/*
+ * RF Front-End IRQ polling mode setup
+ * \value Not Defined - polling mode enabled by driver.set_value(RADIO_PARAM_RX_MODE)
+ * \value 0           - only ISR mode use.
+ * \value 1           - only Poling mode use.
+ */
+#ifdef RF_CORE_CONF_POLL_MODE
+#define RF_CORE_POLL_MODE RF_CORE_CONF_POLL_MODE
+#endif
+/*---------------------------------------------------------------------------*/
 #define RF_CORE_CMD_ERROR                     0
 #define RF_CORE_CMD_OK                        1
 /*---------------------------------------------------------------------------*/

--- a/cpu/cc26xx-cc13xx/rf-core/rf-rat-monitor.c
+++ b/cpu/cc26xx-cc13xx/rf-core/rf-rat-monitor.c
@@ -1,0 +1,208 @@
+/*
+ * rfcore-rat-moninor.c
+ *
+ *  Created on: 21 èþë. 2017 ã.
+ *      Author: alexrayne
+ *
+ * here is RAT timer overflow monitoring moved from ieee-mode
+ * to populate it for prop-mode.
+ */
+/*---------------------------------------------------------------------------*/
+/**
+ * \addtogroup rf-core
+ * @{
+ *
+ * \defgroup rf-core-ieee CC13xx/CC26xx IEEE mode driver
+ *
+ * @{
+ *
+ * \file
+ * Implementation of the CC13xx/CC26xx IEEE mode NETSTACK_RADIO driver
+ */
+/*---------------------------------------------------------------------------*/
+#include "contiki.h"
+#include "dev/radio.h"
+#include "sys/clock.h"
+#include "sys/rtimer.h"
+#include "ti-lib.h"
+#include "rf-core/rf-core.h"
+#include "rf-core/rf-switch.h"
+#include "rf-core/rf-rat.h"
+/*---------------------------------------------------------------------------*/
+#include <stdint.h>
+#include <string.h>
+#include <stdio.h>
+#include <stdbool.h>
+/*---------------------------------------------------------------------------*/
+#define DEBUG 1
+#if DEBUG
+#define PRINTF(...) printf(__VA_ARGS__)
+#else
+#define PRINTF(...)
+#endif
+
+#if DEBUG > 1
+#define ANNOTATE(...) printf(__VA_ARGS__)
+#else
+#define ANNOTATE(...)
+#endif
+
+
+
+/*---------------------------------------------------------------------------*/
+// this code imported from ieee-mode
+extern int32_t rat_offset;
+
+#if RF_RAT_STYLE > 0
+/* SFD timestamp in RAT ticks (but 64 bits) */
+//static uint64_t last_rat_timestamp64 = 0;
+
+/* For RAT overflow handling */
+static struct ctimer rat_overflow_timer;
+struct {
+    rtimer_clock_t          last_time;
+    volatile uint_fast8_t   counter;
+} rat_overflow;
+
+//static
+uint64_t      last_timestamp;
+
+/* RAT has 32-bit register, overflows once 18 minutes */
+#define RAT_RANGE  0x100000000ull
+/* approximate value */
+#define RAT_OVERFLOW_PERIOD_SECONDS (60 * 18)
+
+static struct rf_rat_controler rf_control;
+
+rf_rat_time_t rf_rat_now(){
+    return HWREG(RFC_RAT_BASE + RATCNT);
+}
+/*---------------------------------------------------------------------------*/
+#define GAP_RATE 4
+static const rtimer_clock_t OVERFLOW_GAP = (RAT_OVERFLOW_PERIOD_SECONDS * RTIMER_SECOND / GAP_RATE);
+static const rtimer_clock_t RAT_OVERFLOW_PERIOD_RT = RADIO_TO_RTIMER(RAT_RANGE);
+        //(RAT_OVERFLOW_PERIOD_SECONDS * RTIMER_SECOND);
+uint_fast8_t rf_rat_check_overflow(bool first_time)
+{
+  static uint32_t last_value;
+  uint32_t current_value;
+  uint8_t interrupts_disabled;
+
+  /* Bail out if the RF is not on */
+  if(!rf_core_is_accessible()) {
+    return 0;
+  }
+
+  interrupts_disabled = ti_lib_int_master_disable();
+  // need to protect timestamp calculation vs situation when
+  //   evaluation time occurs after overflow, but actual stamp exposed before
+  // to fix it, use virtual oveflow terminator with some gap before oveflow.
+  // this gap can be compensated at evaluation time.
+  if(first_time) {
+    last_value = rf_rat_now();
+    rtimer_clock_t now = RTIMER_NOW();
+    if (now < (RAT_OVERFLOW_PERIOD_RT - OVERFLOW_GAP))
+    rat_overflow.counter = 0;
+    else
+    if ( RTIMER_CLOCK_DIFF( now, rat_overflow.last_time) < (RAT_OVERFLOW_PERIOD_RT - OVERFLOW_GAP) )
+        // rat_overflow.counter no need update since last check time
+        {;}
+    else {
+        rat_overflow.counter = now / RAT_OVERFLOW_PERIOD_RT;
+    }
+    rat_overflow.last_time = now;
+    if ( last_value <= (RAT_RANGE / GAP_RATE) )
+        rat_overflow.last_time += OVERFLOW_GAP;
+  } else {
+    current_value = rf_rat_now();// + RAT_RANGE / GAP_RATE;
+    if( current_value < last_value) {
+      /* Overflow detected */
+      //* last_time assign to end of safe gap period from virtual overflow, after that
+      //* RTtime of timestamp is surely after overflow
+      rat_overflow.last_time = RTIMER_NOW() +OVERFLOW_GAP;
+      rat_overflow.counter++;
+    }
+    last_value = current_value;
+  }
+  if(!interrupts_disabled) {
+    ti_lib_int_master_enable();
+  }
+  return 1;
+}
+
+/*---------------------------------------------------------------------------*/
+static const clock_time_t RAT_CHECK_PERIOD = RAT_OVERFLOW_PERIOD_SECONDS * CLOCK_SECOND / 6;
+static void
+handle_rat_overflow(void *unused)
+{
+  if(rf_core_is_accessible()) {
+  uint_fast8_t success = 0;
+      //* if RF is powerdown, nothing to check
+  success = rf_rat_check_overflow(false);
+
+  ANNOTATE("RF RAT overflow check %d : overs=%d at %lu\n"
+          , success
+          , rat_overflow.counter, rat_overflow.last_time);
+  }
+
+  ctimer_set(&rat_overflow_timer, RAT_CHECK_PERIOD,
+               handle_rat_overflow, NULL);
+}
+
+/*---------------------------------------------------------------------------*/
+/**
+ * \brief prepare RAT timer time, for later timestamp evaluate rf_rat_calc_last_packet_rttime
+ * \param rat_timestamp - RAT timer value - time of last RF operation
+ */
+static
+rf_rat_time_t last_rat;
+void     rf_rat_last_timestamp(rf_rat_time_t rat_timestamp)
+{
+    int     adjusted_overflow_counter;
+    last_rat = rat_timestamp;
+
+    rf_rat_check_overflow(false);
+    adjusted_overflow_counter = rat_overflow.counter;
+
+  /* if the timestamp is large and the last oveflow was recently,
+     assume that the timestamp refers to the time before the overflow */
+  if( rat_timestamp > (uint32_t)(RAT_RANGE - (RAT_RANGE/GAP_RATE)) ) {
+    if( RTIMER_CLOCK_LT(RTIMER_NOW(), rat_overflow.last_time) )
+    {
+        adjusted_overflow_counter--;
+        }
+      }
+  /* add the overflowed time to the timestamp */
+  last_timestamp = (rat_timestamp - rat_offset)
+                + RAT_RANGE * adjusted_overflow_counter;
+}
+
+/**
+* \brief evaluates timestamp of prepared RAT value at last rf_rat_last_packet_timestamp
+* \return - timestamp in RTTimer ticks
+*/
+uint32_t rf_rat_calc_last_rttime(){
+  return RADIO_TO_RTIMER(last_timestamp);
+}
+
+void rf_rat_monitor_init(const struct rf_rat_controler* rf){
+    memcpy(&rf_control, rf, sizeof(rf_control));
+    last_timestamp          = 0;
+    rat_overflow.last_time  = 0;
+    rat_overflow.counter    = 0;
+    rf_rat_check_overflow(true);
+    ctimer_set(&rat_overflow_timer, RAT_CHECK_PERIOD,
+               handle_rat_overflow, NULL);
+}
+
+void rf_rat_debug_dump(void){
+    PRINTF("RAT calc: last stamp $%llx rat $%lx [rt %lu] , overs %d, over_time %lu\n"
+            , last_timestamp, last_rat
+            , rf_rat_calc_last_rttime()
+            , rat_overflow.counter, rat_overflow.last_time);
+}
+
+#else //RF_RAT_STYLE > 0
+rf_rat_time_t rf_rat_last_timestamp;
+#endif
+

--- a/cpu/cc26xx-cc13xx/rf-core/rf-rat.h
+++ b/cpu/cc26xx-cc13xx/rf-core/rf-rat.h
@@ -1,0 +1,102 @@
+/*
+ * rfcore-rat.h
+ *
+ *  Created on: 21 èþë. 2017 ã.
+ *      Author: alexrayne
+ */
+/*---------------------------------------------------------------------------*/
+/**
+ * \addtogroup rf-core
+ * @{
+ *
+ * \defgroup rf-core-prop CC13xx Prop mode driver
+ *
+ * @{
+ *
+ * \file
+ * Header file for the CC13xx RAT timer handling.
+ * it provides monitor for RAT oveflow monitoring, and RAT timeStamps evaluate
+ */
+
+#ifndef CPU_RF_CORE_RF_RAT_H_
+#define CPU_RF_CORE_RF_RAT_H_
+
+#include <stdint.h>
+#include <stdbool.h>
+
+/*---------------------------------------------------------------------------*/
+/*
+ * FR RAT Front-End usage selection
+ * \value 0           - time stamps not implements, it just retrieved as is
+ * \value 1 (Default) - fully implements RAT timestamps at RTTimer domain
+ * \value Not Defined - same
+ */
+#ifdef RF_RAT_CONF_STYLE
+#define RF_RAT_STYLE RF_RAT_CONF_STYLE
+#else
+#define RF_RAT_STYLE 1
+#endif
+/*---------------------------------------------------------------------------*/
+struct rf_rat_controler{
+    uint8_t (*is_on)(void);
+    int     (*on)(void);
+    int     (*off)(void);
+};
+
+typedef uint32_t rf_rat_time_t;
+
+rf_rat_time_t rf_rat_now();
+
+#if RF_RAT_STYLE > 0
+/**
+ * \brief explicit RAT timer overflow check.
+ *  MUST call with powered RF - core
+ */
+uint_fast8_t rf_rat_check_overflow(bool first_time);
+
+/**
+ * \brief Initates and start RAT timer overflow monitor
+ * \param rf_rat_controler - provide an interface for RFcore enabling/disabling
+ *  MUST call with powered RF - core
+ */
+void rf_rat_monitor_init(const struct rf_rat_controler* rf);
+
+/**
+ * \brief prepare RAT timer time, for later timestamp evaluate rf_rat_calc_last_packet_rttime
+ * \param rat_timestamp - RAT timer value - time of last RF operation
+ *  MUST call with powered RF - core
+ */
+void     rf_rat_last_timestamp(rf_rat_time_t rat_timestamp);
+
+/**
+ * \brief evaluates timestamp of prepared RAT value at last rf_rat_last_packet_timestamp
+ * \return - timestamp in RTTimer ticks
+ */
+uint32_t rf_rat_calc_last_rttime(void);
+
+/**
+ * \brief just debug prints RAT internals
+ */
+void rf_rat_debug_dump(void);
+
+#else
+#define rf_rat_monitor_init(...)
+#define rf_rat_check_overflow(...)
+#define rf_rat_debug_dump(...)
+
+extern rf_rat_time_t rf_rat_timestamp;
+
+static inline
+void     rf_rat_last_timestamp(rf_rat_time_t t){
+    rf_rat_timestamp = t;
+}
+
+static inline
+uint32_t rf_rat_calc_last_rttime(void){
+    return rf_rat_timestamp;
+}
+
+#endif
+
+
+#endif /* CPU_RF_CORE_RF_RAT_H_ */

--- a/platform/srf06-cc26xx/launchpad/board.c
+++ b/platform/srf06-cc26xx/launchpad/board.c
@@ -67,9 +67,9 @@ LPM_MODULE(launchpad_module, NULL, NULL, wakeup_handler, LPM_DOMAIN_NONE);
 static void
 configure_unused_pins(void)
 {
-  uint32_t pins[] = BOARD_UNUSED_PINS;
+  const uint32_t pins[] = BOARD_UNUSED_PINS;
 
-  uint32_t *pin;
+  const uint32_t *pin;
 
   for(pin = pins; *pin != IOID_UNUSED; pin++) {
     ti_lib_ioc_pin_type_gpio_input(*pin);


### PR DESCRIPTION
Here is an set of patches, for cc26xx prop-mode rf-core driver, that provides minimal functionality enough for TSCH.
1) for aside work - was deployed RAT timer syncronise-monitor code from ieee-mode driver into stanalone object rf-rat-monitor.
2) optimised set_value operation for speed - now it not on/off rf-core if one powerdowned. this gives speed effort this method. this affects radio-chanel and tx-power setup parameters.
3) appends agressive RAT sync checking mode - this will checks that retrieved rx-operation timestamp is valid, and if not - checks sincronisation of RAT vs RTtimer.
4) a bit optimised code for size
