### PR TITLE
+cc26xx uart tx buffer - UART_TXBUFSIZE enables buffer for uart output

### DIFF
--- a/core/lib/ringbuf16index.c
+++ b/core/lib/ringbuf16index.c
@@ -1,0 +1,168 @@
+/*
+ * Copyright (c) 2015, SICS Swedish ICT.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * This file is part of the Contiki operating system.
+ *
+ */
+
+/**
+ * \file
+ *         ringbuf16index library. Implements basic support for ring buffers
+ *         of any type, as opposed to the core/lib/ringbuf module which
+ *         is only for byte arrays. Simply returns index in the ringbuf
+ *         rather than actual elements. The ringbuf size must be power of two.
+ *         Like the original ringbuf, this module implements atomic put and get.
+ * \author
+ *         Simon Duquennoy <simonduq@sics.se>
+ *         based on Contiki's core/lib/ringbuf library by Adam Dunkels
+ */
+
+#include <string.h>
+#include "lib/ringbuf16index.h"
+
+/* Initialize a ring buffer. The size must be a power of two */
+void
+ringbuf16index_init(struct ringbuf16index *r, uint16_t size)
+{
+  r->mask = size - 1;
+  r->put_ptr = 0;
+  r->get_ptr = 0;
+}
+/* Put one element to the ring buffer */
+int
+ringbuf16index_put(struct ringbuf16index *r)
+{
+  /* Check if buffer is full. If it is full, return 0 to indicate that
+     the element was not inserted.
+
+     XXX: there is a potential risk for a race condition here, because
+     the ->get_ptr field may be written concurrently by the
+     ringbuf16index_get() function. To avoid this, access to ->get_ptr must
+     be atomic. We use an uint8_t type, which makes access atomic on
+     most platforms, but C does not guarantee this.
+   */
+  if(((r->put_ptr - r->get_ptr) & r->mask) == r->mask) {
+    return 0;
+  }
+  r->put_ptr = (r->put_ptr + 1) & r->mask;
+  return 1;
+}
+
+/**
+ * \brief Check solid space size to put an element.
+ * \param r Pinter to ringbuf16index
+ * \retval size of solid space at put position, avail for fill
+ */
+unsigned ringbuf16index_put_free(const struct ringbuf16index *r){
+    if (r->put_ptr >= r->get_ptr){
+        return (r->mask+1 - r->put_ptr);
+    }
+    return (r->get_ptr - r->put_ptr);
+}
+
+/**
+ * \brief Put one element to the ring buffer
+ * \param r Pointer to ringbuf16index
+ * \param n amount of placed items
+ * \retval amount of free solid space at put, \sa ringbuf16index_put_len
+ */
+int ringbuf16index_putn(struct ringbuf16index *r, uint16_t size){
+    r->put_ptr = (r->put_ptr + size) & r->mask;
+    return (r->get_ptr - r->put_ptr);
+}
+
+/* Check if there is space to put an element.
+ * Return the index where the next element is to be added */
+int
+ringbuf16index_peek_put(const struct ringbuf16index *r)
+{
+  /* Check if there are bytes in the buffer. If so, we return the
+     first one. If there are no bytes left, we return -1.
+   */
+  if(((r->put_ptr - r->get_ptr) & r->mask) == r->mask) {
+    return -1;
+  }
+  return r->put_ptr;
+}
+/* Remove the first element and return its index */
+int
+ringbuf16index_get(struct ringbuf16index *r)
+{
+  int get_ptr;
+
+  /* Check if there are bytes in the buffer. If so, we return the
+     first one and increase the pointer. If there are no bytes left, we
+     return -1.
+
+     XXX: there is a potential risk for a race condition here, because
+     the ->put_ptr field may be written concurrently by the
+     ringbuf16index_put() function. To avoid this, access to ->get_ptr must
+     be atomic. We use an uint8_t type, which makes access atomic on
+     most platforms, but C does not guarantee this.
+   */
+  if(((r->put_ptr - r->get_ptr) & r->mask) > 0) {
+    get_ptr = r->get_ptr;
+    r->get_ptr = (r->get_ptr + 1) & r->mask;
+    return get_ptr;
+  } else {
+    return -1;
+  }
+}
+/* Return the index of the first element
+ * (which will be removed if calling ringbuf16index_peek) */
+int
+ringbuf16index_peek_get(const struct ringbuf16index *r)
+{
+  /* Check if there are bytes in the buffer. If so, we return the
+     first one. If there are no bytes left, we return -1.
+   */
+  if(((r->put_ptr - r->get_ptr) & r->mask) > 0) {
+    return r->get_ptr;
+  } else {
+    return -1;
+  }
+}
+/* Return the number of elements currently in the ring buffer */
+int
+ringbuf16index_elements(const struct ringbuf16index *r)
+{
+  return (r->put_ptr - r->get_ptr) & r->mask;
+}
+/* Is the ring buffer full? */
+int
+ringbuf16index_full(const struct ringbuf16index *r)
+{
+  return ((r->put_ptr - r->get_ptr) & r->mask) == r->mask;
+}
+
+/**
+ * \brief Check solid space size to put an element.
+ * \param r Pinter to ringbuf16index
+ * \retval size of solid space at put position, avail for fill
+ */
+unsigned ringbuf16index_put_len(const struct ringbuf16index *r);

