### PR TITLE
cc26xx SPI - introduce lpm control

### DIFF
--- a/platform/srf06-cc26xx/common/board-spi.c
+++ b/platform/srf06-cc26xx/common/board-spi.c
@@ -40,8 +40,14 @@
 #include "ti-lib.h"
 #include "board-spi.h"
 #include "board.h"
+#include <lpm.h>
 
 #include <stdbool.h>
+
+#ifndef BOARD_SPI_LPM
+#define BOARD_SPI_LPM BOARD_SPI_LPM_NONE
+#endif
+
 /*---------------------------------------------------------------------------*/
 static bool
 accessible(void)
@@ -59,6 +65,60 @@ accessible(void)
 
   return true;
 }
+
+bool  board_spi_busy(void){
+    return ti_lib_ssi_busy(SSI0_BASE) || ((ti_lib_ssi_status(SSI0_BASE) & SSI_TX_EMPTY) == 0);
+}
+
+static void board_spi_config(uint32_t bit_rate, uint32_t clk_pin);
+static void board_spi_down();
+
+#if BOARD_SPI_LPM == BOARD_SPI_LPM_BASIC
+
+static
+uint8_t lpm_request(void)
+{
+    return LPM_MODE_SLEEP;
+}
+
+LPM_MODULE(board_spi_module, lpm_request, NULL, NULL, LPM_DOMAIN_SERIAL | LPM_DOMAIN_PERIPH);
+
+#elif BOARD_SPI_LPM == BOARD_SPI_LPM_DEEPSLEEP_OFF
+
+static
+uint8_t lpm_request(void)
+{
+
+  if (accessible() != false)
+  if (board_spi_busy())
+      return LPM_MODE_SLEEP;
+
+  return LPM_MODE_MAX_SUPPORTED;
+}
+
+static void lpm_wake(void);
+static void lpm_down(uint8_t mode);
+
+LPM_MODULE(board_spi_module, lpm_request, lpm_down, lpm_wake, LPM_DOMAIN_NONE);
+struct board_spi_lpmsave_t{
+        uint32_t bit_rate;
+        uint32_t clk_pin;
+} board_spi_lpmsave;
+
+static
+void lpm_wake(void){
+    board_spi_config(board_spi_lpmsave.bit_rate, board_spi_lpmsave.clk_pin);
+}
+
+static
+void lpm_down(uint8_t mode){
+    if (mode >= LPM_MODE_DEEP_SLEEP){
+        board_spi_down();
+    }
+}
+
+#endif
+
 /*---------------------------------------------------------------------------*/
 bool
 board_spi_write(const uint8_t *buf, size_t len)
@@ -112,8 +172,9 @@ board_spi_flush()
   while(ti_lib_rom_ssi_data_get_non_blocking(SSI0_BASE, &ul));
 }
 /*---------------------------------------------------------------------------*/
+static
 void
-board_spi_open(uint32_t bit_rate, uint32_t clk_pin)
+board_spi_config(uint32_t bit_rate, uint32_t clk_pin)
 {
   uint32_t buf;
 
@@ -124,8 +185,13 @@ board_spi_open(uint32_t bit_rate, uint32_t clk_pin)
 
   /* Enable clock in active mode */
   ti_lib_rom_prcm_peripheral_run_enable(PRCM_PERIPH_SSI0);
+  ti_lib_rom_prcm_peripheral_sleep_enable(PRCM_PERIPH_SSI0);
   ti_lib_prcm_load_set();
   while(!ti_lib_prcm_load_get());
+
+#if BOARD_SPI_LPM > BOARD_SPI_LPM_NONE
+  board_spi_module.domain_lock = LPM_DOMAIN_SERIAL;
+#endif
 
   /* SPI configuration */
   ti_lib_ssi_int_disable(SSI0_BASE, SSI_RXOR | SSI_RXFF | SSI_RXTO | SSI_TXFF);
@@ -140,11 +206,39 @@ board_spi_open(uint32_t bit_rate, uint32_t clk_pin)
   /* Get rid of residual data from SSI port */
   while(ti_lib_ssi_data_get_non_blocking(SSI0_BASE, &buf));
 }
