### PR TITLE
TSCH adaptive sync estimation of sync timeut

### DIFF
--- a/core/net/mac/tsch/tsch-adaptive-timesync.h
+++ b/core/net/mac/tsch/tsch-adaptive-timesync.h
@@ -75,6 +75,17 @@
 /* The approximate number of slots per second */
 #define TSCH_SLOTS_PER_SECOND (1000000 / TSCH_DEFAULT_TS_TIMESLOT_LENGTH)
 
+/* Base drift value.
+ * Used to compensate locally know inaccuracies, such as
+ * the effect of having a binary 32.768 kHz timer as the TSCH time base. */
+#ifdef TSCH_CONF_DRIFT_SYNC_ESTIMATE
+#define TSCH_DRIFT_SYNC_ESTIMATE TSCH_CONF_DRIFT_SYNC_ESTIMATE
+#else
+#define TSCH_DRIFT_SYNC_ESTIMATE 0
+#endif
+
+// a handle for last_drift_ppm correction. invoke on learning in tsch_timesync_update
+//#define TSCH_TIMESYNC_ON_DRIFT(last_drift_ppm, time_delta_asn, drift_ticks) last_drift_ppm
 /***** External Variables *****/
 
 /* The neighbor last used as our time source */
@@ -85,5 +96,11 @@ extern struct tsch_neighbor *last_timesource_neighbor;
 void tsch_timesync_update(struct tsch_neighbor *n, uint16_t time_delta_asn, int32_t drift_correction);
 
 int32_t tsch_timesync_adaptive_compensate(rtimer_clock_t delta_ticks);
+
+#if TSCH_DRIFT_SYNC_ESTIMATE
+// estimates maximum time for keep in sync, update must be turn around in this time
+// \return timeout [ASN]
+int tsch_timesync_estimate_sync_timeout();
+#endif
 
 #endif /* __TSCH_ADAPTIVE_TIMESYNC_H__ */

--- a/core/net/mac/tsch/tsch-private.h
+++ b/core/net/mac/tsch/tsch-private.h
@@ -81,6 +81,7 @@ extern const linkaddr_t tsch_broadcast_address;
 extern const linkaddr_t tsch_eb_address;
 /* The current Absolute Slot Number (ASN) */
 extern struct tsch_asn_t tsch_current_asn;
+extern struct tsch_asn_t tsch_last_sync_asn;
 extern uint8_t tsch_join_priority;
 extern struct tsch_link *current_link;
 /* TSCH channel hopping sequence */
@@ -95,11 +96,6 @@ PROCESS_NAME(tsch_send_eb_process);
 PROCESS_NAME(tsch_pending_events_process);
 
 /********** Functions *********/
-
-/* Set TSCH to send a keepalive message after TSCH_KEEPALIVE_TIMEOUT */
-void tsch_schedule_keepalive(void);
-/* Leave the TSCH network */
-void tsch_disassociate(void);
 
 /************ Macros **********/
 

--- a/core/net/mac/tsch/tsch-slot-operation.c
+++ b/core/net/mac/tsch/tsch-slot-operation.c
@@ -932,6 +932,10 @@ PT_THREAD(tsch_rx_slot(struct pt *pt, struct rtimer *t))
   PT_END(pt);
 }
 /*---------------------------------------------------------------------------*/
+#ifndef TSCH_DESYNC_THRESHOLD_SLOTS
+#define TSCH_DESYNC_THRESHOLD_SLOTS() (100 * TSCH_CLOCK_TO_SLOTS(TSCH_DESYNC_THRESHOLD / 100, tsch_timing[tsch_ts_timeslot_length]))
+#endif
+
 /* Protothread for slot operation, called from rtimer interrupt
  * and scheduled from tsch_schedule_slot_operation */
 static
@@ -998,8 +1002,10 @@ PT_THREAD(tsch_slot_operation(struct rtimer *t, void *ptr))
     /* End of slot operation, schedule next slot or resynchronize */
 
     /* Do we need to resynchronize? i.e., wait for EB again */
-    if(!tsch_is_coordinator && (TSCH_ASN_DIFF(tsch_current_asn, tsch_last_sync_asn) >
-        (100 * TSCH_CLOCK_TO_SLOTS(TSCH_DESYNC_THRESHOLD / 100, tsch_timing[tsch_ts_timeslot_length])))) {
+    if(!tsch_is_coordinator
+       && (TSCH_ASN_DIFF(tsch_current_asn, tsch_last_sync_asn) >  TSCH_DESYNC_THRESHOLD_SLOTS())
+       )
+    {
       TSCH_LOG_ADD(tsch_log_message,
             snprintf(log->message, sizeof(log->message),
                 "! leaving the network, last sync %u",

--- a/core/net/mac/tsch/tsch.h
+++ b/core/net/mac/tsch/tsch.h
@@ -64,6 +64,9 @@
 #define TSCH_DESYNC_THRESHOLD (2 * TSCH_MAX_KEEPALIVE_TIMEOUT)
 #endif
 
+// this handle use to get check last synt timeout. it overrides TSCH_DESYNC_THRESHOLD
+//#define TSCH_DESYNC_THRESHOLD_SLOTS()
+
 /* Period between two consecutive EBs */
 #ifdef TSCH_CONF_EB_PERIOD
 #define TSCH_EB_PERIOD TSCH_CONF_EB_PERIOD


### PR DESCRIPTION
+TSCH:tsch_timesync_estimate_sync_timeout - provides estimation for in-sync time. estimation calculates 
               from absolute maximum drifts, provided for learning.
+     TSCH_DESYNC_THRESHOLD_SLOTS() - provides hook for network leave timeout. used
                                by slots to detect loose of net, when time-source packets are loose
+     TSCH_TIMESYNC_ON_DRIFT(...) - hook for timesync_learn_drift_ticks, allows reacts on drift learning changes