### PR TITLE
Stm32nucleo st7580

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -17,3 +17,6 @@
 [submodule "tools/sensniff"]
 	path = tools/sensniff
 	url = https://github.com/g-oikonomou/sensniff.git
+[submodule "platform/stm32nucleo-st7580/stm32cube-lib"]
+	path = platform/stm32nucleo-st7580/stm32cube-lib
+	url = https://github.com/STclab/stm32nucleo-st7580-lib.git

--- a/examples/ipv6/rpl-udp/project-conf.h
+++ b/examples/ipv6/rpl-udp/project-conf.h
@@ -49,8 +49,6 @@
 
 #undef NETSTACK_CONF_RDC
 #define NETSTACK_CONF_RDC     nullrdc_driver
-#undef NULLRDC_CONF_802154_AUTOACK
-#define NULLRDC_CONF_802154_AUTOACK       1
 
 /* Define as minutes */
 #define RPL_CONF_DEFAULT_LIFETIME_UNIT   60

--- a/platform/stm32nucleo-st7580/Makefile.stm32nucleo-st7580
+++ b/platform/stm32nucleo-st7580/Makefile.stm32nucleo-st7580
@@ -1,0 +1,186 @@
+
+CONTIKI_TARGET_DIRS = .
+
+### Include the board-specific makefile
+PLATFORM_ROOT_DIR = $(CONTIKI)/platform/$(TARGET)
+
+#Currently we support only GCC
+GCC=1
+
+CONTIKI_TARGET_DIRS += dev
+CONTIKI_TARGET_DIRS += stm32cube-lib/stm32cube-prj/Src
+CONTIKI_TARGET_DIRS += stm32cube-lib/drivers/stm32l1xx_nucleo
+CONTIKI_TARGET_DIRS += stm32cube-lib/drivers/x_nucleo_plm01a1
+CONTIKI_TARGET_DIRS += stm32cube-lib/drivers/Common
+CONTIKI_TARGET_DIRS += stm32cube-lib/drivers/st7580/src stm32cube-lib/drivers/st7580/inc
+CONTIKI_TARGET_DIRS += stm32cube-lib/drivers/CMSIS
+CONTIKI_TARGET_DIRS += stm32cube-lib/drivers/STM32L1xx_HAL_Driver
+CONTIKI_TARGET_DIRS += stm32cube-lib/drivers/STM32L1xx_HAL_Driver/Src
+CONTIKI_TARGET_DIRS += stm32cube-lib/drivers/STM32L1xx_HAL_Driver/Inc
+
+
+ARCH_DEV = button-sensor.c leds-arch.c
+
+ARCH_NUCLEOST7580 = contiki-st7580-main.c  uart-msg.c  st7580.c  node-id.c
+
+ARCH_NUCLEOST7580_STM32CUBEHAL = stm32l1xx_hal_msp.c  stm32l1xx_it.c stm32cube_hal_init.c
+
+ARCH_DRIVERS_STM32L1xx = stm32l1xx_nucleo.c
+
+ARCH_DRIVERS_ST7580_SHIELD = plm_gpio.c  stm32_plm01a1.c
+
+ARCH_DRIVERS_ST7580 = ST7580_Serial.c
+
+STM32L1XX_HAL =\
+	stm32l1xx_hal.c\
+	stm32l1xx_hal_adc_ex.c\
+	stm32l1xx_hal_adc.c\
+	stm32l1xx_hal_comp.c\
+	stm32l1xx_hal_cortex.c\
+	stm32l1xx_hal_crc.c\
+	stm32l1xx_hal_cryp_ex.c\
+	stm32l1xx_hal_cryp.c\
+	stm32l1xx_hal_dac_ex.c\
+	stm32l1xx_hal_dac.c\
+	stm32l1xx_hal_dma.c\
+	stm32l1xx_hal_flash_ex.c\
+	stm32l1xx_hal_flash.c\
+	stm32l1xx_hal_flash_ramfunc.c\
+	stm32l1xx_hal_gpio.c\
+	stm32l1xx_hal_i2c.c\
+	stm32l1xx_hal_i2s.c\
+	stm32l1xx_hal_irda.c\
+	stm32l1xx_hal_iwdg.c\
+	stm32l1xx_hal_lcd.c\
+	stm32l1xx_hal_nor.c\
+	stm32l1xx_hal_opamp_ex.c\
+	stm32l1xx_hal_opamp.c\
+	stm32l1xx_hal_pcd_ex.c\
+	stm32l1xx_hal_pcd.c\
+	stm32l1xx_hal_pwr_ex.c\
+	stm32l1xx_hal_pwr.c\
+	stm32l1xx_hal_rcc_ex.c\
+	stm32l1xx_hal_rcc.c\
+	stm32l1xx_hal_rtc_ex.c\
+	stm32l1xx_hal_rtc.c\
+	stm32l1xx_hal_sd.c\
+	stm32l1xx_hal_smartcard.c\
+	stm32l1xx_hal_spi_ex.c\
+	stm32l1xx_hal_spi.c\
+	stm32l1xx_hal_sram.c\
+	stm32l1xx_hal_tim_ex.c\
+	stm32l1xx_hal_tim.c\
+	stm32l1xx_hal_uart.c\
+	stm32l1xx_hal_usart.c\
+	stm32l1xx_hal_wwdg.c\
+	stm32l1xx_ll_fsmc.c\
+	stm32l1xx_ll_sdmmc.c
+
+ARCH+=$(ARCH_DEV)
+ARCH+=$(ARCH_NUCLEOST7580)
+ARCH+=$(ARCH_NUCLEOST7580_STM32CUBEHAL)
+ARCH+=$(ARCH_DRIVERS_STM32L1xx)
+ARCH+=$(ARCH_DRIVERS_ST7580_SHIELD)
+ARCH+=$(ARCH_DRIVERS_ST7580)
+ARCH+=$(STM32L1XX_HAL)
+
+CFLAGS += -DUSE_STM32L152_EVAL \
+		-DSTM32L152xE \
+		-DUSE_STM32L1XX_NUCLEO \
+		-DUSE_HAL_DRIVER \
+		-DUSE_STDPERIPH_DRIVER \
+		-DNO_EEPROM \
+
+CFLAGS += -I. \
+	  -I$(CONTIKI)/platform/$(TARGET)/ \
+	  -I$(CONTIKI)/platform/$(TARGET)/stm32cube-lib/stm32cube-prj/Inc \
+	  -I$(CONTIKI)/platform/$(TARGET)/stm32cube-lib/drivers/Common \
+	  -I$(CONTIKI)/platform/$(TARGET)/stm32cube-lib/drivers/st7580/inc \
+	  -I$(CONTIKI)/platform/$(TARGET)/stm32cube-lib/drivers/CMSIS \
+	  -I$(CONTIKI)/platform/$(TARGET)/stm32cube-lib/drivers/STM32L1xx_HAL_Driver/Inc \
+	  -I$(CONTIKI)/cpu/arm/stm32l152 \
+	  -I$(CONTIKI)/core                   \
+	  -I$(CONTIKI)/platform/$(TARGET)/dev
+
+ifdef UIP_CONF_IPV6
+CFLAGS += -DWITH_UIP6=1
+endif
+
+
+ifndef CONTIKI_TARGET_MAIN
+CONTIKI_TARGET_MAIN = contiki-st7580-main.c
+endif
+
+CONTIKI_TARGET_SOURCEFILES += $(ARCH) $(CONTIKI_TARGET_MAIN)
+
+MCU=stm32l152
+CONTIKI_CPU=$(CONTIKI)/cpu/arm/stm32l152
+include $(CONTIKI)/cpu/arm/stm32l152/Makefile.stm32l152
+
+
+MODULES+=core/net \
+         core/net/mac core/net/mac/contikimac \
+         core/net/llsec
+
+
+# build rules ------------------------------------
+
+CLEAN += *.stm32nucleo-st7580 symbols.c symbols.h contiki-stm32nucleo-st7580.log 
+
+contiki-$(TARGET).a: ${addprefix $(OBJECTDIR)/,symbols.o}
+
+help:
+	@echo A few useful make commands:
+	@echo make help - shows this help
+	@echo make TARGET=stm32nucleo-st7580 savetarget - stores selection of target to avoid using TARGET= on every make invokation
+	@echo make program.upload - compiles and uploads program to connected board
+	@echo make program.upload IAR=1 - uses the IAR compiler instead of gcc (not implemented yet)
+	@echo make program.upload NODEID=x - uploads with node_id set to x
+
+# Serialdump rules
+ifeq ($(HOST_OS),Windows)
+  SERIALDUMP = serialdump-windows
+  # this ID is a string with which the node identifies itself as, and is used to
+  # find the proper /dev/comX-port in Cygwin to connect to.
+  CYGWIN_DEV_ID="stm32nucleo-st7580 St7580 Platform"
+# include $(CONTIKI)/tools/cygwin/Makefile.cygwin
+endif
+ifeq ($(HOST_OS),Darwin)
+  SERIALDUMP = serialdump-macos
+endif
+ifndef SERIALDUMP
+  # Assume Linux
+  SERIALDUMP = serialdump-linux
+endif
+
+# IAR/windows/cygwin only for now; after GCC port, see if stm32flash works with Linux
+STLINKCLI=ST-LINK_CLI.exe
+%.upload: %.hex
+	#Note: this command only uploads to a single connected device
+	#$(STLINKCLI) -ME || $(STLINKCLI) -ME || $(STLINKCLI) -ME || $(STLINKCLI) -ME
+	$(STLINKCLI) -Q -P $*.hex -V -Run
+
+
+# devcon requires WinDriverKit, downloadable from microsoft.com
+DEVCON=devcon.exe
+DEVCON_ALLDEVS=$(shell $(DEVCON) find =USB | grep "STMicroelectronics STLink dongle" | cut -d " " -f 1)
+devcon_enableonly:
+	devcon disable =USB @"USB\VID_0483&PID_3748\*"
+	devcon enable =USB @"$(ID)"
+
+%.uploadall: %.hex
+	$(foreach D,$(DEVCON_ALLDEVS), echo D IS "$(D)" && make devcon_enableonly ID="$(D)" && make $*.upload && ) echo "Done"
+	devcon enable =USB @"USB\VID_0483&PID_3748\*"
+
+login:
+	@echo "Connecting to $(COMPORT)"
+	$(CONTIKI)/tools/sky/$(SERIALDUMP) -b115200 $(COMPORT)
+
+%.ramusage: %.$(TARGET)
+	$(NM) -S $< --size-sort --line-numbers | grep -v " T " | grep -v " t "
+%.romusage: %.$(TARGET)
+	$(NM) -S $< --size-sort --line-numbers | grep -v " b " | grep -v " B " | grep -v " d " | grep -v " D "
+
+
+
+

