### PR TITLE
!TSCH - correct init attributes PACKETBUF_ATTR_TSCH_SLOTFRAME

### DIFF
--- a/core/net/packetbuf.c
+++ b/core/net/packetbuf.c
@@ -198,6 +198,10 @@ packetbuf_attr_clear(void)
   for(i = 0; i < PACKETBUF_NUM_ADDRS; ++i) {
     linkaddr_copy(&packetbuf_addrs[i].addr, &linkaddr_null);
   }
+#if TSCH_WITH_LINK_SELECTOR
+  packetbuf_set_attr(PACKETBUF_ATTR_TSCH_SLOTFRAME, (packetbuf_attr_t)~0);
+  packetbuf_set_attr(PACKETBUF_ATTR_TSCH_TIMESLOT, (packetbuf_attr_t)~0);
+#endif
 }
 /*---------------------------------------------------------------------------*/
 void


### PR DESCRIPTION
using TSCH with TSCH_WITH_LINK_SELECTOR requres corect initialisation for PACKETBUF_ATTR_TSCH_SLOTFRAME/TIMESLOT, that looks like forgotten.

* TSCH uses thouse attributes with ignore value ~0 (0xffff), if it will not be correct
  initialised before send, packet can be ommited for send, and can breaks neiboughor queue.
  So packetbuf_attr_clear need to initialise attributes to valid defaults, to allow normaly schedule
  packets, even for tsch internals - keepalive, EBs.