### PR TITLE
TSCH: protect against invalid slot-time drift, caused invalid timestamps

### DIFF
--- a/core/net/mac/tsch/tsch-log.c
+++ b/core/net/mac/tsch/tsch-log.c
@@ -118,6 +118,11 @@ tsch_log_process_pending(void)
       case tsch_log_message:
         printf("%s\n", log->message);
         break;
+      case tsch_log_rx_drift:
+       printf("RX : fantastic drift %ld = %lu[expect time] - %lu[rx time]\n"
+              , log->rx_drift.drift
+              , log->rx_drift.expect_us, log->rx_drift.start_us);
+       break;
     }
     /* Remove input from ringbuf */
     ringbufindex_get(&log_ringbuf);

--- a/core/net/mac/tsch/tsch-log.h
+++ b/core/net/mac/tsch/tsch-log.h
@@ -79,6 +79,7 @@
 struct tsch_log_t {
   enum { tsch_log_tx,
          tsch_log_rx,
+         tsch_log_rx_drift,
          tsch_log_message
   } type;
   struct tsch_asn_t asn;
@@ -105,6 +106,11 @@ struct tsch_log_t {
       uint8_t sec_level;
       uint8_t drift_used;
     } rx;
+    struct {
+        int32_t     drift;
+        uint32_t    start_us;
+        uint32_t    expect_us;
+    } rx_drift;
   };
 };
 

--- a/core/net/mac/tsch/tsch-slot-operation.c
+++ b/core/net/mac/tsch/tsch-slot-operation.c
@@ -66,6 +66,8 @@
 #endif /* TSCH_LOG_LEVEL */
 #include "net/net-debug.h"
 
+#include <stdlib.h>
+
 /* TSCH debug macros, i.e. to set LEDs or GPIOs on various TSCH
  * timeslot events */
 #ifndef TSCH_DEBUG_INIT
@@ -834,6 +836,15 @@ PT_THREAD(tsch_rx_slot(struct pt *pt, struct rtimer *t))
              || linkaddr_cmp(&destination_address, &linkaddr_null)) {
             int do_nack = 0;
             estimated_drift = RTIMER_CLOCK_DIFF(expected_rx_time, rx_start_time);
+
+            if (abs(estimated_drift) > tsch_timing[tsch_ts_timeslot_length]){
+                TSCH_LOG_ADD(tsch_log_rx_drift,
+                    log->rx_drift.drift     = estimated_drift;
+                    log->rx_drift.expect_us = expected_rx_time;
+                    log->rx_drift.start_us  = rx_start_time;
+                );
+                estimated_drift = 0;
+            }
 
 #if TSCH_TIMESYNC_REMOVE_JITTER
             /* remove jitter due to measurement errors */


### PR DESCRIPTION
If radio-driver returns invalid timestamp on received packet, it evaluates disaster drift value. Wich cause unsync with coordinator, when applyed. 
this patch add checks that drift value is in time-slot limits, and ommit drift, if it goes out of slot bounds.

        such a disaster can be caused by RAT miss-sinc. if not ommit this failed drift,
        it surely breaks slots sinchronising