### PR TITLE
!TSCH:on/off control  - fixed for sure deactivate TSCH stack

### DIFF
--- a/core/net/mac/tsch/tsch.c
+++ b/core/net/mac/tsch/tsch.c
@@ -40,6 +40,7 @@
  *
  */
 
+#include <stdbool.h>
 #include "contiki.h"
 #include "dev/radio.h"
 #include "net/netstack.h"
@@ -120,16 +121,26 @@ const linkaddr_t tsch_broadcast_address = { { 0xff, 0xff } };
 const linkaddr_t tsch_eb_address = { { 0, 0 } };
 #endif /* LINKADDR_SIZE == 8 */
 
-/* Is TSCH started? */
-int tsch_is_started = 0;
+enum TSCH_StateID{
+      tschNONE
 /* Has TSCH initialization failed? */
-int tsch_is_initialized = 0;
+    , tschINITIALISED
+    , tschSTARTED
+    , tschDISABLED = tschSTARTED
+    , tschACTIVE
+};
+typedef enum TSCH_StateID TSCH_StateID;
+TSCH_StateID tsch_status = tschNONE;
+inline
+bool tsch_is_active(){return tsch_status >= tschACTIVE;}
+void tsch_activate(bool onoff);
+
 /* Are we coordinator of the TSCH network? */
-int tsch_is_coordinator = 0;
+bool tsch_is_coordinator = 0;
 /* Are we associated to a TSCH network? */
-int tsch_is_associated = 0;
+bool tsch_is_associated = 0;
 /* Is the PAN running link-layer security? */
-int tsch_is_pan_secured = LLSEC802154_ENABLED;
+bool tsch_is_pan_secured = LLSEC802154_ENABLED;
 /* The current Absolute Slot Number (ASN) */
 struct tsch_asn_t tsch_current_asn;
 /* Device rank or join priority:
@@ -158,14 +169,14 @@ static void packet_input(void);
 
 /*---------------------------------------------------------------------------*/
 void
-tsch_set_coordinator(int enable)
+tsch_set_coordinator(bool enable)
 {
   tsch_is_coordinator = enable;
   tsch_set_eb_period(TSCH_EB_PERIOD);
 }
 /*---------------------------------------------------------------------------*/
 void
-tsch_set_pan_secured(int enable)
+tsch_set_pan_secured(bool enable)
 {
   tsch_is_pan_secured = LLSEC802154_ENABLED && enable;
 }
@@ -416,13 +427,28 @@ tsch_start_coordinator(void)
   tsch_slot_operation_sync(RTIMER_NOW(), &tsch_current_asn);
 }
 /*---------------------------------------------------------------------------*/
+void tsch_poll(void){
+    process_post(&tsch_process, PROCESS_EVENT_POLL, NULL);
+}
+
+void tsch_activate(bool onoff){
+    if (onoff)
+        tsch_status = tschACTIVE;
+    else
+        tsch_status = tschDISABLED;
+    if (tsch_is_associated)
+        tsch_disassociate();
+    else
+        tsch_poll();
+}
+
 /* Leave the TSCH network */
 void
 tsch_disassociate(void)
 {
   if(tsch_is_associated == 1) {
     tsch_is_associated = 0;
-    process_post(&tsch_process, PROCESS_EVENT_POLL, NULL);
+    tsch_poll();
     PRINTF("TSCH: leaving the network\n");
   }
 }
