### PR TITLE
+TSCH:log:sec keys - append logging used security keys

### DIFF
--- a/core/net/mac/tsch/tsch-log.c
+++ b/core/net/mac/tsch/tsch-log.c
@@ -95,8 +95,9 @@ tsch_log_process_pending(void)
     }
     switch(log->type) {
       case tsch_log_tx:
-        printf("%s-%u-%u %u tx %d, st %d-%d",
-            log->tx.dest == 0 ? "bc" : "uc", log->tx.is_data, log->tx.sec_level,
+        printf("%s-%u-%u[%u] %u tx %d, st %d-%d",
+            log->tx.dest == 0 ? "bc" : "uc", log->tx.is_data
+            , log->tx.sec_level, log->tx.sec_key,
                 log->tx.datalen,
                 log->tx.dest,
                 log->tx.mac_tx_status, log->tx.num_tx);
@@ -106,8 +107,9 @@ tsch_log_process_pending(void)
         printf("\n");
         break;
       case tsch_log_rx:
-        printf("%s-%u-%u %u rx %d",
-            log->rx.is_unicast == 0 ? "bc" : "uc", log->rx.is_data, log->rx.sec_level,
+        printf("%s-%u-%u[%u] %u rx %d",
+            log->rx.is_unicast == 0 ? "bc" : "uc", log->rx.is_data
+            , log->rx.sec_level,log->rx.sec_key,
                 log->rx.datalen,
                 log->rx.src);
         if(log->rx.drift_used) {

--- a/core/net/mac/tsch/tsch-log.h
+++ b/core/net/mac/tsch/tsch-log.h
@@ -94,6 +94,7 @@ struct tsch_log_t {
       uint8_t is_data;
       uint8_t sec_level;
       uint8_t drift_used;
+      uint8_t sec_key;
     } tx;
     struct {
       int src;
@@ -104,6 +105,7 @@ struct tsch_log_t {
       uint8_t is_data;
       uint8_t sec_level;
       uint8_t drift_used;
+      uint8_t sec_key;
     } rx;
   };
 };

--- a/core/net/mac/tsch/tsch-slot-operation.c
+++ b/core/net/mac/tsch/tsch-slot-operation.c
@@ -699,9 +699,10 @@ PT_THREAD(tsch_tx_slot(struct pt *pt, struct rtimer *t))
     log->tx.datalen = queuebuf_datalen(current_packet->qb);
     log->tx.drift = drift_correction;
     log->tx.drift_used = is_drift_correction_used;
-    log->tx.is_data = ((((uint8_t *)(queuebuf_dataptr(current_packet->qb)))[0]) & 7) == FRAME802154_DATAFRAME;
+    log->tx.is_data = ((((uint8_t *)(queuebuf_dataptr(current_packet->qb)))[0]) & 7);// == FRAME802154_DATAFRAME;
 #if LLSEC802154_ENABLED
     log->tx.sec_level = queuebuf_attr(current_packet->qb, PACKETBUF_ATTR_SECURITY_LEVEL);
+    log->tx.sec_key   = queuebuf_attr(current_packet->qb, PACKETBUF_ATTR_KEY_INDEX);
 #else /* LLSEC802154_ENABLED */
     log->tx.sec_level = 0;
 #endif /* LLSEC802154_ENABLED */
@@ -904,9 +905,16 @@ PT_THREAD(tsch_rx_slot(struct pt *pt, struct rtimer *t))
               log->rx.datalen = current_input->len;
               log->rx.drift = drift_correction;
               log->rx.drift_used = is_drift_correction_used;
-              log->rx.is_data = frame.fcf.frame_type == FRAME802154_DATAFRAME;
-              log->rx.sec_level = frame.aux_hdr.security_control.security_level;
+              log->rx.is_data = frame.fcf.frame_type;// == FRAME802154_DATAFRAME;
               log->rx.estimated_drift = estimated_drift;
+              if (frame.fcf.security_enabled){
+              log->rx.sec_level = frame.aux_hdr.security_control.security_level;
+              log->tx.sec_key   = frame.aux_hdr.key_index;
+              }
+              else {
+                  log->rx.sec_level = 0;
+                  log->rx.sec_key   = 0;
+              }
             );
           }
 


### PR DESCRIPTION
Here is provided enhancement for TSCH log, that shows frame type and security keyid