### PR TITLE
cc26xx/sensortag: Use correct calibration data structure size

### DIFF
--- a/platform/srf06-cc26xx/sensortag/bmp-280-sensor.c
+++ b/platform/srf06-cc26xx/sensortag/bmp-280-sensor.c
@@ -88,7 +88,6 @@
 /*---------------------------------------------------------------------------*/
 /* Misc. */
 #define MEAS_DATA_SIZE                      6
-#define CALIB_DATA_SIZE                     24
 /*---------------------------------------------------------------------------*/
 #define RES_OFF                             0
 #define RES_ULTRA_LOW_POWER                 1
@@ -121,6 +120,7 @@ typedef struct bmp_280_calibration {
   int32_t t_fine;
 } bmp_280_calibration_t;
 /*---------------------------------------------------------------------------*/
+#define CALIB_DATA_SIZE (sizeof(bmp_280_calibration_t))
 static uint8_t calibration_data[CALIB_DATA_SIZE];
 /*---------------------------------------------------------------------------*/
 #define SENSOR_STATUS_DISABLED     0


### PR DESCRIPTION
The CALIB_DATA_SIZE was set to 24 while the actual structure size is 28.
Because of this, some other variables in the module were overwritten after the sensor read operation. This, for example, prevented reading the temperature immediately after the pressure (or vice versa), because the "enabled" static variable contained garbage.