@@ -682,6 +708,7 @@ PROCESS_THREAD(tsch_process, ev, data)
 
   while(1) {
 
+    PROCESS_YIELD_UNTIL(tsch_is_active());
     while(!tsch_is_associated) {
       if(tsch_is_coordinator) {
         /* We are coordinator, start operating now */
@@ -852,7 +879,7 @@ tsch_init(void)
   ringbufindex_init(&input_ringbuf, TSCH_MAX_INCOMING_PACKETS);
   ringbufindex_init(&dequeued_ringbuf, TSCH_DEQUEUED_ARRAY_SIZE);
 
-  tsch_is_initialized = 1;
+  tsch_status = tschINITIALISED;
 
 #if TSCH_AUTOSTART
   /* Start TSCH operation.
@@ -871,7 +898,7 @@ send_packet(mac_callback_t sent, void *ptr)
   const linkaddr_t *addr = packetbuf_addr(PACKETBUF_ADDR_RECEIVER);
 
   if(!tsch_is_associated) {
-    if(!tsch_is_initialized) {
+    if(tsch_status < tschINITIALISED) {
       PRINTF("TSCH:! not initialized (see earlier logs), drop outgoing packet\n");
     } else {
       PRINTF("TSCH:! not associated, drop outgoing packet\n");
@@ -986,8 +1013,8 @@ packet_input(void)
 static int
 turn_on(void)
 {
-  if(tsch_is_initialized == 1 && tsch_is_started == 0) {
-    tsch_is_started = 1;
+  if(tsch_status == tschINITIALISED) {
+    tsch_status = tschSTARTED;
     /* Process tx/rx callback and log messages whenever polled */
     process_start(&tsch_pending_events_process, NULL);
     /* periodically send TSCH EBs */
@@ -995,10 +1022,10 @@ turn_on(void)
     /* try to associate to a network or start one if setup as coordinator */
     process_start(&tsch_process, NULL);
     PRINTF("TSCH: starting as %s\n", tsch_is_coordinator ? "coordinator" : "node");
+  }
+  tsch_activate(true);
     return 1;
   }
-  return 0;
-}
 /*---------------------------------------------------------------------------*/
 static int
 turn_off(int keep_radio_on)
@@ -1008,6 +1035,7 @@ turn_off(int keep_radio_on)
   } else {
     NETSTACK_RADIO.off();
   }
+  tsch_activate(false);
   return 1;
 }
 /*---------------------------------------------------------------------------*/

--- a/core/net/mac/tsch/tsch.h
+++ b/core/net/mac/tsch/tsch.h
@@ -35,6 +35,7 @@
 
 /********** Includes **********/
 
+#include <stdbool.h>
 #include "contiki.h"
 #include "net/mac/mac.h"
 #include "net/mac/tsch/tsch-security.h"
@@ -160,11 +161,11 @@ void TSCH_CALLBACK_LEAVING_NETWORK();
 /***** External Variables *****/
 
 /* Are we coordinator of the TSCH network? */
-extern int tsch_is_coordinator;
+extern bool tsch_is_coordinator;
 /* Are we associated to a TSCH network? */
-extern int tsch_is_associated;
+extern bool tsch_is_associated;
 /* Is the PAN running link-layer security? */
-extern int tsch_is_pan_secured;
+extern bool tsch_is_pan_secured;
 /* The TSCH MAC driver */
 extern const struct mac_driver tschmac_driver;
 
@@ -177,8 +178,8 @@ void tsch_set_eb_period(uint32_t period);
 /* The keep-alive timeout */
 void tsch_set_ka_timeout(uint32_t timeout);
 /* Set the node as PAN coordinator */
-void tsch_set_coordinator(int enable);
+void tsch_set_coordinator(bool enable);
 /* Set the pan as secured or not */
-void tsch_set_pan_secured(int enable);
+void tsch_set_pan_secured(bool enable);
 
 #endif /* __TSCH_H__ */


### PR DESCRIPTION
tsch MAC stack off() now can surely deactivate TSCH until on()

!     tschmac_driver.off - now disassociates. there was leaving associated state
                after turn_off. it looks - invalid behaviour.
!     tsch_process - now waits activation before start net association/coordinator
+     tsch_status - provides more complex.tsch states scheme - append ACTIVE phase.
                also a bit optimisation about memory usage.
*     bool args - a bit optimisation on code and memoty via use bool, that can be smaller then int

*Note: tsch_process was try to start association/coordinator always when it not associated.
        this process is turn on rf. so there is no way to turn RF activity off with TSCH.
        now introduces tschACTIVE phase for tsch state. and tschmac_driver.on/off are
        control over it. so invoke NETSTACK_MAC.on()/off() is enough to completely control 
        RF activity RF and TSCH stack.