### PR TITLE
TSCH: times - add prefetching slot time for slow RF on()

### DIFF
--- a/core/net/mac/tsch/tsch-conf.h
+++ b/core/net/mac/tsch/tsch-conf.h
@@ -91,6 +91,12 @@
 #define TSCH_CONF_RX_WAIT 2200
 #endif /* TSCH_CONF_RX_WAIT */
 
+/* Configurable guard time [us] for turn on radio, before slot activity */
+#ifndef TSCH_CONF_RFON_GUARD_TIME
+#define TSCH_CONF_RFON_GUARD_TIME 0
+#endif /* TSCH_CONF_RX_WAIT */
+
+
 /* The default timeslot timing in the standard is a guard time of
  * 2200 us, a Tx offset of 2120 us and a Rx offset of 1120 us.
  * As a result, the listening device has a guard time not centered

--- a/core/net/mac/tsch/tsch-private.h
+++ b/core/net/mac/tsch/tsch-private.h
@@ -70,6 +70,7 @@ enum tsch_timeslot_timing_elements {
   tsch_ts_max_ack,
   tsch_ts_max_tx,
   tsch_ts_timeslot_length,
+  tsch_ts_rfon_prepslot_guard,
   tsch_ts_elements_count, /* Not a timing element */
 };
 

--- a/core/net/mac/tsch/tsch.c
+++ b/core/net/mac/tsch/tsch.c
@@ -106,6 +106,7 @@ static const uint16_t tsch_default_timing_us[tsch_ts_elements_count] = {
   TSCH_DEFAULT_TS_MAX_ACK,
   TSCH_DEFAULT_TS_MAX_TX,
   TSCH_DEFAULT_TS_TIMESLOT_LENGTH,
+  TSCH_CONF_RFON_GUARD_TIME,
 };
 /* TSCH timeslot timing (in rtimer ticks) */
 rtimer_clock_t tsch_timing[tsch_ts_elements_count];


### PR DESCRIPTION
add guard time - prepending slot start for turn RF on.

+     TSCH_CONF_FRON_GUARD_TIME

*  this time need when too slow radio turn-on violates with tsch_ts_rx/tx_offset
   timeout. 
*  tsch_timings[tsch_ts_rfon_prepslot_guard] forces to start slot operation before slot start time, 
   therefore activates radio before slot start, and can be ready rigth when it need