### PR TITLE
fix TSCH - stop slots  operations on disassociate and some rtimer issue

### DIFF
--- a/core/net/mac/tsch/tsch-slot-operation.c
+++ b/core/net/mac/tsch/tsch-slot-operation.c
@@ -301,6 +301,11 @@ tsch_schedule_slot_operation(struct rtimer *tm, rtimer_clock_t ref_time, rtimer_
     return 0;
   }
   ref_time += offset;
+  // FIX: this is when rtimer_set cant overide current timer. When, for some
+  //    cause, last timer was expired - in this case expired timer will counts for
+  //    rtimer clock override. thus, during override wait it will block new rtimer
+  //    operation start.
+  rtimer_cancel(tm);
   r = rtimer_set(tm, ref_time, 1, (void (*)(struct rtimer *, void *))tsch_slot_operation, NULL);
   if(r != RTIMER_OK) {
     return 0;
@@ -1053,10 +1058,10 @@ PT_THREAD(tsch_slot_operation(struct rtimer *t, void *ptr))
 /*---------------------------------------------------------------------------*/
 /* Set global time before starting slot operation,
  * with a rtimer time and an ASN */
+static struct rtimer tsch_slot_operation_timer;
 void
 tsch_slot_operation_start(void)
 {
-  static struct rtimer slot_operation_timer;
   rtimer_clock_t time_to_next_active_slot;
   rtimer_clock_t prev_slot_start;
   TSCH_DEBUG_INIT();
@@ -1076,8 +1081,13 @@ tsch_slot_operation_start(void)
     /* Update current slot start */
     prev_slot_start = current_slot_start;
     current_slot_start += time_to_next_active_slot;
-  } while(!tsch_schedule_slot_operation(&slot_operation_timer, prev_slot_start, time_to_next_active_slot, "association"));
+  } while(!tsch_schedule_slot_operation(&tsch_slot_operation_timer, prev_slot_start, time_to_next_active_slot, "association"));
 }
+/*---------------------------------------------------------------------------*/
+void tsch_slot_operation_stop(void){
+    rtimer_cancel(&tsch_slot_operation_timer);
+}
+
 /*---------------------------------------------------------------------------*/
 /* Start actual slot operation */
 void

--- a/core/net/mac/tsch/tsch-slot-operation.h
+++ b/core/net/mac/tsch/tsch-slot-operation.h
@@ -120,5 +120,6 @@ void tsch_slot_operation_sync(rtimer_clock_t next_slot_start,
     struct tsch_asn_t *next_slot_asn);
 /* Start actual slot operation */
 void tsch_slot_operation_start(void);
+void tsch_slot_operation_stop(void);
 
 #endif /* __TSCH_SLOT_OPERATION_H__ */

--- a/core/net/mac/tsch/tsch.c
+++ b/core/net/mac/tsch/tsch.c
@@ -192,6 +192,7 @@ static void
 tsch_reset(void)
 {
   int i;
+  tsch_slot_operation_stop();
   frame802154_set_pan_id(0xffff);
   /* First make sure pending packet callbacks are sent etc */
   process_post_synch(&tsch_pending_events_process, PROCESS_EVENT_POLL, NULL);


### PR DESCRIPTION
provide explisit slot operations stop on disassciaton. this helpful when need to sutdown after TSCH off.
also fix slot rtimer override - cancels slots rtimer before start new operation,
                cause some implementation of rtimer can`t override current running
                rtimer, and therefore slot not starts on expired rtimer. this situation
                leads to block whole tsch activity. i`ve got this issue wih PR#1290