### PR TITLE
adjust cc26xx rtimer resolution

### DIFF
--- a/cpu/cc26xx-cc13xx/clock.c
+++ b/cpu/cc26xx-cc13xx/clock.c
@@ -138,8 +138,13 @@ update_clock_variable(void)
   } while(aon_rtc_secs_now != aon_rtc_secs_now2);
 
   /* Convert AON RTC ticks to clock tick counter */
+#if RTIMER_SECOND == RTIMER_ARCH_SECOND_NORM
   const unsigned CLK2RT_RATIO = (RTIMER_SECOND/CLOCK_SECOND);
   count = (aon_rtc_secs_now * CLOCK_SECOND) + (aon_rtc_ticks_now / CLK2RT_RATIO);
+#else
+  uint64_t rtc_now = ((uint64_t)aon_rtc_secs_now<<16)|aon_rtc_ticks_now;
+  count = rtc_now * CLOCK_SECOND / RTIMER_SECOND;
+#endif
 }
 /*---------------------------------------------------------------------------*/
 CCIF clock_time_t

--- a/cpu/cc26xx-cc13xx/clock.c
+++ b/cpu/cc26xx-cc13xx/clock.c
@@ -62,6 +62,7 @@
 #include "contiki.h"
 
 #include "ti-lib.h"
+#include <sys/rtimer.h>
 /*---------------------------------------------------------------------------*/
 static volatile uint64_t count;
 /*---------------------------------------------------------------------------*/
@@ -137,7 +138,8 @@ update_clock_variable(void)
   } while(aon_rtc_secs_now != aon_rtc_secs_now2);
 
   /* Convert AON RTC ticks to clock tick counter */
-  count = (aon_rtc_secs_now * CLOCK_SECOND) + (aon_rtc_ticks_now >> 9);
+  const unsigned CLK2RT_RATIO = (RTIMER_SECOND/CLOCK_SECOND);
+  count = (aon_rtc_secs_now * CLOCK_SECOND) + (aon_rtc_ticks_now / CLK2RT_RATIO);
 }
 /*---------------------------------------------------------------------------*/
 CCIF clock_time_t

--- a/platform/srf06-cc26xx/contiki-conf.h
+++ b/platform/srf06-cc26xx/contiki-conf.h
@@ -343,7 +343,9 @@
  * Those values are not meant to be modified by the user
  * @{
  */
+#ifndef CLOCK_CONF_SECOND
 #define CLOCK_CONF_SECOND 128
+#endif
 
 /* Compiler configurations */
 #define CCIF


### PR DESCRIPTION
cc26xx:RTIMER_CONF_ARCH_SECOND - provide RTC resolution setup. now tick of RTC can be setup.

*Note: this patch overrides default RTC setup, if user provides differ RTIMER_CONF_ARCH_SECOND
    RTC SEC and SUBSEC register are loose their mean in this case.
    RTC compare registers maped to SEC[0:15]SUBSEC[31:16] - so looks like fixed point of sec.subsec
    with new settings, this point moves into SUBSEC, and provide more bits for seconds.
    So now RTC can operate with more time range, with penalty of less precision
* on cc13/26xx RTC always run with 32kHz, but default setup gives it 16 bits, so
    override RTIMER_CONF_ARCH_SECOND to 32k will not loose precision, but give twice time range