### PR TITLE
TSCH: rtimer us_to_rtimerticks/rtimerticks_to_us - routines prefer macros

### DIFF
--- a/core/net/mac/tsch/tsch-adaptive-timesync.c
+++ b/core/net/mac/tsch/tsch-adaptive-timesync.c
@@ -141,8 +141,8 @@ compensate_internal(uint32_t time_delta_usec, int32_t drift_ppm, int32_t *remain
   *remainder = (int32_t)(d - amount * TSCH_DRIFT_UNIT);
 
   amount += *tick_conversion_error;
-  amount_ticks = US_TO_RTIMERTICKS(amount);
-  *tick_conversion_error = amount - RTIMERTICKS_TO_US(amount_ticks);
+  amount_ticks = us_to_rtimerticks(amount);
+  *tick_conversion_error = amount - rtimerticks_to_us(amount_ticks);
 
   if(ABS(amount_ticks) > RTIMER_ARCH_SECOND / 128) {
     TSCH_LOG_ADD(tsch_log_message,

--- a/core/net/mac/tsch/tsch-slot-operation.c
+++ b/core/net/mac/tsch/tsch-slot-operation.c
@@ -643,7 +643,7 @@ PT_THREAD(tsch_tx_slot(struct pt *pt, struct rtimer *t))
 
               if(ack_len != 0) {
                 if(is_time_source) {
-                  int32_t eack_time_correction = US_TO_RTIMERTICKS(ack_ies.ie_time_correction);
+                  int32_t eack_time_correction = us_to_rtimerticks(ack_ies.ie_time_correction);
                   int32_t since_last_timesync = TSCH_ASN_DIFF(tsch_current_asn, last_sync_asn);
                   if(eack_time_correction > SYNC_IE_BOUND) {
                     drift_correction = SYNC_IE_BOUND;

--- a/core/net/mac/tsch/tsch.c
+++ b/core/net/mac/tsch/tsch.c
@@ -206,7 +206,7 @@ tsch_reset(void)
   current_link = NULL;
   /* Reset timeslot timing to defaults */
   for(i = 0; i < tsch_ts_elements_count; i++) {
-    tsch_timing[i] = US_TO_RTIMERTICKS(tsch_default_timing_us[i]);
+    tsch_timing[i] = us_to_rtimerticks(tsch_default_timing_us[i]);
   }
 #ifdef TSCH_CALLBACK_LEAVING_NETWORK
   TSCH_CALLBACK_LEAVING_NETWORK();

--- a/core/sys/rtimer.c
+++ b/core/sys/rtimer.c
@@ -104,5 +104,19 @@ rtimer_run_next(void)
   return;
 }
 /*---------------------------------------------------------------------------*/
+//* rtimer-arch should provide this macro for many net-stack modules
+//* often us-ticks conversion uses mul/div ops,
+//* use of routines helps deruce code size.
+#ifdef US_TO_RTIMERTICKS
+rtimer_diff_t us_to_rtimerticks(rtimer_diff_t val){
+    return US_TO_RTIMERTICKS(val);
+}
+#endif
+
+#ifdef RTIMERTICKS_TO_US
+rtimer_diff_t rtimerticks_to_us(rtimer_diff_t val){
+    return RTIMERTICKS_TO_US(val);
+}
+#endif
 
 /** @}*/

--- a/core/sys/rtimer.h
+++ b/core/sys/rtimer.h
@@ -134,6 +134,22 @@ void rtimer_run_next(void);
  */
 #define RTIMER_NOW() rtimer_arch_now()
 
+#ifndef __rtimer_diff_t
+#define __rtimer_diff_t rtimer_diff_t
+typedef int32_t rtimer_diff_t;
+#endif
+
+//* rtimer-arch should provide this macro for TSCH net-stack module
+//* often us-ticks conversion uses mul/div ops,
+//* use of routines helps deruce code size.
+#ifdef US_TO_RTIMERTICKS
+rtimer_diff_t us_to_rtimerticks(rtimer_diff_t val);
+#endif
+
+#ifdef RTIMERTICKS_TO_US
+rtimer_diff_t rtimerticks_to_us(rtimer_diff_t val);
+#endif
+
 /**
  * \brief      Get the time that a task last was executed
  * \param task The task


### PR DESCRIPTION
Here is rtimer.h provided convertion routines us_to_rtimerticks/rtimerticks_to_us - static code wraps version of RTIMERTICKS_TO_US/US_TO_RTIMERTICKS macro, that intends to common code optimise

*Note: rtime-us convertion is not trivial, often use mul/div. so better to provide routines
        for variable conversion. vs macro - uses onluh for constansts evaluation