### PR TITLE
supress warns on DEBUG define to compiler

### DIFF
--- a/core/lib/trickle-timer.c
+++ b/core/lib/trickle-timer.c
@@ -47,6 +47,7 @@
 #include "sys/cc.h"
 #include "lib/random.h"
 /*---------------------------------------------------------------------------*/
+#undef DEBUG
 #define DEBUG 0
 
 #if DEBUG

--- a/core/net/link-stats.c
+++ b/core/net/link-stats.c
@@ -37,6 +37,7 @@
 #include "net/link-stats.h"
 #include <stdio.h>
 
+#undef DEBUG
 #define DEBUG 0
 #if DEBUG
 #define PRINTF(...) printf(__VA_ARGS__)

--- a/core/net/mac/contikimac/contikimac-framer.c
+++ b/core/net/mac/contikimac/contikimac-framer.c
@@ -65,6 +65,7 @@
 
 extern const struct framer DECORATED_FRAMER;
 
+#undef DEBUG
 #define DEBUG 0
 #if DEBUG
 #include <stdio.h>

--- a/core/net/mac/contikimac/contikimac.c
+++ b/core/net/mac/contikimac/contikimac.c
@@ -242,6 +242,7 @@ static volatile uint8_t contikimac_keep_radio_on = 0;
 static volatile unsigned char we_are_sending = 0;
 static volatile unsigned char radio_is_on = 0;
 
+#undef DEBUG
 #define DEBUG 0
 #if DEBUG
 #include <stdio.h>

--- a/core/net/mac/csma.c
+++ b/core/net/mac/csma.c
@@ -55,6 +55,7 @@
 
 #include <stdio.h>
 
+#undef DEBUG
 #define DEBUG 0
 #if DEBUG
 #include <stdio.h>

--- a/core/net/mac/frame802154e-ie.c
+++ b/core/net/mac/frame802154e-ie.c
@@ -40,6 +40,7 @@
 #include <string.h>
 #include "net/mac/frame802154e-ie.h"
 
+#undef DEBUG
 #define DEBUG DEBUG_NONE
 #include "net/net-debug.h"
 

--- a/core/net/mac/framer-802154.c
+++ b/core/net/mac/framer-802154.c
@@ -43,6 +43,7 @@
 #include "lib/random.h"
 #include <string.h>
 
+#undef DEBUG
 #define DEBUG 0
 
 #if DEBUG

--- a/core/net/mac/framer-nullmac.c
+++ b/core/net/mac/framer-nullmac.c
@@ -39,6 +39,7 @@
 #include "net/mac/framer-nullmac.h"
 #include "net/packetbuf.h"
 
+#undef DEBUG
 #define DEBUG 0
 
 #if DEBUG

--- a/core/net/mac/mac.c
+++ b/core/net/mac/mac.c
@@ -32,6 +32,7 @@
 
 #include "net/mac/mac.h"
 
+#undef DEBUG
 #define DEBUG 0
 #if DEBUG
 #include <stdio.h>

--- a/core/net/mac/nullrdc.c
+++ b/core/net/mac/nullrdc.c
@@ -51,6 +51,7 @@
 #include "sys/cooja_mt.h"
 #endif /* CONTIKI_TARGET_COOJA || CONTIKI_TARGET_COOJA_IP64 */
 
+#undef DEBUG
 #define DEBUG 0
 #if DEBUG
 #include <stdio.h>