+
+void
+board_spi_open(uint32_t bit_rate, uint32_t clk_pin){
+#if BOARD_SPI_LPM == BOARD_SPI_LPM_DEEPSLEEP_OFF
+    board_spi_lpmsave.bit_rate = bit_rate;
+    board_spi_lpmsave.clk_pin  = clk_pin;
+#endif
+    board_spi_config(bit_rate, clk_pin);
+#if BOARD_SPI_LPM > BOARD_SPI_LPM_NONE
+    lpm_register_module(&board_spi_module);
+#endif
+}
+
+
 /*---------------------------------------------------------------------------*/
 void
 board_spi_close()
 {
+#if BOARD_SPI_LPM > BOARD_SPI_LPM_NONE
+  lpm_unregister_module(&board_spi_module);
+#endif
+  board_spi_down();
+}
+
+static
+void board_spi_down(){
+
+#if BOARD_SPI_LPM > BOARD_SPI_LPM_NONE
+  board_spi_module.domain_lock = LPM_DOMAIN_NONE | PRCM_DOMAIN_PERIPH;
+#endif
+
   /* Power down SSI0 */
+  ti_lib_rom_prcm_peripheral_sleep_disable(PRCM_PERIPH_SSI0);
   ti_lib_rom_prcm_peripheral_run_disable(PRCM_PERIPH_SSI0);
   ti_lib_prcm_load_set();
   while(!ti_lib_prcm_load_get());
@@ -160,4 +254,5 @@ board_spi_close()
   ti_lib_ioc_io_port_pull_set(BOARD_IOID_SPI_CLK_FLASH, IOC_IOPULL_DOWN);
 }
 /*---------------------------------------------------------------------------*/
+
 /** @} */

--- a/platform/srf06-cc26xx/common/board-spi.h
+++ b/platform/srf06-cc26xx/common/board-spi.h
@@ -53,6 +53,17 @@
 #include <stdlib.h>
 #include <stdint.h>
 #include <stdbool.h>
+
+// requred LPM support style for board SPI defined by BOARD_SPI_LPM
+// supported LPM modes:
+//< no LPM manage - minimum code size
+#define BOARD_SPI_LPM_NONE          0
+//< provides serial power domain on during SPI opened
+#define BOARD_SPI_LPM_BASIC         1
+//< allow deep_sleep mode, when SPI not busy
+//  shutdown SPI to enter deep_sleep, and reconfigures it when wake_up
+#define BOARD_SPI_LPM_DEEPSLEEP_OFF 2
+
 /*---------------------------------------------------------------------------*/
 /**
  * \brief Initialize the SPI interface

--- a/platform/srf06-cc26xx/common/board-spi.h
+++ b/platform/srf06-cc26xx/common/board-spi.h
@@ -53,6 +53,9 @@
 #include <stdlib.h>
 #include <stdint.h>
 #include <stdbool.h>
+#include "ti-lib.h"
+
+#define BOARD_SSI_BASE         SSI0_BASE
 
 // requred LPM support style for board SPI defined by BOARD_SPI_LPM
 // supported LPM modes:
@@ -115,6 +118,19 @@ bool board_spi_read(uint8_t *buf, size_t length);
  * recommended to call board_spi_close() at the end of an operation.
  */
 bool board_spi_write(const uint8_t *buf, size_t length);
+
+bool  board_spi_busy(void);
+
+__STATIC_INLINE
+bool  board_spi_empty(void){
+    return ((ti_lib_ssi_status(BOARD_SSI_BASE) & SSI_TX_EMPTY) != 0);
+}
+
+__STATIC_INLINE
+bool  board_spi_full(void){
+    return ((ti_lib_ssi_status(BOARD_SSI_BASE) & SSI_TX_NOT_FULL) == 0);
+}
+
 /*---------------------------------------------------------------------------*/
 #endif /* BOARD_SPI_H_ */
 /*---------------------------------------------------------------------------*/


### PR DESCRIPTION
There is itroduced LPM control for srf06-cc26xx platform board_spi module. 

SPI should manage it power domain with os sleep polls. that is for LPM module should preserve SERIAL PD, when need. 

when BOARD_SPI_LPM declared some style - SSI clock enabled in sleep mode.

BOARD_SPI_LPM_DEEPSLEEP_OFF - provide most effective power mode. it always turn  off/on SPI when go/out deep-sleep. This most purposes - that PR designed for.