--- a/core/lib/ringbuf16index.c
+++ b/core/lib/ringbuf16index.c
@@ -88,7 +88,7 @@ unsigned ringbuf16index_put_free(const struct ringbuf16index *r){
 /**
  * \brief Put one element to the ring buffer
  * \param r Pointer to ringbuf16index
- * \param n amount of placed items
+ * \param size amount of placed items
  * \retval amount of free solid space at put, \sa ringbuf16index_put_len
  */
 int ringbuf16index_putn(struct ringbuf16index *r, uint16_t size){

--- a/core/lib/ringbuf16index.c
+++ b/core/lib/ringbuf16index.c
@@ -160,9 +160,13 @@ ringbuf16index_full(const struct ringbuf16index *r)
   return ((r->put_ptr - r->get_ptr) & r->mask) == r->mask;
 }
 
-/**
- * \brief Check solid space size to put an element.
- * \param r Pinter to ringbuf16index
- * \retval size of solid space at put position, avail for fill
- */
-unsigned ringbuf16index_put_len(const struct ringbuf16index *r);
+#if !LIB_INLINES
+int ringbuf16index_size(const struct ringbuf16index *r)
+{
+  return r->mask + 1;
+}
+
+int ringbuf16index_empty(const struct ringbuf16index *r){
+    return r->get_ptr == r->put_ptr;
+}
+#endif

--- a/core/lib/ringbuf16index.h
+++ b/core/lib/ringbuf16index.h
@@ -42,6 +42,12 @@
 
 #include "contiki-conf.h"
 
+#if (PACKETBUF_CONF_ATTRS_INLINE) || defined(__GNUC__)
+#define LIB_INLINES     1
+#else
+#define LIB_INLINES     0
+#endif
+
 struct ringbuf16index {
   uint16_t mask;
   /* These must be 8-bit quantities to avoid race conditions. */
@@ -77,10 +83,11 @@ int ringbuf16index_peek_put(const struct ringbuf16index *r);
  * \retval size of solid space at put position, avail for fill
  */
 unsigned ringbuf16index_put_free(const struct ringbuf16index *r);
+
 /**
  * \brief Put size elements to the ring buffer
  * \param r Pointer to ringbuf16index
- * \param size amount of placed items
+ * \param size Amount of placed items
  * \retval amount of free solid space at new put, \sa ringbuf16index_put_free
  */
 int ringbuf16index_putn(struct ringbuf16index *r, uint16_t size);
@@ -107,11 +114,15 @@ int ringbuf16index_peek_get(const struct ringbuf16index *r);
  * \param r Pinter to ringbuf16index
  * \return The size of the ring buffer
  */
-static inline int ringbuf16index_size(const struct ringbuf16index *r)
+#if LIB_INLINES
+static inline
+int ringbuf16index_size(const struct ringbuf16index *r)
 {
   return r->mask + 1;
-}
-
+};
+#else
+int ringbuf16index_size(const struct ringbuf16index *r);
+#endif
 
 /**
  * \brief Return the number of elements currently in the ring buffer.
@@ -132,10 +143,13 @@ int ringbuf16index_full(const struct ringbuf16index *r);
  * \retval 0 Not empty
  * \retval 1 Empty
  */
+#if LIB_INLINES
 static inline
 int ringbuf16index_empty(const struct ringbuf16index *r){
     return r->get_ptr == r->put_ptr;
-}
-
+};
+#else
+int ringbuf16index_empty(const struct ringbuf16index *r);
+#endif
 
 #endif /* __RINGBUFINDEX_H__ */

