### PR TITLE
Removed Apple][ mouse driver file.

### DIFF
--- a/tools/6502/Makefile
+++ b/tools/6502/Makefile
@@ -184,7 +184,6 @@ else
 	java -jar $(AC) -p  $@ lan91c96.eth       rel 0 < ../../cpu/6502/ethconfig/lan91c96.eth
 	java -jar $(AC) -p  $@ w5100.eth          rel 0 < ../../cpu/6502/ethconfig/w5100.eth
 endif
-	java -jar $(AC) -p  $@ contiki.mou        rel 0 < $(CC65)/apple2enh/drv/mou/a2e.stdmou.mou
 	java -jar $(AC) -p  $@ index.htm          bin 0 < ../../examples/webserver/httpd-cfs/index.htm
 	java -jar $(AC) -p  $@ backgrnd.gif       bin 0 < ../../examples/webserver/httpd-cfs/backgrnd.gif
 	java -jar $(AC) -p  $@ contiki.gif        bin 0 < ../../examples/webserver/httpd-cfs/contiki.gif


### PR DESCRIPTION
The Apple][ mouse driver file became obsolete with https://github.com/oliverschmidt/contiki/commit/91beb8670f9c8000330c11e54ed46c8e5ac4049f.