### PR TITLE
TSCH: conf -  set of configuration TSCH stack

### DIFF
--- a/core/net/mac/tsch/tsch-conf.h
+++ b/core/net/mac/tsch/tsch-conf.h
@@ -91,6 +91,14 @@
 #define TSCH_CONF_RX_WAIT 2200
 #endif /* TSCH_CONF_RX_WAIT */
 
+#ifndef TSCH_CONF_TS_MAX_TX
+#define TSCH_CONF_TS_MAX_TX 4256
+#endif /* TSCH_CONF_RX_WAIT */
+
+#ifndef TSCH_CONF_TS_MAX_ACK
+#define TSCH_CONF_TS_MAX_ACK 2400
+#endif /* TSCH_CONF_RX_WAIT */
+
 /* The default timeslot timing in the standard is a guard time of
  * 2200 us, a Tx offset of 2120 us and a Rx offset of 1120 us.
  * As a result, the listening device has a guard time not centered
@@ -118,7 +126,7 @@
 #define TSCH_DEFAULT_TS_ACK_WAIT           400
 #define TSCH_DEFAULT_TS_RX_TX              192
 #define TSCH_DEFAULT_TS_MAX_ACK            2400
-#define TSCH_DEFAULT_TS_MAX_TX             4256
+#define TSCH_DEFAULT_TS_MAX_TX             TSCH_CONF_TS_MAX_TX
 #define TSCH_DEFAULT_TS_TIMESLOT_LENGTH    10000
 
 #elif TSCH_CONF_DEFAULT_TIMESLOT_LENGTH == 15000
@@ -128,13 +136,13 @@
 #define TSCH_DEFAULT_TS_CCA                128
 #define TSCH_DEFAULT_TS_TX_OFFSET          4000
 #define TSCH_DEFAULT_TS_RX_OFFSET          (TSCH_DEFAULT_TS_TX_OFFSET - (TSCH_CONF_RX_WAIT / 2))
-#define TSCH_DEFAULT_TS_RX_ACK_DELAY       3600
 #define TSCH_DEFAULT_TS_TX_ACK_DELAY       4000
 #define TSCH_DEFAULT_TS_RX_WAIT            TSCH_CONF_RX_WAIT
 #define TSCH_DEFAULT_TS_ACK_WAIT           800
+#define TSCH_DEFAULT_TS_RX_ACK_DELAY       (TSCH_DEFAULT_TS_TX_ACK_DELAY - (TSCH_DEFAULT_TS_ACK_WAIT/2))
 #define TSCH_DEFAULT_TS_RX_TX              2072
-#define TSCH_DEFAULT_TS_MAX_ACK            2400
-#define TSCH_DEFAULT_TS_MAX_TX             4256
+#define TSCH_DEFAULT_TS_MAX_ACK            TSCH_CONF_TS_MAX_ACK
+#define TSCH_DEFAULT_TS_MAX_TX             TSCH_CONF_TS_MAX_TX
 #define TSCH_DEFAULT_TS_TIMESLOT_LENGTH    15000
 
 #elif TSCH_CONF_DEFAULT_TIMESLOT_LENGTH == 65000U
@@ -155,7 +163,7 @@
 #define TSCH_DEFAULT_TS_ACK_WAIT           800
 #define TSCH_DEFAULT_TS_RX_TX              2072
 #define TSCH_DEFAULT_TS_MAX_ACK            2400
-#define TSCH_DEFAULT_TS_MAX_TX             4256
+#define TSCH_DEFAULT_TS_MAX_TX             TSCH_CONF_TS_MAX_TX
 #define TSCH_DEFAULT_TS_TIMESLOT_LENGTH    65000
 
 #else

--- a/core/net/mac/tsch/tsch-log.h
+++ b/core/net/mac/tsch/tsch-log.h
@@ -56,6 +56,7 @@
 #endif /* TSCH_LOG_ID_FROM_LINKADDR */
 
 /* TSCH log levels:
+ * -1: no any print, even failure reports
  * 0: no log
  * 1: basic PRINTF enabled
  * 2: basic PRINTF enabled and tsch-log module enabled */

--- a/core/net/mac/tsch/tsch-private.h
+++ b/core/net/mac/tsch/tsch-private.h
@@ -106,7 +106,13 @@ void tsch_disassociate(void);
 /* Calculate packet tx/rx duration in rtimer ticks based on sent
  * packet len in bytes with 802.15.4 250kbps data rate.
  * One byte = 32us. Add two bytes for CRC and one for len field */
