### PR TITLE
Make git ignore generated *.co files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ summary
 *.runlog
 *.faillog
 *.orig
+*.co
 *~
 .DS_Store
 obj_*


### PR DESCRIPTION
*.co files are generated in regressions tests' code folder among others. These clutter the result of git status, it is especially annoying when working in a repo that has contiki as a submodule.