### PR TITLE
Correctly set the node id when running TinyOS binaries in Cooja with MicaZ motes

### DIFF
--- a/tools/cooja/apps/avrora/src/org/contikios/cooja/avrmote/interfaces/MicaZID.java
+++ b/tools/cooja/apps/avrora/src/org/contikios/cooja/avrmote/interfaces/MicaZID.java
@@ -138,7 +138,13 @@ public class MicaZID extends MoteID {
         }
         if (tosID) {
             moteMem.setIntValueOf("TOS_NODE_ID", newID);
-            moteMem.setIntValueOf("ActiveMessageAddressC$addr", newID);
+
+            if (moteMem.variableExists("ActiveMessageAddressC__addr")) {
+                moteMem.setIntValueOf("ActiveMessageAddressC__addr", newID);
+            }
+            else {
+                moteMem.setIntValueOf("ActiveMessageAddressC$addr", newID);
+            }
         }
         setChanged();
         notifyObservers();


### PR DESCRIPTION
When running TinyOS binaries in Cooja with MicaZ motes the error shown below is thrown. This is because TinyOS changes the variable name "ActiveMessageAddressC$addr" to "ActiveMessageAddressC__addr". This patch sets ActiveMessageAddressC__addr if it exists and otherwise falls back to setting the $ variable version. This is similar to how MspMoteID achieves this.


FATAL [main] (Cooja.java:1337) - Exception when loading simulation: 
org.contikios.cooja.Cooja$SimulationCreationException: Unknown error: Unknown variable name: ActiveMessageAddressC$addr
	at org.contikios.cooja.Cooja.loadSimulationConfig(Cooja.java:3454)
	at org.contikios.cooja.Cooja.loadSimulationConfig(Cooja.java:3361)
	at org.contikios.cooja.Cooja.quickStartSimulationConfig(Cooja.java:1330)
	at org.contikios.cooja.Cooja.main(Cooja.java:3239)
Caused by: org.contikios.cooja.mote.memory.UnknownVariableException: Unknown variable name: ActiveMessageAddressC$addr
	at org.contikios.cooja.mote.memory.VarMemory.getVariable(VarMemory.java:104)
	at org.contikios.cooja.mote.memory.VarMemory.setIntValueOf(VarMemory.java:323)
	at org.contikios.cooja.avrmote.interfaces.MicaZID.setMoteID(MicaZID.java:141)
	at org.contikios.cooja.avrmote.interfaces.MicaZID.setConfigXML(MicaZID.java:171)
	at org.contikios.cooja.avrmote.MicaZMote.setConfigXML(MicaZMote.java:259)
	at org.contikios.cooja.Simulation.setConfigXML(Simulation.java:734)
	at org.contikios.cooja.Cooja.loadSimulationConfig(Cooja.java:3432)
	... 3 more