### PR TITLE
TSCH:  ACK time position estimates from receive/transmit operation end

### DIFF
--- a/core/net/mac/tsch/tsch-conf.h
+++ b/core/net/mac/tsch/tsch-conf.h
@@ -198,4 +198,20 @@
 #define TSCH_CHANNEL_SCAN_DURATION CLOCK_SECOND
 #endif
 
+/* ACK timing style:
+ * \value 0 - default: old behaviour - where ACK at time position from estimated
+ *              packet trasmition time.
+ *              tx_duration(t) + TSCH_DEFAULT_TS_TX_ACK_DELAY
+ * \value 1 - immediate ACK after receive + TSCH_DEFAULT_TS_TX_ACK_DELAY.
+ *          rely on radio_driver behaviour - that blocks receive/transmit operation
+ *          right for operation time.
+ *  */
+#define TSCH_ACK_TIMING_OLD         0
+#define TSCH_ACK_TIMING_IMMEDIATE   1
+#ifdef TSCH_CONF_ACK_TIMING_STYLE
+#define TSCH_ACK_TIMING_STYLE TSCH_CONF_ACK_TIMING_STYLE
+#else
+#define TSCH_ACK_TIMING_STYLE TSCH_ACK_TIMING_IMMEDIATE
+#endif
+
 #endif /* __TSCH_CONF_H__ */

--- a/core/net/mac/tsch/tsch-private.h
+++ b/core/net/mac/tsch/tsch-private.h
@@ -108,6 +108,11 @@ void tsch_disassociate(void);
  * One byte = 32us. Add two bytes for CRC and one for len field */
 #define TSCH_PACKET_DURATION(len) US_TO_RTIMERTICKS(32 * ((len) + 3))
 
+/* Delay between the SFD RSSI detects preamble and it is detected in software. */
+#ifndef RADIO_RSSI_DETECT_DELAY
+#define RADIO_RSSI_DETECT_DELAY TSCH_PACKET_DURATION(0)
+#endif
+
 /* Convert rtimer ticks to clock and vice versa */
 #define TSCH_CLOCK_TO_TICKS(c) (((c) * RTIMER_SECOND) / CLOCK_SECOND)
 #define TSCH_CLOCK_TO_SLOTS(c, timeslot_length) (TSCH_CLOCK_TO_TICKS(c) / timeslot_length)


### PR DESCRIPTION
This patch gives ACK time position estimates from receive/transmit operation end  vs op-start+calculated packet time. This behaviour rejects dependence on accurate packet time calculation.
+TSCH:conf: TSCH_ACK_TIMING_STYLE - provides selection of ACK timing behaviour between new and old one.
+     conf: RADIO_RSSI_DETECT_DELAY - enhances ACK wait time for preamble delay, that need by receiving detection.

* if radio driver realises accuracy blocking receive/send so that operation ends
   right after radio packet, we can use operation end-time, instead of calculation
   packet time. so ACK will be functional even with invalid packet time formula.
*  for RF settimgs with low baudrate, RSSI detection time can be sufficient, therefore
        need enhance ACK wait time for this delay. By default calculate it as TSCH_PACKET_DURATION(0)