--- a/core/lib/ringbuf16index.h
+++ b/core/lib/ringbuf16index.h
@@ -107,8 +107,7 @@ int ringbuf16index_peek_get(const struct ringbuf16index *r);
  * \param r Pinter to ringbuf16index
  * \return The size of the ring buffer
  */
-static inline
-int ringbuf16index_size(const struct ringbuf16index *r)
+static inline int ringbuf16index_size(const struct ringbuf16index *r)
 {
   return r->mask + 1;
 }

--- a/core/lib/ringbuf16index.h
+++ b/core/lib/ringbuf16index.h
@@ -80,7 +80,7 @@ unsigned ringbuf16index_put_free(const struct ringbuf16index *r);
 /**
  * \brief Put size elements to the ring buffer
  * \param r Pointer to ringbuf16index
- * \param n amount of placed items
+ * \param size amount of placed items
  * \retval amount of free solid space at new put, \sa ringbuf16index_put_free
  */
 int ringbuf16index_putn(struct ringbuf16index *r, uint16_t size);

--- a/core/lib/ringbuf16index.h
+++ b/core/lib/ringbuf16index.h
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 2015, SICS Swedish ICT.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * This file is part of the Contiki operating system.
+ *
+ */
+
+/**
+ * \file
+ *         Header file for the ringbuf16index library
+ * \author
+ *         Simon Duquennoy <simonduq@sics.se>
+ */
+
+#ifndef __RINGBUF16INDEX_H__
+#define __RINGBUF16INDEX_H__
+
+#include "contiki-conf.h"
+
+struct ringbuf16index {
+  uint16_t mask;
+  /* These must be 8-bit quantities to avoid race conditions. */
+  uint16_t put_ptr, get_ptr;
+};
+
+/**
+ * \brief Initialize a ring buffer. The size must be a power of two
+ * \param r Pointer to ringbuf16index
+ * \param size Size of ring buffer
+ */
+void ringbuf16index_init(struct ringbuf16index *r, uint16_t size);
+
+/**
+ * \brief Put one element to the ring buffer
+ * \param r Pointer to ringbuf16index
+ * \retval 0 Failure; the ring buffer is full
+ * \retval 1 Success; an element is added
+ */
+int ringbuf16index_put(struct ringbuf16index *r);
+
+/**
+ * \brief Check if there is space to put an element.
+ * \param r Pinter to ringbuf16index
+ * \retval >= 0 The index where the next element is to be added.
+ * \retval -1 Failure; the ring buffer is full
+ */
+int ringbuf16index_peek_put(const struct ringbuf16index *r);
+
+/**
+ * \brief Check solid space size to put an element.
+ * \param r Pointer to ringbuf16index
+ * \retval size of solid space at put position, avail for fill
+ */
+unsigned ringbuf16index_put_free(const struct ringbuf16index *r);
+/**
+ * \brief Put size elements to the ring buffer
+ * \param r Pointer to ringbuf16index
+ * \param n amount of placed items
+ * \retval amount of free solid space at new put, \sa ringbuf16index_put_free
+ */
+int ringbuf16index_putn(struct ringbuf16index *r, uint16_t size);
+
+/**
+ * \brief Remove the first element and return its index
+ * \param r Pinter to ringbuf16index
+ * \retval >= 0 The index of the first element
+ * \retval -1 No element in the ring buffer
+ */
+int ringbuf16index_get(struct ringbuf16index *r);
+
+/**
+ * \brief Return the index of the first element which will be removed if calling
+ *        ringbuf16index_get.
+ * \param r Pinter to ringbuf16index
+ * \retval >= 0 The index of the first element
+ * \retval -1 No element in the ring buffer
+ */
+int ringbuf16index_peek_get(const struct ringbuf16index *r);
+
+/**
+ * \brief Return the ring buffer size
+ * \param r Pinter to ringbuf16index
+ * \return The size of the ring buffer
+ */
+static inline
+int ringbuf16index_size(const struct ringbuf16index *r)
+{
+  return r->mask + 1;
+}
+
+
+/**
+ * \brief Return the number of elements currently in the ring buffer.
+ * \param r Pinter to ringbuf16index
+ * \return The number of elements in the ring buffer
+ */
+int ringbuf16index_elements(const struct ringbuf16index *r);
+
+/**
+ * \brief Is the ring buffer full?
+ * \retval 0 Not full
+ * \retval 1 Full
+ */
+int ringbuf16index_full(const struct ringbuf16index *r);
+
+/**
+ * \brief Is the ring buffer empty?
+ * \retval 0 Not empty
+ * \retval 1 Empty
+ */
+static inline
+int ringbuf16index_empty(const struct ringbuf16index *r){
+    return r->get_ptr == r->put_ptr;
+}
+
+
+#endif /* __RINGBUFINDEX_H__ */

