### PR TITLE
+cc26xx:prop-mode:rf on timeout - prevents code hung when OSC not start

### DIFF
--- a/cpu/cc26xx-cc13xx/dev/oscillators.c
+++ b/cpu/cc26xx-cc13xx/dev/oscillators.c
@@ -111,6 +111,27 @@ oscillators_request_hf_xosc(void)
   /* Release the OSC AUX consumer */
   aux_ctrl_unregister_consumer(&osc);
 }
+
+/*---------------------------------------------------------------------------*/
+bool oscillators_wait_ready_hf_xosc(rtimer_clock_t timeout)
+{
+  /* Request AUX access, with OSCCTRL and SMPH clocks */
+  aux_consumer_module_t osc = {
+    .clocks = AUX_WUC_OSCCTRL_CLOCK | AUX_WUC_SMPH_CLOCK
+  };
+  aux_ctrl_register_consumer(&osc);
+  bool res = true;
+  while (!ti_lib_osc_hf_source_ready()){
+      if (RTIMER_CLOCK_LT( timeout, RTIMER_NOW() )){
+          res = false;
+          break;
+      }
+  }
+  /* Release the OSC AUX consumer */
+  aux_ctrl_unregister_consumer(&osc);
+  return res;
+}
+
 /*---------------------------------------------------------------------------*/
 void
 oscillators_switch_to_hf_xosc(void)

--- a/cpu/cc26xx-cc13xx/dev/oscillators.h
+++ b/cpu/cc26xx-cc13xx/dev/oscillators.h
@@ -48,6 +48,9 @@
 /*---------------------------------------------------------------------------*/
 #ifndef OSCILLATORS_H_
 #define OSCILLATORS_H_
+
+#include <stdbool.h>
+
 /*---------------------------------------------------------------------------*/
 /**
  * \brief Set the LF clock source to be the LF XOSC
@@ -80,6 +83,16 @@ void oscillators_select_lf_rcosc(void);
  * The XOSC is requested as the source for the HF as well as the MF clock.
  */
 void oscillators_request_hf_xosc(void);
+
+/**
+ * \brief waits until <timeout> for HF clock be ready, after requested the
+ *   HF XOSC as the source for the HF clock.
+ * \sa oscillators_request_hf_xosc
+ *
+ * This checks while an startup HF XOSC in progess
+ *
+ */
+bool oscillators_wait_ready_hf_xosc(rtimer_clock_t timeout);
 
 /**
  * \brief Performs the switch to the XOSC

--- a/cpu/cc26xx-cc13xx/rf-core/rf-core.h
+++ b/cpu/cc26xx-cc13xx/rf-core/rf-core.h
@@ -103,6 +103,17 @@
 #define RF_CORE_PROP_BIAS_MODE RF_CORE_BIAS_MODE_EXTERNAL
 #endif
 /*---------------------------------------------------------------------------*/
+/* RF-Front End RAT resyncing strategy provides mechanisms for RAT sync monitoring
+ *  and resyncing
+ *  0 :    resync only on rf-core propety setup
+ *  1 :    validate RF-timestamp in window of current operation, and resync if violate
+ * */
+#ifdef RF_CORE_CONF_HFOSC_STARTUP_TOUS
+#define RF_CORE_HFOSC_STARTUP_TOUS    RF_CORE_CONF_HFOSC_STARTUP_TOUS
+#else
+//#define RF_CORE_HFOSC_STARTUP_TOUS    1000
+#endif
+/*---------------------------------------------------------------------------*/
 #define RF_CORE_CMD_ERROR                     0
 #define RF_CORE_CMD_OK                        1
 /*---------------------------------------------------------------------------*/


### PR DESCRIPTION
turn on radio checks HF OSC for timeout, ant fails if OSC not ready for RF_CORE_CONF_HFOSC_STARTUP_TOUS
+cc26xx:oscillators:oscillators_wait_ready_hf_xosc - waiting HF OSC ready until timeout

*Note - if OSC is bad, and can`t start, therefore mcu hung forever. when RF_CORE_CONF_HFOSC_STARTUP_TOUS defined, it checks with this timeout and reports failure