--- a/core/net/mac/phase.c
+++ b/core/net/mac/phase.c
@@ -77,6 +77,7 @@ struct phase_queueitem {
 MEMB(queued_packets_memb, struct phase_queueitem, PHASE_QUEUESIZE);
 NBR_TABLE(struct phase, nbr_phase);
 
+#undef DEBUG
 #define DEBUG 0
 #if DEBUG
 #include <stdio.h>

--- a/core/net/mac/tsch/tsch-log.c
+++ b/core/net/mac/tsch/tsch-log.c
@@ -52,8 +52,10 @@
 #include "lib/ringbufindex.h"
 
 #if TSCH_LOG_LEVEL >= 1
+#undef DEBUG
 #define DEBUG DEBUG_PRINT
 #else /* TSCH_LOG_LEVEL */
+#undef DEBUG
 #define DEBUG DEBUG_NONE
 #endif /* TSCH_LOG_LEVEL */
 #include "net/net-debug.h"

--- a/core/net/mac/tsch/tsch-packet.c
+++ b/core/net/mac/tsch/tsch-packet.c
@@ -56,8 +56,10 @@
 #include <string.h>
 
 #if TSCH_LOG_LEVEL >= 1
+#undef DEBUG
 #define DEBUG DEBUG_PRINT
 #else /* TSCH_LOG_LEVEL */
+#undef DEBUG
 #define DEBUG DEBUG_NONE
 #endif /* TSCH_LOG_LEVEL */
 #include "net/net-debug.h"

--- a/core/net/mac/tsch/tsch-queue.c
+++ b/core/net/mac/tsch/tsch-queue.c
@@ -57,8 +57,10 @@
 #include <string.h>
 
 #if TSCH_LOG_LEVEL >= 1
+#undef DEBUG
 #define DEBUG DEBUG_PRINT
 #else /* TSCH_LOG_LEVEL */
+#undef DEBUG
 #define DEBUG DEBUG_NONE
 #endif /* TSCH_LOG_LEVEL */
 #include "net/net-debug.h"

--- a/core/net/mac/tsch/tsch-schedule.c
+++ b/core/net/mac/tsch/tsch-schedule.c
@@ -56,8 +56,10 @@
 #include <string.h>
 
 #if TSCH_LOG_LEVEL >= 1
+#undef DEBUG
 #define DEBUG DEBUG_PRINT
 #else /* TSCH_LOG_LEVEL */
+#undef DEBUG
 #define DEBUG DEBUG_NONE
 #endif /* TSCH_LOG_LEVEL */
 #include "net/net-debug.h"

--- a/core/net/mac/tsch/tsch-security.c
+++ b/core/net/mac/tsch/tsch-security.c
@@ -54,8 +54,10 @@
 #include <string.h>
 
 #if TSCH_LOG_LEVEL >= 1
+#undef DEBUG
 #define DEBUG DEBUG_PRINT
 #else /* TSCH_LOG_LEVEL */
+#undef DEBUG
 #define DEBUG DEBUG_NONE
 #endif /* TSCH_LOG_LEVEL */
 #include "net/net-debug.h"

--- a/core/net/mac/tsch/tsch-slot-operation.c
+++ b/core/net/mac/tsch/tsch-slot-operation.c
@@ -60,8 +60,10 @@
 #endif /* CONTIKI_TARGET_COOJA || CONTIKI_TARGET_COOJA_IP64 */
 
 #if TSCH_LOG_LEVEL >= 1
+#undef DEBUG
 #define DEBUG DEBUG_PRINT
 #else /* TSCH_LOG_LEVEL */
+#undef DEBUG
 #define DEBUG DEBUG_NONE
 #endif /* TSCH_LOG_LEVEL */
 #include "net/net-debug.h"

--- a/core/net/mac/tsch/tsch.c
+++ b/core/net/mac/tsch/tsch.c
@@ -62,8 +62,10 @@
 #endif
 
 #if TSCH_LOG_LEVEL >= 1
+#undef DEBUG
 #define DEBUG DEBUG_PRINT
 #else /* TSCH_LOG_LEVEL */
+#undef DEBUG
 #define DEBUG DEBUG_NONE
 #endif /* TSCH_LOG_LEVEL */
 #include "net/net-debug.h"

--- a/core/net/nbr-table.c
+++ b/core/net/nbr-table.c
@@ -40,6 +40,7 @@
 #include "lib/list.h"
 #include "net/nbr-table.h"
 
+#undef DEBUG
 #define DEBUG 0
 #if DEBUG
 #include <stdio.h>

--- a/core/net/packetbuf.c
+++ b/core/net/packetbuf.c
@@ -63,6 +63,7 @@ static uint8_t hdrlen;
 static uint32_t packetbuf_aligned[(PACKETBUF_SIZE + 3) / 4];
 static uint8_t *packetbuf = (uint8_t *)packetbuf_aligned;
 
+#undef DEBUG
 #define DEBUG 0
 #if DEBUG
 #include <stdio.h>

--- a/core/net/queuebuf.c
+++ b/core/net/queuebuf.c
@@ -116,6 +116,7 @@ static struct ctimer renew_timer;
 LIST(queuebuf_list);
 #endif /* QUEUEBUF_DEBUG */
 
+#undef DEBUG
 #define DEBUG 0
 #if DEBUG
 #include <stdio.h>

--- a/core/net/rime/abc.c
+++ b/core/net/rime/abc.c
@@ -48,6 +48,7 @@
 #include "net/rime/rime.h"
 
 
+#undef DEBUG
 #define DEBUG 0
 #if DEBUG
 #include <stdio.h>

--- a/core/net/rime/broadcast-announcement.c
+++ b/core/net/rime/broadcast-announcement.c
@@ -84,6 +84,7 @@ static struct broadcast_announcement_state {
 } c;
 
 
+#undef DEBUG
 #define DEBUG 0
 #if DEBUG
 #include <stdio.h>

--- a/core/net/rime/broadcast.c
+++ b/core/net/rime/broadcast.c
@@ -50,6 +50,7 @@ static const struct packetbuf_attrlist attributes[] =
     BROADCAST_ATTRIBUTES PACKETBUF_ATTR_LAST
   };
 