--- a/cpu/cc26xx-cc13xx/dev/cc26xx-uart.c
+++ b/cpu/cc26xx-cc13xx/dev/cc26xx-uart.c
@@ -63,6 +63,145 @@
 #define cc26xx_uart_isr UART0IntHandler
 /*---------------------------------------------------------------------------*/
 static int (*input_handler)(unsigned char c);
+
+//*****************************************************************************
+#if UART_TXBUFSIZE
+
+#include <lib/ringbuf16index.h>
+
+typedef struct uart_tx_s{
+    //uintptr_t   io_base;
+    struct {
+        struct ringbuf16index   idx;
+        char                    data[UART_TXBUFSIZE];
+    }           buf;
+} uart_tx_t;
+uart_tx_t   uart_txbuf;
+#define UIO_BASE(buf)   UART0_BASE
+
+#if (~(UART_TXBUFSIZE-1) & UART_TXBUFSIZE) != UART_TXBUFSIZE
+#error UART_TXBUFSIZE MUST be power 2
+#endif
+void cc26xx_uart_buf_init(void){
+    uart_tx_t* tx = &uart_txbuf;
+    ringbuf16index_init(&tx->buf.idx, UART_TXBUFSIZE);
+}
+
+//* \return = 0 - buffer is empty
+int cc26xx_uart_bufsend(void /*struct uart_tx_t* buf*/)
+{
+    uart_tx_t* tx = &uart_txbuf;
+    while (!ringbuf16index_empty(&tx->buf.idx)){
+        char tmp = tx->buf.data[tx->buf.idx.get_ptr];
+        if (ti_lib_uart_char_put_non_blocking(UIO_BASE(tx), tmp)){
+            if ( ringbuf16index_get(&tx->buf.idx) >= 0)
+                {;}
+            else
+                //* buffer empty
+                break;
+        }
+        else
+            return 1;
+    }
+    return 0;
+}
+
+int cc26xx_uart_send_empty(void){
+    uart_tx_t* tx = &uart_txbuf;
+    return ringbuf16index_empty(&tx->buf.idx);
+}
+
+int cc26xx_uart_buf_free(void){
+    uart_tx_t* tx = &uart_txbuf;
+    return UART_TXBUFSIZE - ringbuf16index_elements(&tx->buf.idx);
+}
+
+int cc26xx_uart_write_bufs(/*struct uart_tx_t* buf*/ const void* data, unsigned len)
+{
+    uart_tx_t* tx = &uart_txbuf;
+    if (cc26xx_uart_send_empty()){
+        if (len == 1) {
+            if ( ti_lib_uart_char_put_non_blocking(UIO_BASE(tx), *(const char*)data) ){
+            return 1;
+    }
+        }
+    }
+    else if (ringbuf16index_full(&tx->buf.idx)){
+        return 0;
+    }
+
+    //* buf index operations should be atomic
+    bool interrupts_disabled = ti_lib_int_master_disable();
+
+    if(ringbuf16index_empty(&tx->buf.idx)) {
+        //* reset buffer, if empty, to have maximum linear free block
+        tx->buf.idx.put_ptr = 0;
+        tx->buf.idx.get_ptr = 0;
+    }
+    unsigned res = 0;
+    if (len == 1) {
+        tx->buf.data[tx->buf.idx.put_ptr] = *(const char*)data;
+    ringbuf16index_put(&tx->buf.idx);
+        res = 1;
+    }
+    else {
+        unsigned avail = ringbuf16index_put_free(&tx->buf.idx);
+        if (avail >= len)
+            avail = len;
+        memcpy(tx->buf.data+tx->buf.idx.put_ptr, data, avail);
+        res  = avail;
+        len -= avail;
+        avail = ringbuf16index_putn(&tx->buf.idx, avail);
+        if (len > 0){
+            const char* b = (const char*)data;
+            if (avail >= len)
+                avail = len;
+            memcpy(tx->buf.data+tx->buf.idx.put_ptr, b+res, avail);
+            res += avail;
+            avail = ringbuf16index_putn(&tx->buf.idx, avail);
+        }
+    }
+    ti_lib_uart_int_enable(UIO_BASE(tx), UART_INT_TX);
+
+    cc26xx_uart_bufsend();
+    if(!interrupts_disabled) {
+      ti_lib_int_master_enable();
+    }
+
+    return res;
+}
+
+
+int cc26xx_uart_write_buf(/*struct uart_tx_t* buf*/ char x){
+    uart_tx_t* tx = &uart_txbuf;
+    while (ringbuf16index_full(&tx->buf.idx)){
+            //volatile uart_tx_t* vtx = (volatile uart_tx_t*)tx;
+            while (ringbuf16index_full(&tx->buf.idx)) ;
+    }
+
+    unsigned tmp = x;
+    return cc26xx_uart_write_bufs(&tmp, 1);
+}
+
+#else
+
+#define cc26xx_uart_buf_init(x)
+#define cc26xx_uart_bufsend(x) 0
+
+inline
+int cc26xx_uart_write_buf(char x){
+    ti_lib_uart_char_put(UART0_BASE, x);
+    return 1;
+}
+
+#define cc26xx_uart_buf_free(x) 0
+
+inline
+int cc26xx_uart_write_bufs(const void* data, unsigned len){
+    return ti_lib_uart_char_put_non_blocking(UART0_BASE, *(const char*)data);
+}
+
+#endif //UART_TXBUFSIZE
 /*---------------------------------------------------------------------------*/
 static bool
 usable_rx(void)