--- a/platform/stm32nucleo-st7580/README.md
+++ b/platform/stm32nucleo-st7580/README.md
@@ -1,0 +1,110 @@
+Getting Started with Contiki for STM32 Nucleo equipped with ST7580 FSK, PSK multi-mode power 
+line networking system-on-chip expansion boards
+=============================================================================================
+
+This guide explains how to get started with the STM32 Nucleo and expansion boards port to Contiki.
+
+Maintainers and Contacts
+========================
+
+Long-term maintainers:
+* Stefano Bosisio, stefano.bosisio@st.com, github user: [stebosisio](https://github.com/stebosisio)
+* Giorgio Balbusso, giorgio.balbusso@st.com, github user: [giorgiobalbussost](https://github.com/giorgiobalbussost)
+
+Contributors:
+* Stefano Bosisio, stefano.bosisio@st.com, github user: [stebosisio](https://github.com/stebosisio)
+* Giorgio Balbusso, giorgio.balbusso@st.com, github user: [giorgiobalbussost](https://github.com/giorgiobalbussost)
+
+Port Feature
+============
+
+The port supports the following boards from ST:
+-   NUCLEO-L152RE board, based on the STM32L152RET6 ultra-low power microcontroller
+-   X-NUCLEO-PLM01A1 based on ST7580 FSK, PSK multi-mode power line networking system-on-chip
+
+The following drivers are included:
+- LEDs and user button
+- USB
+- ST7580 FSK, PSK multi-mode power line networking system-on-chip
+
+Hardware Requirements
+=====================
+
+* NUCLEO-L152RE development board
+
+ >The NUCLEO-L152RE board belongs to the STM32 Nucleo family.
+It features an STM32L152RET6 ultra-low power microcontroller based on ARM Cortex M3 MCU.
+For detailed information on the NUCLEO-L152RE development board, please go to http://www.st.com and search for the "NUCLEO-L152RE" part number.
+
+
+* X-NUCLEO-PLM01A1 Power line communication expansion board 
+
+ >For detailed information on the X-NUCLEO-PLM01A1 expansion board, or the ST7580 FSK, PSK multi-mode power line networking system-on-chip please go to http://www.st.com and search for the "X-NUCLEO-PLM01A1" part number.
+ 
+* USB type A to Mini-B USB cable, to connect the STM32 Nucleo board to the PC
+
+Software Requirements
+=====================
+
+The following software are needed:
+
+* ST port of Contiki for STM32 Nucleo and expansion boards. 
+ 
+ >The port is automatically installed when both the Contiki and the submodule repository are cloned: the former hosts the Contiki distribution and the ST platform interface, the latter hosts the actual library. The following command downloads the full porting: 
+
+	git clone --recursive https://github.com/contiki-os/contiki
+
+Alternatively, if you cloned the contiki repository without the "--recursive" option, you can simply download the submodule repository with the following commands:
+
+	cd contiki/
+	git submodule init
+	git submodule update
+
+The platform name is: stm32nucleo-st7580
+
+* A toolchain to build the firmware: The port has been developed and tested with GNU Tools 
+for ARM Embedded Processors.
+ >The toolchain can be found at: https://launchpad.net/gcc-arm-embedded
+
+
+Examples
+========
+
+The following examples have been successfully tested:
+
+* examples/ipv6 (rpl-border-router, rpl-udp)
+
+
+Build an example
+================
+In order to build an example go to the selected example directory (see a list of tested
+examples in the previous section).
+
+For example, go to examples/ipv6/rpl-border-router directory.
+
+The following must be run:
+
+	make TARGET=stm32nucleo-st7580 clean
+	make TARGET=stm32nucleo-st7580
+
+This will create executables for rpl-border-router node.
+
+In order to generate binary file that can be flashed on the STM32 Nucleo the following command must be run:
+
+	arm-none-eabi-objcopy -O binary border-router.stm32nucleo-st7580 border_rouer.bin
+
+This executable can be programmed on the node using the procedure described hereafter.
+
+System setup
+============ 
+
+1. Connect the X-NUCLEO-PLM01A1 board to the STM32 Nucleo board (NUCLEO-L152RE) from the top.
+
+2. Power the STM32 Nucleo board using the Mini-B USB cable connected to the PC.
+
+3. Program the firmware on the STM32 Nucleo board. 
+This can be done by copying the binary file on the USB mass storage that is 
+automatically created when plugging the STM32 Nucleo board to the PC.
+
+4. Reset the MCU by using the reset button on the STM32 Nucleo board
+

--- a/platform/stm32nucleo-st7580/contiki-conf.h
+++ b/platform/stm32nucleo-st7580/contiki-conf.h
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2017, STMicroelectronics.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ *
+ */
+/*---------------------------------------------------------------------------*/
+#ifndef __CONTIKI_CONF_H__
+#define __CONTIKI_CONF_H__
+/*---------------------------------------------------------------------------*/
+#include "platform-conf.h"
+/*---------------------------------------------------------------------------*/
+#define SLIP_BRIDGE_CONF_NO_PUTCHAR 1
+
+#define NETSTACK_CONF_RDC_CHANNEL_CHECK_RATE 8
+#define NULLRDC_CONF_802154_AUTOACK 0
+#define NETSTACK_CONF_FRAMER  framer_802154
+#define NETSTACK_CONF_NETWORK sicslowpan_driver
+
+#undef NETSTACK_CONF_RDC
+#define NETSTACK_CONF_RDC     nullrdc_driver
+#define NETSTACK_RDC_HEADER_LEN 0
+
+#undef NETSTACK_CONF_MAC
+#define NETSTACK_CONF_MAC csma_driver
+#define NETSTACK_MAC_HEADER_LEN 0
+
+#define SICSLOWPAN_CONF_MAC_MAX_PAYLOAD \
+  (NETSTACK_RADIO_MAX_PAYLOAD_LEN - NETSTACK_MAC_HEADER_LEN - \
+   NETSTACK_RDC_HEADER_LEN)
+
+#define RIMESTATS_CONF_ENABLED 0
+#define RIMESTATS_CONF_ON 0
+
+/* Network setup for IPv6 */
+#define CXMAC_CONF_ANNOUNCEMENTS         0
+
+/* A trick to resolve a compilation error with IAR. */
+#ifdef __ICCARM__
+#define UIP_CONF_DS6_AADDR_NBU              1
+#endif
+
+/* radio driver blocks until ACK is received */
+#define NULLRDC_CONF_ACK_WAIT_TIME          (0)
+#define CONTIKIMAC_CONF_BROADCAST_RATE_LIMIT 0
+#define IEEE802154_CONF_PANID       0xABCD
+
+#define AODV_COMPLIANCE
+
+#define WITH_ASCII 1
+
+#define PROCESS_CONF_NUMEVENTS 8
+#define PROCESS_CONF_STATS 1
+/*#define PROCESS_CONF_FASTPOLL    4*/
+
+#define LINKADDR_CONF_SIZE              8
+
+#define UIP_CONF_LL_802154              1
+#define UIP_CONF_LLH_LEN                0
+
+#define UIP_CONF_ROUTER                 1
+
+/* configure number of neighbors and routes */
+#ifndef UIP_CONF_DS6_ROUTE_NBU
+#define UIP_CONF_DS6_ROUTE_NBU   30
+#endif /* UIP_CONF_DS6_ROUTE_NBU */
+
+#define UIP_CONF_ND6_SEND_RA    0
+#define UIP_CONF_ND6_REACHABLE_TIME    600000 /* 90000// 600000 */
+#define UIP_CONF_ND6_RETRANS_TIMER      10000
+
+#define UIP_CONF_IPV6                   1
+#ifndef UIP_CONF_IPV6_QUEUE_PKT
+#define UIP_CONF_IPV6_QUEUE_PKT         0
+#endif /* UIP_CONF_IPV6_QUEUE_PKT */
+#define UIP_CONF_IP_FORWARD             0
+#ifndef UIP_CONF_BUFFER_SIZE
+#define UIP_CONF_BUFFER_SIZE    280
+/* #define UIP_CONF_BUFFER_SIZE    600 */
+#endif
+
+#define SICSLOWPAN_CONF_MAXAGE                  4
+#define SICSLOWPAN_CONF_MAX_ADDR_CONTEXTS       2
+
+#ifndef SICSLOWPAN_CONF_MAX_MAC_TRANSMISSIONS
+#define SICSLOWPAN_CONF_MAX_MAC_TRANSMISSIONS   5
+#endif /* SICSLOWPAN_CONF_MAX_MAC_TRANSMISSIONS */
+
+#define UIP_CONF_ICMP_DEST_UNREACH 1
+
+#define UIP_CONF_DHCP_LIGHT
+#define UIP_CONF_LLH_LEN         0
+#ifndef UIP_CONF_RECEIVE_WINDOW
+#define UIP_CONF_RECEIVE_WINDOW  150
+#endif
+#ifndef UIP_CONF_TCP_MSS
+#define UIP_CONF_TCP_MSS         UIP_CONF_RECEIVE_WINDOW
+#endif
+#define UIP_CONF_MAX_CONNECTIONS 4
+#define UIP_CONF_MAX_LISTENPORTS 8
+#define UIP_CONF_UDP_CONNS       12
+#define UIP_CONF_FWCACHE_SIZE    30
+#define UIP_CONF_BROADCAST       1
+#define UIP_ARCH_IPCHKSUM        0
+#define UIP_CONF_UDP             1
+#define UIP_CONF_UDP_CHECKSUMS   1
+#define UIP_CONF_TCP     1
+/*---------------------------------------------------------------------------*/
+/* include the project config */
+/* PROJECT_CONF_H might be defined in the project Makefile */
+#ifdef PROJECT_CONF_H
+#include PROJECT_CONF_H
+#endif /* PROJECT_CONF_H */
+/*---------------------------------------------------------------------------*/
+#endif /* CONTIKI_CONF_H */
+/*---------------------------------------------------------------------------*/

--- a/platform/stm32nucleo-st7580/contiki-st7580-main.c
+++ b/platform/stm32nucleo-st7580/contiki-st7580-main.c
@@ -1,0 +1,161 @@
+/*
+ * Copyright (c) 2017, STMicroelectronics.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ *
+ */
+/*---------------------------------------------------------------------------*/
+/**
+ * \addtogroup stm32nucleo-s7580
+ * @{
+ *
+ * \file
+ * main file for stm32nucleo-st7580 platform
+ */
+/*---------------------------------------------------------------------------*/
+#include <stdio.h>
+#include <string.h>
+#include "stm32cube_hal_init.h"
+#include "contiki.h"
+#include "contiki-net.h"
+#include "sys/autostart.h"
+#include "dev/leds.h"
+#include "dev/serial-line.h"
+#include "dev/slip.h"
+#include "dev/watchdog.h"
+#include "dev/xmem.h"
+#include "lib/random.h"
+#include "net/netstack.h"
+#include "net/ip/uip.h"
+#include "net/mac/frame802154.h"
+#include "net/rime/rime.h"
+#include "stm32l1xx.h"
+#include "st7580.h"
+#include "node-id.h"
+#include "hw-config.h"
+#include "stdbool.h"
+#include "dev/button-sensor.h"
+#include "dev/radio-sensor.h"
+/*---------------------------------------------------------------------------*/
+#if NETSTACK_CONF_WITH_IPV6
+#include "net/ipv6/uip-ds6.h"
+#endif /*NETSTACK_CONF_WITH_IPV6*/
+/*---------------------------------------------------------------------------*/
+SENSORS(&button_sensor);
+/*---------------------------------------------------------------------------*/
+extern unsigned char node_mac[8];
+/*---------------------------------------------------------------------------*/
+#ifdef __GNUC__
+/* With GCC/RAISONANCE, small printf (option LD Linker->Libraries->Small printf
+   set to 'Yes') calls __io_putchar() */
+#define PUTCHAR_PROTOTYPE int __io_putchar(int ch)
+#else
+#define PUTCHAR_PROTOTYPE int fputc(int ch, FILE * f)
+#endif /* __GNUC__ */
+/*---------------------------------------------------------------------------*/
+#if NETSTACK_CONF_WITH_IPV6
+PROCINIT(&etimer_process, &tcpip_process);
+#else /*NETSTACK_CONF_WITH_IPV6*/
+PROCINIT(&etimer_process);
+#warning "No TCP/IP process!"
+#endif /*NETSTACK_CONF_WITH_IPV6*/
+/*---------------------------------------------------------------------------*/
+#define BUSYWAIT_UNTIL(cond, max_time) \
+  do { \
+    rtimer_clock_t t0; \
+    t0 = RTIMER_NOW(); \
+    while(!(cond) && RTIMER_CLOCK_LT(RTIMER_NOW(), t0 + (max_time))) ; \
+  } while(0)
+/*---------------------------------------------------------------------------*/
+static void set_rime_addr(void);
+void stm32cube_hal_init();
+/*---------------------------------------------------------------------------*/
+int
+main(int argc, char *argv[])
+{
+  stm32cube_hal_init();
+
+  /* init LEDs */
+  leds_init();
+
+  /* Initialize Contiki and our processes. */
+  clock_init();
+  ctimer_init();
+  rtimer_init();
+  watchdog_init();
+  process_init();
+  process_start(&etimer_process, NULL);
+
+  /* Restore node id if such has been stored in external mem */
+  node_id_restore(); /* also configures node_mac[] */
+
+  set_rime_addr();
+  random_init(node_id);
+
+  netstack_init();
+  st7580_radio_driver.on();
+
+  energest_init();
+
+#if NETSTACK_CONF_WITH_IPV6
+  memcpy(&uip_lladdr.addr, node_mac, sizeof(uip_lladdr.addr));
+
+  queuebuf_init();
+  process_start(&tcpip_process, NULL);
+
+  uip_ipaddr_t ipaddr;
+  uip_ip6addr(&ipaddr, 0xfc00, 0, 0, 0, 0, 0, 0, 0);
+  uip_ds6_set_addr_iid(&ipaddr, &uip_lladdr);
+  uip_ds6_addr_add(&ipaddr, 0, ADDR_AUTOCONF);
+#endif /* NETSTACK_CONF_WITH_IPV6*/
+
+  process_start(&sensors_process, NULL);
+
+  autostart_start(autostart_processes);
+
+  watchdog_start();
+
+  while(1) {
+    int r = 0;
+    do {
+      r = process_run();
+    } while(r > 0);
+  }
+}
+/*---------------------------------------------------------------------------*/
+static void
+set_rime_addr(void)
+{
+  linkaddr_t addr;
+
+  memset(&addr, 0, sizeof(linkaddr_t));
+  memcpy(addr.u8, node_mac, sizeof(addr.u8));
+
+  linkaddr_set_node_addr(&addr);
+}
+/*---------------------------------------------------------------------------*/
+/** @} */

--- a/platform/stm32nucleo-st7580/dev/button-sensor.c
+++ b/platform/stm32nucleo-st7580/dev/button-sensor.c
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2017, STMicroelectronics.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ *
+ */
+/*---------------------------------------------------------------------------*/
+
+/**
+ * \addtogroup stm32nucleo-st7580-peripherals
+ * @{
+ *
+ * \file
+ * Driver for the stm32nucleo-st7580 User Button
+ */
+
+/*---------------------------------------------------------------------------*/
+#include "dev/button-sensor.h"
+#include "lib/sensors.h"
+#include "st-lib.h"
+/*---------------------------------------------------------------------------*/
+static int _active = 0;
+/*---------------------------------------------------------------------------*/
+static void
+init(void)
+{
+  st_lib_bsp_pb_init(BUTTON_USER, BUTTON_MODE_EXTI);
+}
+/*---------------------------------------------------------------------------*/
+static void
+activate(void)
+{
+  _active = 1;
+}
+/*---------------------------------------------------------------------------*/
+static void
+deactivate(void)
+{
+  _active = 0;
+}
+/*---------------------------------------------------------------------------*/
+static int
+active(void)
+{
+  return _active;
+}
+/*---------------------------------------------------------------------------*/
+static int
+value(int type)
+{
+  return st_lib_bsp_pb_get_state(BUTTON_USER);
+}
+/*---------------------------------------------------------------------------*/
+static int
+configure(int type, int value)
+{
+  switch(type) {
+  case SENSORS_HW_INIT:
+    init();
+    return 1;
+  case SENSORS_ACTIVE:
+    if(value) {
+      activate();
+    } else {
+      deactivate();
+    }
+    return 1;
+  }
+
+  return 0;
+}
+/*---------------------------------------------------------------------------*/
+static int
+status(int type)
+{
+  switch(type) {
+  case SENSORS_READY:
+    return active();
+  }
+
+  return 0;
+}
+/*---------------------------------------------------------------------------*/
+SENSORS_SENSOR(button_sensor, BUTTON_SENSOR, value, configure, status);
+/*---------------------------------------------------------------------------*/
+/** @} */

--- a/platform/stm32nucleo-st7580/dev/leds-arch.c
+++ b/platform/stm32nucleo-st7580/dev/leds-arch.c
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2017, STMicroelectronics.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ *
+ */
+/*---------------------------------------------------------------------------*/
+/**
+ * \addtogroup stm32nucleo-st7580-peripherals
+ * @{
+ *
+ * \file
+ * Driver for the stm32nucleo-st7580 LEDs
+ */
+/*---------------------------------------------------------------------------*/
+#include "contiki-conf.h"
+#include "dev/leds.h"
+#include "st-lib.h"
+/*---------------------------------------------------------------------------*/
+
+extern st_lib_gpio_typedef *st_lib_gpio_port[];
+extern const uint16_t st_lib_gpio_pin[];
+/*---------------------------------------------------------------------------*/
+void
+leds_arch_init(void)
+{
+  st_lib_bsp_led_init(LED1);
+  st_lib_bsp_led_off(LED1);
+  st_lib_bsp_led_init(LED2);
+  st_lib_bsp_led_off(LED2);
+}
+/*---------------------------------------------------------------------------*/
+unsigned char
+leds_arch_get(void)
+{
+  unsigned char ret = 0;
+  if(st_lib_hal_gpio_read_pin(st_lib_gpio_port[LED2], st_lib_gpio_pin[LED2])) {
+    ret |= LEDS_GREEN;
+  }
+
+  return ret;
+}
+/*---------------------------------------------------------------------------*/
+void
+leds_arch_set(unsigned char leds)
+{
+  if(leds & LEDS_GREEN) {
+    st_lib_bsp_led_on(LED1);
+  } else {
+    st_lib_bsp_led_off(LED1);
+  }
+
+  if(leds & LEDS_RED) {
+    st_lib_bsp_led_on(LED2);
+  } else {
+    st_lib_bsp_led_off(LED2);
+  }
+}
+/*---------------------------------------------------------------------------*/
+/** @} */

--- a/platform/stm32nucleo-st7580/dev/uart1.h
+++ b/platform/stm32nucleo-st7580/dev/uart1.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2017, STMicroelectronics.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ *
+ */
+/*---------------------------------------------------------------------------*/
+/**
+ * \addtogroup stm32nucleo-st7580-peripherals
+ * @{
+ *
+ *
+ * \file
+ * Header file for UART related definitions.
+ */
+/*---------------------------------------------------------------------------*/
+#ifndef UART1_H_
+#define UART1_H_
+/*---------------------------------------------------------------------------*/
+#define BAUD2UBR(baud) baud
+/*---------------------------------------------------------------------------*/
+#endif /* UART1_H_ */
+/*---------------------------------------------------------------------------*/
+/** @} */

--- a/platform/stm32nucleo-st7580/hw-config.h
+++ b/platform/stm32nucleo-st7580/hw-config.h
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2017, STMicroelectronics.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ *
+ */
+/*---------------------------------------------------------------------------*/
+#ifndef __HW_CONFIG_H
+#define __HW_CONFIG_H
+/*---------------------------------------------------------------------------*/
+#include "stm32l-st7580-config.h"
+/*---------------------------------------------------------------------------*/
+#define UART_RxBufferSize    512
+/*---------------------------------------------------------------------------*/
+/* User can use this section to tailor USARTx/UARTx instance used and associated
+   resources */
+/* Definition for USARTx clock resources */
+#define USARTx                           USART2
+#define USARTx_CLK_ENABLE()              __USART2_CLK_ENABLE()
+#define DMAx_CLK_ENABLE()                __DMA1_CLK_ENABLE()
+#define USARTx_RX_GPIO_CLK_ENABLE()      __GPIOA_CLK_ENABLE()
+#define USARTx_TX_GPIO_CLK_ENABLE()      __GPIOA_CLK_ENABLE()
+
+#define USARTx_FORCE_RESET()             __USART2_FORCE_RESET()
+#define USARTx_RELEASE_RESET()           __USART2_RELEASE_RESET()
+
+/* Definition for USARTx Pins */
+#define USARTx_TX_PIN                    GPIO_PIN_2
+#define USARTx_TX_GPIO_PORT              GPIOA
+
+#define USARTx_RX_PIN                    GPIO_PIN_3
+#define USARTx_RX_GPIO_PORT              GPIOA
+
+/* Definition for USARTx's NVIC */
+#define USARTx_IRQn                      USART2_IRQn
+#define USARTx_IRQHandler                USART2_IRQHandler
+
+#define USARTx_TX_AF                     GPIO_AF7_USART2
+#define USARTx_RX_AF                     GPIO_AF7_USART2
+
+/* USART1 */
+
+#define UARTplm_RxBufferSize 512
+
+#define PLM_USART                           USART1
+#define PLM_USART_BAUDRATE                  57600
+#define PLM_USART_CLK_ENABLE()              __USART1_CLK_ENABLE()
+#define PLM_USART_RX_GPIO_CLK_ENABLE()      __GPIOA_CLK_ENABLE()
+#define PLM_USART_TX_GPIO_CLK_ENABLE()      __GPIOA_CLK_ENABLE()
+
+#define PLM_USART_FORCE_RESET()             __USART1_FORCE_RESET()
+#define PLM_USART_RELEASE_RESET()           __USART1_RELEASE_RESET()
+
+/* Definition for USARTx Pins */
+#define PLM_USART_TX_PIN                    GPIO_PIN_9
+#define PLM_USART_TX_GPIO_PORT              GPIOA
+
+#define PLM_USART_RX_PIN                    GPIO_PIN_10
+#define PLM_USART_RX_GPIO_PORT              GPIOA
+
+/* Definition for USARTx's NVIC */
+#define PLM_USART_IRQn                      USART1_IRQn
+#define PLM_USART_IRQHandler                USART1_IRQHandler
+
+#define PLM_USART_TX_AF                     GPIO_AF7_USART1
+#define PLM_USART_RX_AF                     GPIO_AF7_USART1
+
+/*---------------------------------------------------------------------------*/
+#endif /*__HW_CONFIG_H*/
+/*---------------------------------------------------------------------------*/

--- a/platform/stm32nucleo-st7580/node-id.c
+++ b/platform/stm32nucleo-st7580/node-id.c
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2017, STMicroelectronics.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ *
+ */
+/*---------------------------------------------------------------------------*/
+#include "node-id.h"
+#include "contiki-conf.h"
+#include <string.h>
+/*---------------------------------------------------------------------------*/
+unsigned short node_id = 0;
+unsigned char node_mac[8];
+volatile uint32_t device_id[3];
+/*---------------------------------------------------------------------------*/
+#define DEVICE_ID_REG0  (*((volatile uint32_t *)0x1FF80050))
+#define DEVICE_ID_REG1  (*((volatile uint32_t *)0x1FF80054))
+#define DEVICE_ID_REG2  (*((volatile uint32_t *)0x1FF80064))
+/*---------------------------------------------------------------------------*/
+void
+node_id_restore(void)
+{
+  device_id[0] = DEVICE_ID_REG0;
+  device_id[1] = DEVICE_ID_REG1;
+  device_id[2] = DEVICE_ID_REG2;
+
+  (*(uint32_t *)node_mac) = DEVICE_ID_REG1;
+  (*(((uint32_t *)node_mac) + 1)) = DEVICE_ID_REG2 + DEVICE_ID_REG0;
+  node_id = (unsigned short)DEVICE_ID_REG2;
+}
+/*---------------------------------------------------------------------------*/

--- a/platform/stm32nucleo-st7580/platform-conf.h
+++ b/platform/stm32nucleo-st7580/platform-conf.h
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2017, STMicroelectronics.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ *
+ */
+/*---------------------------------------------------------------------------*/
+/**
+ * \addtogroup stm32nucleo-st7580
+ * @{
+ *
+ * \defgroup stm32nucleo-st7580-peripherals User Button on STM32 Nucleo
+ *
+ * Defines some of the platforms capabilities
+ * @{
+ *
+ * \file
+ * Header file for the stm32nucleo-st7580 platform configuration
+ */
+/*---------------------------------------------------------------------------*/
+#ifndef __PLATFORM_CONF_H__
+#define __PLATFORM_CONF_H__
+/*---------------------------------------------------------------------------*/
+#include <inttypes.h>
+#include <string.h>
+/*---------------------------------------------------------------------------*/
+#define PLATFORM_HAS_LEDS 1
+#define PLATFORM_HAS_BUTTON 1
+#define PLATFORM_HAS_RADIO 1
+
+#define LEDS_GREEN  1 /*Nucleo LED*/
+#define LEDS_RED    2
+
+/*---------------------------------------------------------------------------*/
+#define F_CPU                   32000000ul
+#define RTIMER_ARCH_SECOND              32768
+#define PRESCALER       ((F_CPU / (RTIMER_ARCH_SECOND * 2)))
+
+#define UART1_CONF_TX_WITH_INTERRUPT        0
+#define WITH_SERIAL_LINE_INPUT              1
+#define TELNETD_CONF_NUMLINES               6
+#define NETSTACK_CONF_RADIO                 st7580_radio_driver
+#define NETSTACK_RADIO_MAX_PAYLOAD_LEN      255
+
+/*---------------------------------------------------------------------------*/
+/* define ticks/second for slow and fast clocks. Notice that these should be a
+   power of two, eg 64,128,256,512 etc, for efficiency as POT's can be optimized
+   well. */
+#define CLOCK_CONF_SECOND             1000
+/*---------------------------------------------------------------------------*/
+typedef unsigned long clock_time_t;
+/*---------------------------------------------------------------------------*/
+#define CC_CONF_REGISTER_ARGS          0
+#define CC_CONF_FUNCTION_POINTER_ARGS  1
+#define CC_CONF_FASTCALL
+#define CC_CONF_VA_ARGS                1
+#define CC_CONF_INLINE                 inline
+
+#define CCIF
+#define CLIF
+/*---------------------------------------------------------------------------*/
+typedef uint8_t u8_t;
+typedef uint16_t u16_t;
+typedef uint32_t u32_t;
+typedef  int32_t s32_t;
+typedef unsigned short uip_stats_t;
+/*---------------------------------------------------------------------------*/
+#define PACKETBUF_CONF_SIZE 255
+#endif /* __PLATFORM_CONF_H__ */
+/*---------------------------------------------------------------------------*/
+/**
+ * @}
+ * @}
+ */

--- a/platform/stm32nucleo-st7580/st-lib.h
+++ b/platform/stm32nucleo-st7580/st-lib.h
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) 2017, STMicroelectronics.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ *
+ */
+/*---------------------------------------------------------------------------*/
+/**
+ * \defgroup stm32nucleo-st7580 STM32Cube HAL APIs
+ *
+ * Abstraction of STM32Cube HAL APIs as per Contiki coding rules
+ * @{
+ *
+ * \file
+ * Header file for the STM32Cube HAL APIs
+ */
+/*---------------------------------------------------------------------------*/
+#ifndef ST_LIB_H_
+#define ST_LIB_H_
+
+/*---------------------------------------------------------------------------*/
+/* extern global varialbles */
+#define st_lib_uart_handle                       UartHandle
+
+/*---------------------------------------------------------------------------*/
+/* misc */
+#define st_lib_tim2_irq_handler(...)                      TIM2_IRQHandler(__VA_ARGS__)
+#define st_lib_sys_tick_handler(...)                      SysTick_Handler(__VA_ARGS__)
+/*---------------------------------------------------------------------------*/
+
+/*---------------------------------------------------------------------------*/
+/* radio_gpio.h */
+#include "plm_gpio.h"
+
+#define st_lib_plm_gpio_interrupt_cmd(...)     PlmGpioInterruptCmd(__VA_ARGS__)
+#define st_lib_plm_gpio_init(...)              PlmGpioInit(__VA_ARGS__)
+/*---------------------------------------------------------------------------*/
+
+/*---------------------------------------------------------------------------*/
+
+/*---------------------------------------------------------------------------*/
+/* stm32l152xe.h */
+#include "stm32l152xe.h"
+
+#define st_lib_irq_n_type                        IRQn_Type
+/*---------------------------------------------------------------------------*/
+
+/*---------------------------------------------------------------------------*/
+/* stm32l1xx.h */
+#include "stm32l1xx.h"
+
+#define st_lib_flag_status                       FlagStatus
+/*---------------------------------------------------------------------------*/
+
+/*---------------------------------------------------------------------------*/
+/* stm32l1xx_hal_cortex.h */
+#include "stm32l1xx_hal_cortex.h"
+
+#define st_lib_hal_nvic_enable_irq(...)           HAL_NVIC_EnableIRQ(__VA_ARGS__)
+#define st_lib_hal_nvic_set_priority(...)         HAL_NVIC_SetPriority(__VA_ARGS__)
+#define st_lib_hal_systick_clk_source_config(...) HAL_SYSTICK_CLKSourceConfig(__VA_ARGS__)
+#define st_lib_hal_systick_config(...)            HAL_SYSTICK_Config(__VA_ARGS__)
+/*---------------------------------------------------------------------------*/
+
+/*---------------------------------------------------------------------------*/
+/* stm32l1xx_hal_rcc.h */
+#include "stm32l1xx_hal_rcc.h"
+
+#define st_lib_tim2_clk_enable(...)              __TIM2_CLK_ENABLE(__VA_ARGS__)
+/*---------------------------------------------------------------------------*/
+
+/*---------------------------------------------------------------------------*/
+/* stm32l1xx_hal_spi.h */
+#include "stm32l1xx_hal_spi.h"
+
+/*---------------------------------------------------------------------------*/
+
+/*---------------------------------------------------------------------------*/
+/* stm32l1xx_hal_tim.h */
+#include "stm32l1xx_hal_tim.h"
+
+#define st_lib_tim_handle_typedef                TIM_HandleTypeDef
+#define st_lib_tim_clock_config_typedef          TIM_ClockConfigTypeDef
+#define st_lib_tim_oc_init_typedef               TIM_OC_InitTypeDef
+
+#define st_lib_hal_tim_base_init(...)            HAL_TIM_Base_Init(__VA_ARGS__)
+#define st_lib_hal_tim_base_start_it(...)        HAL_TIM_Base_Start_IT(__VA_ARGS__)
+#define st_lib_hal_tim_config_clock_source(...)  HAL_TIM_ConfigClockSource(__VA_ARGS__)
+#define st_lib_hal_tim_clear_flag(...)           __HAL_TIM_CLEAR_FLAG(__VA_ARGS__)
+#define st_lib_hal_tim_clear_it(...)             __HAL_TIM_CLEAR_IT(__VA_ARGS__)
+#define st_lib_hal_tim_enable(...)               __HAL_TIM_ENABLE(__VA_ARGS__)
+#define st_lib_hal_tim_enable_it(...)            __HAL_TIM_ENABLE_IT(__VA_ARGS__)
+#define st_lib_hal_tim_oc_init(...)              HAL_TIM_OC_Init(__VA_ARGS__)
+#define st_lib_hal_tim_oc_config_channel(...)    HAL_TIM_OC_ConfigChannel(__VA_ARGS__)
+/*---------------------------------------------------------------------------*/
+
+/*---------------------------------------------------------------------------*/
+/* stm32l1xx_hal_uart.h */
+#include "stm32l1xx_hal_uart.h"
+
+#define st_lib_uart_handle_typedef               UART_HandleTypeDef
+
+#define st_lib_hal_uart_enable_it(...)           __HAL_UART_ENABLE_IT(__VA_ARGS__)
+#define st_lib_hal_uart_init(...)                HAL_UART_Init(__VA_ARGS__)
+#define st_lib_hal_uart_receive(...)             HAL_UART_Receive(__VA_ARGS__)
+#define st_lib_hal_uart_receive_it(...)          HAL_UART_Receive_IT(__VA_ARGS__)
+#define st_lib_hal_uart_rx_cplt_callback(...)    HAL_UART_RxCpltCallback(__VA_ARGS__)
+#define st_lib_hal_uart_transmit(...)            HAL_UART_Transmit(__VA_ARGS__)
+/*---------------------------------------------------------------------------*/
+
+/*---------------------------------------------------------------------------*/
+/* stm32l1xx_nucleo.h */
+#include "stm32l1xx_nucleo.h"
+
+#define st_lib_gpio_typedef                      GPIO_TypeDef
+#define st_lib_gpio_port                         GPIO_PORT
+#define st_lib_gpio_pin                          GPIO_PIN
+
+#define st_lib_bsp_led_init(...)                 BSP_LED_Init(__VA_ARGS__)
+#define st_lib_bsp_led_off(...)                  BSP_LED_Off(__VA_ARGS__)
+#define st_lib_bsp_led_on(...)                   BSP_LED_On(__VA_ARGS__)
+#define st_lib_bsp_pb_init(...)                  BSP_PB_Init(__VA_ARGS__)
+#define st_lib_bsp_pb_get_state(...)             BSP_PB_GetState(__VA_ARGS__)
+#define st_lib_hal_gpio_read_pin(...)            HAL_GPIO_ReadPin(__VA_ARGS__)
+#define st_lib_hal_gpio_write_pin(...)           HAL_GPIO_WritePin(__VA_ARGS__)
+/*---------------------------------------------------------------------------*/
+#endif /*ST_LIB_H_*/
+/*---------------------------------------------------------------------------*/
+/** @} */

--- a/platform/stm32nucleo-st7580/st7580.c
+++ b/platform/stm32nucleo-st7580/st7580.c
@@ -1,0 +1,438 @@
+/*
+ * Copyright (c) 2017, STMicroelectronics.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ *
+ */
+/*---------------------------------------------------------------------------*/
+#include "st7580.h"
+#include "stm32_plm01a1.h"
+#include "plm_gpio.h"
+#include "stm32l1xx.h"
+#include "contiki.h"
+#include "net/mac/frame802154.h"
+#include "net/netstack.h"
+#include "net/packetbuf.h"
+#include "net/rime/rimestats.h"
+#include <stdio.h>
+/*---------------------------------------------------------------------------*/
+#define DEBUG 0
+#if DEBUG
+#include <stdio.h>
+#define PRINTF(...) printf(__VA_ARGS__)
+#else
+#define PRINTF(...)
+#endif
+
+/*---------------------------------------------------------------------------*/
+#define BUSYWAIT_UNTIL(cond, max_time) \
+  do { \
+    rtimer_clock_t t0; \
+    t0 = RTIMER_NOW(); \
+    while(!(cond) && RTIMER_CLOCK_LT(RTIMER_NOW(), t0 + (max_time))) ; \
+  } while(0)
+
+/*---------------------------------------------------------------------------*/
+static volatile uint8_t receiving_packet = 0;
+
+/* RX and TX buffers. Since MAX_PACKET_LEN may be larger than the ST7580 frame lenght,
+ * we need to buffer outgoing packets. */
+#define MAX_PACKET_LEN PACKETBUF_SIZE
+#define MAX_PHY_LEN 255
+
+static volatile uint16_t st7580_rxbuf_len = 0;
+static uint8_t st7580_rxbuf[MAX_PACKET_LEN];
+static volatile uint8_t st7580_txbuf_has_data = 0;
+static uint8_t st7580_txbuf[MAX_PACKET_LEN];
+static int count = 0;
+
+#if NULLRDC_CONF_802154_AUTOACK
+#define ACK_LEN 3
+static int wants_an_ack = 0; /* The packet sent expects an ack */
+static int just_got_an_ack = 0; /* Interrupt callback just detected an ack */
+#define ACKPRINTF printf
+/* #define ACKPRINTF(...) */
+#endif /* NULLRDC_CONF_802154_AUTOACK */
+
+/*---------------------------------------------------------------------------*/
+PROCESS(st7580_radio_process, "ST7580 radio driver");
+/*---------------------------------------------------------------------------*/
+static int st7580_radio_init(void);
+static int st7580_radio_prepare(const void *payload, unsigned short payload_len);
+static int st7580_radio_transmit(unsigned short payload_len);
+static int st7580_radio_send(const void *data, unsigned short len);
+static int st7580_radio_read(void *buf, unsigned short bufsize);
+static int st7580_radio_channel_clear(void);
+static int st7580_radio_receiving_packet(void);
+static int st7580_radio_pending_packet(void);
+static int st7580_radio_on(void);
+static int st7580_radio_off(void);
+/*----------------------------------------------------------------------------*/
+const struct radio_driver st7580_radio_driver =
+{
+  st7580_radio_init,
+  st7580_radio_prepare,
+  st7580_radio_transmit,
+  st7580_radio_send,
+  st7580_radio_read,
+  st7580_radio_channel_clear,
+  st7580_radio_receiving_packet,
+  st7580_radio_pending_packet,
+  st7580_radio_on,
+  st7580_radio_off,
+};
+
+/* ---------------------------------------------------------------------------
+ * ST7580 Communication Parameters
+ * ---------------------------------------------------------------------------*/
+
+static packetbuf_attr_t last_rssi = 0;
+
+/*----------------------------------------------------------------------------*/
+static int
+st7580_radio_init(void)
+{
+
+  PRINTF("RADIO INIT IN\n");
+  /* Physical Reset st7580 */
+  PRINTF("Resetting ST7580\n");
+  BSP_PLM_Init();
+
+  /* Modem configuration */
+  PRINTF("Writing MIB Modem configuration\n");
+  BSP_PLM_Mib_Write(MIB_MODEM_CONF, modem_config, sizeof(modem_config));
+  /* Phy Configuration */
+  PRINTF("Writing MIB Phy configuration\n");
+  BSP_PLM_Mib_Write(MIB_PHY_CONF, phy_config, sizeof(phy_config));
+
+  process_start(&st7580_radio_process, NULL);
+  initialized = 1;
+
+  PRINTF("ST7580 init done\n");
+  return 0;
+}
+/*---------------------------------------------------------------------------*/
+static int
+st7580_radio_prepare(const void *payload, unsigned short payload_len)
+{
+  PRINTF("ST7580: prep %u\n", payload_len);
+  PRINTF("count: %d\n", count);
+
+  /* Checks if the payload length is supported */
+  if(payload_len > MAX_PACKET_LEN) {
+    return RADIO_TX_ERR;
+  }
+
+  /* Should we delay for an ack? */
+#if NULLRDC_CONF_802154_AUTOACK
+  frame802154_t info154;
+  wants_an_ack = 0;
+  if(payload_len > ACK_LEN
+     && frame802154_parse((char *)payload, payload_len, &info154) != 0) {
+    if(info154.fcf.frame_type == FRAME802154_DATAFRAME
+       && info154.fcf.ack_required != 0) {
+      wants_an_ack = 1;
+    }
+  }
+#endif /* NULLRDC_CONF_802154_AUTOACK */
+
+  /* Buffer outgoing data */
+  memcpy(st7580_txbuf, payload, payload_len);
+  st7580_txbuf_has_data = 1;
+
+  /* collision test */
+  if(!(st7580_radio_channel_clear())) {
+    PRINTF("COLLISION!\n");
+    return RADIO_TX_COLLISION;
+  }
+  /* end collision test */
+
+  return RADIO_TX_OK;
+}
+/*---------------------------------------------------------------------------*/
+static int
+st7580_radio_transmit(unsigned short payload_len)
+{
+
+  /* This function blocks until the packet has been transmitted */
+#if NULLRDC_CONF_802154_AUTOACK
+  rtimer_clock_t rtimer_txdone, rtimer_rxack;
+#endif
+  int left = payload_len;
+  int written = 0;
+  int ret;
+  static int tot = 0;
+
+  PRINTF("TRANSMIT IN\n");
+
+#if NULLRDC_CONF_802154_AUTOACK
+  just_got_an_ack = 0;
+#endif
+
+  while(left > 0) {
+    tot += left;
+    if(left < MAX_PHY_LEN) {
+      PRINTF("min left %d max_phy_len %d tot %d\n", left, MAX_PHY_LEN, tot);
+      ret = BSP_PLM_Send_Data(DATA_OPT, &st7580_txbuf[written], (uint8_t)left, NULL);
+      if(ret == 0) {
+        written += left;
+        left = 0;
+      } else {
+        st7580_txbuf_has_data = 0;
+        PRINTF("collision code %d!!!\n\r", ret);
+        return RADIO_TX_COLLISION;
+      }
+    } else {
+      PRINTF("mag left %d max_phy_len %d tot %d \n", left, MAX_PHY_LEN, tot);
+      ret = BSP_PLM_Send_Data(DATA_OPT, &st7580_txbuf[written], MAX_PHY_LEN, NULL);
+      if(ret == 0) {
+        written += MAX_PHY_LEN;
+        left -= MAX_PHY_LEN;
+      } else {
+        st7580_txbuf_has_data = 0;
+        PRINTF("collision code %d!!!\n", ret);
+        return RADIO_TX_COLLISION;
+      }
+    }
+  }
+  st7580_txbuf_has_data = 0; /* clear TX buf */
+
+  /* Reset radio - needed for immediate RX of ack */
+
+#if NULLRDC_CONF_802154_AUTOACK
+  if(wants_an_ack) {
+    rtimer_txdone = RTIMER_NOW();
+#define ACK_DELAY (4 * RTIMER_SECOND / 1000)
+    BUSYWAIT_UNTIL(just_got_an_ack, ACK_DELAY);
+    rtimer_rxack = RTIMER_NOW();
+
+    if(just_got_an_ack) {
+      ACKPRINTF("debug_ack: ack received after %u/%u ticks\n",
+                (uint32_t)(rtimer_rxack - rtimer_txdone), ACK_DELAY);
+    } else {
+      ACKPRINTF("debug_ack: no ack received\n");
+    }
+  }
+#endif /* NULLRDC_CONF_802154_AUTOACK */
+
+  return RADIO_TX_OK;
+}
+/*---------------------------------------------------------------------------*/
+static int
+st7580_radio_send(const void *payload, unsigned short payload_len)
+{
+  int ret;
+
+  /* collision test */
+  if(!(st7580_radio_channel_clear())) {
+    PRINTF("channel not clear!\n");
+    return RADIO_TX_COLLISION;
+  }
+  /* end collision test */
+
+  ret = st7580_radio_prepare(payload, payload_len);
+  if((ret == RADIO_TX_ERR) | (ret == RADIO_TX_COLLISION)) {
+    return ret;
+  }
+
+  return st7580_radio_transmit(payload_len);
+}
+/*---------------------------------------------------------------------------*/
+static int
+st7580_radio_read(void *buf, unsigned short bufsize)
+{
+  int len;
+
+  /* Checks if the RX buffer is empty */
+  if(st7580_rxbuf_len == 0) {
+    PRINTF("READ OUT RX BUF EMPTY\n");
+    return 0;
+  }
+
+  if(bufsize < st7580_rxbuf_len) {
+    st7580_rxbuf_len = 0; /* clear RX buf */
+    return 0;
+  } else {
+    len = st7580_rxbuf_len;
+    memcpy(buf, st7580_rxbuf, st7580_rxbuf_len);
+
+    packetbuf_set_attr(PACKETBUF_ATTR_RSSI, last_rssi);
+    PRINTF("st7580_radio_read SNR %d\n", last_rssi);
+
+    st7580_rxbuf_len = 0; /* clear RX buf */
+  }
+  return len;
+}
+/*---------------------------------------------------------------------------*/
+static int
+st7580_radio_channel_clear(void)
+{
+  return !(PlmGpioGetLevel(PLM_PL_RX_ON));
+}
+/*---------------------------------------------------------------------------*/
+static int
+st7580_radio_receiving_packet(void)
+{
+  return receiving_packet;
+}
+/*---------------------------------------------------------------------------*/
+static int
+st7580_radio_pending_packet(void)
+{
+  return st7580_rxbuf_len != 0;
+}
+/*---------------------------------------------------------------------------*/
+static int
+st7580_radio_off(void)
+{
+  return 0;
+}
+/*---------------------------------------------------------------------------*/
+static int
+st7580_radio_on(void)
+{
+  return 0;
+}
+/*---------------------------------------------------------------------------*/
+void
+wrapped_callback(ST7580Frame *frame)
+{
+  static uint16_t lastCheckSum = 0, dup = 0;
+
+  PRINTF("Inside wrapped callback\n");
+  if(frame == NULL) {
+    PRINTF("wrapped callback frame null\n");
+    return;
+  }
+  if(!((frame->command == CMD_PHY_DATA_IND) || (frame->command == CMD_DL_DATA_IND))) {
+    PRINTF("wrong command %u\n", frame->command);
+    return;
+  }
+
+  PRINTF("checksum:%d LASTchecksum %d DUP %d\n", frame->checksum, lastCheckSum, dup);
+
+  /* Check to avoid duplicated packets */
+  if((frame->stx == ST7580_STX_03) && (lastCheckSum == frame->checksum)) {
+    PRINTF("DUPLICATED Deteched!!!\n");
+    dup++;
+    return;
+  } else {
+    lastCheckSum = frame->checksum;
+  }
+
+  PRINTF("mod: %d\n", frame->data[0]);
+
+  if(st7580_rxbuf_len > 0) {
+    /* We have an unprocessed received packet and have to drop the new packet */
+    /* Note that this is normal behavior for long packets: we expect to get a
+     * RX_DATA_READY interrupt after the RX_FIFO_ALMOST_FULL. */
+    process_poll(&st7580_radio_process);
+    return;
+  }
+
+  receiving_packet = 1;
+
+  memcpy(st7580_rxbuf, &(frame->data[4]), (frame->length - 4));
+  st7580_rxbuf_len = frame->length - 4;
+
+  last_rssi = (packetbuf_attr_t)frame->data[1];
+  PRINTF("Wrapped callback RSSI %d\n", frame->data[1]);
+
+  if(st7580_rxbuf_len == 0) {
+    /* We didn't read the last byte, but aborted prematurely. Discard packet. */
+  }
+
+#if NULLRDC_CONF_802154_AUTOACK
+  if(st7580_rxbuf_len == ACK_LEN) {
+    /* For debugging purposes we assume this is an ack for us */
+    just_got_an_ack = 1;
+  }
+#endif /* NULLRDC_CONF_802154_AUTOACK */
+
+  /* INTPRINTF("RX OK %u %u\n", st7580_rxbuf_len, read); */
+  process_poll(&st7580_radio_process);
+  receiving_packet = 0;
+
+  return;
+}
+/*---------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------*/
+PROCESS_THREAD(st7580_radio_process, ev, data)
+{
+  PROCESS_BEGIN();
+  PRINTF("ST7580: process started\n");
+
+  while(1) {
+    int len;
+
+    PROCESS_YIELD_UNTIL(ev == PROCESS_EVENT_POLL);
+    PRINTF("ST7580: polled\n");
+
+    packetbuf_clear();
+
+    PRINTF("ST7580: calling st7580_radio_read\n");
+    len = st7580_radio_read(packetbuf_dataptr(), PACKETBUF_SIZE);
+
+    if(len > 0) {
+#if NULLRDC_CONF_802154_AUTOACK
+      /* Check if the packet has an ACK request */
+      frame802154_t info154;
+      if(len > ACK_LEN &&
+         frame802154_parse((char *)packetbuf_dataptr(), len, &info154) != 0) {
+        if(info154.fcf.frame_type == FRAME802154_DATAFRAME &&
+           info154.fcf.ack_required != 0 &&
+           rimeaddr_cmp((rimeaddr_t *)&info154.dest_addr,
+                        &rimeaddr_node_addr)) {
+
+          /* Send an ACK packet */
+          uint8_t ack_frame[ACK_LEN] = {
+            FRAME802154_ACKFRAME,
+            0x00,
+            info154.seq
+          };
+          BSP_PLM_Send_Data(DATA_OPT, (uint8_t *)ack_frame, (uint8_t)ACK_LEN, NULL);
+          ACKPRINTF("debug_ack: sent ack %d\n", ack_frame[2]);
+        }
+      }
+#endif /* NULLRDC_CONF_802154_AUTOACK */
+
+      packetbuf_set_datalen(len);
+      NETSTACK_RDC.input();
+    }
+    if(st7580_rxbuf_len != 0) {
+      process_poll(&st7580_radio_process);
+    }
+  }
+
+  PROCESS_END();
+}
+
+void
+st7580_interrupt_callback()
+{
+  count++;
+}

--- a/platform/stm32nucleo-st7580/st7580.h
+++ b/platform/stm32nucleo-st7580/st7580.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2017, STMicroelectronics.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * This file is part of the Contiki operating system.
+ *
+ */
+/*---------------------------------------------------------------------------*/
+#ifndef __ST7580_H__
+#define __ST7580_H__
+/*---------------------------------------------------------------------------*/
+#include "radio.h"
+#include <stdint.h>
+
+extern const struct radio_driver st7580_radio_driver;
+
+extern uint8_t initialized;
+
+void wrapped_callback();
+/*---------------------------------------------------------------------------*/
+#endif /* __ST7580_H__ */
+/*---------------------------------------------------------------------------*/

--- a/platform/stm32nucleo-st7580/stm32l-st7580-config.h
+++ b/platform/stm32nucleo-st7580/stm32l-st7580-config.h
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2017, STMicroelectronics.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ *
+ */
+/*----------------------------------------------------------------------------*/
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32L_ST7580_CONFIG_H
+#define __STM32L_ST7580_CONFIG_H
+
+/* Includes ------------------------------------------------------------------*/
+
+/* Exported types ------------------------------------------------------------*/
+/* Exported constants --------------------------------------------------------*/
+
+/* Define the STM32F10x hardware depending on the used evaluation board */
+#if defined(USE_STM32L152_EVAL) || defined(USE_STM32L152D_EVAL)
+/*
+   For STM32L15xx devices it is possible to use the internal USB pullup
+   controlled by register SYSCFG_PMC (refer to RM0038 reference manual for
+   more details).
+   It is also possible to use external pullup (and disable the internal pullup)
+   by setting the define USB_USE_EXTERNAL_PULLUP in file platform_config.h
+   and configuring the right pin to be used for the external pull up configuration.
+   To have more details on how to use an external pull up, please refer to
+   STM3210E-EVAL evaluation board manuals.
+ */
+/* Uncomment the following define to use an external pull up instead of the
+   integrated STM32L15xx internal pull up. In this case make sure to set up
+   correctly the external required hardware and the GPIO defines below.*/
+/* #define USB_USE_EXTERNAL_PULLUP */
+
+#if !defined(USB_USE_EXTERNAL_PULLUP)
+#define STM32L15_USB_CONNECT                SYSCFG_USBPuCmd(ENABLE)
+#define STM32L15_USB_DISCONNECT             SYSCFG_USBPuCmd(DISABLE)
+
+#elif defined(USB_USE_EXTERNAL_PULLUP)
+/* PA0 is chosen just as illustrating example, you should modify the defines
+   below according to your hardware configuration. */
+#define USB_DISCONNECT                      GPIOA
+#define USB_DISCONNECT_PIN                  GPIO_PIN_0
+#define RCC_AHBPeriph_GPIO_DISCONNECT       RCC_AHBPeriph_GPIOA
+#define STM32L15_USB_CONNECT                GPIO_ResetBits(USB_DISCONNECT, USB_DISCONNECT_PIN)
+#define STM32L15_USB_DISCONNECT             GPIO_SetBits(USB_DISCONNECT, USB_DISCONNECT_PIN)
+#endif /* USB_USE_EXTERNAL_PULLUP */
+
+#ifdef USE_STM32L152_EVAL
+#define EVAL_COM1_IRQHandler              USART2_IRQHandler
+#elif defined(USE_STM32L152D_EVAL)
+#define EVAL_COM1_IRQHandler              USART1_IRQHandler
+#endif /*USE_STM32L152_EVAL*/
+
+#endif /* USE_STM32L152_EVAL || USE_STM32L152D_EVAL */
+
+/* Exported macro ------------------------------------------------------------*/
+/* Exported functions ------------------------------------------------------- */
+
+#endif /* __STM32L_ST7580_CONFIG_H */
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/platform/stm32nucleo-st7580/uart-msg.c
+++ b/platform/stm32nucleo-st7580/uart-msg.c
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2017, STMicroelectronics.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ *
+ */
+/*---------------------------------------------------------------------------*/
+#include "contiki.h"
+#include "dev/leds.h"
+#include "stm32l1xx_nucleo.h"
+#include "platform-conf.h"
+#include <stdio.h>
+#include "dev/slip.h"
+#include "hw-config.h"
+#include "stm32l1xx_hal.h"
+#include "st-lib.h"
+/*---------------------------------------------------------------------------*/
+void uart_send_msg(char *);
+extern st_lib_uart_handle_typedef st_lib_uart_handle;
+/*---------------------------------------------------------------------------*/
+static unsigned char databyte[1] = { 0 };
+/*---------------------------------------------------------------------------*/
+/**
+ * @brief  Rx Transfer completed callbacks.
+ * @param  huart: Pointer to a st_lib_uart_handle_typedef structure that contains
+ *                the configuration information for the specified UART module.
+ * @retval None
+ */
+void
+st_lib_hal_uart_rx_cplt_callback(st_lib_uart_handle_typedef *huart)
+{
+  slip_input_byte(databyte[0]);
+  st_lib_hal_uart_receive_it(&st_lib_uart_handle, databyte, 1);
+}
+/*---------------------------------------------------------------------------*/
+void
+uart1_set_input(int (*input)(unsigned char c))
+{
+  st_lib_hal_uart_receive_it(&st_lib_uart_handle, databyte, 1);
+}
+/*--------------------------------------------------------------------------*/
+void
+slip_arch_init(unsigned long ubr)
+{
+  st_lib_hal_uart_enable_it(&st_lib_uart_handle, UART_IT_RXNE);
+  /* uart1_set_input(slip_input_byte); */
+}
+/*--------------------------------------------------------------------------*/
+void
+slip_arch_writeb(unsigned char c)
+{
+  uart_send_msg((char *)&c);
+}
+/*--------------------------------------------------------------------------*/
+
+/**
+ * @brief  Send a message via UART
+ * @param  msg the pointer to the message to be sent
+ * @retval None
+ */
+void
+uart_send_msg(char *msg)
+{
+  st_lib_hal_uart_transmit(&st_lib_uart_handle, (uint8_t *)msg, 1, 5000);
+}
+/*--------------------------------------------------------------------------*/

--- a/regression-tests/18-compile-arm-ports/Makefile
+++ b/regression-tests/18-compile-arm-ports/Makefile
@@ -47,6 +47,9 @@ stm32nucleo-spirit1/sensor-demo/stm32nucleo-spirit1 \
 ipv6/multicast/stm32nucleo-spirit1 \
 udp-ipv6/stm32nucleo-spirit1 \
 hello-world/stm32nucleo-spirit1 \
+ipv6/rpl-border-router/stm32nucleo-st7580 \
+ipv6/rpl-udp/stm32nucleo-st7580 \
+hello-world/stm32nucleo-st7580 \
 sensniff/cc2538dk \
 sensniff/openmote-cc2538 \
 sensniff/zoul \


### PR DESCRIPTION
The port supports the following boards from ST:

    - NUCLEO-L152RE board, based on the STM32L152RET6 ultra-low power microcontroller
    - X-NUCLEO-PLM01A1 based on the ST7580 FSK, PSK multi-mode power line networking
    system-on-chip expansion board

The port follows the same idea/structure of our already integrated stm32nucleo-spirit1 platform and we have kept in mind issues already discussed in the past for it (e.g. use a git submodule for CMSIS and for our existing headers/sources files that are kept unchanged, put long term maintainers' names in the readme file...) 

ST CLAB team