### PR TITLE
+TSCH: TSCH_CONF_H - provide project specific header for TSCH setup

### DIFF
--- a/core/net/mac/tsch/tsch-conf.h
+++ b/core/net/mac/tsch/tsch-conf.h
@@ -44,6 +44,11 @@
 
 #include "contiki.h"
 
+/* Include Project Specific conf for TSCH*/
+#ifdef TSCH_CONF_H
+#include TSCH_CONF_H
+#endif /* PROJECT_CONF_H */
+
 /******** Configuration *******/
 
 /* Default IEEE 802.15.4e hopping sequences, obtained from https://gist.github.com/twatteyne/2e22ee3c1a802b685695 */
@@ -159,7 +164,7 @@
 #define TSCH_DEFAULT_TS_TIMESLOT_LENGTH    65000
 
 #else
-#error "TSCH: Unsupported default timeslot length"
+//* should be user defined slot timing
 #endif
 
 /* A custom feature allowing upper layers to assign packets to


### PR DESCRIPTION
TSCH_CONF_H - provide project specific header for TSCH,  this header intends to lightweight rebuild on tsch parameters change

*     unsupported TSCH_CONF_DEFAULT_TS_TIMESLOT_LENGTH now relyes to project conf