### PR TITLE
TSCH boolean flasg optimisations

### DIFF
--- a/core/net/mac/tsch/tsch-queue.c
+++ b/core/net/mac/tsch/tsch-queue.c
@@ -360,9 +360,9 @@ tsch_queue_is_empty(const struct tsch_neighbor *n)
 struct tsch_packet *
 tsch_queue_get_packet_for_nbr(const struct tsch_neighbor *n, struct tsch_link *link)
 {
+  if(n != NULL) {
   if(!tsch_is_locked()) {
-    int is_shared_link = link != NULL && link->link_options & LINK_OPTION_SHARED;
-    if(n != NULL) {
+      int is_shared_link = (link != NULL) && (link->link_options & LINK_OPTION_SHARED);
       int16_t get_index = ringbufindex_peek_get(&n->tx_ringbuf);
       if(get_index != -1 &&
           !(is_shared_link && !tsch_queue_backoff_expired(n))) {    /* If this is a shared link,

--- a/core/net/mac/tsch/tsch-slot-operation.c
+++ b/core/net/mac/tsch/tsch-slot-operation.c
@@ -797,9 +797,11 @@ PT_THREAD(tsch_rx_slot(struct pt *pt, struct rtimer *t))
         current_input->rssi = (signed)radio_last_rssi;
         current_input->channel = current_channel;
         header_len = frame802154_parse((uint8_t *)current_input->payload, current_input->len, &frame);
-        frame_valid = header_len > 0 &&
-          frame802154_check_dest_panid(&frame) &&
-          frame802154_extract_linkaddr(&frame, &source_address, &destination_address);
+        frame_valid = header_len > 0;
+        if( !frame802154_check_dest_panid(&frame))
+            frame_valid = false;
+        if( !frame802154_extract_linkaddr(&frame, &source_address, &destination_address) )
+            frame_valid = false;
 
 #if TSCH_RESYNC_WITH_SFD_TIMESTAMPS
         /* At the end of the reception, get an more accurate estimate of SFD arrival time */

--- a/core/net/mac/tsch/tsch-slot-operation.h
+++ b/core/net/mac/tsch/tsch-slot-operation.h
@@ -35,6 +35,7 @@
 
 /********** Includes **********/
 
+#include <stdbool.h>
 #include "contiki.h"
 #include "lib/ringbufindex.h"
 #include "net/mac/tsch/tsch-packet.h"
@@ -108,17 +109,39 @@ extern struct input_packet input_array[TSCH_MAX_INCOMING_PACKETS];
 
 /* Returns a 802.15.4 channel from an ASN and channel offset */
 uint8_t tsch_calculate_channel(struct tsch_asn_t *asn, uint8_t channel_offset);
-/* Is TSCH locked? */
-int tsch_is_locked(void);
-/* Lock TSCH (no link operation) */
-int tsch_get_lock(void);
-/* Release TSCH lock */
-void tsch_release_lock(void);
 /* Set global time before starting slot operation,
  * with a rtimer time and an ASN */
 void tsch_slot_operation_sync(rtimer_clock_t next_slot_start,
     struct tsch_asn_t *next_slot_asn);
 /* Start actual slot operation */
 void tsch_slot_operation_start(void);
+
+
+
+#ifndef LIB_INLINES
+#if (PACKETBUF_CONF_ATTRS_INLINE) //|| defined(__GNUC__)
+#define LIB_INLINES     1
+#else
+#define LIB_INLINES     0
+#endif
+#endif //LIB_INLINES
+
+#if LIB_INLINES
+extern
+volatile bool tsch_locked;
+static inline
+bool tsch_is_locked(void){return tsch_locked;};
+static inline
+void tsch_release_lock(void){tsch_locked = 0;};
+
+#else
+/* Is TSCH locked? */
+bool tsch_is_locked(void);
+/* Release TSCH lock */
+void tsch_release_lock(void);
+#endif
+/* Lock TSCH (no link operation) */
+bool tsch_get_lock(void);
+
 
 #endif /* __TSCH_SLOT_OPERATION_H__ */


### PR DESCRIPTION
here provided an trivial optimisations:
- for some null pointer chesks
- for boolean values allocation. uses bool type from "stdbool.h", unstead int. this could give a bit less data mamory usage . 
- also provide optimisations via inline checks of bool flags