### PR TITLE
TSCH: Fixes crash due to missing check for NULL pointer

### DIFF
--- a/core/net/mac/tsch/tsch.c
+++ b/core/net/mac/tsch/tsch.c
@@ -239,12 +239,14 @@ keepalive_send()
 {
   if(tsch_is_associated) {
     struct tsch_neighbor *n = tsch_queue_get_time_source();
-    /* Simply send an empty packet */
-    packetbuf_clear();
-    packetbuf_set_addr(PACKETBUF_ADDR_RECEIVER, &n->addr);
-    NETSTACK_LLSEC.send(keepalive_packet_sent, NULL);
-    PRINTF("TSCH: sending KA to %u\n",
-           TSCH_LOG_ID_FROM_LINKADDR(&n->addr));
+    if(n != NULL) {
+      /* Simply send an empty packet */
+      packetbuf_clear();
+      packetbuf_set_addr(PACKETBUF_ADDR_RECEIVER, &n->addr);
+      NETSTACK_LLSEC.send(keepalive_packet_sent, NULL);
+      PRINTF("TSCH: sending KA to %u\n",
+             TSCH_LOG_ID_FROM_LINKADDR(&n->addr));
+    }
   }
 }
 /*---------------------------------------------------------------------------*/


### PR DESCRIPTION
A missing check for NULL in the keepalive_send crashes TSCH if tsch_queue_get_time_source returns NULL.

More specifically this happened when we tried updating the schedules dynamically in run-time. Seemed to be a race condition that resulted in NULL being returned (the lock perhaps?).