@@ -285,6 +424,8 @@ cc26xx_uart_init()
     return;
   }
 
+  cc26xx_uart_buf_init();
+
   /* Disable Interrupts */
   interrupts_disabled = ti_lib_int_master_disable();
 
@@ -303,6 +444,7 @@ cc26xx_uart_init()
   if(!interrupts_disabled) {
     ti_lib_int_master_enable();
   }
+  lpm_drop_handler(LPM_MODE_SHUTDOWN);
 }
 /*---------------------------------------------------------------------------*/
 void
@@ -317,8 +459,27 @@ cc26xx_uart_write_byte(uint8_t c)
     enable();
   }
 
-  ti_lib_uart_char_put(UART0_BASE, c);
+  cc26xx_uart_write_buf(c);
 }
+/*---------------------------------------------------------------------------*/
+/**
+ * \brief nonblocking put bytes to UART
+ * \param data The characters to transmit
+ * \param len  amount of characters to transmit
+ * \return number of writen characters
+ */
+int cc26xx_uart_write_bytes(const void* data, unsigned len){
+    /* Return early if disabled by user conf or if ports are misconfigured */
+    if(usable_tx() == false) {
+      return -1;
+    }
+
+    if(accessible() == false) {
+      enable();
+    }
+    return cc26xx_uart_write_bufs(data, len);
+}
+
 /*---------------------------------------------------------------------------*/
 void
 cc26xx_uart_set_input(int (*input)(unsigned char c))
