### PR TITLE
TSCH LINK_SEL attribute for received packets

### DIFF
--- a/core/net/mac/tsch/tsch-conf.h
+++ b/core/net/mac/tsch/tsch-conf.h
@@ -164,6 +164,11 @@
 
 /* A custom feature allowing upper layers to assign packets to
  * a specific slotframe and link */
+// 1 - enables PACKETBUF_ATTR_TSCH_SLOTFRAME/TIMESLOT attributes
+#define  TSCH_LINK_SELECTOR_ENABLED 1
+// 2 - enbles this attributes for received packets
+#define  TSCH_LINK_SELECTOR_ENABLEDRX 2
+
 #ifdef TSCH_CONF_WITH_LINK_SELECTOR
 #define TSCH_WITH_LINK_SELECTOR TSCH_CONF_WITH_LINK_SELECTOR
 #else /* TSCH_CONF_WITH_LINK_SELECTOR */

--- a/core/net/mac/tsch/tsch-slot-operation.c
+++ b/core/net/mac/tsch/tsch-slot-operation.c
@@ -796,6 +796,10 @@ PT_THREAD(tsch_rx_slot(struct pt *pt, struct rtimer *t))
         current_input->rx_asn = tsch_current_asn;
         current_input->rssi = (signed)radio_last_rssi;
         current_input->channel = current_channel;
+#if TSCH_WITH_LINK_SELECTOR
+        current_input->slotframe = current_link->slotframe_handle;
+        current_input->timeslot  = current_link->timeslot;
+#endif
         header_len = frame802154_parse((uint8_t *)current_input->payload, current_input->len, &frame);
         frame_valid = header_len > 0 &&
           frame802154_check_dest_panid(&frame) &&

--- a/core/net/mac/tsch/tsch-slot-operation.c
+++ b/core/net/mac/tsch/tsch-slot-operation.c
@@ -796,7 +796,7 @@ PT_THREAD(tsch_rx_slot(struct pt *pt, struct rtimer *t))
         current_input->rx_asn = tsch_current_asn;
         current_input->rssi = (signed)radio_last_rssi;
         current_input->channel = current_channel;
-#if TSCH_WITH_LINK_SELECTOR
+#if TSCH_WITH_LINK_SELECTOR > 1
         current_input->slotframe = current_link->slotframe_handle;
         current_input->timeslot  = current_link->timeslot;
 #endif

--- a/core/net/mac/tsch/tsch-slot-operation.h
+++ b/core/net/mac/tsch/tsch-slot-operation.h
@@ -37,8 +37,8 @@
 
 #include "contiki.h"
 #include "lib/ringbufindex.h"
-#include "net/mac/tsch/tsch-packet.h"
 #include "net/mac/tsch/tsch-private.h"
+#include "net/mac/tsch/tsch-packet.h"
 
 /******** Configuration *******/
 
@@ -91,6 +91,10 @@ struct input_packet {
   int len; /* Packet len */
   int16_t rssi; /* RSSI for this packet */
   uint8_t channel; /* Channel we received the packet on */
+#if TSCH_WITH_LINK_SELECTOR
+  tsch_sf_h     slotframe;
+  uint16_t      timeslot;
+#endif
 };
 
 /***** External Variables *****/

--- a/core/net/mac/tsch/tsch-slot-operation.h
+++ b/core/net/mac/tsch/tsch-slot-operation.h
@@ -91,8 +91,8 @@ struct input_packet {
   int len; /* Packet len */
   int16_t rssi; /* RSSI for this packet */
   uint8_t channel; /* Channel we received the packet on */
-#if TSCH_WITH_LINK_SELECTOR
-  tsch_sf_h     slotframe;
+#if TSCH_WITH_LINK_SELECTOR > 1
+  uint16_t      slotframe;
   uint16_t      timeslot;
 #endif
 };

--- a/core/net/mac/tsch/tsch.c
+++ b/core/net/mac/tsch/tsch.c
@@ -358,6 +358,10 @@ tsch_rx_process_pending()
       packetbuf_copyfrom(current_input->payload, current_input->len);
       packetbuf_set_attr(PACKETBUF_ATTR_RSSI, current_input->rssi);
       packetbuf_set_attr(PACKETBUF_ATTR_CHANNEL, current_input->channel);
+#if TSCH_WITH_LINK_SELECTOR
+      packetbuf_set_attr(PACKETBUF_ATTR_TSCH_SLOTFRAME, current_input->slotframe);
+      packetbuf_set_attr(PACKETBUF_ATTR_TSCH_TIMESLOT, current_input->timeslot);
+#endif
     }
 
     /* Remove input from ringbuf */

--- a/core/net/mac/tsch/tsch.c
+++ b/core/net/mac/tsch/tsch.c
@@ -358,7 +358,7 @@ tsch_rx_process_pending()
       packetbuf_copyfrom(current_input->payload, current_input->len);
       packetbuf_set_attr(PACKETBUF_ATTR_RSSI, current_input->rssi);
       packetbuf_set_attr(PACKETBUF_ATTR_CHANNEL, current_input->channel);
-#if TSCH_WITH_LINK_SELECTOR
+#if TSCH_WITH_LINK_SELECTOR > 1
       packetbuf_set_attr(PACKETBUF_ATTR_TSCH_SLOTFRAME, current_input->slotframe);
       packetbuf_set_attr(PACKETBUF_ATTR_TSCH_TIMESLOT, current_input->timeslot);
 #endif


### PR DESCRIPTION
Here provided option provides attributes PACKETBUF_ATTR_TSCH_SLOTFRAME/TIMESLOT for received packets.

this ability enables by setup TSCH_CONF_WITH_LINK_SELECTOR =2