### PR TITLE
TSCH: prognose for close active slot to ommit rf power off

### DIFF
--- a/core/net/mac/tsch/tsch-conf.h
+++ b/core/net/mac/tsch/tsch-conf.h
@@ -91,6 +91,12 @@
 #define TSCH_CONF_RX_WAIT 2200
 #endif /* TSCH_CONF_RX_WAIT */
 
+/* Configurable guard time [us] for turn on radio, before slot activity */
+#ifndef TSCH_CONF_RFON_GUARD_TIME
+#define TSCH_CONF_RFON_GUARD_TIME 0
+#endif /* TSCH_CONF_RX_WAIT */
+
+
 /* The default timeslot timing in the standard is a guard time of
  * 2200 us, a Tx offset of 2120 us and a Rx offset of 1120 us.
  * As a result, the listening device has a guard time not centered

--- a/core/net/mac/tsch/tsch-private.h
+++ b/core/net/mac/tsch/tsch-private.h
@@ -70,6 +70,7 @@ enum tsch_timeslot_timing_elements {
   tsch_ts_max_ack,
   tsch_ts_max_tx,
   tsch_ts_timeslot_length,
+  tsch_ts_rfon_prepslot_guard,
   tsch_ts_elements_count, /* Not a timing element */
 };
 

--- a/core/net/mac/tsch/tsch-slot-operation.c
+++ b/core/net/mac/tsch/tsch-slot-operation.c
@@ -302,7 +302,7 @@ tsch_schedule_slot_operation(struct rtimer *tm, rtimer_clock_t ref_time, rtimer_
 
     return 0;
   }
-  ref_time += offset;
+  ref_time += offset - RTIMER_GUARD;
   r = rtimer_set(tm, ref_time, 1, (void (*)(struct rtimer *, void *))tsch_slot_operation, NULL);
   if(r != RTIMER_OK) {
     return 0;
@@ -315,7 +315,7 @@ tsch_schedule_slot_operation(struct rtimer *tm, rtimer_clock_t ref_time, rtimer_
  * ahead of time and then busy wait to exactly hit the target. */
 #define TSCH_SCHEDULE_AND_YIELD(pt, tm, ref_time, offset, str) \
   do { \
-    if(tsch_schedule_slot_operation(tm, ref_time, offset - RTIMER_GUARD, str)) { \
+    if(tsch_schedule_slot_operation(tm, ref_time, offset, str)) { \
       PT_YIELD(pt); \
     } \
     BUSYWAIT_UNTIL_ABS(0, ref_time, offset); \

--- a/core/net/mac/tsch/tsch-slot-operation.c
+++ b/core/net/mac/tsch/tsch-slot-operation.c
@@ -40,6 +40,7 @@
  *
  */
 
+#include <stdbool.h>
 #include "contiki.h"
 #include "dev/radio.h"
 #include "net/netstack.h"
@@ -400,6 +401,14 @@ update_neighbor_state(struct tsch_neighbor *n, struct tsch_packet *p,
   return in_queue;
 }
 /*---------------------------------------------------------------------------*/
+//* TSCH use state of RF to plan next timeslot operation
+enum tsch_rf_states{
+    tsch_rfOFF, tsch_rfON
+};
+typedef enum tsch_rf_states tsch_rf_states;
+static
+tsch_rf_states tsch_rf_state = tsch_rfOFF;
+
 /**
  * This function turns on the radio. Its semantics is dependent on
  * the value of TSCH_RADIO_ON_DURING_TIMESLOT constant:
@@ -428,9 +437,16 @@ tsch_radio_on(enum tsch_radio_state_on_cmd command)
   }
   if(do_it) {
     NETSTACK_RADIO.on();
+    tsch_rf_state = tsch_rfON;
   }
 }
 /*---------------------------------------------------------------------------*/
+//* prognose next active timeslot. for heavy turn on/off RF, this prognose
+//* helps to avoid useless radio-off, and save timeslot time for work
+static
+bool tsch_next_timeslot_far(void);
+
+
 /**
  * This function turns off the radio. In the same way as for tsch_radio_on(),
  * it depends on the value of TSCH_RADIO_ON_DURING_TIMESLOT constant:
@@ -458,8 +474,44 @@ tsch_radio_off(enum tsch_radio_state_off_cmd command)
     break;
   }
   if(do_it) {
+    if (tsch_next_timeslot_far()) {
     NETSTACK_RADIO.off();
+    tsch_rf_state = tsch_rfOFF;
   }
+}
+}
+
+bool tsch_next_timeslot_far(void){
+    if (tsch_timing[tsch_ts_rfon_prepslot_guard] <= 0)
+        return true;
+
+    unsigned tsch_next_timeslot_diff = 0;
+    struct tsch_link * next_link;
+    tsch_next_timeslot_diff = 0;
+    next_link = tsch_schedule_get_next_active_link(&tsch_current_asn
+                    , &tsch_next_timeslot_diff
+                    , &backup_link);
+    if (!next_link)
+        return true;
+    if (tsch_next_timeslot_diff != 1)
+        return true;
+
+    rtimer_clock_t time_to_next_active_slot;
+    time_to_next_active_slot = tsch_timing[tsch_ts_timeslot_length] + drift_correction;
+    rtimer_clock_t next_slot_start = current_slot_start
+                + time_to_next_active_slot
+                - RTIMER_GUARD;
+    rtimer_clock_t now = RTIMER_NOW();
+    long timeout = RTIMER_CLOCK_DIFF(next_slot_start, now);
+    // use tsch_ts_rfon_prepslot_guard to predict rf off+on time
+    const rtimer_clock_t time_gap = tsch_timing[tsch_ts_rfon_prepslot_guard]*2;
+    if (timeout <= time_gap){
+        TSCH_LOG_ADD(tsch_log_fmt,
+            log->fmt.text = "TSCH: supress radio off, since next slot close %ldus\n";
+            log->fmt.arg1 = timeout;
+        );
+    }
+    return (timeout > time_gap);
 }
 /*---------------------------------------------------------------------------*/
 static
@@ -1045,7 +1097,9 @@ PT_THREAD(tsch_slot_operation(struct rtimer *t, void *ptr))
         prev_slot_start = current_slot_start;
         current_slot_start += time_to_next_active_slot;
         current_slot_start += tsch_timesync_adaptive_compensate(time_to_next_active_slot);
+        if (tsch_rf_state == tsch_rfOFF){
         time_to_next_active_slot -= tsch_timing[tsch_ts_rfon_prepslot_guard];
+        }
       } while(!tsch_schedule_slot_operation(t, prev_slot_start, time_to_next_active_slot, "main"));
     }
 

--- a/core/net/mac/tsch/tsch.c
+++ b/core/net/mac/tsch/tsch.c
@@ -106,6 +106,7 @@ static const uint16_t tsch_default_timing_us[tsch_ts_elements_count] = {
   TSCH_DEFAULT_TS_MAX_ACK,
   TSCH_DEFAULT_TS_MAX_TX,
   TSCH_DEFAULT_TS_TIMESLOT_LENGTH,
+  TSCH_CONF_RFON_GUARD_TIME,
 };
 /* TSCH timeslot timing (in rtimer ticks) */
 rtimer_clock_t tsch_timing[tsch_ts_elements_count];


### PR DESCRIPTION
This patch demands(includes) PR #2276 
Here estimates time to next active slot, when demanded rf turn off. 
if next active slot too close, rf leave on, to avoid loose of time on rf off-on cycle. this helps to awake next slot in time.

*Note: this patch relyes on that current slot operation ends not too late, so that ASN of current operation is correct.