@@ -370,6 +531,38 @@ cc26xx_uart_busy(void)
   return ti_lib_uart_busy(UART0_BASE);
 }
 /*---------------------------------------------------------------------------*/
+/**
+ * \brief Returns the UART full status
+ * \return 0  - UART if full, and blocks for write
+ * \return >0 - UART can write bytes without block
+ *
+ * ti_lib_uart_busy() will access UART registers. It is our responsibility
+ * to first make sure the UART is accessible before calling it. Hence this
+ * wrapper.
+ *
+ * Return values are defined in CC26xxware's uart.h:UARTSpaceAvail
+ */
+int cc26xx_uart_space_avail(void){
+    /* Return early if disabled by user conf or if ports are misconfigured */
+    if(usable_tx() == false) {
+      return -1;
+    }
+
+    /* If the UART is not accessible, it is not busy */
+    if(accessible() == false) {
+      return -1;
+    }
+
+    unsigned res = cc26xx_uart_buf_free();
+    if (res > 0)
+        return res;
+    if(ti_lib_uart_space_avail(UART0_BASE))
+        return 1;
+    if (!ti_lib_uart_busy(UART0_BASE))
+        return 1;
+    return 0;
+}
+/*---------------------------------------------------------------------------*/
 void
 cc26xx_uart_isr(void)
 {
@@ -378,6 +571,7 @@ cc26xx_uart_isr(void)
 
   ENERGEST_ON(ENERGEST_TYPE_IRQ);
 
+  if(accessible() == false)
   power_and_clock();
 
   /* Read out the masked interrupt status */
@@ -398,6 +592,11 @@ cc26xx_uart_isr(void)
         input_handler((unsigned char)the_char);
       }
     }
+  }
+
+  if ((flags & UART_INT_TX) != 0) {
+      if (cc26xx_uart_bufsend() == 0)
+          ti_lib_uart_int_disable(UART0_BASE, UART_INT_TX);
   }
 
   ENERGEST_OFF(ENERGEST_TYPE_IRQ);

--- a/cpu/cc26xx-cc13xx/dev/cc26xx-uart.h
+++ b/cpu/cc26xx-cc13xx/dev/cc26xx-uart.h
@@ -61,6 +61,14 @@ void cc26xx_uart_init();
 void cc26xx_uart_write_byte(uint8_t b);
 
 /**
+ * \brief nonblocking put bytes to UART
+ * \param data The characters to transmit
+ * \param len  amount of characters to transmit
+ * \return number of writen characters
+ */
+int cc26xx_uart_write_bytes(const void* data, unsigned len);
+
+/**
  * \brief Assigns a callback to be called when the UART receives a byte
  * \param input A pointer to the function
  *
@@ -89,6 +97,23 @@ void cc26xx_uart_set_input(int (*input)(unsigned char c));
  * Return values are defined in CC26xxware's uart.h
  */
 uint8_t cc26xx_uart_busy(void);
+
+/**
+ * \brief Returns the UART full status
+ * \return <0 - UART not available, turned off
+ * \return 0  - UART if full, and blocks for write
+ * \return >0 - UART can write bytes without block
+ *
+ * ti_lib_uart_busy() will access UART registers. It is our responsibility
+ * to first make sure the UART is accessible before calling it. Hence this
+ * wrapper.
+ *
+ * Return values are defined in CC26xxware's uart.h:UARTSpaceAvail
+ */
+int cc26xx_uart_space_avail(void);
+
+
+
 /** @} */
 /*---------------------------------------------------------------------------*/
 #endif /* CC26XX_UART_H_ */


### PR DESCRIPTION
Hallow! here provided:

buffering uart output, that can be enabled by UART_TXBUFSIZE configuration macro.
enhanced cc26xx_uart api :
- cc26xx_uart_write_bytes - nonbocking write to uart fifo optimised to buffering driver
-cc26xx_uart_space_avail - status of tx fifo
putchar:puts, dbg_send_bytes - migrates to cc26xx_uart_write_bytes for optimisation.
a bit optimised UART ISR - more light check for power and clock.
*Note - using buffering (via UART_TXBUFSIZE) skips waiting for send completion in
routines puts, dbg_send_bytes - that was used for to protect vs poweroff
during transfer.