### PR TITLE
+TSCH provides initialisation packet seq from RT

### DIFF
--- a/core/net/mac/tsch/tsch-conf.h
+++ b/core/net/mac/tsch/tsch-conf.h
@@ -198,4 +198,12 @@
 #define TSCH_CHANNEL_SCAN_DURATION CLOCK_SECOND
 #endif
 
+//* Initiates sequence no of packets from RTclock at strtup.
+//* this should help to pass though duplicates filter when fast
+//* chip restarts.
+#ifndef TSCH_CONF_SEQ_FROMRT
+#define TSCH_CONF_SEQ_FROMRT 0
+#endif
+
+
 #endif /* __TSCH_CONF_H__ */

--- a/core/net/mac/tsch/tsch.c
+++ b/core/net/mac/tsch/tsch.c
@@ -680,6 +680,13 @@ PROCESS_THREAD(tsch_process, ev, data)
 
   PROCESS_BEGIN();
 
+#if TSCH_CONF_SEQ_FROMRT
+  tsch_packet_seqno = RTIMER_NOW();
+  if(tsch_packet_seqno == 0) {
+    tsch_packet_seqno++;
+  }
+#endif
+
   while(1) {
 
     while(!tsch_is_associated) {


### PR DESCRIPTION
TSCH_CONF_SEQ_FROMRT allows use RT for initalisation SEQ counter. this helps pass through duplicates filter. 
When node frequently restarts, and seq value freese in init state. so that all sended packets by frequently resets node are filter out.