### PR TITLE
TSCH: log tsch-ques messages instead print

### DIFF
--- a/core/net/mac/tsch/tsch-log.h
+++ b/core/net/mac/tsch/tsch-log.h
@@ -79,12 +79,24 @@
 struct tsch_log_t {
   enum { tsch_log_tx,
          tsch_log_rx,
+         tsch_log_change_timesrc,
+         tsch_log_packet,       //< post packet[index] info
+         tsch_log_packet_verbose,  //< post locked packet[index]->quebuf neibohour info
+         tsch_log_text,         //< post static const string
+         tsch_log_fmt,          //< post static const string
          tsch_log_message
   } type;
   struct tsch_asn_t asn;
   struct tsch_link *link;
   union {
     char message[48];
+    const char* text;
+    struct {
+        const char* text;
+        int         arg1;
+        int         arg2;
+        int         arg3;
+    } fmt;
     struct {
       int mac_tx_status;
       int dest;
@@ -105,6 +117,18 @@ struct tsch_log_t {
       uint8_t sec_level;
       uint8_t drift_used;
     } rx;
+    struct {
+        linkaddr_t  was;
+        linkaddr_t  now;
+    } timesrc_change;
+    struct {
+        const char* fmt;
+        struct tsch_packet *p;
+        int                 index;
+        struct tsch_neighbor *n;
+        struct queuebuf      *qb;
+        int                 locked;
+    } packet;
   };
 };
 

--- a/core/net/mac/tsch/tsch-queue.c
+++ b/core/net/mac/tsch/tsch-queue.c
@@ -156,9 +156,10 @@ tsch_queue_update_time_source(const linkaddr_t *new_addr)
       }
 
       if(new_time_src != old_time_src) {
-        PRINTF("TSCH: update time source: %u -> %u\n",
-               TSCH_LOG_ID_FROM_LINKADDR(old_time_src ? &old_time_src->addr : NULL),
-               TSCH_LOG_ID_FROM_LINKADDR(new_time_src ? &new_time_src->addr : NULL));
+          TSCH_LOG_ADD(tsch_log_change_timesrc,
+                linkaddr_copy(&log->timesrc_change.was, (old_time_src)? &old_time_src->addr : &linkaddr_null);
+                linkaddr_copy(&log->timesrc_change.now, (new_time_src)? &new_time_src->addr : &linkaddr_null);
+          );
 
         /* Update time source */
         if(new_time_src != NULL) {
@@ -196,13 +197,18 @@ tsch_queue_flush_nbr_queue(struct tsch_neighbor *n)
     if(p != NULL) {
       /* Set return status for packet_sent callback */
       p->ret = MAC_TX_ERR;
-      PRINTF("TSCH-queue:! flushing packet\n");
+      TSCH_LOG_ADD(tsch_log_text,
+          log->text = "TSCH-queue:! flushing packet\n";
+      );
       /* Call packet_sent callback */
       mac_call_sent_callback(p->sent, p->ptr, p->ret, p->transmissions);
       /* Free packet queuebuf */
       tsch_queue_free_packet(p);
     }
-    PRINTF("TSCH-queue: packet is deleted packet=%p\n", p);
+    TSCH_LOG_ADD(tsch_log_packet,
+        log->packet.fmt = "TSCH-queue: packet is deleted packet=%p\n";
+        log->packet.p     = p;
+    );
   }
 }
 /*---------------------------------------------------------------------------*/
@@ -254,8 +260,11 @@ tsch_queue_add_packet(const linkaddr_t *addr, mac_callback_t sent, void *ptr)
             /* Add to ringbuf (actual add committed through atomic operation) */
             n->tx_array[put_index] = p;
             ringbufindex_put(&n->tx_ringbuf);
-            PRINTF("TSCH-queue: packet is added put_index=%u, packet=%p\n",
-                   put_index, p);
+            TSCH_LOG_ADD(tsch_log_packet,
+                log->packet.fmt = "TSCH-queue: packet is added packet=%p[%u]\n";
+                log->packet.p     = p;
+                log->packet.index = put_index;
+            );
             return p;
           } else {
             memb_free(&packet_memb, p);
@@ -264,7 +273,14 @@ tsch_queue_add_packet(const linkaddr_t *addr, mac_callback_t sent, void *ptr)
       }
     }
   }
-  PRINTF("TSCH-queue:! add packet failed: %u %p %d %p %p\n", tsch_is_locked(), n, put_index, p, p ? p->qb : NULL);
+  TSCH_LOG_ADD(tsch_log_packet_verbose,
+      log->packet.fmt = "TSCH-queue:! add packet failed:";
+      log->packet.locked = tsch_is_locked();
+      log->packet.n     = n;
+      log->packet.p     = p;
+      log->packet.index = put_index;
+      log->packet.qb    = p ? p->qb : NULL;
+  );
   return 0;
 }
 /*---------------------------------------------------------------------------*/
@@ -291,7 +307,10 @@ tsch_queue_remove_packet_from_queue(struct tsch_neighbor *n)
       /* Get and remove packet from ringbuf (remove committed through an atomic operation */
       int16_t get_index = ringbufindex_get(&n->tx_ringbuf);
       if(get_index != -1) {
-        PRINTF("TSCH-queue: packet is removed, get_index=%u\n", get_index);
+          TSCH_LOG_ADD(tsch_log_fmt,
+              log->fmt.text = "TSCH-queue: packet is removed, get_index=%u\n";
+              log->fmt.arg1 = get_index;
+          );
         return n->tx_array[get_index];
       } else {
         return NULL;


### PR DESCRIPTION
tsch-ques used PRINTF, and thererfore introduced large delays in timeslot processing. migrating to log makes timeslot more robust.

also provided more kinds of log messages:
+ tsch_log_text  -add printer of constant text string
+ tsch_log_fmt - formated string with 3 args
+ tsch_log_packet[_verbose] - prints formated messages with packet info
+ tsch_log_change_timesrc - prints chnging time source message

this messages intends for more light log
