### PR TITLE
Makefile.include - prevents '.' path reposition 

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -181,7 +181,9 @@ CONTIKI_TARGET_DIRS_CONCAT = ${addprefix ${dir $(target_makefile)}, \
 CONTIKI_CPU_DIRS_CONCAT    = ${addprefix $(CONTIKI_CPU)/, \
                                $(CONTIKI_CPU_DIRS)}
 
-SOURCEDIRS = . $(PROJECTDIRS) $(CONTIKI_TARGET_DIRS_CONCAT) \
+
+SOURCEDIRS = ${if ${findstring ., $(PROJECTDIRS) }, , . } \
+             $(PROJECTDIRS) $(CONTIKI_TARGET_DIRS_CONCAT) \
              $(CONTIKI_CPU_DIRS_CONCAT) $(CONTIKIDIRS) $(APPDS) $(EXTERNALDIRS) ${dir $(target_makefile)}
 
 vpath %.c $(SOURCEDIRS)


### PR DESCRIPTION
When PROJECTDIRS have '.' path, application  suposes that position not changes.  but makefile.include forces it to first.
So, here is patch that prevents '.' path emit, when it alredy provided by app in PROJECTDIRS 