### PR TITLE
*TSCH:time_source - fast implementation tsch_queue_get_time_source

### DIFF
--- a/core/net/mac/tsch/tsch-queue.c
+++ b/core/net/mac/tsch/tsch-queue.c
@@ -122,21 +122,7 @@ tsch_queue_get_nbr(const linkaddr_t *addr)
   return NULL;
 }
 /*---------------------------------------------------------------------------*/
-/* Get a TSCH time source (we currently assume there is only one) */
-struct tsch_neighbor *
-tsch_queue_get_time_source(void)
-{
-  if(!tsch_is_locked()) {
-    struct tsch_neighbor *curr_nbr = list_head(neighbor_list);
-    while(curr_nbr != NULL) {
-      if(curr_nbr->is_time_source) {
-        return curr_nbr;
-      }
-      curr_nbr = list_item_next(curr_nbr);
-    }
-  }
-  return NULL;
-}
+struct tsch_neighbor *n_time_source = NULL;
 /*---------------------------------------------------------------------------*/
 /* Update TSCH time source */
 int
@@ -175,6 +161,7 @@ tsch_queue_update_time_source(const linkaddr_t *new_addr)
         if(old_time_src != NULL) {
           old_time_src->is_time_source = 0;
         }
+        n_time_source = new_time_src;
 
 #ifdef TSCH_CALLBACK_NEW_TIME_SOURCE
         TSCH_CALLBACK_NEW_TIME_SOURCE(old_time_src, new_time_src);

--- a/core/net/mac/tsch/tsch-queue.h
+++ b/core/net/mac/tsch/tsch-queue.h
@@ -148,6 +148,8 @@ struct tsch_neighbor {
 extern struct tsch_neighbor *n_broadcast;
 extern struct tsch_neighbor *n_eb;
 
+//* private variable for xxx_time_source methods. do ton use it directly
+extern struct tsch_neighbor *n_time_source;
 /********** Functions *********/
 
 /* Add a TSCH neighbor */
@@ -155,7 +157,10 @@ struct tsch_neighbor *tsch_queue_add_nbr(const linkaddr_t *addr);
 /* Get a TSCH neighbor */
 struct tsch_neighbor *tsch_queue_get_nbr(const linkaddr_t *addr);
 /* Get a TSCH time source (we currently assume there is only one) */
-struct tsch_neighbor *tsch_queue_get_time_source(void);
+static inline
+struct tsch_neighbor *tsch_queue_get_time_source(void){
+    return n_time_source;
+}
 /* Update TSCH time source */
 int tsch_queue_update_time_source(const linkaddr_t *new_addr);
 /* Add packet to neighbor queue. Use same lockfree implementation as ringbuf.c (put is atomic) */


### PR DESCRIPTION
here is trivial optimisation tsch_queue_get_time_source - that relyes to only one timesource supports at present code. So this source is cahed in variable, instead of search one source through all neboughors