### PR TITLE
Set Orchestra's default debug output level to none

### DIFF
--- a/apps/orchestra/orchestra.c
+++ b/apps/orchestra/orchestra.c
@@ -43,7 +43,7 @@
 #include "net/rpl/rpl-private.h"
 #include "net/rime/rime.h" /* Needed for so-called rime-sniffer */
 
-#define DEBUG DEBUG_PRINT
+#define DEBUG DEBUG_NONE
 #include "net/ip/uip-debug.h"
 
 /* A net-layer sniffer for packets sent and received */


### PR DESCRIPTION
Debug printf is meant for development. An application using Orchestra
does not want output on by default.