### PR TITLE
Route loopback packets via UIP_FALLBACK_INTERFACE.

### DIFF
--- a/core/net/ip/tcpip.c
+++ b/core/net/ip/tcpip.c
@@ -586,7 +586,7 @@ tcpip_ipv6_output(void)
       if(route == NULL) {
         PRINTF("tcpip_ipv6_output: no route found, using default route\n");
         nexthop = uip_ds6_defrt_choose();
-        if(nexthop == NULL) {
+        if(nexthop == NULL || uip_is_addr_loopback(&UIP_IP_BUF->destipaddr)) {
 #ifdef UIP_FALLBACK_INTERFACE
           PRINTF("FALLBACK: removing ext hdrs & setting proto %d %d\n",
               uip_ext_len, *((uint8_t *)UIP_IP_BUF + 40));


### PR DESCRIPTION
`tcpip_ipv6_output` doesn't check the destination address of the packet when it tries to send the packet to one of the default routes. That could lead to the scenario when the packet with `dst_addr == ::1` will
be redirected to the 6lowpan network instead of being routed to the fallback interface.