+#undef DEBUG
 #define DEBUG 0
 #if DEBUG
 #include <stdio.h>

--- a/core/net/rime/chameleon-bitopt.c
+++ b/core/net/rime/chameleon-bitopt.c
@@ -62,6 +62,7 @@ struct bitopt_hdr {
 static const uint8_t bitmask[9] = { 0x00, 0x80, 0xc0, 0xe0, 0xf0,
 				 0xf8, 0xfc, 0xfe, 0xff };
 
+#undef DEBUG
 #define DEBUG 0
 #if DEBUG
 #include <stdio.h>

--- a/core/net/rime/chameleon-raw.c
+++ b/core/net/rime/chameleon-raw.c
@@ -53,6 +53,7 @@
 #define CHAMELEON_WITH_MAC_LINK_ADDRESSES 0
 #endif /* !CHAMELEON_CONF_WITH_MAC_LINK_ADDRESSES */
 
+#undef DEBUG
 #define DEBUG 0
 #if DEBUG
 #include <stdio.h>

--- a/core/net/rime/chameleon.c
+++ b/core/net/rime/chameleon.c
@@ -54,6 +54,7 @@
 
 extern const struct chameleon_module CHAMELEON_MODULE;
 
+#undef DEBUG
 #define DEBUG 0
 #if DEBUG
 #include <stdio.h>

--- a/core/net/rime/collect-link-estimate.c
+++ b/core/net/rime/collect-link-estimate.c
@@ -51,6 +51,7 @@
 
 #define MAX_ESTIMATES 255
 
+#undef DEBUG
 #define DEBUG 0
 #if DEBUG
 #include <stdio.h>

--- a/core/net/rime/collect-neighbor.c
+++ b/core/net/rime/collect-neighbor.c
@@ -69,6 +69,7 @@ MEMB(collect_neighbors_mem, struct collect_neighbor, MAX_COLLECT_NEIGHBORS);
 #define EXPECTED_CONGESTION_DURATION CLOCK_SECOND * 240
 #define CONGESTION_PENALTY           8 * COLLECT_LINK_ESTIMATE_UNIT
 
+#undef DEBUG
 #define DEBUG 0
 #if DEBUG
 #include <stdio.h>

--- a/core/net/rime/collect.c
+++ b/core/net/rime/collect.c
@@ -210,6 +210,7 @@ struct {
 
 /* Debug definition: draw routing tree in Cooja. */
 #define DRAW_TREE 0
+#undef DEBUG
 #define DEBUG 0
 #if DEBUG
 #include <stdio.h>

--- a/core/net/rime/ipolite.c
+++ b/core/net/rime/ipolite.c
@@ -49,6 +49,7 @@
 
 #include <string.h>
 
+#undef DEBUG
 #define DEBUG 0
 #if DEBUG
 #include <stdio.h>

--- a/core/net/rime/mesh.c
+++ b/core/net/rime/mesh.c
@@ -51,6 +51,7 @@
 
 #define PACKET_TIMEOUT (CLOCK_SECOND * 10)
 
+#undef DEBUG
 #define DEBUG 0
 #if DEBUG
 #include <stdio.h>

--- a/core/net/rime/multihop.c
+++ b/core/net/rime/multihop.c
@@ -55,6 +55,7 @@ static const struct packetbuf_attrlist attributes[] =
     PACKETBUF_ATTR_LAST
   };
 
+#undef DEBUG
 #define DEBUG 0
 #if DEBUG
 #include <stdio.h>

--- a/core/net/rime/neighbor-discovery.c
+++ b/core/net/rime/neighbor-discovery.c
@@ -63,6 +63,7 @@ struct adv_msg {
   uint16_t val;
 };
 
+#undef DEBUG
 #define DEBUG 0
 #if DEBUG
 #include <stdio.h>

--- a/core/net/rime/netflood.c
+++ b/core/net/rime/netflood.c
@@ -54,6 +54,7 @@ struct netflood_hdr {
   uint16_t hops;
 };
 
+#undef DEBUG
 #define DEBUG 0
 #if DEBUG
 #include <stdio.h>

--- a/core/net/rime/polite-announcement.c
+++ b/core/net/rime/polite-announcement.c
@@ -82,6 +82,7 @@ static struct polite_announcement_state {
   clock_time_t min_interval, max_interval;
 } c;
 
+#undef DEBUG
 #define DEBUG 0
 #if DEBUG
 #include <stdio.h>

--- a/core/net/rime/rime.c
+++ b/core/net/rime/rime.c
@@ -42,6 +42,7 @@
  * @{
  */
 
+#undef DEBUG
 #define DEBUG 0
 #if DEBUG
 #include <stdio.h>

--- a/core/net/rime/rmh.c
+++ b/core/net/rime/rmh.c
@@ -53,6 +53,7 @@ struct data_hdr {
   uint8_t max_rexmits;
 };
 
+#undef DEBUG
 #define DEBUG 0
 #if DEBUG
 #include <stdio.h>

--- a/core/net/rime/route-discovery.c
+++ b/core/net/rime/route-discovery.c
@@ -68,6 +68,7 @@ struct rrep_hdr {
 #endif
 
 
+#undef DEBUG
 #define DEBUG 0
 #if DEBUG
 #include <stdio.h>

--- a/core/net/rime/route.c
+++ b/core/net/rime/route.c
@@ -78,6 +78,7 @@ static struct ctimer t;
 
 static int max_time = DEFAULT_LIFETIME;
 
+#undef DEBUG
 #define DEBUG 0
 #if DEBUG
 #include <stdio.h>

--- a/core/net/rime/rucb.c
+++ b/core/net/rime/rucb.c
@@ -43,6 +43,7 @@
 
 #define MAX_TRANSMISSIONS 8
 
+#undef DEBUG
 #define DEBUG 0
 #if DEBUG
 #include <stdio.h>

--- a/core/net/rime/rudolph1.c
+++ b/core/net/rime/rudolph1.c
@@ -73,6 +73,7 @@ enum {
   TYPE_NACK,
 };
 
+#undef DEBUG
 #define DEBUG 0
 #if DEBUG
 #include <stdio.h>

--- a/core/net/rime/rudolph2.c
+++ b/core/net/rime/rudolph2.c
@@ -81,6 +81,7 @@ enum {
 #define FLAG_LAST_RECEIVED 0x02
 #define FLAG_IS_STOPPED    0x04
 
+#undef DEBUG
 #define DEBUG 0
 #if DEBUG
 #include <stdio.h>

--- a/core/net/rime/runicast.c
+++ b/core/net/rime/runicast.c
@@ -59,6 +59,7 @@ static const struct packetbuf_attrlist attributes[] =
     PACKETBUF_ATTR_LAST
   };
 
+#undef DEBUG
 #define DEBUG 0
 #if DEBUG
 #include <stdio.h>

--- a/core/net/rime/stunicast.c
+++ b/core/net/rime/stunicast.c
@@ -46,6 +46,7 @@
 #include "net/rime/rime.h"
 #include <string.h>
 
+#undef DEBUG
 #define DEBUG 0
 #if DEBUG
 #include <stdio.h>

--- a/core/net/rime/trickle.c
+++ b/core/net/rime/trickle.c
@@ -62,6 +62,7 @@ static const struct packetbuf_attrlist attributes[] =
   };
 
 
+#undef DEBUG
 #define DEBUG 0
 #if DEBUG
 #include <stdio.h>

--- a/core/net/rime/unicast.c
+++ b/core/net/rime/unicast.c
@@ -52,6 +52,7 @@ static const struct packetbuf_attrlist attributes[] =
     PACKETBUF_ATTR_LAST
   };
 
+#undef DEBUG
 #define DEBUG 0
 #if DEBUG
 #include <stdio.h>

--- a/core/sys/autostart.c
+++ b/core/sys/autostart.c
@@ -39,6 +39,7 @@
 
 #include "sys/autostart.h"
 
+#undef DEBUG
 #define DEBUG 0
 #if DEBUG
 #include <stdio.h>

--- a/core/sys/ctimer.c
+++ b/core/sys/ctimer.c
@@ -50,6 +50,7 @@ LIST(ctimer_list);
 
 static char initialized;
 
+#undef DEBUG
 #define DEBUG 0
 #if DEBUG
 #include <stdio.h>

--- a/core/sys/process.c
+++ b/core/sys/process.c
@@ -80,6 +80,7 @@ static volatile unsigned char poll_requested;
 
 static void call_process(struct process *p, process_event_t ev, process_data_t data);
 
+#undef DEBUG
 #define DEBUG 0
 #if DEBUG
 #include <stdio.h>

--- a/core/sys/rtimer.c
+++ b/core/sys/rtimer.c
@@ -46,6 +46,7 @@
 #include "sys/rtimer.h"
 #include "contiki.h"
 
+#undef DEBUG
 #define DEBUG 0
 #if DEBUG
 #include <stdio.h>

--- a/cpu/cc26xx-cc13xx/dev/batmon-sensor.c
+++ b/cpu/cc26xx-cc13xx/dev/batmon-sensor.c
@@ -45,6 +45,7 @@
 #include <stdint.h>
 #include <stdio.h>
 /*---------------------------------------------------------------------------*/
+#undef DEBUG
 #define DEBUG 0
 #if DEBUG
 #define PRINTF(...) printf(__VA_ARGS__)

--- a/cpu/cc26xx-cc13xx/rf-core/ieee-mode.c
+++ b/cpu/cc26xx-cc13xx/rf-core/ieee-mode.c
@@ -77,6 +77,7 @@
 #include <stdio.h>
 #include <stdbool.h>
 /*---------------------------------------------------------------------------*/
+#undef DEBUG
 #define DEBUG 0
 #if DEBUG
 #define PRINTF(...) printf(__VA_ARGS__)

--- a/cpu/cc26xx-cc13xx/rf-core/rf-ble.c
+++ b/cpu/cc26xx-cc13xx/rf-core/rf-ble.c
@@ -55,6 +55,7 @@
 #include <stdbool.h>
 #include <stdio.h>
 /*---------------------------------------------------------------------------*/
+#undef DEBUG
 #define DEBUG 0
 #if DEBUG
 #define PRINTF(...) printf(__VA_ARGS__)

--- a/cpu/cc26xx-cc13xx/rf-core/rf-core.c
+++ b/cpu/cc26xx-cc13xx/rf-core/rf-core.c
@@ -62,6 +62,7 @@
 #include <stdio.h>
 #include <string.h>
 /*---------------------------------------------------------------------------*/
+#undef DEBUG
 #define DEBUG 0
 #if DEBUG
 #define PRINTF(...) printf(__VA_ARGS__)


### PR DESCRIPTION
now undef DEBUG everywhere it redefines, to supress compiler warning about redefine

* usual way to note compiler about release/debug target is provide DEBUG definition.
  contiki code usualy localy override it, so build with DEBUG generates a lot of warnings