### PR TITLE
Cooja with dynamically moving motes

### DIFF
--- a/examples/circular_motion/Makefile
+++ b/examples/circular_motion/Makefile
@@ -1,0 +1,7 @@
+CONTIKI = ../..
+
+all: circular-motion
+TARGET_LIBFILES = -lm
+
+CONTIKI_WITH_RIME = 1
+include $(CONTIKI)/Makefile.include

--- a/examples/circular_motion/Readme.md
+++ b/examples/circular_motion/Readme.md
@@ -1,0 +1,13 @@
+<!---Author: Manish Kausik H-->
+
+Circular Motion
+================
+
+This folder contains a demo of how dynamic mobility can be implemented in contiki-cooja setup.
+
+There are 2 global variables in the contiki code: pos_x and pos_y. These two variables are updated in accordance with the equation of a circle. 
+Cooja reads these variables to update the position of the motes in GUI.
+
+For more information, please checkout tools/cooja/Readme_Mobility.md
+
+

--- a/examples/circular_motion/circular-motion.c
+++ b/examples/circular_motion/circular-motion.c
@@ -1,0 +1,50 @@
+#include "contiki.h"
+#include "random.h"
+
+
+#include <stdio.h>
+#include <math.h>
+
+static float pos_x=100;
+static float pos_y=0;
+
+
+/*---------------------------------------------------------------------------*/
+PROCESS(circular_motion_process, "CIRCULAR MOTION example");
+AUTOSTART_PROCESSES(&circular_motion_process);
+/*---------------------------------------------------------------------------*/
+
+
+
+/*---------------------------------------------------------------------------*/
+PROCESS_THREAD(circular_motion_process, ev, data)
+{
+  static struct etimer et;
+
+  PROCESS_BEGIN();
+  random_init(25);
+
+  
+
+  static float ang_velocity=0.5;
+  static float del_t=0.001;
+
+  
+  while(1) {
+
+    /* Delay 2-4 seconds */
+    etimer_set(&et, del_t*CLOCK_SECOND);
+
+    PROCESS_WAIT_EVENT_UNTIL(etimer_expired(&et));
+
+    
+ 
+    pos_x = pos_x - (pos_y*ang_velocity*del_t);
+    pos_y = pos_y + (pos_x*ang_velocity*del_t);
+
+
+  }
+
+  PROCESS_END();
+}
+/*---------------------------------------------------------------------------*/

--- a/tools/cooja/Readme_Mobility.md
+++ b/tools/cooja/Readme_Mobility.md
@@ -1,0 +1,55 @@
+<!---Author: Manish Kausik H-->
+
+# Cooja Mobility
+	This version of cooja has the option of moving motes via a contiki process. 
+	
+## How to use this verion of Cooja?
+	1. To compile and launch cooja, the steps are the same as the older cooja versions:
+		ant jar // to compile only
+		ant run // to compile and launch cooja
+		
+	2. To setup mote tracking :
+		a. Go to File ---> New Simulation
+		b. In the New Simulation Dialog box, enable "Track Positions of Node" checkbox
+		c. Fill in all other details as per your needs
+		d. Press "Create".
+	
+	Now you can operate Cooja just as before!
+	
+## What is expected from the contiki code?
+	The contiki code that you upload to the virtual motes in cooja MUST define 2 Global variables called "pos_x" and "pos_y".
+	They must be declared like this:
+		static float pos_x=<value>;
+		static float pos_y=<value>;
+		
+	These are the variables that you MUST update, so that cooja can update positions in the GUI.
+	Note: If these variables are not declared as Global Variables or are not declared at all, a NULL_POINTER_EXCEPTION will be thrown by Cooja.
+	These Variables are relevant and compulsory only if the Track Position checkbox was enabled when creating the simulation.
+	
+## Some other important details
+	Cooja updates the positions of the motes every 100ms. Any changes made to pos_x and pos_y before 100ms time will not be reflected in Cooja.
+	
+## Examples
+	the example folder in contiki parent folder contains an example of a contiki process that makes the mote moving in a circle. The folder is named "circular-motion"
+	
+## Potential Application
+	The dynamic mobility feature has been introduced so that motes can make decisions on how to move on the run, while communicating with other motes.
+	This gives a platform for research on various path planning methods in tight sync with various communication stacks already available in contiki. 
+
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+

