### PR TITLE
Fix make deps

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -202,8 +202,10 @@ endif
 ### Automatic dependency generation
 
 ifneq ($(MAKECMDGOALS),clean)
--include ${addprefix $(OBJECTDIR)/,$(CONTIKI_SOURCEFILES:.c=.d) \
-                                   $(PROJECT_SOURCEFILES:.c=.d)}
+DEPS = $(CONTIKI_OBJECTFILES:.o=.d) \
+       $(PROJECT_OBJECTFILES:.o=.d)
+#$(info deps: ${DEPS})
+-include ${DEPS}
 endif
 
 ### See http://make.paulandlesley.org/autodep.html#advanced

--- a/Makefile.include
+++ b/Makefile.include
@@ -203,7 +203,9 @@ endif
 
 ifneq ($(MAKECMDGOALS),clean)
 DEPS = $(CONTIKI_OBJECTFILES:.o=.d) \
-       $(PROJECT_OBJECTFILES:.o=.d)
+       $(PROJECT_OBJECTFILES:.o=.d) \
+       $(TARGET_STARTFILES:.o=.d)
+
 #$(info deps: ${DEPS})
 -include ${DEPS}
 endif
@@ -278,7 +280,7 @@ ifndef LD
 endif
 
 ifndef CUSTOM_RULE_LINK
-%.$(TARGET): %.co $(PROJECT_OBJECTFILES) $(PROJECT_LIBRARIES) contiki-$(TARGET).a
+%.$(TARGET): %.co $(PROJECT_OBJECTFILES) $(TARGET_STARTFILES) $(PROJECT_LIBRARIES) contiki-$(TARGET).a
 	$(TRACE_LD)
 	$(Q)$(LD) $(LDFLAGS) $(TARGET_STARTFILES) ${filter-out %.a,$^} \
 	    ${filter %.a,$^} $(TARGET_LIBFILES) -o $@


### PR DESCRIPTION
Here is patch on make:
1) generate dependance list from objects list - gives more relyable .d file path-names, and it more adecvate to compiler units
2) look like TARGET_STARTFILES forgotten, so append to link prerequesites rule and deps list