### PR TITLE
fix a bug in the file contiki/core/sys/lc-switch.h

### DIFF
--- a/core/sys/lc-switch.h
+++ b/core/sys/lc-switch.h
@@ -62,7 +62,7 @@
 /** \hideinitializer */
 typedef unsigned short lc_t;
 
-#define LC_INIT(s) s = 0;
+#define LC_INIT(s) s = 0
 
 #define LC_RESUME(s) switch(s) { case 0:
 


### PR DESCRIPTION
the bug is in the line 65. the ';' should be removed, it is redundant and may cause problem.
**for example:**

#define LC_INIT(s)   s = 0;
#define PT_INIT(pt)   LC_INIT((pt)->lc)
if we use PT_INIT just like it is use in the dhcpc.c file：
PT_INIT(&s.pt);
it is equal to :
s.pt->lc = 0**;;**
there will be two ';' in the code，so may be a problem sometimes in some conditions.

by the way , every version of contiki has this problem