### PR TITLE
Allow to search "customrules" in additional directories.

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -226,7 +226,8 @@ clean:
 distclean: clean
 	-rm -f ${addsuffix .$(TARGET),$(CONTIKI_PROJECT)}
 
--include $(CONTIKI)/platform/$(TARGET)/Makefile.customrules-$(TARGET)
+target_customrules_makefile := $(wildcard $(CONTIKI)/platform/$(TARGET)/Makefile.customrules-$(TARGET) ${foreach TDIR, $(TARGETDIRS), $(TDIR)/$(TARGET)/Makefile.customrules-$(TARGET)})
+-include $(target_customrules_makefile)
 
 ifndef CUSTOM_RULE_C_TO_CE
 %.ce: %.c


### PR DESCRIPTION
This PR allows to define `Makefile.customrules-$(TARGET)` files outside of Contiki source tree (for instance, to define custom out-of-tree version of cooja target).