### PR TITLE
cpu/cc26xx-cc13xx : own linker script can be used

### DIFF
--- a/cpu/cc26xx-cc13xx/Makefile.cc26xx-cc13xx
+++ b/cpu/cc26xx-cc13xx/Makefile.cc26xx-cc13xx
@@ -27,7 +27,7 @@ CFLAGS += -I$(TI_XXWARE) -I$(CONTIKI)/$(TI_XXWARE_SRC)
 CFLAGS += -I$(TI_XXWARE)/inc
 MODULES += $(TI_XXWARE_SRC)
 
-LDSCRIPT = $(CONTIKI_CPU)/cc26xx.ld
+LDSCRIPT ?= $(CONTIKI_CPU)/cc26xx.ld
 
 CFLAGS += -mcpu=cortex-m3 -mthumb -mlittle-endian
 CFLAGS += -ffunction-sections -fdata-sections


### PR DESCRIPTION
It is possible to use your own linker script in your project
directory.

Signed-off-by: Aurelien Fillau <aurelien.fillau@gmail.com>