### PR TITLE
fix make drop of builded intermediate objects

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -206,6 +206,9 @@ ifneq ($(MAKECMDGOALS),clean)
                                    $(PROJECT_SOURCEFILES:.c=.d)}
 endif
 
+# prevent delete project objects that have deps but not included in contiki lib  
+.SECONDARY : $(PROJECT_OBJECTFILES) $(TARGET_STARTFILES)
+
 ### See http://make.paulandlesley.org/autodep.html#advanced
 
 define FINALIZE_DEPENDENCY


### PR DESCRIPTION
Here patch for prevent remove objects files, that not in contiki lib - project and target start files.
that objects treats as intermediate  - and to prevent ones drop, it declares as secondary
