### PR TITLE
!lib/assert - fix for c++ usage, since it overrides standart lib header

### DIFF
--- a/core/lib/assert.h
+++ b/core/lib/assert.h
@@ -31,6 +31,10 @@
 #ifndef ASSERT_H_
 #define ASSERT_H_
 
+#ifdef __cplusplus
+extern "C"{
+#endif /* !__cplusplus */
+
 #undef assert
 #ifdef NDEBUG
 #define assert(e) ((void)0)
@@ -44,5 +48,9 @@ void _xassert(const char *, int);
 #define _CTASSERT(x, y)         __CTASSERT(x, y)
 #define __CTASSERT(x, y)        typedef char __assert ## y[(x) ? 1 : -1]
 #endif
+
+#ifdef __cplusplus
+}
+#endif /* !__cplusplus */
 
 #endif /* ASSERT_H_ */


### PR DESCRIPTION
since assert.h is a standart lib header, so need to protect it for c++ usage.
<assert.h> natively must be compatible with c++, since it is compatible in standart lib.