--- a/tools/cooja/java/org/contikios/cooja/Simulation.java
+++ b/tools/cooja/java/org/contikios/cooja/Simulation.java
@@ -29,7 +29,7 @@
 package org.contikios.cooja;
 
 import java.util.*;
-import java.nio.*; //manish
+import java.nio.*; // added by manish
 
 import javax.swing.JOptionPane;
 
@@ -38,10 +38,10 @@ import org.jdom.Element;
 
 import org.contikios.cooja.dialogs.CreateSimDialog;
 //import org.contikios.cooja.mspmote.interfaces.SkyPositionUpdate;
-//import org.contikios.cooja.mspmote.MspMoteMemory; //manish
-import org.contikios.cooja.mote.memory.MemoryInterface; //manish
-import org.contikios.cooja.mote.memory.MemoryInterface.Symbol; //manish
-import org.contikios.cooja.interfaces.Position; //manish
+//import org.contikios.cooja.mspmote.MspMoteMemory; //added by manish
+import org.contikios.cooja.mote.memory.MemoryInterface; //added by manish
+import org.contikios.cooja.mote.memory.MemoryInterface.Symbol; //added by manish
+import org.contikios.cooja.interfaces.Position; //added by manish
 
 /**
  * A simulation consists of a number of motes and mote types.
@@ -50,7 +50,9 @@ import org.contikios.cooja.interfaces.Position; //manish
  * changed simulation state, added or deleted motes etc are observed.
  * To track mote changes, observe the mote (interfaces) itself.
  *
- * @author Fredrik Osterlind
+ * Mobility related features were added by Manish Kausik H
+ * @author Fredrik Osterlind, Manish Kausik H
+ 
  */
 public class Simulation extends Observable implements Runnable {
   public static final long MICROSECOND = 1L;
@@ -351,13 +353,6 @@ public class Simulation extends Observable implements Runnable {
         /*logger.info("Executing event #" + EVENT_COUNTER++ + " @ " + currentSimulationTime + ": " + nextEvent);*/
         nextEvent.execute(currentSimulationTime);
 
-        /*
-          Edit by Manish Kausik H
-         */
-//        updatePositions();
-        /*
-          End of Edit ny Manish Kausik H
-         */
 
         if (stopSimulation) {
           isRunning = false;

--- a/tools/cooja/java/org/contikios/cooja/dialogs/CreateSimDialog.java
+++ b/tools/cooja/java/org/contikios/cooja/dialogs/CreateSimDialog.java
@@ -80,6 +80,7 @@ public class CreateSimDialog extends JDialog {
 
   private JFormattedTextField randomSeed, delayedStartup;
   private JCheckBox randomSeedGenerated;
+  private JCheckBox trackPos; //edit by Manish  Kausik H
 
   private JTextField title;
   private JComboBox radioMediumBox;
@@ -313,7 +314,6 @@ public class CreateSimDialog extends JDialog {
           randomSeed.setValue(new Integer(123456));
         }
       }
-
     });
 
     horizBox.add(label);
@@ -323,6 +323,34 @@ public class CreateSimDialog extends JDialog {
     advancedBox.add(horizBox);
     advancedBox.add(Box.createVerticalStrut(5));
 
+    /*
+      Edit by Manish Kausik H
+     */
+    horizBox = Box.createHorizontalBox();
+    horizBox.setMaximumSize(new Dimension(Integer.MAX_VALUE,LABEL_HEIGHT));
+    horizBox.setAlignmentX(Component.LEFT_ALIGNMENT);
+    label = new JLabel("Track Positions of Node");
+    label.setPreferredSize(new Dimension(LABEL_WIDTH,LABEL_HEIGHT));
+    trackPos = new JCheckBox();
+    trackPos.setToolTipText("Tracks the positions of each node and updates them periodically");
+//    trackPos.addActionListener(new ActionListener() {
+//      public void actionPerformed(ActionEvent e) {
+//        /*
+//          Some changes related to how often to update etc can come here
+//         */
+//      }
+//    });
+
+    horizBox.add(label);
+    horizBox.add(Box.createHorizontalStrut(173));
+    horizBox.add(trackPos);
+
+    advancedBox.add(horizBox);
+    advancedBox.add(Box.createVerticalStrut(5));
+
+    /*
+      End of Edit by Manish Kausik H
+     */
     vertBox.add(advancedBox);
     vertBox.add(Box.createVerticalGlue());
 
@@ -363,6 +391,17 @@ public class CreateSimDialog extends JDialog {
         mySimulation.setRandomSeed(((Number) randomSeed.getValue()).longValue());
       }
 
+      /*
+        Edit Made by Manish Kausik H
+       */
+      if(trackPos.isSelected()){
+        mySimulation.setTrackPositions(true);
+      }else{
+        mySimulation.setTrackPositions((false));
+      }
+      /*
+        End of Edit made by Manish Kausik H
+       */
       mySimulation.setDelayedMoteStartupTime((int) ((Number) delayedStartup.getValue()).intValue()*Simulation.MILLISECOND);
 
       dispose();

--- a/tools/cooja/java/org/contikios/cooja/dialogs/CreateSimDialog.java
+++ b/tools/cooja/java/org/contikios/cooja/dialogs/CreateSimDialog.java
@@ -67,7 +67,8 @@ import org.contikios.cooja.Simulation;
 /**
  * A dialog for creating and configuring a simulation.
  *
- * @author Fredrik Osterlind
+ * Mobility related features were added by Manish Kausik H
+ * @author Fredrik Osterlind, Manish Kausik H
  */
 public class CreateSimDialog extends JDialog {
   private static final long serialVersionUID = 1L;

--- a/tools/cooja/java/org/contikios/cooja/plugins/SimControl.java
+++ b/tools/cooja/java/org/contikios/cooja/plugins/SimControl.java
@@ -307,12 +307,31 @@ public class SimControl extends VisPlugin implements HasQuickHelp {
   private Action startAction = new AbstractAction("Start") {
     public void actionPerformed(ActionEvent e) {
       simulation.startSimulation();
+      /*
+        Edit By Manish Kausik H
+       */
+      if(simulation.getTrackPosiions()){
+        simulation.startTrackingScheduler();
+      }
+      /*
+        End of edit by Manish Kausik H
+       */
       stopButton.requestFocus();
     }
   };
   private Action stopAction = new AbstractAction("Pause") {
     public void actionPerformed(ActionEvent e) {
       simulation.stopSimulation();
+      /*
+        Edit by Manish Kausik H
+       */
+      if(simulation.getTrackPosiions()){
+        simulation.stopTrackingScheduler();
+      }
+
+      /*
+        End of Edit by Manish Kausik H
+       */
       startButton.requestFocus();
     }
   };
@@ -324,6 +343,15 @@ public class SimControl extends VisPlugin implements HasQuickHelp {
   private Action reloadAction = new AbstractAction("Reload") {
     public void actionPerformed(ActionEvent e) {
       simulation.getCooja().reloadCurrentSimulation(simulation.isRunning());
+      /*
+        Edit By Manish Kausik H
+       */
+      if(simulation.getTrackPosiions()){
+        simulation.startTrackingScheduler();
+      }
+      /*
+        End of edit by Manish Kausik H
+       */
     }
   };
 

--- a/tools/cooja/java/org/contikios/cooja/plugins/SimControl.java
+++ b/tools/cooja/java/org/contikios/cooja/plugins/SimControl.java
@@ -60,8 +60,8 @@ import org.contikios.cooja.VisPlugin;
 
 /**
  * Control panel for starting and pausing the current simulation.
- *
- * @author Fredrik Osterlind
+ * Mobility related features were added by Manish Kausik H
+ * @author Fredrik Osterlind, Manish Kausik H
  */
 @ClassDescription("Simulation control")
 @PluginType(PluginType.SIM_STANDARD_PLUGIN)


### PR DESCRIPTION
I have added a new facility to cooja, where the motes can change their position on the run, by dynamically taking decisions. This feature will help the community to advance in Research related to MANETS, VANETS etc, where the interaction between communication and mobility-concerned decision making of the motes will be tightly linked. 

I have also given an option in the Cooja GUI so that only those who need this facility will be able to track the motes in the GUI, where as the rest can use Cooja just as before.

For more details about this feature kindly have a look at "tools/cooja/Readme_mobility.md" in the contiki folder.

closes #2689