### PR TITLE
+process:process_abort - silent exit process

### DIFF
--- a/core/sys/process.c
+++ b/core/sys/process.c
@@ -203,6 +203,11 @@ process_exit(struct process *p)
 {
   exit_process(p, PROCESS_CURRENT());
 }
+
+void process_abort(void){
+    PROCESS_CURRENT()->state = PROCESS_STATE_NONE;
+}
+
 /*---------------------------------------------------------------------------*/
 void
 process_init(void)

--- a/core/sys/process.h
+++ b/core/sys/process.h
@@ -389,6 +389,17 @@ CCIF void process_post_synch(struct process *p,
  */
 CCIF void process_exit(struct process *p);
 
+/**
+ * \brief Makes status of current process not running, for silent process exiting
+ *
+ *       exiting of process generates events PROCESS_EVENT_EXITED for all
+ *       active processes, and PROCESS_EVENT_EXIT for current process
+ *       such notification can be useless and wasteful. so process_abort can
+ *       mark process alredy stops, to block notification in process_exit
+ * */
+CCIF void process_abort(void);
+
+#define PROCESS_ABORT()             process_abort()
 
 /**
  * Get a pointer to the currently running process.


### PR DESCRIPTION
process_abort provides extit process silently, without any events broadcast. 
ordinal process END/EXIT generates broadcasts events.