-#define TSCH_PACKET_DURATION(len) US_TO_RTIMERTICKS(32 * ((len) + 3))
+#ifdef RF_CORE_CONF_BAUD
+#define TSCH_BYTE_US (8000000ul/RF_CORE_CONF_BAUD)
+#else
+#define TSCH_BYTE_US 32
+#endif
+
+#define TSCH_PACKET_DURATION(len) US_TO_RTIMERTICKS(TSCH_BYTE_US * ((len) + 3))
 
 /* Convert rtimer ticks to clock and vice versa */
 #define TSCH_CLOCK_TO_TICKS(c) (((c) * RTIMER_SECOND) / CLOCK_SECOND)

--- a/core/net/mac/tsch/tsch-schedule.c
+++ b/core/net/mac/tsch/tsch-schedule.c
@@ -310,10 +310,11 @@ tsch_schedule_get_link_by_timeslot(struct tsch_slotframe *slotframe, uint16_t ti
 /*---------------------------------------------------------------------------*/
 /* Returns the next active link after a given ASN, and a backup link (for the same ASN, with Rx flag) */
 struct tsch_link *
-tsch_schedule_get_next_active_link(struct tsch_asn_t *asn, uint16_t *time_offset,
+tsch_schedule_get_next_active_link(struct tsch_asn_t *asn
+    , tsch_slot_offset_t *time_offset,
     struct tsch_link **backup_link)
 {
-  uint16_t time_to_curr_best = 0;
+  tsch_slot_offset_t time_to_curr_best = 0;
   struct tsch_link *curr_best = NULL;
   struct tsch_link *curr_backup = NULL; /* Keep a back link in case the current link
   turns out useless when the time comes. For instance, for a Tx-only link, if there is
@@ -324,10 +325,10 @@ tsch_schedule_get_next_active_link(struct tsch_asn_t *asn, uint16_t *time_offset
     /* For each slotframe, look for the earliest occurring link */
     while(sf != NULL) {
       /* Get timeslot from ASN, given the slotframe length */
-      uint16_t timeslot = TSCH_ASN_MOD(*asn, sf->size);
+      tsch_slot_offset_t timeslot = TSCH_ASN_MOD(*asn, sf->size);
       struct tsch_link *l = list_head(sf->links_list);
       while(l != NULL) {
-        uint16_t time_to_timeslot =
+          tsch_slot_offset_t time_to_timeslot =
           l->timeslot > timeslot ?
           l->timeslot - timeslot :
           sf->size.val + l->timeslot - timeslot;

--- a/core/net/mac/tsch/tsch-schedule.h
+++ b/core/net/mac/tsch/tsch-schedule.h
@@ -157,8 +157,10 @@ int tsch_schedule_remove_link(struct tsch_slotframe *slotframe, struct tsch_link
 /* Removes a link from slotframe and timeslot. Return a 1 if success, 0 if failure */
 int tsch_schedule_remove_link_by_timeslot(struct tsch_slotframe *slotframe, uint16_t timeslot);
 
+typedef uint_fast16_t tsch_slot_offset_t;
 /* Returns the next active link after a given ASN, and a backup link (for the same ASN, with Rx flag) */
-struct tsch_link * tsch_schedule_get_next_active_link(struct tsch_asn_t *asn, uint16_t *time_offset,
+struct tsch_link * tsch_schedule_get_next_active_link(struct tsch_asn_t *asn
+    , tsch_slot_offset_t *time_offset,
     struct tsch_link **backup_link);
 
 #endif /* __TSCH_SCHEDULE_H__ */

--- a/core/net/mac/tsch/tsch-slot-operation.c
+++ b/core/net/mac/tsch/tsch-slot-operation.c
@@ -1017,7 +1017,7 @@ PT_THREAD(tsch_slot_operation(struct rtimer *t, void *ptr))
     } else {
       /* backup of drift correction for printing debug messages */
       /* int32_t drift_correction_backup = drift_correction; */
-      uint16_t timeslot_diff = 0;
+      tsch_slot_offset_t timeslot_diff = 0;
       rtimer_clock_t prev_slot_start;
       /* Time to next wake up */
       rtimer_clock_t time_to_next_active_slot;
@@ -1069,7 +1069,7 @@ tsch_slot_operation_start(void)
   rtimer_clock_t prev_slot_start;
   TSCH_DEBUG_INIT();
   do {
-    uint16_t timeslot_diff;
+    tsch_slot_offset_t timeslot_diff;
     /* Get next active link */
     current_link = tsch_schedule_get_next_active_link(&tsch_current_asn, &timeslot_diff, &backup_link);
     if(current_link == NULL) {

--- a/core/net/mac/tsch/tsch-slot-operation.c
+++ b/core/net/mac/tsch/tsch-slot-operation.c
@@ -248,10 +248,17 @@ tsch_release_lock(void)
 
 /* Return channel from ASN and channel offset */
 uint8_t
-tsch_calculate_channel(struct tsch_asn_t *asn, uint8_t channel_offset)
+tsch_calculate_channel(struct tsch_asn_t *asn, int_fast8_t channel_offset)
 {
-  uint16_t index_of_0 = TSCH_ASN_MOD(*asn, tsch_hopping_sequence_length);
-  uint16_t index_of_offset = (index_of_0 + channel_offset) % tsch_hopping_sequence_length.val;
+    if (tsch_hopping_sequence_length.val <= 1){
+        return tsch_hopping_sequence[0];
+    }
+  uint_fast8_t index_of_0 = TSCH_ASN_MOD(*asn, tsch_hopping_sequence_length);
+  int_fast8_t index_of_offset = (index_of_0 + channel_offset);
+  if (index_of_offset > tsch_hopping_sequence_length.val)
+      index_of_offset -= tsch_hopping_sequence_length.val;
+  else if (index_of_offset < 0)
+      index_of_offset += tsch_hopping_sequence_length.val;
   return tsch_hopping_sequence[index_of_offset];
 }
 

--- a/core/net/mac/tsch/tsch-slot-operation.c
+++ b/core/net/mac/tsch/tsch-slot-operation.c
@@ -912,11 +912,11 @@ PT_THREAD(tsch_rx_slot(struct pt *pt, struct rtimer *t))
 
           /* Poll process for processing of pending input and logs */
           process_poll(&tsch_pending_events_process);
-        }
-      }
+        }//if(frame_valid)
+      }//if(NETSTACK_RADIO.pending_packet())
 
       tsch_radio_off(TSCH_RADIO_CMD_OFF_END_OF_TIMESLOT);
-    }
+    }//else(!packet_seen)
 
     if(input_queue_drop != 0) {
       TSCH_LOG_ADD(tsch_log_message,
@@ -1017,8 +1017,9 @@ PT_THREAD(tsch_slot_operation(struct rtimer *t, void *ptr))
       /* Schedule next wakeup skipping slots if missed deadline */
       do {
         if(current_link != NULL
-            && current_link->link_options & LINK_OPTION_TX
-            && current_link->link_options & LINK_OPTION_SHARED) {
+            && (current_link->link_options & LINK_OPTION_TX)
+            && (current_link->link_options & LINK_OPTION_SHARED) )
+        {
           /* Decrement the backoff window for all neighbors able to transmit over
            * this Tx, Shared link. */
           tsch_queue_update_all_backoff_windows(&current_link->addr);

--- a/core/net/mac/tsch/tsch-slot-operation.h
+++ b/core/net/mac/tsch/tsch-slot-operation.h
@@ -107,7 +107,7 @@ extern struct input_packet input_array[TSCH_MAX_INCOMING_PACKETS];
 /********** Functions *********/
 
 /* Returns a 802.15.4 channel from an ASN and channel offset */
-uint8_t tsch_calculate_channel(struct tsch_asn_t *asn, uint8_t channel_offset);
+uint8_t tsch_calculate_channel(struct tsch_asn_t *asn, int_fast8_t channel_offset);
 /* Is TSCH locked? */
 int tsch_is_locked(void);
 /* Lock TSCH (no link operation) */

--- a/core/net/mac/tsch/tsch.c
+++ b/core/net/mac/tsch/tsch.c
@@ -197,6 +197,7 @@ tsch_set_eb_period(uint32_t period)
 static void
 tsch_reset(void)
 {
+  ANNOTATE("TSCH:reset");
   int i;
   frame802154_set_pan_id(0xffff);
   /* First make sure pending packet callbacks are sent etc */
@@ -278,6 +279,7 @@ eb_input(struct input_packet *current_input)
   if(tsch_packet_parse_eb(current_input->payload, current_input->len,
                           &frame, &eb_ies, NULL, 1)) {
     /* PAN ID check and authentication done at rx time */
+    ANNOTATE("TSCH: got EB\n");
 
 #if TSCH_AUTOSELECT_TIME_SOURCE
     if(!tsch_is_coordinator) {
@@ -339,7 +341,7 @@ eb_input(struct input_packet *current_input)
 #endif /* TSCH_AUTOSELECT_TIME_SOURCE */
       }
     }
-  }
+  }//if(tsch_packet_parse_eb
 }
 
 /*---------------------------------------------------------------------------*/
@@ -678,6 +680,7 @@ PT_THREAD(tsch_scan(struct pt *pt))
       PT_WAIT_UNTIL(pt, etimer_expired(&scan_timer));
     }
   }
+  ANNOTATE("TSCH: scanning complete\n");
 
   PT_END(pt);
 }

--- a/core/net/mac/tsch/tsch.c
+++ b/core/net/mac/tsch/tsch.c
@@ -442,7 +442,11 @@ tsch_associate(const struct input_packet *input_eb, rtimer_clock_t timestamp)
   uint8_t hdrlen;
   int i;
 
-  if(input_eb == NULL || tsch_packet_parse_eb(input_eb->payload, input_eb->len,
+  if(input_eb == NULL){
+      PRINTF("TSCH:! failed EB - looks stack damaged\n");
+      return 0;
+  }
+  if(tsch_packet_parse_eb(input_eb->payload, input_eb->len,
                                               &frame, &ies, &hdrlen, 0) == 0) {
     PRINTF("TSCH:! failed to parse EB (len %u)\n", input_eb->len);
     return 0;

--- a/core/net/mac/tsch/tsch.c
+++ b/core/net/mac/tsch/tsch.c
@@ -504,6 +504,7 @@ tsch_associate(const struct input_packet *input_eb, rtimer_clock_t timestamp)
     return 0;
   }
 
+#ifndef TSCH_DEBUG_NO_TIMING_FROM_EB
   /* TSCH timeslot timing */
   for(i = 0; i < tsch_ts_elements_count; i++) {
     if(ies.ie_tsch_timeslot_id == 0) {
@@ -512,6 +513,7 @@ tsch_associate(const struct input_packet *input_eb, rtimer_clock_t timestamp)
       tsch_timing[i] = US_TO_RTIMERTICKS(ies.ie_tsch_timeslot[i]);
     }
   }
+#endif
 
   /* TSCH hopping sequence */
   if(ies.ie_channel_hopping_sequence_id == 0) {

--- a/core/net/mac/tsch/tsch.c
+++ b/core/net/mac/tsch/tsch.c
@@ -68,6 +68,12 @@
 #endif /* TSCH_LOG_LEVEL */
 #include "net/net-debug.h"
 
+#if TSCH_LOG_LEVEL >= 0
+#define PRINTF_FAIL(...)    printf(__VA_ARGS__)
+#else
+#define PRINTF_FAIL(...)
+#endif
+
 /* Use to collect link statistics even on Keep-Alive, even though they were
  * not sent from an upper layer and don't have a valid packet_sent callback */
 #ifndef TSCH_LINK_NEIGHBOR_CALLBACK
@@ -804,7 +810,7 @@ tsch_init(void)
 
   /* Radio Rx mode */
   if(NETSTACK_RADIO.get_value(RADIO_PARAM_RX_MODE, &radio_rx_mode) != RADIO_RESULT_OK) {
-    printf("TSCH:! radio does not support getting RADIO_PARAM_RX_MODE. Abort init.\n");
+    PRINTF_FAIL("TSCH:! radio does not support getting RADIO_PARAM_RX_MODE. Abort init.\n");
     return;
   }
   /* Disable radio in frame filtering */
@@ -814,34 +820,35 @@ tsch_init(void)
   /* Set radio in poll mode */
   radio_rx_mode |= RADIO_RX_MODE_POLL_MODE;
   if(NETSTACK_RADIO.set_value(RADIO_PARAM_RX_MODE, radio_rx_mode) != RADIO_RESULT_OK) {
-    printf("TSCH:! radio does not support setting required RADIO_PARAM_RX_MODE. Abort init.\n");
+    PRINTF_FAIL("TSCH:! radio does not support setting required RADIO_PARAM_RX_MODE. Abort init.\n");
     return;
   }
 
   /* Radio Tx mode */
   if(NETSTACK_RADIO.get_value(RADIO_PARAM_TX_MODE, &radio_tx_mode) != RADIO_RESULT_OK) {
-    printf("TSCH:! radio does not support getting RADIO_PARAM_TX_MODE. Abort init.\n");
+    PRINTF_FAIL("TSCH:! radio does not support getting RADIO_PARAM_TX_MODE. Abort init.\n");
     return;
   }
   /* Unset CCA */
   radio_tx_mode &= ~RADIO_TX_MODE_SEND_ON_CCA;
   if(NETSTACK_RADIO.set_value(RADIO_PARAM_TX_MODE, radio_tx_mode) != RADIO_RESULT_OK) {
-    printf("TSCH:! radio does not support setting required RADIO_PARAM_TX_MODE. Abort init.\n");
+    PRINTF_FAIL("TSCH:! radio does not support setting CCA off RADIO_PARAM_TX_MODE. Abort init.\n");
     return;
   }
   /* Test setting channel */
   if(NETSTACK_RADIO.set_value(RADIO_PARAM_CHANNEL, TSCH_DEFAULT_HOPPING_SEQUENCE[0]) != RADIO_RESULT_OK) {
-    printf("TSCH:! radio does not support setting channel. Abort init.\n");
+    PRINTF_FAIL("TSCH:! radio does not support setting channel. Abort init.\n");
     return;
   }
   /* Test getting timestamp */
   if(NETSTACK_RADIO.get_object(RADIO_PARAM_LAST_PACKET_TIMESTAMP, &t, sizeof(rtimer_clock_t)) != RADIO_RESULT_OK) {
-    printf("TSCH:! radio does not support getting last packet timestamp. Abort init.\n");
+    PRINTF_FAIL("TSCH:! radio does not support getting last packet timestamp. Abort init.\n");
     return;
   }
   /* Check max hopping sequence length vs default sequence length */
   if(TSCH_HOPPING_SEQUENCE_MAX_LEN < sizeof(TSCH_DEFAULT_HOPPING_SEQUENCE)) {
-    printf("TSCH:! TSCH_HOPPING_SEQUENCE_MAX_LEN < sizeof(TSCH_DEFAULT_HOPPING_SEQUENCE). Abort init.\n");
+    PRINTF_FAIL("TSCH:! TSCH_HOPPING_SEQUENCE_MAX_LEN < sizeof(TSCH_DEFAULT_HOPPING_SEQUENCE). Abort init.\n");
+    return;
   }
 
   /* Init TSCH sub-modules */

--- a/core/net/mac/tsch/tsch.c
+++ b/core/net/mac/tsch/tsch.c
@@ -130,8 +130,10 @@ const linkaddr_t tsch_eb_address = { { 0, 0 } };
 int tsch_is_started = 0;
 /* Has TSCH initialization failed? */
 int tsch_is_initialized = 0;
+#ifndef TSCH_IS_COORDINATOR
 /* Are we coordinator of the TSCH network? */
 int tsch_is_coordinator = 0;
+#endif
 /* Are we associated to a TSCH network? */
 int tsch_is_associated = 0;
 /* Is the PAN running link-layer security? */
@@ -166,7 +168,14 @@ static void packet_input(void);
 void
 tsch_set_coordinator(int enable)
 {
+#ifndef TSCH_IS_COORDINATOR
   tsch_is_coordinator = enable;
+#else
+  if (tsch_is_coordinator != enable){
+      PRINTF_FAIL("TCSH: missed coordinator request %d vs hardcoded", enable);
+      return;
+  }
+#endif
   tsch_set_eb_period(TSCH_EB_PERIOD);
 }
 /*---------------------------------------------------------------------------*/

--- a/core/net/mac/tsch/tsch.h
+++ b/core/net/mac/tsch/tsch.h
@@ -134,6 +134,10 @@
 #define TSCH_INIT_SCHEDULE_FROM_EB 1
 #endif
 
+/* By default: TSCH loads slot timing from coordinator EB
+ * but for debug purposes it can be ommited by enabling this macro*/
+//#define TSCH_DEBUG_NO_TIMING_FROM_EB
+
 /* An ad-hoc mechanism to have TSCH select its time source without the
  * help of an upper-layer, simply by collecting statistics on received
  * EBs and their join priority. Disabled by default as we recomment

--- a/core/net/mac/tsch/tsch.h
+++ b/core/net/mac/tsch/tsch.h
@@ -160,7 +160,14 @@ void TSCH_CALLBACK_LEAVING_NETWORK();
 /***** External Variables *****/
 
 /* Are we coordinator of the TSCH network? */
+#ifndef TSCH_IS_COORDINATOR
+/* Are we coordinator of the TSCH network? */
 extern int tsch_is_coordinator;
+#elif TSCH_IS_COORDINATOR == 0
+static const int tsch_is_coordinator = 0;
+#else
+static const int tsch_is_coordinator = 1;
+#endif
 /* Are we associated to a TSCH network? */
 extern int tsch_is_associated;
 /* Is the PAN running link-layer security? */


### PR DESCRIPTION
Here provided configuring on TSCH capability. 
1) can enabled/disabled Coordinator functionality
2) disable generator EB :  if TSCH_EB_PERIOD==0 - beacons not sends
3) more flexible config TSCH_DEFAULT_TS_MAX_ACK, TSCH_DEFAULT_TS_MAX_TX
also provided a bit speedup TSCH code