### PR TITLE
When creating a MicaZ mote allow the source to be missing if the firmware is specified and vice versa

### DIFF
--- a/tools/cooja/apps/avrora/src/org/contikios/cooja/avrmote/MicaZMoteType.java
+++ b/tools/cooja/apps/avrora/src/org/contikios/cooja/avrmote/MicaZMoteType.java
@@ -316,7 +316,7 @@ public class MicaZMoteType implements MoteType {
 
     setMoteInterfaceClasses(intfClasses);
 
-    if (fileFirmware == null || fileSource == null) {
+    if (fileFirmware == null && fileSource == null) {
       throw new MoteTypeCreationException("Either source or firmware not specified");
     }
 


### PR DESCRIPTION
MicaZ motes cannot be created in COOJA unless both source and firmware are specified. I would like to create a csc file where no source file is specified and only a firmware.

Sky and Z1 mote types currently allow this behaviour.